### PR TITLE
@lefnire => Initial 'Rest' support

### DIFF
--- a/locales/en/app.json
+++ b/locales/en/app.json
@@ -1,6 +1,6 @@
 {
 "_commenttut": "TUTORIAL",
-  
+
 "_commenthead": "HEADER",
   "Health": "Health",
   "Experience": "Experience",
@@ -8,7 +8,7 @@
   "Settings": "Settings",
   "Party": "Party",
   "Logout": "Logout",
-  
+
 "_commentuser": "USER",
   "Anonymous": "Anonymous",
   "Avatar": "Avatar",
@@ -37,7 +37,7 @@
       "MarketContent": "Dying to get that particular pet you're after, but don't want to wait for it to drop? Buy it here!",
   "Stable": "Stable",
   "Tokens": "Tokens",
-  
+
 "_commentitems": "DROPS, ITEMS & REWARDS",
   "_comment": "PET EGGS",
     "WolfEgg": "Wolf Cub",
@@ -63,7 +63,7 @@
     "GoldenPot": "Golden",
   "_comment": "GOLD REWARDS",
 
-  
+
 
 "_commentmain": "MAIN WINDOW",
   "Habits": "Habits",
@@ -94,7 +94,7 @@
       "F": "F",
       "S": "S",
   "Todos": "Todos",
-    "NewTodo": "New Todo", 
+    "NewTodo": "New Todo",
     "DueDate": "Due Date",
     "Remaining": "Remaining",
     "Complete": "Complete",

--- a/src/app/scoring.coffee
+++ b/src/app/scoring.coffee
@@ -258,6 +258,7 @@ updateStats = (model, newStats, batch) ->
 cron = (model) ->
   user = model.at '_user'
   today = +new Date
+  return if user.get 'flags.rest'
   daysPassed = helpers.daysBetween(user.get('lastCron'), today, user.get('preferences.dayStart'))
   if daysPassed > 0
 

--- a/views/app/avatar.html
+++ b/views/app/avatar.html
@@ -9,6 +9,7 @@
                 <ul class="nav nav-tabs">
                     <li class="active"><a data-toggle='tab' href="#profileCustomize">Avatar</a></li>
                     <li><a data-toggle='tab' href="#profileEdit">Profile</a></li>
+                    <li><a data-toggle='tab' data-target="#rest">Rest</a></li>
                     {#if _user.flags.dropsEnabled}
                         <li><a data-toggle='tab' data-target="#profileInventory">Inventory</a></li>
                         <li><a data-toggle='tab' data-target="#profileMarket">Market</a></li>
@@ -23,6 +24,10 @@
 
                     <div class="tab-pane" id="profileEdit">
                         <app:avatar:profile user="{_user}" main="true" />
+                    </div>
+
+                    <div class="tab-pane" id="rest">
+                        <app:avatar:rest />
                     </div>
 
                     <div class="tab-pane" id="profileInventory">
@@ -213,6 +218,9 @@
         </div>
 
     </div>
+
+<rest:>
+    <input type="checkbox" name="rest" checked={_user.flags.rest} >Rest</input>
 
 <achievements:>
     <!--TODO replce this in the future with HTML from BrowserQuest's index.html, which properly handles the achievements


### PR DESCRIPTION
Basically, this adds a checkbox under your avatar that allows you to enable "rest"

In cron, we check if `user.flags.rest` is enabled after we set the date of the last cron. This way, when you come back after a week, cron isn't run and your character isn't killed. Then, just go ahead and turn off 'rest' and your cron will be run tomorrow, thinking that the last time cron was run was only one day before.

I'll continue building out a finer tuned support for _resting_, such as still clearing dailies, but not counting their negative score. But immediately, this should suffice.
