### PR TITLE
@slappybag => Allow locale to be set from a model middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "resolve": "~0.2.3",
     "browserify": "1.17.3",
     "expect.js": "~0.2.0",
-    "derby-i18n": "0.0.1",
+    "derby-i18n": "git://github.com/switz/derby-i18n#master",
     "relative-date": "~1.1.1"
   },
   "private": true,

--- a/src/app/index.coffee
+++ b/src/app/index.coffee
@@ -14,6 +14,8 @@ i18n = require './i18n'
 i18n.localize app,
   availableLocales: ['en', 'he', 'bg']
   defaultLocale: 'en'
+  urlScheme: false
+  checkHeader: true
 
 helpers = require './helpers'
 helpers.viewHelpers view

--- a/src/server/index.coffee
+++ b/src/server/index.coffee
@@ -75,6 +75,7 @@ mongo_store = new MongoStore {url: process.env.NODE_DB_URI}, ->
     )
     # Adds req.getModel method
     .use(store.modelMiddleware())
+    .use(middleware.translate)
     # API should be hit before all other routes
     .use('/api/v1', require('./api').middleware)
     .use(require('./deprecated').middleware)

--- a/src/server/middleware.coffee
+++ b/src/server/middleware.coffee
@@ -1,11 +1,11 @@
-module.exports.splash = (req, res, next) ->
+splash = (req, res, next) ->
   isStatic = req.url.split('/')[1] is 'static'
   unless req.query?.play? or req.getModel().get('_userId') or isStatic
     res.redirect('/static/front')
   else
     next()
 
-module.exports.view = (req, res, next) ->
+view = (req, res, next) ->
   model = req.getModel()
   ## Set _mobileDevice to true or false so view can exclude portions from mobile device
   model.set '_mobileDevice', /Android|webOS|iPhone|iPad|iPod|BlackBerry/i.test(req.header 'User-Agent')
@@ -13,7 +13,7 @@ module.exports.view = (req, res, next) ->
   next()
 
 #CORS middleware
-module.exports.allowCrossDomain = (req, res, next) ->
+allowCrossDomain = (req, res, next) ->
   res.header "Access-Control-Allow-Origin", (req.headers.origin || "*")
   res.header "Access-Control-Allow-Methods", "OPTIONS,GET,POST,PUT,HEAD,DELETE"
   res.header "Access-Control-Allow-Headers", "Content-Type,Accept,Content-Encoding,X-Requested-With,x-api-user,x-api-key"
@@ -23,3 +23,13 @@ module.exports.allowCrossDomain = (req, res, next) ->
     res.send(200);
   else
     next()
+
+translate = (req, res, next) ->
+  model = req.getModel()
+
+  # Set locale to bg on dev
+  model.set '_i18n.locale', 'bg' if process.env.NODE_ENV is "development"
+
+  next()
+
+module.exports = { splash, view, allowCrossDomain, translate}

--- a/views/app/tasks.html
+++ b/views/app/tasks.html
@@ -24,7 +24,7 @@
     <!-- Habits Column -->
     <div class="module">
         <div class="task-column habits">
-            <h2 class="task-column_title">Habits</h2>
+            <h2 class="task-column_title">{{t("Habits")}}</h2>
             <app:tasks:newTask type="habit" inputValue="{_newHabit}" placeHolder="New Habit" />
             <ul class="habits">
                 {#each _habitList as :task}<app:tasks:task />{/}
@@ -104,7 +104,7 @@
 <!-- all the parts of a single task -->
 <task:>
     <li data-id={{:task.id}} class="task {taskClasses(:task, _user.filters, _user.preferences.dayStart, _user.lastCron)} {#if :task.down}{#if :task.up}habit-wide{/}{/}">
-        
+
         <!-- right-hand side control buttons -->
         <div class="task-meta-controls">
             <!-- Streak -->


### PR DESCRIPTION
So instead of futzing around with URLs, I sent a pull request to `derby-i18n` to enable setting a user's locale from a derby model via an express middleware. If that sounds confusing, it's not - I'll show you:

I gave you an example middleware in `src/server/middleware.coffee`

``` coffeescript
translate = (req, res, next) ->
  model = req.getModel()

  # Set locale to bg on dev
  model.set '_i18n.locale', 'bg' if process.env.NODE_ENV is "development"

  next()
```

For now, I've pinned `derby-i18n` to `switz#master`, but I've sent over a pull request here: https://github.com/jamesknelson/derby-i18n/pull/9 

So, I think we should either attach the user object to the session `req.session.user` or somehow attach the language to the session. It will also try to check headers first and see if it can figure out where the person is coming from. If someone from another country wants to test this out once it hits beta.habitrpg.com I'd appreciate it. I have no idea if it will work.

@slappybag If you have any questions, hit me up in IRC.
