### PR TITLE
Move stat formulae to mouseover popup instead of inline

### DIFF
--- a/views/shared/profiles/stats.jade
+++ b/views/shared/profiles/stats.jade
@@ -26,17 +26,22 @@ p
   | : {{profile.stats.exp | number:0}} / {{tnl(profile.stats.lvl)}}
 p
   strong Strength
-  | (Level-1)/2: {{userStr(profile.stats.lvl)}}
+  | :
+  span(popover-trigger='mouseenter', popover='(Level-1)/2') {{userStr(profile.stats.lvl)}}
 p
   strong Defense
-  | (Level-1)/2: {{userDef(profile.stats.lvl)}}
+  | :
+  span(popover-trigger='mouseenter', popover='(Level-1)/2') {{userDef(profile.stats.lvl)}}
 p
   strong Pets Found
   | : {{countExists(profile.items.pets)}}
 hr
 p
   strong Total Experience Boost
-  | (Attack + Strength): {{totalStr(profile.stats.lvl, profile.items.weapon)}} %
+  | :
+  span(popover-trigger='mouseenter', popover='Attack + Strength') {{totalStr(profile.stats.lvl, profile.items.weapon)}} %
+
 p
   strong Total Damage Reduction
-  | (Defense + Protection): {{totalDef(profile.stats.lvl, profile.items.armor, profile.items.head, profile.items.shield)}} %
+  | :
+  span(popover-trigger='mouseenter', popover='Defense + Protection') {{totalDef(profile.stats.lvl, profile.items.armor, profile.items.head, profile.items.shield)}} %


### PR DESCRIPTION
Wasn't happy with the appearance of my exposed stat formulas on the Stats page. So I moved them to popup bubbles instead--mouse over the number and you see how the value was derived.
