### PR TITLE
Tweaks to #1028: Long egg and potions names now contained

### DIFF
--- a/styles/app/inventory.styl
+++ b/styles/app/inventory.styl
@@ -64,11 +64,13 @@
     padding:.3em
     p
       text-align:center
+      width:3em
 .hatchingPotion-menu > div
     float:left
     padding:.3em
     p
       text-align:center
+      width:3em
 
 .pet-button
     border: none


### PR DESCRIPTION
Was able to contain the text similar to how it is done in the market. Currently, long words (i.e. skeleton) do not center due to the size of images and/or divs, which still needs to be fixed. More attention will be necessary, but thus should help with Panda Cub Eggs and the like.

Before:
![screen shot 2013-06-12 at 1 12 20 am](https://f.cloud.github.com/assets/3774345/641786/e6ea46a4-d340-11e2-8cad-d7b32555e282.png)

After:
![screen shot 2013-06-12 at 1 12 31 am](https://f.cloud.github.com/assets/3774345/641785/e27f8f0c-d340-11e2-8f11-db313e6fa142.png)

(Sorry for the double pull request. For some reason, if I try to issue a pull request to the develop branch, it wants to add other folks commits too. Just wanted my small tweak, so assigned to master branch. Ahhhh git hurts my head >_<)
