### PR TITLE
Hides Rare Pets headline if user has no rare pets

### DIFF
--- a/views/options/pets.jade
+++ b/views/options/pets.jade
@@ -21,7 +21,7 @@
           button(class="pet-button pet-not-owned", ng-hide='hasPet(pet.name, potion.name)')
             img(src='/bower_components/habitrpg-shared/img/PixelPaw.png')
 
-  h4 Rare Pets
+  h4(ng-if='hasPet("Wolf", "Veteran") || hasPet("Wolf", "Cerberus") || hasPet("Hydra")') Rare Pets
     menu
       div(ng-if='hasPet("Wolf", "Veteran")')
         button(class="pet-button Pet-Wolf-Veteran", ng-class='{active: isCurrentPet("Wolf", "Veteran")}', ng-click='choosePet("Wolf", "Veteran")', tooltip='Veteran Wolf')

--- a/views/options/pets.jade
+++ b/views/options/pets.jade
@@ -21,7 +21,7 @@
           button(class="pet-button pet-not-owned", ng-hide='hasPet(pet.name, potion.name)')
             img(src='/bower_components/habitrpg-shared/img/PixelPaw.png')
 
-  h4(ng-if='hasPet("Wolf", "Veteran") || hasPet("Wolf", "Cerberus") || hasPet("Hydra")') Rare Pets
+  h4(ng-if='hasPet("Wolf", "Veteran") || hasPet("Wolf", "Cerberus") || hasPet("Dragon", "Hydra")') Rare Pets
     menu
       div(ng-if='hasPet("Wolf", "Veteran")')
         button(class="pet-button Pet-Wolf-Veteran", ng-class='{active: isCurrentPet("Wolf", "Veteran")}', ng-click='choosePet("Wolf", "Veteran")', tooltip='Veteran Wolf')


### PR DESCRIPTION
This will hide the rare pets title if the user doesn't have any. 

Debatable change though, maybe we want people to see this and try to find out how they can get a rare pet?

Didn't really test this with a user that had rare pets, is there a quick way to add and remove rare pets from a test user?
