### PR TITLE
Add 'To next level' to user stats on API

### DIFF
--- a/src/server/api.coffee
+++ b/src/server/api.coffee
@@ -3,6 +3,7 @@ router = new express.Router()
 
 scoring = require '../app/scoring'
 _ = require 'underscore'
+{ tnl } = require '../app/algos'
 validator = require 'derby-auth/node_modules/validator'
 check = validator.check
 sanitize = validator.sanitize
@@ -40,6 +41,8 @@ auth = (req, res, next) ->
 
 router.get '/user', auth, (req, res) ->
   user = req.userObj
+
+  user.stats.tnl = tnl user.stats.lvl
 
   delete user.apiToken
 

--- a/src/server/api.coffee
+++ b/src/server/api.coffee
@@ -43,6 +43,7 @@ router.get '/user', auth, (req, res) ->
   user = req.userObj
 
   user.stats.tnl = tnl user.stats.lvl
+  user.stats.maxHealth = 50
 
   delete user.apiToken
 

--- a/test/api.mocha.coffee
+++ b/test/api.mocha.coffee
@@ -102,6 +102,7 @@ describe 'API', ->
           delete self.apiToken
           # To next level should be 100
           self.stats.tnl = 100
+          self.stats.maxHealth = 50
 
           expect(res.body).to.eql self
           done()

--- a/test/api.mocha.coffee
+++ b/test/api.mocha.coffee
@@ -100,6 +100,8 @@ describe 'API', ->
           expect(res.body.id).not.to.be.empty()
           self = _.clone(currentUser)
           delete self.apiToken
+          # To next level should be 100
+          self.stats.tnl = 100
 
           expect(res.body).to.eql self
           done()


### PR DESCRIPTION
Fairly straightforward. Just add a `tnl` field under `user.stats` to show how much exp is needed to level up.

https://github.com/lefnire/habitrpg/issues/599
