### PR TITLE
Making two tabs for dailys

### DIFF
--- a/src/app/tasks.coffee
+++ b/src/app/tasks.coffee
@@ -4,7 +4,7 @@ _ = require 'underscore'
 moment = require 'moment'
 
 module.exports.view = (view) ->
-  view.fn 'taskClasses', (type, completed, value, repeat) ->
+  view.fn 'taskClasses', (type, completed, value, repeat, editing) ->
     #TODO figure out how to just pass in the task model, so i can access all these properties from one object
     classes = type
 
@@ -13,6 +13,9 @@ module.exports.view = (view) ->
       classes += " completed"
     else
       classes += " uncompleted"
+
+    if editing
+      classes += " editing"
 
     switch
       when value<-8 then classes += ' color-worst'
@@ -115,6 +118,10 @@ module.exports.app = (appExports, model) ->
       task.set('repeat.' + $(el).attr('data-day'), true)
 
   appExports.toggleTaskEdit = (e, el) ->
+    # Toggle the task editing state
+    task = model.at(e.target)
+    task.set('_editing', !task.get('_editing'))
+
     hideId = $(el).attr('data-hide-id')
     toggleId = $(el).attr('data-toggle-id')
     $(document.getElementById(hideId)).hide()

--- a/src/app/tasks.coffee
+++ b/src/app/tasks.coffee
@@ -120,7 +120,8 @@ module.exports.app = (appExports, model) ->
   appExports.toggleTaskEdit = (e, el) ->
     # Toggle the task editing state
     task = model.at(e.target)
-    task.set('_editing', !task.get('_editing'))
+    if task.get('type') in ['habit', 'daily', 'todo']
+      task.set('_editing', !task.get('_editing'))
 
     hideId = $(el).attr('data-hide-id')
     toggleId = $(el).attr('data-toggle-id')
@@ -128,6 +129,11 @@ module.exports.app = (appExports, model) ->
     $(document.getElementById(toggleId)).toggle()
 
   appExports.toggleChart = (e, el) ->
+    # Make sure if it's a task, it's not in editing mode anymore
+    task = model.at(e.target).parent()
+    if task.get('type') in ['habit', 'daily', 'todo']
+      task.set('_editing', false)
+
     hideSelector = $(el).attr('data-hide-id')
     chartSelector = $(el).attr('data-toggle-id')
     historyPath = $(el).attr('data-history-path')

--- a/styles/app/tasks.styl
+++ b/styles/app/tasks.styl
@@ -42,6 +42,9 @@ label.checkbox.inline{
   .task-list li
     display: none
 
+  .task-list li.editing
+    display: block
+
   &.context-completed
     .show-for-completed, .completed
       display: block

--- a/views/app/index.html
+++ b/views/app/index.html
@@ -318,10 +318,16 @@ do a find for the string after "→"
         <ul class="habits">{#each _habitList as :task}<app:task />{/}</ul>
       </div>
 
-      <div class="span3 well dailys">
+      <div class="span3 well dailys context-enabled context-uncompleted tabbable tabs-below" id="daily-well">
         <h2>Daily</h2>
         <app:newTask type="daily" inputValue="{_newDaily}" placeHolder="New Daily" />
-        <ul class='dailys'>{#each _dailyList as :task}<app:task />{/}</ul>
+        <ul class='dailys task-list'>
+          {#each _dailyList as :task}<app:task />{/}
+        </ul>
+        <ul class="nav nav-tabs">
+          <li class="active"><a x-bind=click:changeContext data-target="#daily-well" data-context="context-uncompleted">Due today</a></li>
+          <li><a x-bind=click:changeContext data-target="#daily-well" data-context="context-uncompleted context-completed">All</a></li>
+        </ul>
       </div>
 
       <div class="span3 well todos context-enabled context-uncompleted tabbable tabs-below" id="todo-well">
@@ -344,7 +350,6 @@ do a find for the string after "→"
           <li class="active"><a x-bind=click:changeContext data-target="#todo-well" data-context="context-uncompleted">Remaining</a></li>
           <li><a x-bind=click:changeContext data-target="#todo-well" data-context="context-completed">Complete</a></li>
         </ul>
-
       </div>
 
         <div class="span3 well rewards">
@@ -533,7 +538,7 @@ do a find for the string after "→"
   </form>
 
 <task:>
-  <li data-id={{:task.id}} class="task {taskClasses(:task.type, :task.completed, :task.value, :task.repeat)}">
+  <li data-id={{:task.id}} class="task {taskClasses(:task.type, :task.completed, :task.value, :task.repeat, :task._editing)}">
     <pre>
     <div class="task-meta-controls">
 


### PR DESCRIPTION
One tab that shows only the ones still due today, the other shows all. If we rather want to have the separation like for the todos (remaining/completed) it's easy to just change the data-context attribute of the link.

Fixes #208, I know it's not that high on the trello list, but since I was doing something similar for the todos, it was easy to also apply it to the dailys.
