### PR TITLE
Fixing the dailies and todos casper test (now even with working cron tests)

### DIFF
--- a/test/casper/dailies.casper.coffee
+++ b/test/casper/dailies.casper.coffee
@@ -8,7 +8,7 @@ casper.start url
 # ---------- Daily ------------
 casper.then ->
   helpers.reset()
-  helpers.addTasks()
+  helpers.addTasks(['daily'])
 
 # Gained exp on +daily
 casper.then ->
@@ -27,15 +27,18 @@ casper.then ->
 # ---------- Cron ------------
 casper.then ->
   helpers.reset()
-  helpers.addTasks()
+  helpers.addTasks(['daily'])
 
 casper.then ->
   helpers.cronBeforeAfter (model) ->
     casper.then ->
-      #TODO make sure true for all dailies
-      dailyId = model.before._user.dailyIds[0]
-      casper.test.assert model.before._user.tasks[dailyId].value < model.after._user.tasks[dailyId].value, "daily:cron:daily gained value"
-      casper.test.assert model.before._user.stats.hp < model.after._user.stats.hp, 'daily:cron:hp lost value'
+      casper.test.assert model.before._user.stats.hp > model.after._user.stats.hp, 'daily:cron:hp lost value'
+
+      # Go through all the dailys, all of them are uncompleted, so should all get a negative value
+      casper.echo "Testing all uncompleted dailys after cron"
+      for id in model.before._user.dailyIds
+        casper.test.assertEquals model.before._user.tasks[id].value, 0, "daily:cron:daily value before was 0"
+        casper.test.assert model.after._user.tasks[id].value < 0, "daily:cron:daily value after is negative"
 
 # ---------- Run ------------
 casper.run ->


### PR DESCRIPTION
Next batch of test fixing. The todos.casper.coffee and dailies.casper.coffee should not completely pass, so one can start using them.
