### PR TITLE
Enable Gzip Compression

### DIFF
--- a/.nodemonignore
+++ b/.nodemonignore
@@ -1,2 +1,3 @@
 /public/*
 /assets/*
+/builtAssets/*

--- a/src/server.js
+++ b/src/server.js
@@ -67,10 +67,11 @@ passport.use(new FacebookStrategy({
 
 // ------------  Server Configuration ------------
 app.set("port", nconf.get('PORT'));
+app.use(express.logger("dev"));
+app.use(express.compress());
 app.set("views", __dirname + "/../views");
 app.set("view engine", "jade");
 app.use(express.favicon());
-app.use(express.logger("dev"));
 app.use(middleware.cors);
 app.use(express.bodyParser());
 app.use(require('connect-assets')());


### PR DESCRIPTION
The change in .nodemonignore is needed or the porduction server will continuosly restart due to `builtAssets` being updated, at least on my pc.

We should also add a far away expiration date for `/public` files, with the  `maxAge` option in express. But we can't do this actually because some files in `bower_components` do not change name with new version.

<!---
@huboard:{"order":1293.5}
-->
