### PR TITLE
Paglias/build manifest

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,7 @@
     "jquery-ui": "~1.10.3",
     "angular": "1.2.0-rc.3",
     "angular-sanitize": "1.2.0-rc.3",
+    "restangular": "~1.1.6",
     "angular-ui": "~0.4.0",
     "angular-ui-utils": "~0.0.4",
     "angular-bootstrap": "~0.5.0",

--- a/bower.json
+++ b/bower.json
@@ -31,14 +31,12 @@
     "habitrpg-shared": "git://github.com/HabitRPG/habitrpg-shared.git#master",
     "BrowserQuest": "https://github.com/mozilla/BrowserQuest.git",
     "github-buttons": "git://github.com/mdo/github-buttons.git",
-    "sticky": "*",
     "marked": "~0.2.9",
     "JavaScriptButtons": "git://github.com/paypal/JavaScriptButtons.git#master"
   },
   "resolutions": {
     "jquery": "~2.0.3",
-    "bootstrap": "v2.3.2",
-    "angular": "1.2.0-rc.3"
+    "bootstrap": "v2.3.2"
   },
   "devDependencies": {
     "angular-mocks": "1.2.0-rc.3"

--- a/bower.json
+++ b/bower.json
@@ -15,32 +15,31 @@
   ],
   "dependencies": {
     "jquery": "~2.0.3",
-    "angular": "1.2.0-rc.2",
-    "angular-resource": "1.2.0-rc.2",
+    "jquery-ui": "~1.10.3",
+    "angular": "1.2.0-rc.3",
+    "angular-sanitize": "1.2.0-rc.3",
     "angular-ui": "~0.4.0",
+    "angular-ui-utils": "~0.0.4",
     "angular-bootstrap": "~0.5.0",
-    "habitrpg-shared": "git://github.com/HabitRPG/habitrpg-shared.git#master",
+    "angular-ui-router": "ca3b4777a603df8f86cfd653c8f6c38b2ae05d89",
+    "angular-loading-bar": "~0.0.5",
+    "bootstrap": "v2.3.2",
+    "bootstrap-datepicker": "~1.2.0",
     "bootstrap-tour": "0.5.0",
+    "bootstrap-growl": "~1.1.0",
+    "habitrpg-shared": "git://github.com/HabitRPG/habitrpg-shared.git#master",
     "BrowserQuest": "https://github.com/mozilla/BrowserQuest.git",
     "github-buttons": "git://github.com/mdo/github-buttons.git",
-    "jquery-ui": "~1.10.3",
-    "bootstrap-growl": "~1.1.0",
-    "jquery.cookie": "~1.3.1",
     "sticky": "*",
-    "bootstrap-datepicker": "~1.2.0",
-    "bootstrap": "v2.3.2",
-    "angular-ui-utils": "~0.0.4",
-    "angular-sanitize": "1.2.0-rc.2",
     "marked": "~0.2.9",
-    "JavaScriptButtons": "git://github.com/paypal/JavaScriptButtons.git#master",
-    "angular-ui-router": "ca3b4777a603df8f86cfd653c8f6c38b2ae05d89",
-    "angular-loading-bar": "~0.0.5"
+    "JavaScriptButtons": "git://github.com/paypal/JavaScriptButtons.git#master"
   },
   "resolutions": {
     "jquery": "~2.0.3",
-    "bootstrap": "v2.3.2"
+    "bootstrap": "v2.3.2",
+    "angular": "1.2.0-rc.3"
   },
   "devDependencies": {
-    "angular-mocks": "1.2.0-rc.2"
+    "angular-mocks": "1.2.0-rc.3"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "jquery-ui": "~1.10.3",
     "angular": "1.2.0-rc.3",
     "angular-sanitize": "1.2.0-rc.3",
-    "restangular": "~1.1.6",
+    "angular-resource": "1.2.0-rc.3",
     "angular-ui": "~0.4.0",
     "angular-ui-utils": "~0.0.4",
     "angular-bootstrap": "~0.5.0",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,83 @@
+{
+    "app": {
+        "js": [
+            "bower_components/jquery/jquery.js",
+            "bower_components/bootstrap-growl/jquery.bootstrap-growl.js",
+            "bower_components/bootstrap-tour/build/js/bootstrap-tour.js",
+            "bower_components/angular/angular.js",
+            "bower_components/angular-sanitize/angular-sanitize.js",
+            "bower_components/marked/lib/marked.js",
+            "bower_components/angular-ui-router/release/angular-ui-router.js",
+            "bower_components/angular-resource/angular-resource.min.js",
+            "bower_components/angular-ui/build/angular-ui.js",
+            "bower_components/angular-ui-utils/modules/keypress/keypress.js",
+            "bower_components/angular-loading-bar/build/loading-bar.js",
+
+            "bower_components/bootstrap/docs/assets/js/bootstrap.js",
+            "bower_components/angular-bootstrap/ui-bootstrap.js",
+            "bower_components/angular-bootstrap/ui-bootstrap-tpls.js",
+
+            "bower_components/jquery-ui/ui/minified/jquery.ui.core.min.js",
+            "bower_components/jquery-ui/ui/minified/jquery.ui.widget.min.js",
+            "bower_components/jquery-ui/ui/minified/jquery.ui.mouse.min.js",
+            "bower_components/jquery-ui/ui/minified/jquery.ui.sortable.min.js",
+
+            "bower_components/habitrpg-shared/dist/habitrpg-shared.js",
+
+            "js/app.js",
+            "js/services/authServices.js",
+            "js/services/notificationServices.js",
+            "js/services/sharedServices.js",
+            "js/services/userServices.js",
+            "js/services/groupServices.js",
+            "js/services/memberServices.js",
+            "js/services/guideServices.js",
+            "js/services/challengeServices.js",
+
+            "js/filters/filters.js",
+
+            "js/directives/directives.js",
+
+            "js/controllers/authCtrl.js",
+            "js/controllers/notificationCtrl.js",
+            "js/controllers/rootCtrl.js",
+            "js/controllers/settingsCtrl.js",
+            "js/controllers/headerCtrl.js",
+            "js/controllers/tasksCtrl.js",
+            "js/controllers/filtersCtrl.js",
+            "js/controllers/userCtrl.js",
+            "js/controllers/groupsCtrl.js",
+            "js/controllers/petsCtrl.js",
+            "js/controllers/inventoryCtrl.js",
+            "js/controllers/marketCtrl.js",
+            "js/controllers/footerCtrl.js",
+            "js/controllers/challengesCtrl.js"
+        ],
+        "css": [
+            "bower_components/bootstrap/docs/assets/css/bootstrap.css",
+            "app.css",
+            "bower_components/habitrpg-shared/dist/spritesheets.css"
+        ]
+    },
+    "static": {
+        "js": [
+            "bower_components/jquery/jquery.js",
+            "bower_components/habitrpg-shared/dist/habitrpg-shared.js",
+            "bower_components/angular/angular.js",
+
+            "bower_components/bootstrap/docs/assets/js/bootstrap.js",
+
+            "bower_components/angular-loading-bar/build/loading-bar.js",
+            "js/static.js",
+            "js/services/userServices.js",
+            "js/controllers/authCtrl.js"
+        ],
+        "css": [
+            "bower_components/bootstrap/docs/assets/css/bootstrap.css",
+            "bower_components/bootstrap/docs/assets/css/bootstrap-responsive.css",
+            "bower_components/bootstrap/docs/assets/css/docs.css",
+    
+            "static.css"
+        ]
+    }
+}

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -54,10 +54,36 @@ var walk = function(folder){
 walk(path.join(__dirname, "/../build"));
 
 var getBuildUrl = function(url){
-  if(buildFiles[url]) return buildFiles[url];
+  console.log(url, buildFiles[url])
+  if(buildFiles[url]) return '/' + buildFiles[url];
 
-  return url;
+  return '/' + url;
 }
+
+var manifestFiles = require("../public/manifest.json");
+
+var getManifestFiles = function(page){
+  var files = manifestFiles[page];
+
+  if(!files) throw new Error("Page not found!");
+
+  var css = '';
+
+  _.each(files.css, function(file){
+    css += '<link rel="stylesheet" type="text/css" href="' + getBuildUrl(file) + '">'; 
+  });
+
+  if(nconf.get('NODE_ENV') === 'production'){
+    return css + '<script type="text/javascript" src="' + getBuildUrl(page + '.js') + '"></script>'; 
+  }else{
+    var results = css;
+    _.each(files.js, function(file){
+      results += '<script type="text/javascript" src="' + getBuildUrl(file) + '"></script>'; 
+    });
+    return results;
+  }
+
+} 
 
 module.exports.locals = function(req, res, next) {
   res.locals.habitrpg  = res.locals.habitrpg || {}
@@ -67,6 +93,7 @@ module.exports.locals = function(req, res, next) {
     PAYPAL_MERCHANT: nconf.get('PAYPAL_MERCHANT'),
     IS_MOBILE: /Android|webOS|iPhone|iPad|iPod|BlackBerry/i.test(req.header('User-Agent')),
     STRIPE_PUB_KEY: nconf.get('STRIPE_PUB_KEY'),
+    getManifestFiles: getManifestFiles,
     getBuildUrl: getBuildUrl
   });
   next()

--- a/src/server.js
+++ b/src/server.js
@@ -101,8 +101,8 @@ app.use(passport.session());
 
 app.use(app.router);
 
-var oneYear = 31536000000;
-app.use(express['static'](path.join(__dirname, "/../build"), { maxAge: oneYear }));
+var maxAge = (nconf.get('NODE_ENV') === 'production') ? 31536000000 : 0;
+app.use(express['static'](path.join(__dirname, "/../build"), { maxAge: maxAge }));
 app.use(express['static'](path.join(__dirname, "/../public")));
 
 // development only

--- a/views/index.jade
+++ b/views/index.jade
@@ -4,7 +4,7 @@ html
     title HabitRPG | Your Life The Role Playing Game
 
     // ?v=1 needed to force refresh
-    link(rel='shortcut icon' href='/#{env.getBuildUrl("favicon.ico")}?v=2') 
+    link(rel='shortcut icon' href='#{env.getBuildUrl("favicon.ico")}?v=2') 
 
     script(type='text/javascript').
       window.env = !{JSON.stringify(env)};
@@ -14,74 +14,7 @@ html
         display: none;
       }
 
-    // CSS Remember to update also in Grunfile.js cssmin task!
-    link(rel='stylesheet', href='/#{env.getBuildUrl("bower_components/bootstrap/docs/assets/css/bootstrap.css")}')
-
-    link(rel='stylesheet', href='/#{env.getBuildUrl("app.css")}')
-
-    // HabitRPG Shared
-    link(rel='stylesheet', href='/#{env.getBuildUrl("bower_components/habitrpg-shared/dist/spritesheets.css")}')
-
-    - if(env.NODE_ENV == 'production'){
-      script(type='text/javascript', src='/#{env.getBuildUrl("app.js")}')
-    - }else{
-      // Remember to update the file list in Gruntfile.js!
-      script(type='text/javascript', src='/bower_components/jquery/jquery.min.js')
-      script(type='text/javascript', src='/bower_components/jquery.cookie/jquery.cookie.js')
-      script(type='text/javascript', src='/bower_components/bootstrap-growl/jquery.bootstrap-growl.min.js')
-      script(type='text/javascript', src='/bower_components/bootstrap-tour/build/js/bootstrap-tour.min.js')
-      script(type='text/javascript', src='/bower_components/angular/angular.js')
-      script(type='text/javascript', src='/bower_components/angular-ui-router/release/angular-ui-router.js')
-
-      script(type='text/javascript', src='/bower_components/angular-sanitize/angular-sanitize.min.js')
-      script(type='text/javascript', src='/bower_components/marked/lib/marked.js')
-
-      script(type='text/javascript', src='/bower_components/angular-resource/angular-resource.js')
-      script(type='text/javascript', src='/bower_components/angular-ui/build/angular-ui.js')
-      script(type='text/javascript', src='/bower_components/angular-ui-utils/modules/keypress/keypress.js')
-
-      script(type='text/javascript', src='/bower_components/angular-loading-bar/build/loading-bar.js')
-      // we'll remove this once angular-bootstrap is fixed
-      script(type='text/javascript', src='/bower_components/bootstrap/docs/assets/js/bootstrap.min.js')
-      script(type='text/javascript', src='/bower_components/angular-bootstrap/ui-bootstrap.min.js')
-      script(type='text/javascript', src='/bower_components/angular-bootstrap/ui-bootstrap-tpls.min.js')
-      // Sortable
-      script(type='text/javascript', src='/bower_components/jquery-ui/ui/minified/jquery.ui.core.min.js')
-      script(type='text/javascript', src='/bower_components/jquery-ui/ui/minified/jquery.ui.widget.min.js')
-      script(type='text/javascript', src='/bower_components/jquery-ui/ui/minified/jquery.ui.mouse.min.js')
-      script(type='text/javascript', src='/bower_components/jquery-ui/ui/minified/jquery.ui.sortable.min.js')
-      // habitrpg-shared
-      script(type='text/javascript', src='/bower_components/habitrpg-shared/dist/habitrpg-shared.js')
-      // app
-      script(type='text/javascript', src='/js/app.js')
-      script(type='text/javascript', src='/js/services/authServices.js')
-      script(type='text/javascript', src='/js/services/notificationServices.js')
-      script(type='text/javascript', src='/js/services/sharedServices.js')
-      script(type='text/javascript', src='/js/services/userServices.js')
-      script(type='text/javascript', src='/js/services/groupServices.js')
-      script(type='text/javascript', src='/js/services/memberServices.js')
-      script(type='text/javascript', src='/js/services/guideServices.js')
-      script(type='text/javascript', src='/js/services/challengeServices.js')
-
-      script(type='text/javascript', src='/js/filters/filters.js')
-
-      script(type='text/javascript', src='/js/directives/directives.js')
-
-      script(type='text/javascript', src='/js/controllers/authCtrl.js')
-      script(type='text/javascript', src='/js/controllers/notificationCtrl.js')
-      script(type='text/javascript', src='/js/controllers/rootCtrl.js')
-      script(type='text/javascript', src='/js/controllers/settingsCtrl.js')
-      script(type='text/javascript', src='/js/controllers/headerCtrl.js')
-      script(type='text/javascript', src='/js/controllers/tasksCtrl.js')
-      script(type='text/javascript', src='/js/controllers/filtersCtrl.js')
-      script(type='text/javascript', src='/js/controllers/userCtrl.js')
-      script(type='text/javascript', src='/js/controllers/groupsCtrl.js')
-      script(type='text/javascript', src='/js/controllers/petsCtrl.js')
-      script(type='text/javascript', src='/js/controllers/inventoryCtrl.js')
-      script(type='text/javascript', src='/js/controllers/marketCtrl.js')
-      script(type='text/javascript', src='/js/controllers/footerCtrl.js')
-      script(type='text/javascript', src='/js/controllers/challengesCtrl.js')
-    -}
+    != env.getManifestFiles("app")
 
     //webfonts
     link(href='//fonts.googleapis.com/css?family=Lato:300,400,700,400italic,700italic', rel='stylesheet', type='text/css')

--- a/views/static/layout.jade
+++ b/views/static/layout.jade
@@ -7,35 +7,12 @@ html
     block title
       title HabitRPG | Your Life the Role Playing Game
 
-    link(rel='shortcut icon', href='/#{env.getBuildUrl("favicon.ico")}?v=2')
+    link(rel='shortcut icon', href='#{env.getBuildUrl("favicon.ico")}?v=2')
 
     meta(charset='utf-8')
     meta(name='viewport', content='width=device-width, initial-scale=1.0')
 
-    // CSS Remember to update also in Grunfile.js cssmin task!
-    link(rel='stylesheet', href='/#{env.getBuildUrl("bower_components/bootstrap/docs/assets/css/bootstrap.css")}')
-    // Keep this out of build because the one after has some images and would like not to override it
-    link(rel='stylesheet', href='/#{env.getBuildUrl("bower_components/bootstrap/docs/assets/css/bootstrap-responsive.css")}')
-    link(rel='stylesheet', href='/#{env.getBuildUrl("bower_components/bootstrap/docs/assets/css/docs.css")}')
-    
-    link(rel='stylesheet', href='/#{env.getBuildUrl("static.css")}')
-
-    // JS
-    - if(layoutEnv.NODE_ENV == 'production'){
-      script(type='text/javascript', src='/#{env.getBuildUrl("static.js")}')
-    - }else{
-      // Remember to update the file list in Gruntfile.js!
-      script(type='text/javascript', src='/bower_components/jquery/jquery.min.js')
-      script(type='text/javascript', src='/bower_components/habitrpg-shared/dist/habitrpg-shared.js')
-      script(type='text/javascript', src='/bower_components/angular/angular.min.js')
-      script(type='text/javascript', src='/bower_components/angular-resource/angular-resource.min.js')
-      script(type='text/javascript', src='/bower_components/bootstrap/docs/assets/js/bootstrap.min.js')
-      script(type='text/javascript', src='/bower_components/angular-loading-bar/build/loading-bar.js')
-
-      script(type='text/javascript', src='/js/static.js')
-      script(type='text/javascript', src='/js/services/userServices.js')
-      script(type='text/javascript', src='/js/controllers/authCtrl.js')
-    -}
+    != env.getManifestFiles("static")
 
     script(type='text/javascript').
       $.getScript("//s7.addthis.com/js/250/addthis_widget.js#pubid=lefnire");


### PR DESCRIPTION
Ok these are the changes:
- No need anymore to define js/css files in both index.jade (or static/front.jade) & in Gruntfile.js but only in public/manifest.json which is a lot less error prone & faster to add/remove a file since there's only one file instead of two.
- Updated angular to 1.2.0-rc3 
- Removed jquery.cookie since it wasn't used anywhere, and also "sticky" package (jquery-sticky) from bower.json which wasn't loaded at all on the site.
- It's now possible to edit stylus files without having to restart the server to see changes on development 

I started adding Restangular in place of ngResource but I reverted the change, I'll give it a look tomorrow in case I can't solve the current problems with ngResource (#1742)
