### PR TITLE
Paglias/no reloading

### DIFF
--- a/public/js/controllers/groupsCtrl.js
+++ b/public/js/controllers/groupsCtrl.js
@@ -172,9 +172,8 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Groups', '$http', 'A
           // remove user from group members if guild is public so that he can re-join it immediately
           if(group.privacy == 'public'){
             // slow when a lot of members...? probably yes
-            group.members = _.without(group.members, function(member){
-              member._id !== User.user._id;
-            });
+            group.members = _.without(group.members, member);
+            group.memberCount--;
           }
           $state.go('options.social.guilds');
         });

--- a/public/js/controllers/groupsCtrl.js
+++ b/public/js/controllers/groupsCtrl.js
@@ -140,7 +140,9 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Groups', '$http', 'A
 
         if (confirm("Create Guild for 4 Gems?")) {
           group.$save(function(saved){
-            location.href =  '/#/options/groups/guilds/' + saved._id;
+            $scope.groups.guilds.push(saved);
+            if(saved.privacy === 'public') $scope.groups.public.push(saved);
+            $state.go('options.social.guilds.detail', {gid: saved._id});
           });
         }
       }
@@ -153,9 +155,11 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Groups', '$http', 'A
           group = new Groups.Group({_id:group.id});
         }
 
-        group.$join(function(){
-          // use https://github.com/angular-ui/ui-router/issues/76 when it's available
-          location.reload();
+        group.$join(function(joined){
+          var i = _.findIndex(User.user.invitations.guilds, {id:joined._id});
+          if (~i) User.user.invitations.guilds.splice(i,1);
+          $scope.groups.guilds.push(joined);
+          $state.go('options.social.guilds.detail', {gid: joined._id});
         })
       }
 
@@ -163,9 +167,16 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Groups', '$http', 'A
         if (confirm("Are you sure you want to leave this guild?") !== true) {
           return;
         }
-        group.$leave(function(){
-          // use https://github.com/angular-ui/ui-router/issues/76 when it's available
-          location.reload();
+        group.$leave(function(group){
+          $scope.groups.guilds.splice(_.indexOf($scope.groups.guilds, group), 1);
+          // remove user from group members if guild is public so that he can re-join it immediately
+          if(group.privacy == 'public'){
+            // slow when a lot of members...? probably yes
+            group.members = _.without(group.members, function(member){
+              member._id !== User.user._id;
+            });
+          }
+          $state.go('options.social.guilds');
         });
       }
 
@@ -179,18 +190,15 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Groups', '$http', 'A
     }
   ])
 
-  .controller("PartyCtrl", ['$scope', 'Groups', 'User',
-    function($scope, Groups, User) {
+  .controller("PartyCtrl", ['$scope', 'Groups', 'User', '$state',
+    function($scope, Groups, User, $state) {
       $scope.type = 'party';
       $scope.text = 'Party';
       $scope.group = Groups.groups.party;
       $scope.newGroup = new Groups.Group({type:'party', leader: User.user._id, members: [User.user._id]});
       $scope.create = function(group){
         group.$save(function(newGroup){
-          // Can't get this to work, group is correctly returned, scope updated but not view....
-          //Groups.groups.party = newGroup;
-          //$scope.group = Groups.groups.party;
-          location.reload();
+          $scope.group = newGroup;
         });
       }
 
@@ -198,10 +206,7 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Groups', '$http', 'A
         var group = new Groups.Group({_id: party.id, name: party.name});
         // there a better way to access GroupsCtrl.groups.party?
         group.$join(function(groupJoined){
-          // Can't get this to work, group is correctly returned, scope updated but not view....
-          //Groups.groups.party = groupJoined;
-          //$scope.group = Groups.groups.party;
-          location.reload();
+          $scope.group = groupJoined;
         });
       }
 
@@ -210,7 +215,7 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Groups', '$http', 'A
           return;
         }
         group.$leave(function(){
-          Groups.groups.party = undefined;
+          $scope.group = undefined;
         });
       }
 

--- a/public/js/services/groupServices.js
+++ b/public/js/services/groupServices.js
@@ -21,22 +21,16 @@ angular.module('groupServices', ['ngResource']).
 
         // The user may not visit the public guilds, personal guilds, and tavern pages. So
         // we defer loading them to the html until they've clicked the tabs
-        var partyQ = $q.defer(),
-          guildsQ = $q.defer(),
-          publicQ = $q.defer(),
-          tavernQ = $q.defer();
+        var partyQ = $q.defer();
 
         var groups = {
-          party: partyQ.promise,
-          guilds: guildsQ.promise,
-          public: publicQ.promise,
-          tavern: tavernQ.promise
+          party: partyQ.promise
         };
 
         // But we don't defer triggering Party, since we always need it for the header if nothing else
         Group.get({gid:'party'}, function(party){
           partyQ.resolve(party);
-        })
+        });
 
         return {
 
@@ -44,18 +38,18 @@ angular.module('groupServices', ['ngResource']).
           fetchGuilds: _.once(function(){
             //TODO combine these as {type:'guilds,public'} and create a $filter() to separate them
             Group.query({type:'guilds'}, function(_groups){
-              guildsQ.resolve(_groups);
+              groups.guilds = _groups;
               //Members.populate(_groups);
             });
             Group.query({type:'public'}, function(_groups){
-              publicQ.resolve(_groups);
+              groups.public = _groups;
               //Members.populate(_groups);
             });
           }),
 
           fetchTavern: _.once(function(){
             Group.get({gid:'habitrpg'}, function(_group){
-              tavernQ.resolve(_group);
+              groups.tavern = _group;
             })
           }),
 

--- a/src/controllers/groups.js
+++ b/src/controllers/groups.js
@@ -144,13 +144,19 @@ api.create = function(req, res, next) {
       if(err) return res.json(500,{err:err});
       group.save(function(err, saved){
         if (err) return res.json(500,{err:err});
-        return res.json(saved);
+        saved.populate('members', partyFields, function(err, populated){
+          if (err) return res.json(500,{err:err});
+          return res.json(populated);
+        });
       });
     });    
   }else{
     group.save(function(err, saved){
       if (err) return res.json(500,{err:err});
-      return res.json(saved);
+      saved.populate('members', partyFields, function(err, populated){
+        if (err) return res.json(500,{err:err});
+        return res.json(populated);
+      });
     });
   }
 }

--- a/views/options/social/index.jade
+++ b/views/options/social/index.jade
@@ -17,7 +17,7 @@ script(type='text/ng-template', id='partials/options.social.party.html')
       a.btn.btn-success(data-type='party', ng-click='join(user.invitations.party)') Accept
       a.btn.btn-danger(ng-click='reject()') Reject
       // {/}
-    div(ng-hide='user.invitations.party', ng-controller='PartyCtrl')
+    div(ng-hide='user.invitations.party')
       h2 Create A Party
       p
         | You are not in a party. You can either create one and invite friends, or if you want to join an existing party, have them enter:


### PR DESCRIPTION
No more page reloading for groups operations!

I've removed promises for guilds, public guilds but not for party because otherwise when loading directly the party page (/#/options/groups/party) it wouldn't show up until the user browsed to another path and then back to the party page. 

Angular $scope mysteries here.

Everythign else works fine (I've added members population for guilds/party creation).

https://github.com/HabitRPG/habitrpg/compare/paglias;no-reloading?expand=1#diff-3af08874b33d0895ff0efacc39e1e087R174 is probably going to be slow but we need it or the user will see the public guild as joined.
