### PR TITLE
Remove bland/harsh border styling on eggs and avatar options

### DIFF
--- a/public/css/customizer.styl
+++ b/public/css/customizer.styl
@@ -22,7 +22,7 @@ menu
     line-height: 2
 
 .customize-option
-//  border: 1px solid grey;
+  border: 0px solid grey;
   background-color: hsl(0, 0%, 93%);
   margin-bottom: 10px
   

--- a/public/css/customizer.styl
+++ b/public/css/customizer.styl
@@ -22,7 +22,7 @@ menu
     line-height: 2
 
 .customize-option
-  border: 1px solid grey;
+//  border: 1px solid grey;
   background-color: hsl(0, 0%, 93%);
   margin-bottom: 10px
   


### PR DESCRIPTION
It struck me how harsh the borders look on our eggs and profile buttons at present:

![screenclip](https://f.cloud.github.com/assets/4501321/1558413/bbb68e28-4f8e-11e3-8a1e-e4e8f728a9e4.png)

If we take out the 1px solid grey border from the .customize-option CSS, it falls back to a button look that's much nicer:

![screenclip](https://f.cloud.github.com/assets/4501321/1558416/d935704a-4f8e-11e3-8bb0-f79b7b4d5c74.png)

Checked this on both Firefox and Chrome: both exhibit the same behavior. I think long-term (when some of these screens are less likely to change from one update to the next) it could be fun to do a whole beautification of the UI, but at this moment I feel this is a significant improvement.
