### PR TITLE
Adding a new functionality that allows the context (i.e. css classes)

### DIFF
--- a/styles/app/tasks.styl
+++ b/styles/app/tasks.styl
@@ -37,6 +37,19 @@ label.checkbox.inline{
     background-image: linear-gradient(to bottom, #eee, #aaa);
     background-repeat: repeat-x;
 
+.context-enabled
+  .display-context-dependant,
+  .task-list li
+    display: none
+
+  &.context-completed
+    .show-for-completed, .completed
+      display: block
+
+  &.context-uncompleted
+    .show-for-uncompleted, .uncompleted
+      display: block
+
 .help-icon
   float:right;
 

--- a/views/app/index.html
+++ b/views/app/index.html
@@ -279,37 +279,22 @@
         <app:newTask type=daily><input value={_newDaily} type="text" name=new-task placeholder="New Daily"/></app:newTask>
       </div>
 
-      <div class="span3 well todos">
-        <div class="tabbable"> <!-- Only required for left/right tabs -->
-          <div class="row-fluid">
-            <h2 class="span6">Todos</h2>
-            <ul class="span6 nav nav-pills">
-                <li class="active"><a href="#" data-target="#tab1" data-toggle="tab">Remaining</a></li>
-                <li><a href="#" data-target="#tab2" data-toggle="tab">Complete</a></li>
-            </ul>
-          </div>
-          <div class="tab-content">
-            <div class="tab-pane active" id="tab1">
-              <ul class='todos'>
-                {#each _todoList as :task}
-                  {#if not(:task.completed)}
-                    <app:task />
-                  {/}
-                {/}
-              </ul>
-              <app:newTask type=todo><input value={_newTodo} type="text" name=new-task placeholder="New Todo"/></app:newTask>
-            </div>
-            <div class="tab-pane" id="tab2">
-              <ul class='completeds'>
-                {#each _todoList as :task}
-                  {#if :task.completed}
-                    <app:task />
-                  {/}
-                {/}
-              </ul>
-              <a x-bind=click:clearCompleted>Clear Completed</a>
-            </div>
-          </div>
+      <div class="span3 well todos context-enabled context-uncompleted" id="todo-well">
+        <div class="row-fluid">
+          <h2 class="span6">Todos</h2>
+          <ul class="span6 nav nav-pills">
+            <li class="active"><a x-bind=click:changeContext data-target="#todo-well" data-context="context-uncompleted">Remaining</a></li>
+            <li><a x-bind=click:changeContext data-target="#todo-well" data-context="context-completed">Complete</a></li>
+          </ul>
+        </div>
+        <ul class='todos task-list'>
+          {#each _todoList as :task}<app:task />{/}
+        </ul>
+        <div class="display-context-dependant show-for-uncompleted">
+          <app:newTask type=todo><input value={_newTodo} type="text" name=new-task placeholder="New Todo"/></app:newTask>
+        </div>
+        <div class="display-context-dependant show-for-completed">
+          <a x-bind=click:clearCompleted>Clear Completed</a>
         </div>
         {#if _user.history.todos}
           <a x-bind=click:toggleChart data-toggle-id="todos-chart" data-history-path="_user.history.todos" rel=tooltip title="Progress"><i class=icon-signal></i></a>


### PR DESCRIPTION
of an element to be changed easily. Using this to implement the
'remaining todos' and 'complete todos' views. Reverting fix from
69e5778 that is now not needed anymore since task deletion works as
it used to.

I had to implement something myself, since there was no bootstrap functionality that would do something like that and since derby refLists and filters don't play nice together.

This replaces PR #277

The new changeContext function will also be handy when implementing #208.
