### PR TITLE
Can't select hatching potion to use after buying an egg

### DIFF
--- a/views/options/inventory.jade
+++ b/views/options/inventory.jade
@@ -16,7 +16,7 @@
   .span6(ng-show='hatching')
     h3 Hatch Your Egg
     p(ng-show='userHatchingPotions.length < 1') You don't have any hatching potions yet.
-    div(ng-show='userHatchingPotions')
+    div(ng-show='userHatchingPotions.length >= 1')
       p.
         Which hatching potion will you pour on your <b>{{selectedEgg.text}}</b> egg?
       select(ng-options='hatchingPotion for hatchingPotion in userHatchingPotions', ng-model="selectedPotion")


### PR DESCRIPTION
I've discovered this with HabitRPG installed on my computer: if I don't have any potions, and go to the Inventory/Market page and buy a potion there, and afterwards click on any egg, I can't select which potion to use (the "Hatch Your Egg" section is empty):

![hatching_bug](https://f.cloud.github.com/assets/1175986/1146506/02acb864-1e68-11e3-8b38-858e230c5160.png)

Refreshing the page the problem disappears.
So I've modified the condition used to display that form.
