### PR TITLE
New Algorithms + fixes

### DIFF
--- a/src/app/algos.coffee
+++ b/src/app/algos.coffee
@@ -1,5 +1,5 @@
-
-MODIFIER = .02
+XP = 15
+HP = 2
 
 priorityValue = (priority='!') ->
   switch priority
@@ -9,7 +9,11 @@ priorityValue = (priority='!') ->
     else 1
 
 module.exports.tnl = (level) ->
-	return (Math.pow(level,2)*10)+(level*10)+80
+  if level >= 100
+    value = 0
+  else
+    value = Math.round(((Math.pow(level,2)*0.25)+(10 * level) + 139.75)/10)*10 # round to nearest 10
+  return value
 
 ###
   Calculates Exp modificaiton based on level and weapon strength
@@ -18,11 +22,12 @@ module.exports.tnl = (level) ->
   {level} current user level
   {priority} user-defined priority multiplier
 ###
-module.exports.expModifier = (value, weaponStrength, level, priority='!') ->
-  levelModifier = (level-1) * MODIFIER
-  weaponModifier = weaponStrength / 100
-  strength = 1 + weaponModifier + levelModifier
-  return value * strength * priorityValue(priority)
+module.exports.expModifier = (value, weaponStr, level, priority='!') ->
+  str = (level-1) * 2 # ultimately get this from user
+  totalStr = (str + weaponStr) / 100
+  strMod = 1 + totalStr
+  exp = value * XP * strMod * priorityValue(priority)
+  return Math.round(exp)
 
 ###
   Calculates HP modification based on level and armor defence
@@ -32,11 +37,12 @@ module.exports.expModifier = (value, weaponStrength, level, priority='!') ->
   {level} current user level
   {priority} user-defined priority multiplier
 ###
-module.exports.hpModifier = (value, armorDefense, helmDefense, shieldDefense, level, priority='!') ->
-  levelModifier = (level-1) * MODIFIER
-  armorModifier = (armorDefense + helmDefense + shieldDefense) / 100
-  defense = 1 - levelModifier + armorModifier
-  return value * defense * priorityValue(priority)
+module.exports.hpModifier = (value, armorDef, helmDef, shieldDef, level, priority='!') ->
+  def = (level-1) * 2 # ultimately get this from user?
+  totalDef = (def + armorDef + helmDef + shieldDef) / 100 #ultimate get this from user
+  defMod = 1 - totalDef
+  hp = value * HP * defMod * priorityValue(priority)
+  return Math.round(hp * 10)/10 # round to 1dp
 
 ###
   Future use
@@ -52,10 +58,10 @@ module.exports.gpModifier = (value, modifier, priority='!') ->
   {direction} up or down
 ###
 module.exports.taskDeltaFormula = (currentValue, direction) ->
-	if direction is 'up'
-		delta = Math.max(Math.pow(0.95,currentValue),0.25)
-	else
-		delta = -Math.min(Math.pow(0.95,currentValue),5)
-	#console.log("CV = " + currentValue + " Dir = " + direction + " delta = " + delta)
-	delta = 20 if delta > 20
-	return delta
+  if currentValue < -47.27 then currentValue = -47.27
+  else if currentValue > 21.27 then currentValue = 21.27
+  delta = Math.pow(0.9747,currentValue)
+  return delta if direction is 'up'
+  return -delta
+	
+	

--- a/src/app/browser.coffee
+++ b/src/app/browser.coffee
@@ -9,7 +9,10 @@ restoreRefs = module.exports.restoreRefs = (model) ->
     # see https://github.com/lefnire/habitrpg/issues/4
     # also update in scoring.coffee. TODO create a function accessible in both locations
     #TODO find a method of calling algos.tnl()
-    10*Math.pow(lvl,2)+(lvl*10)+80
+    if lvl==100
+      0
+    else
+      Math.round(((Math.pow(lvl,2)*0.25)+(10 * lvl) + 139.75)/10)*10
 
   #refLists
   _.each ['habit', 'daily', 'todo', 'reward'], (type) ->
@@ -171,13 +174,14 @@ setupGrowlNotifications = (model) ->
     else if num > 0
       statsNotification "<i class='icon-heart'></i> + #{rounded} HP", 'hp' # gained hp from potion/level? 
   
