### PR TITLE
Party members order

### DIFF
--- a/public/js/controllers/groupsCtrl.js
+++ b/public/js/controllers/groupsCtrl.js
@@ -75,7 +75,7 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Groups', '$http', 'A
       $scope.response = [];
       $scope.usernames = [];
     }
-    
+
     $scope.addNewUser = function(user) {
       if($.inArray(user.user,$scope.usernames) == -1) {
         user.username = user.user;
@@ -83,9 +83,9 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Groups', '$http', 'A
         $scope.response.push(user);
       }
     }
-    
+
     $scope.clearUserlist();
-    
+
     $scope.chatChanged = function(newvalue,oldvalue){
       if($scope.group.chat && $scope.group.chat.length > 0){
         for(var i = 0; i < $scope.group.chat.length; i++) {
@@ -93,9 +93,9 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Groups', '$http', 'A
         }
       }
     }
-    
+
     $scope.$watch('group.chat',$scope.chatChanged);
-    
+
     $scope.caretChanged = function(newCaretPos) {
       var relativeelement = $('.-options');
       var textarea = $('.chat-textarea');
@@ -112,23 +112,23 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Groups', '$http', 'A
                 });
       }
     }
-    
+
     $scope.updateTimer = false;
-    
+
     $scope.$watch(function () { return $scope.caretPos; },function(newCaretPos) {
       if($scope.updateTimer){
         $timeout.cancel($scope.updateTimer)
-      }  
+      }
       $scope.updateTimer = $timeout(function(){
         $scope.caretChanged(newCaretPos);
       },$scope.watchDelay)
     });
   }])
-  
+
   .controller('ChatCtrl', ['$scope', 'Groups', 'User', function($scope, Groups, User){
     $scope.message = {content:''};
     $scope._sending = false;
-    
+
     $scope.isUserMentioned = function(user, message) {
       if(message.hasOwnProperty("highlight"))
         return message.highlight;
@@ -171,7 +171,7 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Groups', '$http', 'A
           if(data.chat) group.chat = data.chat;
 
           var i = _.findIndex(group.chat, {id: message.id});
-          if(i !== -1) group.chat.splice(i, 1);          
+          if(i !== -1) group.chat.splice(i, 1);
         });
       }
     }
@@ -179,15 +179,6 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Groups', '$http', 'A
     $scope.sync = function(group){
       group.$get();
     }
-
-    // List of Ordering options for the party members list
-    $scope.partyOrderChoices = {
-      'level': 'Sort by Level',
-      'random': 'Sort randomly',
-      'pets': 'Sort by number of pets',
-      'party_date_joined': 'Sort by Party date joined',
-    };
-
   }])
 
   .controller("GuildsCtrl", ['$scope', 'Groups', 'User', '$rootScope', '$state', '$location',
@@ -293,7 +284,7 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Groups', '$http', 'A
 
       $scope.reject = function(){
         User.user.invitations.party = undefined;
-        User.log({op:'set',data:{'invitations.party':{}}});
+        User.log({op:'set',data:{'invitations.party':{ } }});
       }
     }
   ])
@@ -303,7 +294,7 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Groups', '$http', 'A
       $scope.group = Groups.tavern();
       $scope.rest = function(){
         User.user.flags.rest = !User.user.flags.rest;
-        User.log({op:'set',data:{'flags.rest':User.user.flags.rest}});
+        User.log({op:'set',data:{'flags.rest':User.user.flags.rest }});
       }
       $scope.toggleUserTier = function($event) {
         $($event.target).next().toggle();

--- a/public/js/controllers/headerCtrl.js
+++ b/public/js/controllers/headerCtrl.js
@@ -28,12 +28,15 @@ habitrpg.controller("HeaderCtrl", ['$scope', '$location', 'Groups', 'User',
       ).reverse()
     });
 
