### PR TITLE
Added even spacing between limited edition skins and rainbow skins

### DIFF
--- a/public/css/customizer.styl
+++ b/public/css/customizer.styl
@@ -54,4 +54,4 @@ menu
 
 .well.limited-edition
   padding: 5px
-  margin: 0px
+  margin: 25px 0 0


### PR DESCRIPTION
The spacing between limited edition skins and rainbow skins was messed up, so I added more spacing to make it even with the rest.

Before:
![before](https://f.cloud.github.com/assets/3391909/1507400/b5992f76-497d-11e3-89c1-c9cc428e59db.jpg)

After:
![after](https://f.cloud.github.com/assets/3391909/1507401/ba56a250-497d-11e3-9b40-9c4ff07d645f.jpg)
