### PR TITLE
case-insensitive highlighting for usernames in chat

### DIFF
--- a/views/options/social/chat-message.jade
+++ b/views/options/social/chat-message.jade
@@ -1,4 +1,4 @@
-li(ng-repeat='message in group.chat', ng-class='{highlight: indexOf(message.text, user.profile.name), "own-message": user._id == message.uuid}')
+li(ng-repeat='message in group.chat', ng-class='{highlight: indexOf(message.text.toLowerCase(), user.profile.name.toLowerCase()), "own-message": user._id == message.uuid}')
   a.label.chat-message(class='label-contributor-{{message.contributor.level}}', ng-class='{"label-npc": message.backer.npc}', ng-click='clickMember(message.uuid, true)')
     span(tooltip='{{contribText(message.contributor, message.backer)}}') {{message.user}}&nbsp;
   | &nbsp;


### PR DESCRIPTION
Here's a quickie, BrightBold said that chat messages weren't highlighting because of case-sensitivity... this should fix that.
