### PR TITLE
contrib: Added 'icon-ok' as an upper save button

### DIFF
--- a/views/shared/tasks/task.jade
+++ b/views/shared/tasks/task.jade
@@ -19,6 +19,9 @@ li(ng-repeat='task in obj[list.type+"s"]', class='task {{taskClasses(task, user.
       // cancel
       a(ng-hide='!task._editing', ng-click='editTask(task)', tooltip='Cancel')
         i.icon-remove(ng-hide='!task._editing')
+      // save
+      a(ng-hide='!task._editing', ng-click='editTask(task);saveTask(task)', tooltip='Save')
+        i.icon-ok(ng-hide='!task._editing')
       //challenges
       span(ng-if='task.challenge.id')
         span(ng-if='task.challenge.broken')


### PR DESCRIPTION
Added a new feature, the upper save button.
It looks something like this:

![screenshot](https://f.cloud.github.com/assets/1624978/1541083/30ca9348-4d2e-11e3-8179-9ba43d37b2c1.png)

I hope it helps! :D
