### PR TITLE
Do not allow empty task names when editing tasks

### DIFF
--- a/views/tasks/task.jade
+++ b/views/tasks/task.jade
@@ -83,7 +83,7 @@ li(ng-repeat='task in user[list.type + "s"]', class='task {{taskClasses(task,use
       fieldset.option-group
         // {{#unless taskInChallenge(task)}}
         label.option-title Text
-        input.option-content(type='text', ng-model='task.text')
+        input.option-content(type='text', ng-model='task.text', required)
         // {{/}}
         label.option-title Extra Notes
         // {{#if taskInChallenge(task)}}


### PR DESCRIPTION
When editing tasks, you can set the 'Text' to empty, having nameless tasks as a result.
I've added the 'required' attribute to that input field to prevent this.
