### PR TITLE
Fixes bug when user attempts to create task with no value field through the API

### DIFF
--- a/src/server/api.coffee
+++ b/src/server/api.coffee
@@ -87,9 +87,9 @@ validateTask = (req, res, next) ->
     unless /^(habit|todo|daily|reward)$/.test type
       return res.json 400, err: 'type must be habit, todo, daily, or reward'
 
-  text = sanitize(text).xss()
-  notes = sanitize(notes).xss()
-  value = sanitize(value).toInt()
+  newTask.text = sanitize(text).xss()
+  newTask.notes = sanitize(notes).xss()
+  newTask.value = sanitize(value).toInt()
 
   switch type
     when 'habit'
@@ -97,6 +97,8 @@ validateTask = (req, res, next) ->
       newTask.down = true unless typeof down is 'boolean'
     when 'daily', 'todo'
       newTask.completed = false unless typeof completed is 'boolean'
+
+  newTask.value = 0 if isNaN newTask.value
 
   _.extend task, newTask
   req.task = task

--- a/src/server/api.coffee
+++ b/src/server/api.coffee
@@ -84,12 +84,13 @@ validateTask = (req, res, next) ->
     type = undefined
     delete newTask.type
   else if req.method is 'POST'
+    newTask.value = sanitize(value).toInt()
+    newTask.value = 0 if isNaN newTask.value
     unless /^(habit|todo|daily|reward)$/.test type
       return res.json 400, err: 'type must be habit, todo, daily, or reward'
 
-  newTask.text = sanitize(text).xss()
-  newTask.notes = sanitize(notes).xss()
-  newTask.value = sanitize(value).toInt()
+  newTask.text = sanitize(text).xss() if typeof text is "string"
+  newTask.notes = sanitize(notes).xss() if typeof notes is "string"
 
   switch type
     when 'habit'
@@ -97,8 +98,6 @@ validateTask = (req, res, next) ->
       newTask.down = true unless typeof down is 'boolean'
     when 'daily', 'todo'
       newTask.completed = false unless typeof completed is 'boolean'
-
-  newTask.value = 0 if isNaN newTask.value
 
   _.extend task, newTask
   req.task = task

--- a/test/api.mocha.coffee
+++ b/test/api.mocha.coffee
@@ -159,6 +159,8 @@ describe 'API', ->
             expect(res.body.id).not.to.be.empty()
             # Ensure that user owns the newly created object
             expect(user.get().tasks[res.body.id]).to.be.an('object')
+            # Ensure that value gets set to 0 since not otherwise specified
+            expect(user.get().tasks[res.body.id].value).to.be.equal(0)
             done()
 
     it 'PUT /api/v1/user/task/:id', (done) ->


### PR DESCRIPTION
If the user posts a new task with no value, it got set to NaN in the new task, which ended up getting really nasty as numbers got appended to the string "NaN" into the database... so you'd end up with stuff like NaN.9.8.7 instead of a number.

Also, the sanitized versions of text & notes weren't actually being saved, as they were put in variables that weren't being persisted into the db.
