### PR TITLE
Profile: allow deletion of websites

### DIFF
--- a/public/js/controllers/userCtrl.js
+++ b/public/js/controllers/userCtrl.js
@@ -17,5 +17,6 @@ habitrpg.controller("UserCtrl", ['$scope', '$location', 'User',
   }
   $scope.removeWebsite = function($index){
     User.user.profile.websites.splice($index,1);
+    User.set('profile.websites', User.user.profile.websites);
   }
 }]);

--- a/views/options/profile.jade
+++ b/views/options/profile.jade
@@ -55,11 +55,11 @@
       //{{profile.profile.blurb | linky:'_blank'}}
 
       h4 Websites
-      ul(ng-show='profile.profile.websites')
+      ul(ng-show='profile.profile.websites.length > 0')
         // TODO let's remove links eventually, since we can do markdown on profiles
         li(ng-repeat='website in profile.profile.websites')
           a(target='_blank', ng-href='{{website}}') {{website}}
-      span.muted(ng-hide='profile.profile.websites') - None -
+      span.muted(ng-hide='profile.profile.websites.length > 0') - None -
 
     div.whatever-options(ng-show='_editing.profile')
       // TODO use photo-upload instead: https://groups.google.com/forum/?fromgroups=#!topic/derbyjs/xMmADvxBOak


### PR DESCRIPTION
If I have websites listed on my profile page, and remove one of them, it seems that the removal worked. 
But clicking on the "Sync" option on the upper right corner of the site resets the website list to the original state, so the removed wesite appears again.

I corrected that and fixed the conditions used to show or hide the website list.
