### PR TITLE
Place link to Markdown help prominently in Tavern chat (fix #1906)

### DIFF
--- a/locales/en/app.json
+++ b/locales/en/app.json
@@ -47,7 +47,7 @@
   "reward1" : "1 Episode of Game of Thrones",
     "reward1comment": "-- Rewards: Treat Yourself! -- As you complete goals, you earn gold to buy rewards. Buy them liberally - rewards are integral in forming good habits.",
   "reward2" : "Cake",
-    "reward2comment" : "But only buy if you have enough gold - you lose HP otherwise.",
+    "reward2comment" : "But only buy if you have enough gold!",
 
 "_commentdefaulttags" : "DEFAULT TAGS",
   "morning" : "morning",
@@ -104,7 +104,7 @@
       "S": "S",
   "todos": "To-Dos",
   "Todos": "To-Dos",
-    "newTodo": "New Todo",
+    "newTodo": "New To-Do",
     "dueDate": "Due Date",
     "remaining": "Remaining",
     "complete": "Complete",
@@ -124,7 +124,7 @@
   "dropsEnabled" : "Drops Enabled!",
     "dropsEnabledText1" : "You've unlocked the Drop System! Now when you complete tasks, you have a small chance of finding an item. And guess what, you just found a",
     "dropsEnabledText2" : "egg",
-  "itemDropped" : "An items has dropped",
+  "itemDropped" : "An item has dropped",
 
 
 

--- a/views/options/inventory/inventory.jade
+++ b/views/options/inventory/inventory.jade
@@ -7,7 +7,7 @@ script(type='text/ng-template', id='partials/options.inventory.inventory.html')
 
         li.customize-menu
           menu.pets-menu(label='Eggs ({{eggCount}})')
-            p(ng-show='eggCount < 1') You don't have any eggs yet.
+            p(ng-show='eggCount < 1') You don't have any eggs.
             div(ng-repeat='(egg,points) in ownedItems(user.items.eggs)')
               //TODO move positioning this styling to css
               button.customize-option(popover='{{Items.eggs[egg].notes}}', popover-title='{{Items.eggs[egg].text}} Egg', popover-trigger='mouseenter', popover-placement='right', ng-click='chooseEgg(egg)', class='Pet_Egg_{{egg}}', ng-class='{selectableInventory: selectedPotion && !user.items.pets[egg+"-"+selectedPotion.name]}')
@@ -16,7 +16,7 @@ script(type='text/ng-template', id='partials/options.inventory.inventory.html')
 
         li.customize-menu
           menu.hatchingPotion-menu(label='Hatching Potions ({{potCount}})')
-            p(ng-show='potCount < 1') You don't have any hatching potions yet.
+            p(ng-show='potCount < 1') You don't have any hatching potions.
             div(ng-repeat='(pot,points) in ownedItems(user.items.hatchingPotions)')
               button.customize-option(popover='{{Items.hatchingPotions[pot].notes}}', popover-title='{{Items.hatchingPotions[pot].text}} Potion', popover-trigger='mouseenter', popover-placement='right', ng-click='choosePotion(pot)', class='Pet_HatchingPotion_{{pot}}', ng-class='{selectableInventory: selectedEgg && !user.items.pets[selectedEgg.name+"-"+pot]}')
                 .badge.badge-info.stack-count {{points}}
@@ -24,7 +24,7 @@ script(type='text/ng-template', id='partials/options.inventory.inventory.html')
 
         //-li.customize-menu
           menu.pets-menu(label='Food ({{foodCount}})')
-            p(ng-show='foodCount < 1') You don't have any food yet.
+            p(ng-show='foodCount < 1') You don't have any food.
             div(ng-repeat='(food,points) in ownedItems(user.items.food)')
               button.customize-option(popover='{{Items.food[food].notes}}', popover-title='{{Items.food[food].text}}', popover-trigger='mouseenter', popover-placement='right', ng-click='chooseFood(food)', class='Pet_Food_{{food}}')
                 .badge.badge-info.stack-count {{points}}

--- a/views/options/social/group.jade
+++ b/views/options/social/group.jade
@@ -19,8 +19,8 @@ a.pull-right.gem-wallet(popover-trigger='mouseenter', popover-title='Guild Bank'
             label.control-label Group Name
             input.option-content(type='text', ng-model='group.name', placeholder='Group Name')
           .control-group.option-large
-            label.control-label Description (Markdown OK)
-            textarea.option-content(style='height:15em;', placeholder='Description', ng-model='group.description')
+            label.control-label Description
+            textarea.option-content(style='height:15em;', placeholder='Description shown in public Guilds list (Markdown OK)', ng-model='group.description')
           .control-group.option-large
             label.control-label Logo URL
             input.option-content(type='url', placeholder='Logo URL', ng-model='group.logo')

--- a/views/options/social/group.jade
+++ b/views/options/social/group.jade
@@ -19,9 +19,8 @@ a.pull-right.gem-wallet(popover-trigger='mouseenter', popover-title='Guild Bank'
             label.control-label Group Name
             input.option-content(type='text', ng-model='group.name', placeholder='Group Name')
           .control-group.option-large
-            label.control-label Description
+            label.control-label Description (Markdown OK)
             textarea.option-content(style='height:15em;', placeholder='Description', ng-model='group.description')
-            include ../../shared/formatting-help
           .control-group.option-large
             label.control-label Logo URL
             input.option-content(type='url', placeholder='Logo URL', ng-model='group.logo')
@@ -87,8 +86,7 @@ a.pull-right.gem-wallet(popover-trigger='mouseenter', popover-title='Guild Bank'
   .span8
     div.blah-options(ng-show='group._editing')
       .option-large
-        textarea.option-content(style='height:15em;', placeholder='Message from group leader', ng-model='group.leaderMessage')
-        include ../../shared/formatting-help
+        textarea.option-content(style='height:15em;', placeholder='Message from group leader (Markdown OK)', ng-model='group.leaderMessage')
     table(ng-show='group.leaderMessage')
       tr
         td
@@ -100,6 +98,7 @@ a.pull-right.gem-wallet(popover-trigger='mouseenter', popover-title='Guild Bank'
     div(ng-controller='ChatCtrl')
       h3 Chat
       include ./chat-box
+      include ../../shared/formatting-help
 
       ul.unstyled.tavern-chat
         include ./chat-message

--- a/views/options/social/tavern.jade
+++ b/views/options/social/tavern.jade
@@ -104,7 +104,9 @@
   .span8(ng-controller='ChatCtrl')
     h3 Tavern Talk
       include ./chat-box
-      small.alert.alert-info.
-        Note: if you're reporting a bug, the developers won't see it here. <a href='http://community.habitrpg.com/node/280' target='_blank'>Follow these instructions</a> instead.
+      small
+        include ../../shared/formatting-help
+        alert.alert-info.
+          Note: if you're reporting a bug, the developers won't see it here. <a href='http://community.habitrpg.com/node/280' target='_blank'>Follow these instructions</a> instead.
     ul.unstyled.tavern-chat
       include ./chat-message

--- a/views/options/social/tavern.jade
+++ b/views/options/social/tavern.jade
@@ -59,10 +59,10 @@
               a.label.label-contributor-1(ng-click='toggleUserTier($event)') Friend (1-2)
               div(style='display:none;')
                 p.
-                  <span class='achievement achievement-firefox'></span> When your <strong>first</strong> submission is deployed, you will receive the HabitRPG Contributor's badge. Your name in Tavern chat will proudly display that you are a contributor.
+                  <span class='achievement achievement-firefox'></span> When your <strong>first</strong> submission is deployed, you will receive the HabitRPG Contributor's badge. Your name in Tavern chat will proudly display that you are a contributor. As a bounty for your work, you will also receive <strong>2 Gems</strong>.
                 hr
                 p.
-                  <span class='shop_armor_7 shop-sprite item-img'></span> When your <strong>second</strong> submission is deployed, the <strong>Crystal Armor</strong> will be available for purchase in the Rewards shop after the Golden Armor. As a bounty for your great work, you will also receive <strong>2 Gems</strong>.
+                  <span class='shop_armor_7 shop-sprite item-img'></span> When your <strong>second</strong> submission is deployed, the <strong>Crystal Armor</strong> will be available for purchase in the Rewards shop after the Golden Armor. As a bounty for your continued work, you will also receive <strong>2 Gems</strong>.
           tr
             td
               a.label.label-contributor-3(ng-click='toggleUserTier($event)') Elite (3-4)
@@ -71,23 +71,23 @@
                  <span class='shop_head_7 shop-sprite item-img'></span> When your <strong>third</strong> submission is deployed, the <strong>Crystal Helmet</strong> will be available for purchase in the Rewards shop after the Golden Helmet. As a bounty for your great work, you will also receive <strong>2 Gems</strong>.
                 hr
                 p.
-                  <span class='shop_weapon_8 shop-sprite item-img'></span> When your <strong>fourth</strong> submission is deployed, the <strong>Crystal Sword</strong> will be available for purchase in the Rewards shop after the Golden Sword. As a bounty for your great work, you will also receive <strong>2 Gems</strong>.
+                  <span class='shop_weapon_8 shop-sprite item-img'></span> When your <strong>fourth</strong> submission is deployed, the <strong>Crystal Sword</strong> will be available for purchase in the Rewards shop after the Golden Sword. You will once again receive a bounty of <strong>2 Gems</strong>.
 
           tr
             td
               a.label.label-contributor-5(ng-click='toggleUserTier($event)') Champion (5-6)
               div(style='display:none;')
                 p.
-                  <span class='shop_shield_7 shop-sprite item-img'></span> When your <em>fifth</em> submission is deployed, the <strong>Crystal Shield</strong> will be available for purchase in the Reward shop after the Golden Shield. As a bounty for your great work, you will also receive <strong>2 Gems</strong>.
+                  <span class='shop_shield_7 shop-sprite item-img'></span> When your <em>fifth</em> submission is deployed, the <strong>Crystal Shield</strong> will be available for purchase in the Reward shop after the Golden Shield. You will also receive <strong>2 Gems</strong>.
                 hr
                 p.
-                 <div class='Pet-Dragon-Hydra pull-left'></div> When your <em>sixth</em> submission is deployed, you will receive a <strong>Hydra Pet</strong>. As a bounty for your great work, you will also receive <strong>2 Gems</strong>.
+                 <div class='Pet-Dragon-Hydra pull-left'></div> When your <em>sixth</em> submission is deployed, you will receive a <strong>Hydra Pet</strong>. You will also receive <strong>2 Gems</strong>.
           tr
             td
               a.label.label-contributor-7(ng-click='toggleUserTier($event)') Legendary (7)
               div(style='display:none;')
                 p.
-                  When your <em>seventh</em> submission is deployed, you will receive <strong>2 Gems</strong> and become a member of the honored Contributor's Guild and be privy to the behind-the-scenes details of HabitRPG!
+                  When your <em>seventh</em> submission is deployed, you will receive <strong>2 Gems</strong> and become a member of the honored Contributor's Guild and be privy to the behind-the-scenes details of HabitRPG! Further contributions do not increase your level, but you may continue to earn Gem bounties and titles.
           tr
             td
               a.label.label-contributor-8(ng-click='toggleUserTier($event)') Heroic

--- a/views/shared/formatting-help.jade
+++ b/views/shared/formatting-help.jade
@@ -1,2 +1,2 @@
 small
-  a(target='_blank', href='http://daringfireball.net/projects/markdown/') Use Markdown form formatting
+  a(target='_blank', href='http://habitrpg.wikia.com/wiki/Markdown_Cheat_Sheet') Markdown formatting allowed


### PR DESCRIPTION
Added the Markdown help link beneath all chatboxes. This caused an awkward repetition of the link when editing groups, so I stripped the links there and simply clarified in the prompts that Markdown is OK in those fields.