-  user.on 'set', 'stats.exp', (captures, args, isLocal, silent) ->
-      num = captures - args
-      rounded = Math.abs(num.toFixed(1))
-      if num < 0 and not silent
-        statsNotification "<i class='icon-star'></i> - #{rounded} XP", 'xp'
-      else if num > 0
-        statsNotification "<i class='icon-star'></i> + #{rounded} XP", 'xp'
+  user.on 'set', 'stats.exp', (captures, args, isLocal, silent=false) ->
+    # unless silent
+    num = captures - args
+    rounded = Math.abs(num.toFixed(1))
+    if num < 0 and num > -100 # TODO fix hackey negative notification supress
+      statsNotification "<i class='icon-star'></i> - #{rounded} XP", 'xp'
+    else if num > 0
+      statsNotification "<i class='icon-star'></i> + #{rounded} XP", 'xp'
 
   user.on 'set', 'stats.gp', (captures, args) ->
     num = captures - args
@@ -195,7 +199,7 @@ setupGrowlNotifications = (model) ->
   user.on 'set', 'stats.lvl', (captures, args) ->
     if captures > args
       if captures is 1 and args is 0
-        statsNotification '<i class="icon-death"></i> You died!', 'death' 
+        statsNotification '<i class="icon-death"></i> You died! Game over.', 'death' 
       else 
         statsNotification '<i class="icon-chevron-up"></i> Level Up!', 'lvl'
 

--- a/src/app/debug.coffee
+++ b/src/app/debug.coffee
@@ -8,8 +8,13 @@ module.exports.app = (appExports, model) ->
     user.set 'lastCron', yesterday
     window.location.reload()
 
+  appExports.emulateTenDays = ->
+    yesterday = +moment().subtract('days', 10).toDate()
+    user.set 'lastCron', yesterday
+    window.location.reload()
+
   appExports.cheat = ->
-    user.incr 'stats.exp', 20
+    user.incr 'stats.exp', model.get '_tnl'
     user.incr 'stats.gp', 1000
 
   appExports.reset = ->

--- a/src/app/helpers.coffee
+++ b/src/app/helpers.coffee
@@ -19,6 +19,9 @@ module.exports.viewHelpers = (view) ->
 
   view.fn "floor", (num) ->
     Math.floor num
+
+  view.fn "ceil", (num) ->
+    Math.ceil num
     
   view.fn "lt", (a, b) ->
     a < b

--- a/views/app/footer.html
+++ b/views/app/footer.html
@@ -19,7 +19,8 @@
             {else}
             <div class='pull-right'>
                 <button class='btn' x-bind="click:emulateNextDay">Emulate Next Day</button>
-                <button class='btn' x-bind="click:cheat">Add GP & Exp</button>
+                <button class='btn' x-bind="click:emulateTenDays">Emulate 10 Days</button>
+                <button class='btn' x-bind="click:cheat">Insta Level</button>
                 <button class='btn' x-bind='click:reset'>Reset Level</button>
             </div>
             {/}

--- a/views/app/header.html
+++ b/views/app/header.html
@@ -20,7 +20,7 @@
             <div class="progress-bars">
                 <div class="progress progress-danger" rel=tooltip data-placement=bottom title="Health">
                     <div class="bar" style="width: {percent(_user.stats.hp, 50)}%;"></div>
-                    <span class="progress-text"><i class=icon-heart></i> {round(_user.stats.hp)} / 50</span>
+                    <span class="progress-text"><i class=icon-heart></i> {ceil(_user.stats.hp)} / 50</span>
                 </div>
 
                 <div class="progress progress-warning" rel=tooltip data-placement=bottom title="Experience">


### PR DESCRIPTION
Properly fixed the algorithms now, this is after discussions with @Pandoro and @lefnire. The TNL and OHV algorithms are set for level 1 -> level 100 ~ 400 days @ 150 XP per day (10 normal tasks). Standard tasks are worth 15xp, standard HP loss is -2. I've added a level cap at level 100, from here on XP will turn into gold. We can change gold into a new currency in the future.

The database will need normalising before merging this, there won't be any drastic effects from low task values, but the tasks won't properly normalise as the deltas will be too small.

@lefnire I've removed the .pass(silent:true) stuff for suppressing negative XP notifications, I couldn't get it working at all, I did notice a huge speed increase after removing it though, so I think we need to think elsewhere. I've added in a hacky check for large negative values on the notifications themselves - seems to work well.
