### PR TITLE
Make it easier for people to find "how to contribute" wiki page

### DIFF
--- a/public/css/customizer.styl
+++ b/public/css/customizer.styl
@@ -22,7 +22,7 @@ menu
     line-height: 2
 
 .customize-option
-  border: 1px solid grey;
+//  border: 1px solid grey;
   background-color: hsl(0, 0%, 93%);
   margin-bottom: 10px
   


### PR DESCRIPTION
Adding an additional link to the Player Tiers sidebar, for folks who want to jump straight to "how do I contribute?"

(Git n00b puzzlement about the extra commit there. Think that happened when I merged some of @paglias's changes into my local repo. But the changed file data looks correct.)