-      $scope.partyOrderChoices = {
-        'level': 'Sort by Level',
-        'random': 'Sort randomly',
-        'pets': 'Sort by number of pets',
-        'party_date_joined': 'Sort by Party date joined',
-      };
+    $scope.partyOrderChoices = {
+      'level': 'Sort by Level',
+      'contrib': 'Sort by Contributors level',
+      'created': 'Sort by Oldest members',
+      'lastseen': 'Sort by Last Seen',
+      'random': 'Sort randomly',
+      'pets': 'Sort by Number of pets',
+      'party_date_joined': 'Sort by Party date joined',
+    };
  
     $scope.updatePartyOrder = function () {
         User.set('party.order', $scope.user.party.order);
@@ -55,6 +58,15 @@ habitrpg.controller("HeaderCtrl", ['$scope', '$location', 'Groups', 'User',
                   case 'pets':
                     return member.items.pets.length;
                     break;
+                  case 'contrib':
+                    return member.contributor.level;
+                    break;
+                  case 'lastseen':
+                    return member.auth.timestamps.loggedin;
+                    break;
+                  case 'created':
+                    return member.auth.timestamps.created;
+                    break;
                   default:
                     // party date joined
                     return true;
@@ -62,8 +74,6 @@ habitrpg.controller("HeaderCtrl", ['$scope', '$location', 'Groups', 'User',
             }
           ).reverse()
         });
-
-
     }
   }
 ]);

