### PR TITLE
Moar Inventory Layout Fixes in CSS & Tavern Chat Abuse Fix

### DIFF
--- a/public/img/sprites/PetEggs.css
+++ b/public/img/sprites/PetEggs.css
@@ -1,25 +1,25 @@
 .Pet_Egg_Wolf, .Pet_Egg_TigerCub, .Pet_Egg_PolarBear, .Pet_Egg_PandaCub, .Pet_Egg_LionCub, .Pet_Egg_Fox, .Pet_Egg_FlyingPig, .Pet_Egg_Dragon, .Pet_Egg_Cactus, .Pet_Egg_BearCub, .Pet_HatchingPotion_Base, .Pet_HatchingPotion_White, .Pet_HatchingPotion_Desert, .Pet_HatchingPotion_Red, .Pet_HatchingPotion_Shade, .Pet_HatchingPotion_Skeleton, .Pet_HatchingPotion_Zombie, .Pet_HatchingPotion_CottonCandyPink, .Pet_HatchingPotion_CottonCandyBlue, .Pet_HatchingPotion_Golden, .Pet_Currency_Gem, .Pet_Currency_Gem2x, .Pet_Currency_Gem1x {background: url("/img/sprites/Egg_Sprite_Sheet.png") no-repeat}
-.Pet_Egg_Wolf {background-position: 0px 0px; width: 48px; height: 51px}
-.Pet_Egg_TigerCub {background-position: 0px -51px; width: 48px; height: 51px}
-.Pet_Egg_PolarBear {background-position: 0px -102px; width: 48px; height: 51px}
-.Pet_Egg_PandaCub {background-position: 0px -153px; width: 48px; height: 51px}
-.Pet_Egg_LionCub {background-position: 0px -204px; width: 48px; height: 51px}
-.Pet_Egg_Fox {background-position: 0px -255px; width: 48px; height: 51px}
-.Pet_Egg_FlyingPig {background-position: 0px -306px; width: 48px; height: 51px}
-.Pet_Egg_Dragon {background-position: 0px -357px; width: 48px; height: 51px}
-.Pet_Egg_Cactus {background-position: 0px -408px; width: 48px; height: 51px}
-.Pet_Egg_BearCub {background-position: 0px -459px; width: 48px; height: 51px}
+.Pet_Egg_Wolf {background-position: 0px 0px; width: 48px; height: 53px; margin-left: 1.25em;}
+.Pet_Egg_TigerCub {background-position: 0px -51px; width: 48px; height: 53px; margin-left: 1.25em;}
+.Pet_Egg_PolarBear {background-position: 0px -102px; width: 48px; height: 53px; margin-left: 1.25em;}
+.Pet_Egg_PandaCub {background-position: 0px -153px; width: 48px; height: 53px; margin-left: 1.25em;}
+.Pet_Egg_LionCub {background-position: 0px -204px; width: 48px; height: 53px; margin-left: 1.25em;}
+.Pet_Egg_Fox {background-position: 0px -255px; width: 48px; height: 53px; margin-left: 1.25em;}
+.Pet_Egg_FlyingPig {background-position: 0px -306px; width: 48px; height: 53px; margin-left: 1.25em;}
+.Pet_Egg_Dragon {background-position: 0px -357px; width: 48px; height: 53px; margin-left: 1.25em;}
+.Pet_Egg_Cactus {background-position: 0px -408px; width: 48px; height: 53px; margin-left: 1.25em;}
+.Pet_Egg_BearCub {background-position: 0px -459px; width: 48px; height: 53px; margin-left: 1.25em;}
 
