### PR TITLE
Fixed case-insensitive highlighting issues and identified a possibly *major* performance problem

### DIFF
--- a/public/js/controllers/groupsCtrl.js
+++ b/public/js/controllers/groupsCtrl.js
@@ -128,6 +128,24 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Groups', '$http', 'A
   .controller('ChatCtrl', ['$scope', 'Groups', 'User', function($scope, Groups, User){
     $scope.message = {content:''};
     $scope._sending = false;
+    
+    $scope.isUserMentioned = function(user, message) {
+      if(message.hasOwnProperty("highlight"))
+        return message.highlight;
+      message.highlight = false;
+      var messagetext = message.text.toLowerCase();
+      var username = user.profile.name;
+      var mentioned = messagetext.indexOf(username.toLowerCase());
+      var pattern = "(\s|@|^){1}"+username+"([^\w]|$){1}";
+      if(mentioned > -1) {
+        var preceedingchar = messagetext.substring(mentioned-1,mentioned);
+        if(mentioned == 0 || preceedingchar.trim() == '' || preceedingchar == '@'){
+          var regex = new RegExp(pattern,'i');
+          message.highlight = regex.test(messagetext);
+        }
+      }
+      return message.highlight;
+    }
 
     $scope.postChat = function(group, message){
       if (_.isEmpty(message) || $scope._sending) return;

--- a/views/options/social/chat-message.jade
+++ b/views/options/social/chat-message.jade
@@ -1,4 +1,4 @@
-li(ng-repeat='message in group.chat', ng-class='{highlight: indexOf(message.text.toLowerCase(), user.profile.name.toLowerCase()), "own-message": user._id == message.uuid}')
+li(ng-repeat='message in group.chat', ng-class='{highlight: isUserMentioned(user,message), "own-message": user._id == message.uuid}')
   a.label.chat-message(class='label-contributor-{{message.contributor.level}}', ng-class='{"label-npc": message.backer.npc}', ng-click='clickMember(message.uuid, true)')
     span(tooltip='{{contribText(message.contributor, message.backer)}}') {{message.user}}&nbsp;
   | &nbsp;


### PR DESCRIPTION
how this works:
- rather than throw an expensive regular expression at each chat message, we start by checking to see if the users name exists.
- then, by simple string manipulation we verify that the preceeding character before the alleged username is whitespace, the start of a line, or an '@' character.
- FINALLY, we verify the following character is a non-word character using a regular expression.
- then we cache the highlight status on the local `message` object, because for some reason, this function is called **every time a character is typed in the chatbox.** this seems like a huge performance problem to me, need to see if there is a way to disable that or something
