### PR TITLE
Getting rid of the completedList and completedIds

### DIFF
--- a/src/app/index.coffee
+++ b/src/app/index.coffee
@@ -59,15 +59,12 @@ get '/', (page, model, next) ->
     ## Task List Cleanup
     # FIXME temporary hack to fix lists (Need to figure out why these are happening)
     # FIXME consolidate these all under user.listIds so we can set them en-masse
-    _.each ['habit','daily','todo', 'completed', 'reward'], (type) ->
+    _.each ['habit','daily','todo','reward'], (type) ->
       path = "#{type}Ids"
 
       # 1. remove duplicates
       # 2. restore missing zombie tasks back into list
       where = {type:type}
-      if type in ['completed', 'todo']
-        where.type = 'todo'
-        where.completed = if type == 'completed' then true else false
       taskIds =  _.pluck( _.where(userObj.tasks, where), 'id')
       union = _.union userObj[path], taskIds
 

--- a/src/app/schema.coffee
+++ b/src/app/schema.coffee
@@ -12,7 +12,6 @@ module.exports.userSchema = ->
     habitIds: []
     dailyIds: []
     todoIds: []
-    completedIds: []
     rewardIds: []
 
   for task in content.defaultTasks

--- a/test/user.mocha.coffee
+++ b/test/user.mocha.coffee
@@ -84,7 +84,6 @@ describe 'User', ->
     expect(_.size(user.habitIds)).to.eql 3
     expect(_.size(user.dailyIds)).to.eql 3
     expect(_.size(user.todoIds)).to.eql 1
-    expect(_.size(user.completedIds)).to.eql 0
     expect(_.size(user.rewardIds)).to.eql 2
   
   ##### Habits #####  

--- a/views/app/index.html
+++ b/views/app/index.html
@@ -210,13 +210,21 @@
           <div class="tab-content">
             <div class="tab-pane active" id="tab1">
               <ul class='todos'>
-                {#each _todoList as :task}<app:task />{/}
+                {#each _todoList as :task}
+                  {#if not(:task.completed)}
+                    <app:task />
+                  {/}
+                {/}
               </ul>
               <app:newTask type=todo><input value={_newTodo} type="text" name=new-task placeholder="New Todo"/></app:newTask>
             </div>
             <div class="tab-pane" id="tab2">
               <ul class='completeds'>
-                {#each _completedList as :task}<app:task />{/}
+                {#each _todoList as :task}
+                  {#if :task.completed}
+                    <app:task />
+                  {/}
+                {/}
               </ul>
               <a x-bind=click:clearCompleted>Clear Completed</a>
             </div>


### PR DESCRIPTION
Instead only using the 'completed' attribute of the todo task. This fixes some issues were a task was at the same time in the todoIds and completedIds as described in #73.

This change requires an update of all the users in the database. The user.completedIds have to be merged into user.todoIds and can then be removed. I don't know where one would do that. Is there something like database migrations? If someone can give me a hint I'd be happy to write the update script.
