### PR TITLE
Use nconf to load in configuration values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 #lib/
 *.swp
 .idea*
+config.json

--- a/config.json.example
+++ b/config.json.example
@@ -1,0 +1,15 @@
+{
+    "PORT":3000,
+    "IP":"0.0.0.0",
+    "BASE_URL": "http://localhost",
+    "FACEBOOK_KEY":"123456789012345",
+    "FACEBOOK_SECRET":"aaaabbbbccccddddeeeeffff00001111",
+    "NODE_DB_URI":"mongodb://user:pass@hostname:27017/db_name",
+    "NODE_ENV":"development",
+    "SESSION_SECRET":"YOUR SECRET HERE",
+    "SMTP_USER":"user@domain.com",
+    "SMTP_PASS":"password",
+    "SMTP_SERVICE":"Gmail",
+    "STRIPE_API_KEY":"aaaabbbbccccddddeeeeffff00001111",
+    "STRIPE_PUB_KEY":"22223333444455556666777788889999"
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "lodash": "*",
     "coffee-script": "*",
     "underscore": "*",
-    "mongoskin": "*"
+    "mongoskin": "*",
+    "nconf": "*"
   },
   "private": true,
   "subdomain": "habitrpg",

--- a/server.js
+++ b/server.js
@@ -1,3 +1,27 @@
+// Load nconf and define default configuration values if config.json or ENV vars are not found
+var conf = require('nconf');
+conf.argv().env().file({ file: __dirname + "/config.json" }).defaults({
+   'PORT': 3000,
+   'IP': '0.0.0.0',
+   'BASE_URL': 'http://localhost',
+   'NODE_ENV': 'development'
+});
+
+// Override normal ENV values with nconf ENV values (ENV values are used the same way without nconf)
+process.env.IP = conf.get("IP");
+process.env.PORT = conf.get("PORT");
+process.env.BASE_URL = conf.get("BASE_URL");
+process.env.FACEBOOK_KEY = conf.get("FACEBOOK_KEY");
+process.env.FACEBOOK_SECRET = conf.get("FACEBOOK_SECRET");
+process.env.NODE_DB_URI = conf.get("NODE_DB_URI");
+process.env.NODE_ENV = conf.get("NODE_ENV");
+process.env.SESSION_SECRET = conf.get("SESSION_SECRET");
+process.env.SMTP_USER = conf.get("SMTP_USER");
+process.env.SMTP_PASS = conf.get("SMTP_PASS");
+process.env.SMTP_SERVICE = conf.get("SMTP_SERVICE");
+process.env.STRIPE_API_KEY = conf.get("STRIPE_API_KEY");
+process.env.STRIPE_PUB_KEY = conf.get("STRIPE_PUB_KEY");
+
 process.on('uncaughtException', function (error) {
 
     function sendEmail(mailData) {
@@ -35,7 +59,7 @@ process.on('uncaughtException', function (error) {
 });
 
 require('coffee-script') // remove intermediate compilation requirement
-require('./src/server').listen(process.env.PORT || 3000);
+require('./src/server').listen(process.env.PORT || 3000, process.env.IP || '0.0.0.0');
 
 // Note: removed "up" module, which is default for development (but interferes with and production + PaaS)
 // Restore to 5310bb0 if I want it back (see https://github.com/codeparty/derby/issues/165#issuecomment-10405693)


### PR DESCRIPTION
A config.json file can be used for all ENV settings, and nconf will still allow using ENV overrides. See https://github.com/flatiron/nconf for syntax, or copy the config.json.example file to config.json.
