### PR TITLE
@lefnire => Block non-https calls to API + fix non-gzip compatible requests

### DIFF
--- a/src/server/index.coffee
+++ b/src/server/index.coffee
@@ -61,7 +61,7 @@ mongo_store = new MongoStore {url: process.env.NODE_DB_URI}, ->
     expressApp.use(gzippo.staticGzip(publicPath, maxAge: ONE_YEAR))
 
   expressApp
-    .use('api/v1', middleware.allowCrossDomain)
+    .use('/api/v1', middleware.allowCrossDomain)
     .use(express.favicon("#{publicPath}/favicon.ico"))
     # Gzip dynamically rendered content
     .use(express.compress())

--- a/src/server/index.coffee
+++ b/src/server/index.coffee
@@ -58,7 +58,7 @@ auth.store(store, habitrpgStore.customAccessControl)
 mongo_store = new MongoStore {url: process.env.NODE_DB_URI}, ->
   expressApp.configure 'development', ->
     # Gzip static files and serve from memory
-    expressApp.use(gzippo.staticGzip(publicPath, maxAge: ONE_YEAR))
+    expressApp.use express.static(publicPath)
 
   expressApp
     .use('/api/v1', middleware.allowCrossDomain)

--- a/src/server/index.coffee
+++ b/src/server/index.coffee
@@ -56,11 +56,13 @@ options =
 auth.store(store, habitrpgStore.customAccessControl)
 
 mongo_store = new MongoStore {url: process.env.NODE_DB_URI}, ->
+  expressApp.configure 'development', ->
+    # Gzip static files and serve from memory
+    expressApp.use(gzippo.staticGzip(publicPath, maxAge: ONE_YEAR))
+
   expressApp
     .use(middleware.allowCrossDomain)
     .use(express.favicon("#{publicPath}/favicon.ico"))
-    # Gzip static files and serve from memory
-    .use(gzippo.staticGzip(publicPath, maxAge: ONE_YEAR))
     # Gzip dynamically rendered content
     .use(express.compress())
     .use(express.bodyParser())
@@ -90,6 +92,7 @@ mongo_store = new MongoStore {url: process.env.NODE_DB_URI}, ->
     .use(serverError(root))
 
   priv.routes(expressApp)
+
 
   # Errors
   expressApp.all '*', (req) ->

--- a/src/server/index.coffee
+++ b/src/server/index.coffee
@@ -78,6 +78,7 @@ mongo_store = new MongoStore {url: process.env.NODE_DB_URI}, ->
     # Adds req.getModel method
     .use(store.modelMiddleware())
     # API should be hit before all other routes
+    .use('/api/v1', middleware.httpsApi)
     .use('/api/v1', require('./api').middleware)
     .use(require('./deprecated').middleware)
     # Show splash page for newcomers

--- a/src/server/index.coffee
+++ b/src/server/index.coffee
@@ -1,7 +1,6 @@
 http = require 'http'
 path = require 'path'
 express = require 'express'
-gzippo = require 'gzippo'
 derby = require 'derby'
 racer = require 'racer'
 auth = require 'derby-auth'

--- a/src/server/index.coffee
+++ b/src/server/index.coffee
@@ -61,7 +61,7 @@ mongo_store = new MongoStore {url: process.env.NODE_DB_URI}, ->
     expressApp.use(gzippo.staticGzip(publicPath, maxAge: ONE_YEAR))
 
   expressApp
-    .use(middleware.allowCrossDomain)
+    .use('api/v1', middleware.allowCrossDomain)
     .use(express.favicon("#{publicPath}/favicon.ico"))
     # Gzip dynamically rendered content
     .use(express.compress())

--- a/src/server/middleware.coffee
+++ b/src/server/middleware.coffee
@@ -19,10 +19,9 @@ allowCrossDomain = (req, res, next) ->
   res.header "Access-Control-Allow-Headers", "Content-Type,X-Requested-With,x-api-user,x-api-key"
 
   # wtf is this for?
-  if req.method is 'OPTIONS'
-    res.send(200);
-  else
-    next()
+  return res.send 200 if req.method is 'OPTIONS'
+
+  next()
 
 httpsApi = (req, res, next) ->
   return next() if process.env.NODE_ENV == 'development' || req.headers["x-forwarded-proto"] == "https"

--- a/src/server/middleware.coffee
+++ b/src/server/middleware.coffee
@@ -1,11 +1,11 @@
-module.exports.splash = (req, res, next) ->
+splash = (req, res, next) ->
   isStatic = req.url.split('/')[1] is 'static'
   unless req.query?.play? or req.getModel().get('_userId') or isStatic
     res.redirect('/static/front')
   else
     next()
 
-module.exports.view = (req, res, next) ->
+view = (req, res, next) ->
   model = req.getModel()
   ## Set _mobileDevice to true or false so view can exclude portions from mobile device
   model.set '_mobileDevice', /Android|webOS|iPhone|iPad|iPod|BlackBerry/i.test(req.header 'User-Agent')
@@ -13,7 +13,7 @@ module.exports.view = (req, res, next) ->
   next()
 
 #CORS middleware
-module.exports.allowCrossDomain = (req, res, next) ->
+allowCrossDomain = (req, res, next) ->
   res.header "Access-Control-Allow-Origin", (req.headers.origin || "*")
   res.header "Access-Control-Allow-Methods", "OPTIONS,GET,POST,PUT,HEAD,DELETE"
   res.header "Access-Control-Allow-Headers", "Content-Type,X-Requested-With,x-api-user,x-api-key"
@@ -23,3 +23,9 @@ module.exports.allowCrossDomain = (req, res, next) ->
     res.send(200);
   else
     next()
+
+httpsApi = (req, res, next) ->
+  return next() if process.env.NODE_ENV == 'development' || req.headers["x-forwarded-proto"] == "https"
+  res.json err: 'You must use https via the api. Please fix your request.'
+
+module.exports = { splash, view, allowCrossDomain, httpsApi }


### PR DESCRIPTION
1) Gzippo was blocking non-gzip compatible api requests. Since nginx is serving our static files anyway, we can just disable this on anything but development. Fixes #830

Serving static files from public with nginx:

```
location ~ ^/(images/|img/|javascript/|js/|css/|stylesheets/|flash/|media/|static/|robots.txt|humans.txt|favicon.ico) {
          root /var/www/path/to/current/public;
          access_log off;
          expires max;
}

```

It should maintain the path (`public/foo/bar.png` will be `habitrpg.com/foo/bar.png`) - make sure to update any paths

2) It's very unsafe to redirect http calls to https. I don't believe that's exactly what we were doing, but this should automatically deny any http calls to the API. nginx might pop in and try to redirect before this, but we won't know until this hits beta.habit.
