### PR TITLE
Fixing the dailies casper tests (almost). Found out that the main problem...

### DIFF
--- a/test/casper/dailies.casper.coffee
+++ b/test/casper/dailies.casper.coffee
@@ -1,47 +1,42 @@
-helper = new require('./test/casper/helpers')()
-casper = helper.casper
-utils = helper.utils
-url = helper.url
+helpers = new require('./test/casper/helpers')()
+casper = helpers.casper
+utils = helpers.utils
+url = helpers.playUrl
 
-casper.start url + '/?play=1'
+casper.start url
 
 # ---------- Daily ------------
 casper.then ->
-  helper.reset()
-  helper.addTasks()
+  helpers.reset()
+  helpers.addTasks()
 
 # Gained exp on +daily
 casper.then ->
-  user = helper.userBeforeAfter (-> casper.click '.dailys input[type="checkbox"]')
-  @test.assertEquals user.before.stats.hp, user.after.stats.hp, '+daily =hp'
-  @test.assert user.before.stats.exp < user.after.stats.exp, '+daily +exp'
-  @test.assert user.before.stats.money < user.after.stats.money, '+daily +money'
+  helpers.modelBeforeAfter (-> casper.click '.dailys input[type="checkbox"]'), (model) ->
+    casper.test.assertEquals model.before._user.stats.hp, model.after._user.stats.hp, '+daily =hp'
+    casper.test.assert model.before._user.stats.exp < model.after._user.stats.exp, '+daily +exp'
+    casper.test.assert model.before._user.stats.gp < model.after._user.stats.gp, '+daily +gp'
 
 # -daily acts as undo
 casper.then ->
-  user = helper.userBeforeAfter (-> casper.click '.dailys input[type="checkbox"]')
-  @test.assertEquals user.before.stats.hp, user.after.stats.hp, '-daily =hp'
-  @test.assert user.before.stats.exp > user.after.stats.exp, '-daily -exp'
-  @test.assert user.before.stats.money > user.after.stats.money, '-daily -money'
+  helpers.modelBeforeAfter (-> casper.click '.dailys input[type="checkbox"]'), (model) ->
+    casper.test.assertEquals model.before._user.stats.hp, model.after._user.stats.hp, '-daily =hp'
+    casper.test.assert model.before._user.stats.exp > model.after._user.stats.exp, '-daily -exp'
+    casper.test.assert model.before._user.stats.gp > model.after._user.stats.gp, '-daily -gp'
 
 # ---------- Cron ------------
+casper.then ->
+  helpers.reset()
+  helpers.addTasks()
 
 casper.then ->
-  helper.reset()
-  helper.addTasks()
-
-casper.then ->
-  helper.cronBeforeAfter (beforeAfter) ->
+  helpers.cronBeforeAfter (model) ->
     casper.then ->
-        #TODO make sure true for all dailies
-        dailyId = beforeAfter.before.tasks.daily[0].id
-#        utils.dump
-#          dailyBefore:user.before.tasks[dailyId].value
-#          dailyAfter:user.before.tasks[dailyId].value
-        casper.test.assert beforeAfter.before.user.tasks[dailyId].value < beforeAfter.after.user.tasks[dailyId].value, "daily:cron:daily gained value"
-        casper.test.assert beforeAfter.before.user.stats.hp < beforeAfter.after.user.stats.hp, 'daily:cron:hp lost value'
+      #TODO make sure true for all dailies
+      dailyId = model.before._user.dailyIds[0]
+      casper.test.assert model.before._user.tasks[dailyId].value < model.after._user.tasks[dailyId].value, "daily:cron:daily gained value"
+      casper.test.assert model.before._user.stats.hp < model.after._user.stats.hp, 'daily:cron:hp lost value'
 
 # ---------- Run ------------
-
 casper.run ->
   @test.renderResults true


### PR DESCRIPTION
why most tests aren't working: the derby app seems to need some time after a click/action before the model is updated. This means sometime the user object was completely empty. I've introduced a short wait before retrieving the model that fixes this problem.

The cron test dailies.casper.coffee still doesn't work, but I think that there's an actual problem there, not just a faulty test.

I'm slowly starting to get a hang of these tests. I will work on the other test files in the next days, but you can already merge and use this if you want.

Refs #122