--- a/public/js/controllers/headerCtrl.js
+++ b/public/js/controllers/headerCtrl.js
@@ -3,9 +3,9 @@
 habitrpg.controller("HeaderCtrl", ['$scope', 'Groups', 'User',
   function($scope, Groups, User) {
     var getParty = function() {
-      return Groups.party(function() {
+      return Groups.party(function(party) {
         $scope.partyMinusSelf = _.sortBy(
-          _.filter($scope.party.members, function(member){
+          _.filter(party.members, function(member){
             return member._id !== User.user._id;
           }),
           function (member) {
@@ -28,7 +28,7 @@ habitrpg.controller("HeaderCtrl", ['$scope', 'Groups', 'User',
         ).reverse()
       });
     }
-    $scope.party = getParty();
+    getParty();
 
     $scope.partyOrderChoices = {
       'level': 'Sort by Level',
@@ -41,7 +41,7 @@ habitrpg.controller("HeaderCtrl", ['$scope', 'Groups', 'User',
     };
     $scope.updatePartyOrder = function () {
       User.set('party.order', $scope.user.party.order);
-      $scope.party = getParty();
+      getParty();
     }
   }
 ]);

--- a/public/js/controllers/headerCtrl.js
+++ b/public/js/controllers/headerCtrl.js
@@ -1,8 +1,7 @@
 "use strict";
 
-habitrpg.controller("HeaderCtrl", ['$scope', 'Groups', 'User',
-  function($scope, Groups, User) {
-
+habitrpg.controller("HeaderCtrl", ['$scope', '$location', 'Groups', 'User',
+  function($scope, $location, Groups, User) {
 
     $scope.party = Groups.party(function(){
       $scope.partyMinusSelf = _.sortBy(
@@ -28,5 +27,43 @@ habitrpg.controller("HeaderCtrl", ['$scope', 'Groups', 'User',
         }
       ).reverse()
     });
+
+      $scope.partyOrderChoices = {
+        'level': 'Sort by Level',
+        'random': 'Sort randomly',
+        'pets': 'Sort by number of pets',
+        'party_date_joined': 'Sort by Party date joined',
+      };
+ 
+    $scope.updatePartyOrder = function () {
+        User.set('party.order', $scope.user.party.order);
+
+        $scope.party = Groups.party(function(){
+          $scope.partyMinusSelf = _.sortBy(
+            _.filter($scope.party.members, function(member){
+              return member._id !== User.user._id;
+            }),
+            function (member) {
+              switch(User.user.party.order)
+              {
+                  case 'level':
+                    return member.stats.lvl;
+                    break;
+                  case 'random':
+                    return Math.random();
+                    break;
+                  case 'pets':
+                    return member.items.pets.length;
+                    break;
+                  default:
+                    // party date joined
+                    return true;
+              }
+            }
+          ).reverse()
+        });
+
+
+    }
   }
 ]);

--- a/public/js/controllers/headerCtrl.js
+++ b/public/js/controllers/headerCtrl.js
@@ -1,32 +1,34 @@
 "use strict";
 
-habitrpg.controller("HeaderCtrl", ['$scope', '$location', 'Groups', 'User',
-  function($scope, $location, Groups, User) {
-
-    $scope.party = Groups.party(function(){
-      $scope.partyMinusSelf = _.sortBy(
-        _.filter($scope.party.members, function(member){
-          return member._id !== User.user._id;
-        }),
-        function (member) {
-          switch(User.user.party.order)
-          {
-              case 'level':
-                return member.stats.lvl;
-                break;
-              case 'random':
-                return Math.random();
-                break;
-              case 'pets':
-                return member.items.pets.length;
-                break;
-              default:
-                // party date joined
-                return true;
+habitrpg.controller("HeaderCtrl", ['$scope', 'Groups', 'User',
+  function($scope, Groups, User) {
+    var getParty = function() {
+      return Groups.party(function() {
+        $scope.partyMinusSelf = _.sortBy(
+          _.filter($scope.party.members, function(member){
+            return member._id !== User.user._id;
+          }),
+          function (member) {
+            switch(User.user.party.order)
+            {
+                case 'level':
+                  return member.stats.lvl;
+                  break;
+                case 'random':
+                  return Math.random();
+                  break;
+                case 'pets':
+                  return member.items.pets.length;
+                  break;
+                default:
+                  // party date joined
+                  return true;
+            }
           }
-        }
-      ).reverse()
-    });
+        ).reverse()
+      });
+    }
+    $scope.party = getParty();
 
     $scope.partyOrderChoices = {
       'level': 'Sort by Level',
@@ -37,43 +39,9 @@ habitrpg.controller("HeaderCtrl", ['$scope', '$location', 'Groups', 'User',
       'pets': 'Sort by Number of pets',
       'party_date_joined': 'Sort by Party date joined',
     };
- 
     $scope.updatePartyOrder = function () {
-        User.set('party.order', $scope.user.party.order);
-
-        $scope.party = Groups.party(function(){
-          $scope.partyMinusSelf = _.sortBy(
-            _.filter($scope.party.members, function(member){
-              return member._id !== User.user._id;
-            }),
-            function (member) {
-              switch(User.user.party.order)
-              {
-                  case 'level':
-                    return member.stats.lvl;
-                    break;
-                  case 'random':
-                    return Math.random();
-                    break;
-                  case 'pets':
-                    return member.items.pets.length;
-                    break;
-                  case 'contrib':
-                    return member.contributor.level;
-                    break;
-                  case 'lastseen':
-                    return member.auth.timestamps.loggedin;
-                    break;
-                  case 'created':
-                    return member.auth.timestamps.created;
-                    break;
-                  default:
-                    // party date joined
-                    return true;
-              }
-            }
-          ).reverse()
-        });
+      User.set('party.order', $scope.user.party.order);
+      $scope.party = getParty();
     }
   }
 ]);

--- a/views/options/social/group.jade
+++ b/views/options/social/group.jade
@@ -40,15 +40,6 @@ a.pull-right.gem-wallet(popover-trigger='mouseenter', popover-title='Guild Bank'
       .modal-header
         h3 Members
       .modal-body
-        span
-          | Party Members list ordering
-        select#partyOrder(
-          style='width:140px',
-          ng-model='user.party.order',
-          ng-controller='ChatCtrl',
-          ng-options='k as v for (k , v) in partyOrderChoices',
-          ng-change='set("party.order", user.party.order)'
-          )
         table.table.table-striped(bindonce='group')
           tr(ng-repeat='member in group.members')
             td

--- a/views/shared/header/menu.jade
+++ b/views/shared/header/menu.jade
@@ -1,4 +1,12 @@
 .user-menu(ng-controller='AuthCtrl')
+  select#partyOrder(
+    style='width:90px',
+    ng-model='user.party.order',
+    ng-controller='HeaderCtrl',
+    ng-options='k as v for (k , v) in partyOrderChoices',
+    ng-change='updatePartyOrder()'
+    )
+
   button.task-action-btn.tile.solid(ng-hide='authenticated()', style='cursor: pointer;', ng-click="modals.login = true") Login / Register
   ul.nav.site-nav(ng-show='authenticated()')
     li.flyout


### PR DESCRIPTION
This pull request moves the **party members order** selection from party->members to the header (there was a bug with the select being visible in all guilds pages, and add a few more ordering options.

**Warning:** Do not merge this pull request until fixes are done:
- Fix design "sort by" select in header menu:
  
  ![menu](https://f.cloud.github.com/assets/260983/1607988/9c2783c6-54bd-11e3-8ec2-d1642cb96434.png)
  
  Maybe replace text by icons ?
- Add a new **headerService** that will allow the divs **ng-repeat="profile in partyMinusSelf"** to reupdate themselves when the select option is selected.

I spent several hours trying to figure out how to autoupdate the header, but my AngularJS knowledge is too weak, and I can't dive more into it. Please have a guru take care of it :) ( @lefnire ?)
I'm no good with css and design either, hopefully someone can do this properly ( @zakkain ?)
