### PR TITLE
Tweaks to #1028: Long egg and potions names now contained

### DIFF
--- a/styles/app/inventory.styl
+++ b/styles/app/inventory.styl
@@ -64,11 +64,13 @@
     padding:.3em
     p
       text-align:center
+      width:3em
 .hatchingPotion-menu > div
     float:left
     padding:.3em
     p
       text-align:center
+      width:3em
 
 .pet-button
     border: none

--- a/views/app/header.html
+++ b/views/app/header.html
@@ -9,7 +9,7 @@
         <div class="hero-stats">
             <div class="meter health" title="Health">
                 <div class="bar" style="width: {percent(_user.stats.hp, 50)}%;"></div>
-                <span class="meter-text"><i class=icon-heart></i> {ceil(_user.stats.hp)} / 50</span>
+                <span class="meter-text"><i class=icon-heart></i> {floor(_user.stats.hp)} / 50</span>
             </div>
 
             <div class="meter experience" title="Experience">


### PR DESCRIPTION
Was able to contain the text similar to how it is done in the market. Currently, long words (i.e. skeleton) do not center due to the size of images and/or divs, which still needs to be fixed. More attention will be necessary, but thus should help with Panda Cub Eggs and the like.

Before:
![screen shot 2013-06-12 at 1 12 20 am](https://f.cloud.github.com/assets/3774345/641756/e73675e8-d33f-11e2-89e3-aa47f2d50cc9.png)

After:
![screen shot 2013-06-12 at 1 12 31 am](https://f.cloud.github.com/assets/3774345/641757/ed18a8f0-d33f-11e2-87a9-fb82eb21e065.png)
