### PR TITLE
Static Header & Popups

### DIFF
--- a/styles/app/index.styl
+++ b/styles/app/index.styl
@@ -20,6 +20,11 @@ html,body,p,h1,ul,li,table,tr,th,td
   position:fixed
   width: 100%;
 
+#head .pull-right{
+  margin-right: 2%
+  margin-left: 1%
+  }
+
 .color-worst pre
   background-color: rgb(230, 184, 175)
 .color-worse pre

--- a/styles/app/index.styl
+++ b/styles/app/index.styl
@@ -166,7 +166,6 @@ li:hover .task-meta-controls .hover-show
 /* Bootstrap website boilerplate */
 .footer {
   padding: 70px 0;
-  margin-top: 70px;
   border-top: 1px solid #e5e5e5;
   background-color: #f5f5f5;
 }
@@ -184,7 +183,7 @@ li:hover .task-meta-controls .hover-show
 
 /* Customizations to make footer sticky */
 /*html, body {height: 100%;}*/                                                                                                                                                                                                                   
-#wrap {min-height: 100%; position: relative; top:130px; z-index:-1}                                                                                                                                                                                                                    
+#wrap {min-height: 100%; margin-top:130px; z-index:-1}                                                                                                                                                                                                                    
 #main                                                                                                                                                                                                                                        
   /*overflow:auto;*/                                                                                                                                                                                                                             
   padding-bottom: 250px; /* don't know why this works, sticky footers are weird */                                                                                                                                                                             

--- a/styles/app/index.styl
+++ b/styles/app/index.styl
@@ -17,6 +17,7 @@ html,body,p,h1,ul,li,table,tr,th,td
   box-shadow: inset 0 1px #f7f7f7, 0 1px #888, 0 2px #e7e7e7
   padding: 12px 16px
   white-space: nowrap
+  position:fixed
 
 .color-worst pre
   background-color: rgb(230, 184, 175)
@@ -183,7 +184,7 @@ li:hover .task-meta-controls .hover-show
 
 /* Customizations to make footer sticky */
 /*html, body {height: 100%;}*/                                                                                                                                                                                                                   
-#wrap {min-height: 100%;}                                                                                                                                                                                                                    
+#wrap {min-height: 100%; position: relative; top:130px; z-index:-1}                                                                                                                                                                                                                    
 #main                                                                                                                                                                                                                                        
   /*overflow:auto;*/                                                                                                                                                                                                                             
   padding-bottom: 250px; /* don't know why this works, sticky footers are weird */                                                                                                                                                                             

--- a/styles/app/index.styl
+++ b/styles/app/index.styl
@@ -18,6 +18,7 @@ html,body,p,h1,ul,li,table,tr,th,td
   padding: 12px 16px
   white-space: nowrap
   position:fixed
+  width: 100%;
 
 .color-worst pre
   background-color: rgb(230, 184, 175)

--- a/styles/bootstrap-responsive.styl
+++ b/styles/bootstrap-responsive.styl
@@ -440,10 +440,6 @@
   .row-fluid .thumbnails {
     margin-left: 0;
   }
-  #head .pull-right {
-  margin-right: 2%
-  margin-left: 1%
-  }
 }
 
 @media (min-width: 768px) and (max-width: 979px) {
@@ -785,10 +781,6 @@
   .uneditable-input.span1 {
     width: 28px;
   }
-  #head .pull-right{
-  margin-right: 2%
-  margin-left: 1%
-  }
 }
 
 @media (max-width: 767px) {
@@ -887,11 +879,6 @@
   .modal.fade.in {
     top: 20px;
   }
-  #head .pull-right{
-  margin-right: 3%
-  margin-left: 1%
-  }
-
 }
 
 @media (max-width: 480px) {

--- a/styles/bootstrap-responsive.styl
+++ b/styles/bootstrap-responsive.styl
@@ -888,7 +888,7 @@
     top: 20px;
   }
   #head .pull-right{
-  margin-right: 2%
+  margin-right: 3%
   margin-left: 1%
   }
 

--- a/styles/bootstrap-responsive.styl
+++ b/styles/bootstrap-responsive.styl
@@ -89,6 +89,7 @@
   .hidden-phone {
     display: none !important;
   }
+
 }
 
 @media (min-width: 1200px) {
@@ -439,6 +440,10 @@
   .row-fluid .thumbnails {
     margin-left: 0;
   }
+  #head .pull-right {
+  margin-right: 2%
+  margin-left: 1%
+  }
 }
 
 @media (min-width: 768px) and (max-width: 979px) {
@@ -780,6 +785,10 @@
   .uneditable-input.span1 {
     width: 28px;
   }
+  #head .pull-right{
+  margin-right: 2%
+  margin-left: 1%
+  }
 }
 
 @media (max-width: 767px) {
@@ -878,6 +887,11 @@
   .modal.fade.in {
     top: 20px;
   }
+  #head .pull-right{
+  margin-right: 2%
+  margin-left: 1%
+  }
+
 }
 
 @media (max-width: 480px) {

--- a/styles/ui.styl
+++ b/styles/ui.styl
@@ -1,5 +1,5 @@
 .connection {
-  position: absolute;
+  position: fixed;
   text-align: center;
   top: 0;
   left: 0;

--- a/views/app/index.html
+++ b/views/app/index.html
@@ -346,10 +346,7 @@
       </div>
       
       {#if :task.notes}
-        {#if equal(:task.type,'reward')}
-          <span rel="popover" data-trigger="hover" data-placement="left" data-content="{:task.notes}" data-original-title="{:task.text}" class='task-notes'><i class="icon-comment"></i></span>
-        {else}
-          <span rel="popover" data-trigger="hover" data-content="{:task.notes}" data-original-title="{:task.text}" class='task-notes'><i class="icon-comment"></i></span>
+       <span rel="popover" data-trigger="hover" data-placement="left" data-content="{:task.notes}" data-original-title="{:task.text}" class='task-notes'><i class="icon-comment"></i></span>
         {/}  
       {/}
     </div>


### PR DESCRIPTION
Header fixed to top of browser, connection display also fixed. As per this issue; 
https://github.com/lefnire/habitrpg/issues/100#issuecomment-12408991
https://trello.com/c/mrbELa6J

Wrap div now relative, top 130px. I'm not 100% if the relative 130px is the best way to do it, it works fine on my screen at various sizes but I dont know if that changes on a mobile browser. 

It also moves all popups to the left, as per this issue;
https://github.com/lefnire/habitrpg/issues/206

Note: I've not been able to test directly as I'm installing an SSD into my primary machine & my linux laptop hasn't got this set up. I did test in Chromes developer tools though. I just wanted to get some code done in my downtime =P
