### PR TITLE
Reduce response size

### DIFF
--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -37,7 +37,8 @@ api.auth = function(req, res, next) {
     if (_.isEmpty(user)) {
       return res.json(401, NO_USER_FOUND);
     }
-    res.locals.wasModified = +user._v !== +req.query._v;
+
+    res.locals.wasModified = (req.query._v ? +user._v !== +req.query._v : true);
     res.locals.user = user;
     req.session.userId = user._id;
     return next();

--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -38,7 +38,7 @@ api.auth = function(req, res, next) {
       return res.json(401, NO_USER_FOUND);
     }
 
-    res.locals.wasModified = (req.query._v ? +user._v !== +req.query._v : true);
+    res.locals.wasModified = req.query._v ? +user._v !== +req.query._v : true;
     res.locals.user = user;
     req.session.userId = user._id;
     return next();

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -715,7 +715,7 @@ api.batchUpdate = function(req, res, next) {
     if(response.wasModified){
       res.json(200, response);
     }else{
-      res.json(204);
+      res.json(200, {_v: response._v});
     }
 
     return console.log("Reply sent");

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -710,7 +710,14 @@ api.batchUpdate = function(req, res, next) {
     response = user.toJSON();
     response.wasModified = res.locals.wasModified;
     if (response._tmp && response._tmp.drop) response.wasModified = true;
-    res.json(200, response);
+
+    // Send the response to the server
+    if(response.wasModified){
+      res.json(200, response);
+    }else{
+      res.json(204);
+    }
+
     return console.log("Reply sent");
   });
 };


### PR DESCRIPTION
This was discussed in #1419 

It is only for batchUpdate, other routes will still send down the whole user object (like update user)
- Set wasModified = true always when ?v is missing
- Only send the _v when user is not modified, it works also without a response at all but I tought it could be needed by the local object to know the user version. @lefnire let me if it's not needed and i'll make it send a 204 http code with no response (but then I believe we'll need to update the User Service in the mobile app or it'll break with an empty response)

Tested and working.

Maybe when we'll revisit the api (the v2 @lefnire talked about in #1419) we can also optimize the other routes. As for the website now it sends down only ~15bytes of data.
