### PR TITLE
pfenwick went and changed his github username to pjf

### DIFF
--- a/views/static/extensions.html
+++ b/views/static/extensions.html
@@ -38,7 +38,7 @@
             <p>A PHP class for the HabitRPG API. Will be expanded when more features become available in the API.</p>
 
             <h2 id="perl-api"><a href="https://metacpan.org/module/WebService::HabitRPG">WebService::HabitRPG — Perl API</a></h2>
-            <p>A full-featured <a href="https://metacpan.org/module/WebService::HabitRPG">Perl interface</a> for HabitRPG. Development versions are available on <a href="https://github.com/pfenwick/WebService-HabitRPG">github</a>.
+            <p>A full-featured <a href="https://metacpan.org/module/WebService::HabitRPG">Perl interface</a> for HabitRPG. Development versions are available on <a href="https://github.com/pjf/WebService-HabitRPG">github</a>.
 
             <h2 id="hrpg-cmd"><a href="https://metacpan.org/module/hrpg">hrpg - HabitRPG command line client</a></h2>
             <p>Command-line client for HabitRPG. Supports viewing status, listing tasks by types, creation of new types, incrementing/decrementing of tasks, API debugging, and more.</p>


### PR DESCRIPTION
So apparently github lets you have your preferred username if you just ask nicely.

This fixes a link since I've now moved from `pfenwick` to `pjf` on github.
