### PR TITLE
Fix #1647

### DIFF
--- a/migrations/20131027_add_streak_default.js
+++ b/migrations/20131027_add_streak_default.js
@@ -1,0 +1,4 @@
+db.users.find().forEach(function(user){
+  if (!user.achievements) user.achievements = {streak: 0};
+  db.users.update({_id:user._id}, {$set:{'achievements': user.achievements}});
+});

--- a/migrations/20131027_add_streak_default.js
+++ b/migrations/20131027_add_streak_default.js
@@ -1,4 +1,0 @@
-db.users.find().forEach(function(user){
-  if (!user.achievements) user.achievements = {streak: 0};
-  db.users.update({_id:user._id}, {$set:{'achievements': user.achievements}});
-});

--- a/src/models/group.js
+++ b/src/models/group.js
@@ -54,7 +54,7 @@ var GroupSchema = new Schema({
   leaderMessage: String
 }, {
   strict: 'throw', 
-  minimize: false
+  minimize: false // So empty objects are returned
 });
 
 

--- a/src/models/group.js
+++ b/src/models/group.js
@@ -52,7 +52,10 @@ var GroupSchema = new Schema({
   balance: Number,
   logo: String,
   leaderMessage: String
-}, {strict: 'throw'});
+}, {
+  strict: 'throw', 
+  minimize: false
+});
 
 
 /**

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -227,7 +227,7 @@ var UserSchema = new Schema({
 
 }, {
   strict: true,
-  minimize: false
+  minimize: false // So empty objects are returned
 });
 
 // Legacy Derby Function?

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -35,7 +35,7 @@ var UserSchema = new Schema({
     helpedHabit: Boolean,
     ultimateGear: Boolean,
     beastMaster: Boolean,
-    streak: Number
+    streak: {type: Number, 'default': 0}
   },
   auth: {
     facebook: Schema.Types.Mixed,

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -35,7 +35,7 @@ var UserSchema = new Schema({
     helpedHabit: Boolean,
     ultimateGear: Boolean,
     beastMaster: Boolean,
-    streak: {type: Number, 'default': 0}
+    streak: Number
   },
   auth: {
     facebook: Schema.Types.Mixed,
@@ -226,7 +226,8 @@ var UserSchema = new Schema({
   */
 
 }, {
-  strict: true
+  strict: true,
+  minimize: false
 });
 
 // Legacy Derby Function?


### PR DESCRIPTION
@lefnire this is a fix for #1647: new users object are created with an undefined `user.achievements` so it returns an error when it tried to set the first streak achievement.

I tried to set a default for `user.achievements` but since I couldn't find how to do so because it's an object which stores other fields I added the default for `user.achievements.streak`.

There's also a db migration to create `user.achievements` for users without it.
