### PR TITLE
Changing expModifier and hpModifier algo to be less influenced by level....

### DIFF
--- a/src/app/algos.coffee
+++ b/src/app/algos.coffee
@@ -23,7 +23,7 @@ module.exports.tnl = (level) ->
   {priority} user-defined priority multiplier
 ###
 module.exports.expModifier = (value, weaponStr, level, priority='!') ->
-  str = (level-1) * 2 # ultimately get this from user
+  str = (level-1) / 2 # ultimately get this from user
   totalStr = (str + weaponStr) / 100
   strMod = 1 + totalStr
   exp = value * XP * strMod * priorityValue(priority)
@@ -38,7 +38,7 @@ module.exports.expModifier = (value, weaponStr, level, priority='!') ->
   {priority} user-defined priority multiplier
 ###
 module.exports.hpModifier = (value, armorDef, helmDef, shieldDef, level, priority='!') ->
-  def = (level-1) * 2 # ultimately get this from user?
+  def = (level-1) / 2 # ultimately get this from user?
   totalDef = (def + armorDef + helmDef + shieldDef) / 100 #ultimate get this from user
   defMod = 1 - totalDef
   hp = value * HP * defMod * priorityValue(priority)


### PR DESCRIPTION
... For high lvls (~50), you actually get HP instead of losing them with the current formula. This now doesn't happen anymore (at least for levels up to 100, which is the current max).
Also changed the formula in the same way for the exp modifier, although there it didn't create any problems. But I thought it's better to have the influence of the level be the same everywhere.
