### PR TITLE
Make it easier for people to find "how to contribute" wiki page

### DIFF
--- a/views/options/social/tavern.jade
+++ b/views/options/social/tavern.jade
@@ -47,10 +47,12 @@
     // Player Tiers
     .modal(style='position: relative;top: auto;left: auto;right: auto;margin: 0 auto 20px;z-index: 1;max-width: 100%;')
       .modal-header
-        h3 Player Tier Legend
+        h3 Player Tiers
       .modal-body
         small.
-          Click labels to expand. See <a href='http://habitrpg.wikia.com/wiki/Contributor_Rewards' target='_blank'>contribution details.</a>
+          Click tier labels below for more information. <br />
+          <a href='http://habitrpg.wikia.com/wiki/Contributor_Rewards' target='_blank'>Learn more about contributor rewards</a> <br />
+          <a href='http://habitrpg.wikia.com/wiki/Contributing_to_HabitRPG' target='_blank'>Learn how to contribute to HabitRPG</a>
         table.table.table-striped
           tr
             td


### PR DESCRIPTION
Adding an additional link to the Player Tiers sidebar, for folks who want to jump straight to "how do I contribute?"
