### PR TITLE
Completed and remaining todos are shown and hidden with CSS. 

### DIFF
--- a/src/app/helpers.coffee
+++ b/src/app/helpers.coffee
@@ -14,6 +14,8 @@ module.exports.viewHelpers = (view) ->
     # show as completed if completed (naturally) or not required for today
     if completed or (repeat and repeat[dayMapping[moment().day()]]==false)
       classes += " completed"
+    else
+      classes += " not-completed"
       
     switch
       when value<-8 then classes += ' color-worst'

--- a/src/app/index.coffee
+++ b/src/app/index.coffee
@@ -165,15 +165,7 @@ ready (model) ->
 
   exports.del = (e, el) ->
     # Derby extends model.at to support creation from DOM nodes
-    #task = model.at(e.target)
-    # FIXME normally that would work, and we'd later simply call `user.del task` (instead of that 4-liner down there)
-    # however, see https://github.com/lefnire/habitrpg/pull/226#discussion_r2810391
-
-    id = $(e.target).parents('li.task').attr('data-id')
-    return unless id?
-
-    task = user.at "tasks.#{id}"
-    type = task.get('type')
+    task = model.at(e.target)
 
     history = task.get('history')
     if history and history.length>2
@@ -184,7 +176,7 @@ ready (model) ->
           return # Cancel. Don't delete, don't hurt user 
         else
           task.set('type','habit') # hack to make sure it hits HP, instead of performing "undo checkbox"
-          scoring.score(id, direction:'down')
+          scoring.score(task.get('id'), direction:'down')
           
       # prevent accidently deleting long-standing tasks
       else
@@ -194,12 +186,8 @@ ready (model) ->
     #TODO bug where I have to delete from _users.tasks AND _{type}List, 
     # fix when query subscriptions implemented properly
     $('[rel=tooltip]').tooltip('hide')
-
-    ids = user.get("#{type}Ids")
-    ids.splice(ids.indexOf(id),1)
-    user.del('tasks.'+id)
-    user.set("#{type}Ids", ids)
-
+    user.del('tasks.'+task.get('id'))
+    task.remove()
     
   exports.clearCompleted = (e, el) ->
     todoIds = user.get('todoIds')

--- a/styles/app/index.styl
+++ b/styles/app/index.styl
@@ -53,6 +53,10 @@ label.checkbox.inline{
     color: #005580
     background-color: #DEE5F2
 
+#tab-todos-remaining .completed,
+#tab-todos-completed .not-completed
+  display: none
+
 .dailys
   .repeat-days > .btn:not(.active)
     background-color: #aaa;

--- a/views/app/index.html
+++ b/views/app/index.html
@@ -207,28 +207,20 @@
           <div class="row-fluid">
             <h2 class="span6">Todos</h2>
             <ul class="span6 nav nav-pills">
-                <li class="active"><a href="#" data-target="#tab1" data-toggle="tab">Remaining</a></li>
-                <li><a href="#" data-target="#tab2" data-toggle="tab">Complete</a></li>
+                <li class="active"><a href="#" data-target="#tab-todos-remaining" data-toggle="tab">Remaining</a></li>
+                <li><a href="#" data-target="#tab-todos-completed" data-toggle="tab">Complete</a></li>
             </ul>
           </div>
           <div class="tab-content">
-            <div class="tab-pane active" id="tab1">
+            <div class="tab-pane active" id="tab-todos-remaining">
               <ul class='todos'>
-                {#each _todoList as :task}
-                  {#if not(:task.completed)}
-                    <app:task />
-                  {/}
-                {/}
+                {#each _todoList as :task}<app:task />{/}
               </ul>
               <app:newTask type=todo><input value={_newTodo} type="text" name=new-task placeholder="New Todo"/></app:newTask>
             </div>
-            <div class="tab-pane" id="tab2">
+            <div class="tab-pane" id="tab-todos-completed">
               <ul class='completeds'>
-                {#each _todoList as :task}
-                  {#if :task.completed}
-                    <app:task />
-                  {/}
-                {/}
+                {#each _todoList as :task}<app:task />{/}
               </ul>
               <a x-bind=click:clearCompleted>Clear Completed</a>
             </div>


### PR DESCRIPTION
Reverting fix from 69e5778 that is now not needed anymore since task deletion works as it used to.

Completely different approach to fixing this problem. One might also completely get rid of the tab and simply change a css class to define if the remaining or the completed todos are shown. Then one wouldn't need to render the list twice.

I tried to ran the casper tests, but somehow they don't want to work yet. So make sure to run them on your end before merging this.

Refs #226, #73
