### PR TITLE
change avatars lvl colors

### DIFF
--- a/public/css/index.styl
+++ b/public/css/index.styl
@@ -164,7 +164,6 @@ div.tooltip-inner {
     position absolute
     bottom 0px
     right 0px
-    background-color #dfe9ea
     padding 1px 3px 1px 3px
 
 a

--- a/views/shared/header/avatar.jade
+++ b/views/shared/header/avatar.jade
@@ -27,4 +27,5 @@ figure.herobox(ng-click='clickMember(profile._id)', data-name='{{profile.profile
     // Pet
     // FIXME handle @minimal, this might have to be a directive
     span.current-pet(class='Pet-{{profile.items.currentPet}}', ng-show='profile.items.currentPet && !minimal')
-  .avatar-level Lvl {{profile.stats.lvl}}
+  .avatar-level(class='label label-contributor-{{profile.contributor.level}}' ng-class='{"badge badge-info": {{party.leader==profile._id}}}')
+    | Lvl {{profile.stats.lvl}}


### PR DESCRIPTION
Reusing contrib colors and team leader color, so we can easily recognize users.

![avatar_color](https://f.cloud.github.com/assets/260983/1606521/5ca4ca12-5448-11e3-9b4d-bbcdd60b0f0a.png)

Related to pull request #1896
