### PR TITLE
Add angular routing choices to header menu

### DIFF
--- a/views/options/inventory/inventory.jade
+++ b/views/options/inventory/inventory.jade
@@ -2,7 +2,7 @@ script(type='text/ng-template', id='partials/options.inventory.inventory.html')
   .row-fluid(ng-controller='InventoryCtrl')
     .span6.border-right
       h2 Inventory
-      p.well Hatch pets by first clicking the hatching potion you want to use. This will highlight all eligible eggs in green. Just click one of those eggs, and, presto, your new pet is born. You can also sell unwanted drops to Alexander the Merchant.
+      p.well Click an egg to see useable potions highlighted in green. Click that egg again to deselect it, and, instead, click a potion first to have the useable eggs highlighted. You can also sell unwanted drops to Alexander the Merchant.
       menu.inventory-list(type='list')
         li.customize-menu
           menu.pets-menu(label='Eggs ({{userEggs.length}})')

--- a/views/shared/header/menu.jade
+++ b/views/shared/header/menu.jade
@@ -12,6 +12,35 @@
             span(ng-show='$state.includes("tasks")', ui-sref='options')
               i.icon.icon-wrench
               |  Options
+
+/ These are suggested new selections (that need to be completed )
+        li
+          a.task-action-btn.tile.solid(ng-click='valueNeeded()')
+            i.icon.valueNeeded
+            |  Tavern
+        li
+          a.task-action-btn.tile.solid(ng-click='valueNeeded()')
+            i.icon.valueNeeded
+            |  Challenges
+        li
+          a.task-action-btn.tile.solid(ng-click='valueNeeded()')
+            i.icon.valueNeeded
+            |  Guilds
+        li
+          a.task-action-btn.tile.solid(ng-click='valueNeeded()')
+            i.icon.valueNeeded
+            |  Inventory
+        li
+          a.task-action-btn.tile.solid(ng-click='valueNeeded()')
+            i.icon.valueNeeded
+            |  Stable
+        li
+          a.task-action-btn.tile.solid(ng-click='valueNeeded()')
+            i.icon.valueNeeded
+            |  Settings
+
+-# These are the original selections
+
         li
           a.task-action-btn.tile.solid(ng-click='User.sync()')
             i.icon.icon-refresh


### PR DESCRIPTION
Because tavern and other options can be accessed directly now, these
additions to the menu will make it easier to access features that
currently can take up to 3 clicks to get to. I didn't add all the tabs to keep 
the list from being way to long (may be already).

The code still needs work but at the very least is a start to
implementing issue #1715. I inserted "valueNeeded" in the places I
can't finish. Hope this helps more than it's a PITA.
