### PR TITLE
Quick Fix - Task Editing Cancel

### DIFF
--- a/views/tasks/task.jade
+++ b/views/tasks/task.jade
@@ -9,8 +9,11 @@ li(ng-repeat='task in user[list.type + "s"]', class='task {{taskClasses(task,use
     i.icon-tags(tooltip='{{appliedTags(user.tags, task.tags)}}', ng-hide='noTags(task.tags)')
 
     // edit
-    a(ng-click='task._editing = !task._editing', tooltip='Edit')
-      i.icon-pencil
+    a(ng-hide='task._editing', ng-click='task._editing = !task._editing', tooltip='Edit')
+      i.icon-pencil(ng-hide='task._editing')
+    // cancel
+    a(ng-hide='!task._editing', ng-click='task._editing = !task._editing', tooltip='Cancel')
+      i.icon-remove(ng-hide='!task._editing')
     //- challenges
     //  {{#if task.challenge}}
     //      {{#if brokenChallengeLink(task)}}
@@ -27,7 +30,7 @@ li(ng-repeat='task in user[list.type + "s"]', class='task {{taskClasses(task,use
     a(ng-show='task.history', x-bind='click:toggleChart', ng-click='notPorted()', data-id='{{task.id}}', tooltip='Progress')
       i.icon-signal
     // notes
-    span.task-notes(ng-show='task.notes', popover-trigger='mouseenter', popover-placement='left', popover='{{task.notes}}', popover-title='{{task.text}}')
+    span.task-notes(ng-hide='task._editing', ng-show='task.notes', popover-trigger='mouseenter', popover-placement='left', popover='{{task.notes}}', popover-title='{{task.text}}')
       i.icon-comment
 
   // left-hand side checkbox


### PR DESCRIPTION
Temp fix for #1599

Hides the edit button on task editing.
Shows new cancel button on task editing.
Hides task notes on task editing.

Notes:
Still needs a save button up top, `save(task)` didn't seem to be working with ng-click (also tried a couple other things.) Will revisit.
'ng-if's could also work instead of 'ng-hide's.
Decided that we don't really need to have the task notes popover display while editing tasks since that stuff is already in the task editing pane.