-.Pet_HatchingPotion_Base {background-position: -48px -0px; width: 48px; height: 51px}
-.Pet_HatchingPotion_White {background-position: -48px -51px; width: 48px; height: 51px}
-.Pet_HatchingPotion_Desert {background-position: -48px -102px; width: 48px; height: 51px}
-.Pet_HatchingPotion_Red {background-position: -48px -153px; width: 48px; height: 51px}
-.Pet_HatchingPotion_Shade {background-position: -48px -204px; width: 48px; height: 51px}
-.Pet_HatchingPotion_Skeleton {background-position: -48px -255px; width: 48px; height: 51px}
-.Pet_HatchingPotion_Zombie {background-position: -48px -306px; width: 48px; height: 51px}
-.Pet_HatchingPotion_CottonCandyPink {background-position: -48px -357px; width: 48px; height: 51px}
-.Pet_HatchingPotion_CottonCandyBlue {background-position: -48px -408px; width: 48px; height: 51px}
-.Pet_HatchingPotion_Golden {background-position: -48px -459px; width: 48px; height: 51px}
+.Pet_HatchingPotion_Base {background-position: -48px -0px; width: 48px; height: 53px; margin-left: 1.25em;}
+.Pet_HatchingPotion_White {background-position: -48px -51px; width: 48px; height: 53px; margin-left: 1.25em;}
+.Pet_HatchingPotion_Desert {background-position: -48px -102px; width: 48px; height: 53px; margin-left: 1.25em;}
+.Pet_HatchingPotion_Red {background-position: -48px -153px; width: 48px; height: 53px; margin-left: 1.25em;}
+.Pet_HatchingPotion_Shade {background-position: -48px -204px; width: 48px; height: 53px; margin-left: 1.25em;}
+.Pet_HatchingPotion_Skeleton {background-position: -48px -255px; width: 48px; height: 53px; margin-left: 1.25em;}
+.Pet_HatchingPotion_Zombie {background-position: -48px -306px; width: 48px; height: 53px; margin-left: 1.25em;}
+.Pet_HatchingPotion_CottonCandyPink {background-position: -48px -357px; width: 48px; height: 53px; margin-left: 1.25em;}
+.Pet_HatchingPotion_CottonCandyBlue {background-position: -48px -408px; width: 48px; height: 53px; margin-left: 1.25em;}
+.Pet_HatchingPotion_Golden {background-position: -48px -459px; width: 48px; height: 53px; margin-left: 1.25em;}
 
 .Pet_Currency_Gem {background-position: 0px -510px; width: 51px; height: 45px} /* Not an egg or potion so has a different size */
 .Pet_Currency_Gem2x {background-position: -55px -513px; width: 34px; height: 30px}

--- a/styles/app/game-pane.styl
+++ b/styles/app/game-pane.styl
@@ -21,6 +21,9 @@
     padding-top:15px
     padding-bottom:15px
     border-bottom 1px solid #ddd
+    word-wrap: break-word;
+    max-height: 12em;
+    overflow: scroll;
 
     &.highlight
       background #EEE

--- a/styles/app/game-pane.styl
+++ b/styles/app/game-pane.styl
@@ -21,9 +21,6 @@
     padding-top:15px
     padding-bottom:15px
     border-bottom 1px solid #ddd
-    word-wrap: break-word;
-    max-height: 12em;
-    overflow: scroll;
 
     &.highlight
       background #EEE

--- a/styles/app/game-pane.styl
+++ b/styles/app/game-pane.styl
@@ -21,6 +21,9 @@
     padding-top:15px
     padding-bottom:15px
     border-bottom 1px solid #ddd
+    word-wrap:break-word
+    max-height:12em
+    overflow:scroll
 
     &.highlight
       background #EEE

--- a/styles/app/inventory.styl
+++ b/styles/app/inventory.styl
@@ -60,17 +60,23 @@
 .inventory-list li
     clear:both
 .pets-menu > div
-    float:left
+    display:inline-block
+    vertical-align:top
     padding:.3em
+    width:7em
+    margin-top:1em
     p
       text-align:center
-      width:3em
+      width:6em
 .hatchingPotion-menu > div
-    float:left
+    display:inline-block
+    vertical-align:top
     padding:.3em
+    width:6em
+    margin-top:1em
     p
       text-align:center
-      width:3em
+      width:6em
 
 .pet-button
     border: none

--- a/styles/app/inventory.styl
+++ b/styles/app/inventory.styl
@@ -68,6 +68,7 @@
     p
       text-align:center
       width:6em
+      margin-top:-.5em
 .hatchingPotion-menu > div
     display:inline-block
     vertical-align:top
@@ -77,6 +78,7 @@
     p
       text-align:center
       width:6em
+      margin-top:-.5em
 
 .pet-button
     border: none

--- a/styles/app/inventory.styl
+++ b/styles/app/inventory.styl
@@ -63,7 +63,7 @@
     display:inline-block
     vertical-align:top
     padding:.3em
-    width:7em
+    width:6em
     margin-top:1em
     p
       text-align:center


### PR DESCRIPTION
- fixed CSS alignment issues with long names breaking flow (stupid Cotton Candies)
- gave eggs and potions more wiggle room
- center egg and potion artwork in div, for better alignment
- centered text beneath newly centered artworks
- adjusted CSS to show full egg and potion artwork (was clipping 2px before)
- moved item labels slightly closer to artwork, for better readability (added as a separate commit, in case people don't agree)
- made tavern chat posts word-wrap, with a max-height to prevent long posts from disrupting scrolling of site
