### PR TITLE
Party members order

### DIFF
--- a/migrations/20131123_set_default_party_order.js
+++ b/migrations/20131123_set_default_party_order.js
@@ -1,0 +1,8 @@
+//Add default to randomize party members list
+db.users.update(
+    {},
+    {$set:{
+        'party.order': 'random',
+    }},
+    {multi:true}
+)

--- a/public/js/controllers/groupsCtrl.js
+++ b/public/js/controllers/groupsCtrl.js
@@ -180,6 +180,13 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Groups', '$http', 'A
       group.$get();
     }
 
+    // List of Ordering options for the party members list
+    $scope.partyOrderChoices = {
+      'level': 'Sort by Level',
+      'random': 'Sort randomly',
+      'pets': 'Sort by number of pets',
+    };
+
   }])
 
   .controller("GuildsCtrl", ['$scope', 'Groups', 'User', '$rootScope', '$state', '$location',

--- a/public/js/controllers/groupsCtrl.js
+++ b/public/js/controllers/groupsCtrl.js
@@ -185,6 +185,7 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Groups', '$http', 'A
       'level': 'Sort by Level',
       'random': 'Sort randomly',
       'pets': 'Sort by number of pets',
+      'party_date_joined': 'Sort by Party date joined',
     };
 
   }])

--- a/public/js/controllers/headerCtrl.js
+++ b/public/js/controllers/headerCtrl.js
@@ -3,9 +3,14 @@
 habitrpg.controller("HeaderCtrl", ['$scope', 'Groups', 'User',
   function($scope, Groups, User) {
     $scope.party = Groups.party(function(){
-      $scope.partyMinusSelf = _.filter($scope.party.members, function(member){
-        return member._id !== User.user._id;
-      });
+      $scope.partyMinusSelf = _.sortBy(
+        _.filter($scope.party.members, function(member){
+          return member._id !== User.user._id;
+        }),
+        function (member) {
+          return member.stats.lvl
+        }
+      ).reverse()
     });
   }
 ]);

--- a/public/js/controllers/headerCtrl.js
+++ b/public/js/controllers/headerCtrl.js
@@ -2,13 +2,29 @@
 
 habitrpg.controller("HeaderCtrl", ['$scope', 'Groups', 'User',
   function($scope, Groups, User) {
+
+
     $scope.party = Groups.party(function(){
       $scope.partyMinusSelf = _.sortBy(
         _.filter($scope.party.members, function(member){
           return member._id !== User.user._id;
         }),
         function (member) {
-          return member.stats.lvl
+          switch(User.user.party.order)
+          {
+              case 'level':
+                return member.stats.lvl;
+                break;
+              case 'random':
+                return Math.random();
+                break;
+              case 'pets':
+                return member.items.pets.length;
+                break;
+              default:
+                // party date joined
+                return true;
+          }
         }
       ).reverse()
     });

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -110,8 +110,7 @@ var UserSchema = new Schema({
     head: Number,
     shield: Number,
 
-    // -------------- Animals -------------------
-
+    // -------------- Animals ------------------- 
     // Complex bit here. The result looks like:
     // pets: {
     //   'Wolf-Desert': 0, // 0 means does not own
@@ -182,7 +181,8 @@ var UserSchema = new Schema({
     current: String, // party._id
     invitation: String, // party._id
     lastMessageSeen: String,
-    leader: Boolean
+    leader: Boolean,
+    order: {type:String, 'default':'level'}
   },
   preferences: {
     armorSet: String,

--- a/views/options/social/group.jade
+++ b/views/options/social/group.jade
@@ -40,6 +40,15 @@ a.pull-right.gem-wallet(popover-trigger='mouseenter', popover-title='Guild Bank'
       .modal-header
         h3 Members
       .modal-body
+        span
+          | Party Members list ordering
+        select#partyOrder(
+          style='width:140px',
+          ng-model='user.party.order',
+          ng-controller='ChatCtrl',
+          ng-options='k as v for (k , v) in partyOrderChoices',
+          ng-change='set("party.order", user.party.order)'
+          )
         table.table.table-striped(bindonce='group')
           tr(ng-repeat='member in group.members')
             td


### PR DESCRIPTION
This feature adds a select input in `Social → Party → Members`, to allow users to sort the party members by level, random, number of pets, or party date joined (the current sorting).

Need to review the design, maybe the select isn't in the right place.

Also note that I couldn't add the **partyOrderChoices** dictionary in `HeaderCtrl` (something about $scope.party.members raising an error at that moment). Maybe it would better fit in PartyCtrl though.
