### PR TITLE
Add WebService::HabitRPG to list of extensions.

### DIFF
--- a/views/static/extensions.html
+++ b/views/static/extensions.html
@@ -36,7 +36,15 @@
             <p>Python command line app for HabitRPG (http://habitrpg.com)</p>
             <h2 id="php-api"><a href="http://github.com/ruddfawcett/HabitRPG_PHP">PHP API</a></h2>
             <p>A PHP class for the HabitRPG API. Will be expanded when more features become available in the API.</p>
+
+            <h2 id="perl-api"><a href="https://metacpan.org/module/WebService::HabitRPG">WebService::HabitRPG — Perl API</a></h2>
+            <p>A full-featured <a href="https://metacpan.org/module/WebService::HabitRPG">Perl interface</a> for HabitRPG. Development versions are available on <a href="https://github.com/pfenwick/WebService-HabitRPG">github</a>.
+
+            <h2 id="hrpg-cmd"><a href="https://metacpan.org/module/hrpg">hrpg - HabitRPG command line client</a></h2>
+            <p>Command-line client for HabitRPG. Supports viewing status, listing tasks by types, creation of new types, incrementing/decrementing of tasks, API debugging, and more.</p>
+
             <h2 id="suggest-an-add-on-extension">Suggest an Add-on / Extension</h2>
+
             <p><a href="mailto:tylerrenelle@gmail.com">Email me</a> to have something listed here</p>
         </div>
     </div>


### PR DESCRIPTION
Static HTML change that adds `WebService::HabitRPG` and `hrpg` to the list of HabitRPG extensions.
