### PR TITLE
Tweaks from Sabe

### DIFF
--- a/locales/en/app.json
+++ b/locales/en/app.json
@@ -302,7 +302,7 @@
   "_commentitemsother" : "OTHER ITEMS",
     "healthPotionName" : "Health Potion",
       "healthPotionNotes" : "Recover 15 HP Instantly",
-    "rerollName" : "Re-Roll",
+    "rerollName" : "Fortify",
       "rerollNotes" : "Resets your task values back to yellow. Useful when everything's red and it's hard to stay alive.",
       "rerollModelHeader" : "Reset Your Tasks",
       "rerollModelText1" : "Highly discouraged because red tasks provide good incentive to improve",

--- a/public/js/controllers/inventoryCtrl.js
+++ b/public/js/controllers/inventoryCtrl.js
@@ -55,21 +55,29 @@ habitrpg.controller("InventoryCtrl", ['$rootScope', '$scope', 'User', 'API_URL',
           'items.eggs': user.items.eggs,
           'stats.gp': User.user.stats.gp + $scope.selectedEgg.value
         });
-        $scope.selectedEgg = null;
+        if (user.items.eggs[$scope.selectedEgg.name] < 1) {
+            $scope.selectedEgg = null;
+        }
+
       } else if ($scope.selectedPotion) {
         user.items.hatchingPotions[$scope.selectedPotion.name]--;
         User.setMultiple({
           'items.hatchingPotions': user.items.hatchingPotions,
           'stats.gp': User.user.stats.gp + $scope.selectedPotion.value
         });
-        $scope.selectedPotion = null;
+        if (user.items.hatchingPotions[$scope.selectedPotion.name] < 1) {
+            $scope.selectedPotion = null;
+        }
+
       } else if ($scope.selectedFood) {
         user.items.food[$scope.selectedFood.name]--;
         User.setMultiple({
           'items.food': user.items.food,
           'stats.gp': User.user.stats.gp + $scope.selectedFood.value
         });
-        $scope.selectedFood = null;
+        if (user.items.food[$scope.selectedFood.name] < 1) {
+            $scope.selectedFood = null;
+        }
       }
 
     }
@@ -81,7 +89,7 @@ habitrpg.controller("InventoryCtrl", ['$rootScope', '$scope', 'User', 'API_URL',
     $scope.hatch = function(egg, potion){
       var pet = egg.name+"-"+potion.name;
       if (user.items.pets[pet])
-        return alert("You already have that pet, hatch a different combo.");
+        return alert("You already have that pet. Try hatching a different combination!");
 
       var setObj = {};
       setObj['items.pets.' + pet] = 5;

--- a/public/js/controllers/tasksCtrl.js
+++ b/public/js/controllers/tasksCtrl.js
@@ -110,7 +110,7 @@ habitrpg.controller("TasksCtrl", ['$scope', '$rootScope', '$location', 'User', '
       /* Figure out whether we wanna put this in habitrpg-shared
        */
 
-      sorted = [updated.weapon, updated.armor, updated.head, updated.shield, updated.potion, updated.reroll];
+      sorted = [updated.weapon, updated.armor, updated.head, updated.shield, updated.potion];
       $scope.itemStore = sorted;
     }
 

--- a/views/options/inventory/inventory.jade
+++ b/views/options/inventory/inventory.jade
@@ -80,7 +80,7 @@ script(type='text/ng-template', id='partials/options.inventory.inventory.html')
           li.customize-menu
             menu.pets-menu(label='Services')
               div
-                button.btn(popover='Return all tasks to neutral value (yellow color).', popover-title=env.t('rerollName'), popover-trigger='mouseenter', popover-placement='left', ng-click='modals.reroll = true') Fortify
-              div
-                | 4
-                span.Pet_Currency_Gem1x.inline-gems
+                // Once grunt-spritesmith is merged, let's use https://github.com/browserquest/BrowserQuest/blob/master/client/img/1/item-firepotion.png
+                button.btn(popover='Return all tasks to neutral value (yellow color).', popover-title=env.t('rerollName'), popover-trigger='mouseenter', popover-placement='left', ng-click='modals.reroll = true')
+                  | Fortify 4
+                  span.Pet_Currency_Gem1x.inline-gems

--- a/views/options/inventory/inventory.jade
+++ b/views/options/inventory/inventory.jade
@@ -44,7 +44,7 @@ script(type='text/ng-template', id='partials/options.inventory.inventory.html')
                   a(target='_blank', href='http://www.kickstarter.com/profile/523661924') Alexander the Merchant
                 .popover-content
                   p
-                    | Welcome to the Market. Dying to get that particular pet you're after, but don't want to wait for it to drop? Buy it here! If you have unwanted drops, sell them to me.
+                    | Welcome to the Market! Buy hard-to-find eggs and potions! Sell your extras! Commission useful services! Come see what we have to offer.
                   p
                     button.btn.btn-primary(ng-show='selectedEgg', ng-click='sellInventory()')
                       | Sell {{selectedEgg.name}} for {{selectedEgg.value}} Gold
@@ -77,6 +77,10 @@ script(type='text/ng-template', id='partials/options.inventory.inventory.html')
                 p
                   |  {{food.value}}
                   span.Pet_Currency_Gem1x.inline-gems
-
-
-
+          li.customize-menu
+            menu.pets-menu(label='Services')
+              div
+                button.btn(popover='Return all tasks to neutral value (yellow color).', popover-title=env.t('rerollName'), popover-trigger='mouseenter', popover-placement='left', ng-click='modals.reroll = true') Fortify
+              div
+                | 4
+                span.Pet_Currency_Gem1x.inline-gems

--- a/views/options/settings.jade
+++ b/views/options/settings.jade
@@ -30,10 +30,11 @@ script(type='text/ng-template', id='partials/options.settings.settings.html')
       select(ng-model='language.code', ng-options='lang.code as lang.name for lang in avalaibleLanguages', ng-change='changeLanguage()')
       hr
       h4 Misc
-      button.btn(ng-hide='user.preferences.hideHeader', ng-click='set("preferences.hideHeader",true)') Hide Header
-      button.btn(ng-show='user.preferences.hideHeader', ng-click='set("preferences.hideHeader",false)') Show Header
-      button.btn(ng-click='showTour()') Show Tour
-      button.btn(ng-click='showBailey()') Show Bailey
+      button.btn(ng-hide='user.preferences.hideHeader', ng-click='set("preferences.hideHeader",true)', popover-trigger='mouseenter', popover-placement='right', popover='Hide your avatar, Health/Experience bars, and party.') Hide Header
+      button.btn(ng-show='user.preferences.hideHeader', ng-click='set("preferences.hideHeader",false)', popover-trigger='mouseenter', popover='Display your avatar, Health/Experience bars, and party.') Show Header
+      button.btn(ng-click='showTour()', popover-trigger='mouseenter', popover='Restart the introductory tour from when you first joined HabitRPG.') Show Tour
+      button.btn(ng-click='showBailey()', popover-trigger='mouseenter', popover='Bring Bailey the Town Crier out of hiding so you can review past news.') Show Bailey
+      button.btn(ng-click='modals.restore = true', popover-trigger='mouseenter', popover='Manually change values like Health, Level, and Gold.') Fix Character Values
 
       div(ng-show='user.auth.local')
         hr
@@ -49,9 +50,8 @@ script(type='text/ng-template', id='partials/options.settings.settings.html')
 
       hr
       h4 Danger Zone
-      a.btn.btn-danger(ng-click='modals.reset = true', tooltip='Resets your entire account (dangerous).') Reset
-      a.btn.btn-danger(ng-click='modals.restore = true', tooltip='Restores attributes to your character.') Restore
-      a.btn.btn-danger(ng-click='modals.delete = true', tooltip='Delete your account.') Delete
+      a.btn.btn-danger(ng-click='modals.reset = true', popover-trigger='mouseenter', popover-placement='right', popover='Start over, removing all levels, gold, gear, history, and tasks.') Reset Account
+      a.btn.btn-danger(ng-click='modals.delete = true', popover-trigger='mouseenter', popover='Cancel and remove your HabitRPG account.') Delete Account
 
 script(type='text/ng-template', id='partials/options.settings.api.html')
   .row.fluid

--- a/views/options/social/tavern.jade
+++ b/views/options/social/tavern.jade
@@ -27,7 +27,7 @@
         table.table.table-striped
           tr
             td
-              a(target='_blank', href='http://community.habitrpg.com/forums/lfg') LFG Posts
+              a(target='_blank', href='http://community.habitrpg.com/forums/lfg') Looking for Group (Party Wanted) Posts
           tr
             td
               a(target='_blank', href='http://www.youtube.com/watch?feature=player_embedded&v=cT5ghzZFfao') Tutorial

--- a/views/shared/gems.jade
+++ b/views/shared/gems.jade
@@ -1,4 +1,4 @@
-a.pull-right.gem-wallet(ng-click='modals.buyGems = true', popover-trigger='mouseenter', popover-title='Gems', popover="Used for buying special items (reroll, eggs, hatching potions, etc). You'll need to unlock those features before being able to use Gems.", popover-placement='bottom')
+a.pull-right.gem-wallet(ng-click='modals.buyGems = true', popover-trigger='mouseenter', popover-title='Gems', popover="Used for buying special items and services (eggs, hatching potions, Fortify, etc.). You'll need to unlock those features before being able to use Gems.", popover-placement='bottom')
   span.task-action-btn.tile.flush.bright.add-gems-btn ＋
   span.task-action-btn.tile.flush.neutral
     .Gems

--- a/views/shared/modals/reroll.jade
+++ b/views/shared/modals/reroll.jade
@@ -1,12 +1,12 @@
 // Re-Roll modal
 div(modal='modals.reroll')
   .modal-header
-    h3 Reset Your Tasks
+    h3 Fortify: Back to Yellow
   .modal-body
     include ../gems
     p.
-      Purchasing a Re-Roll will reset all your tasks to a neutral (yellow) state, as if you'd just added them. Consider
-      this an option of last resort, red tasks provide good incentive to improve. But if all that red fills you with
+      Fortify will return all your tasks to a neutral (yellow) state, as if you'd just added them. Consider
+      this an option of last resort! Red tasks provide good incentive to improve. But if all that red fills you with
       despair, and the beginning of each new day proves lethal, spend the Gems and catch a reprieve!
 
   .modal-footer
@@ -14,6 +14,6 @@ div(modal='modals.reroll')
       a.btn.btn-success.btn-large(ng-click="modals.buyGems = true") Buy More Gems
       span.gem-cost Not enough Gems
     span(ng-if='user.balance >= 1', ng-controller='SettingsCtrl')
-      a.btn.btn-danger.btn-large(ng-click='reroll()') Re-Roll
+      a.btn.btn-danger.btn-large(ng-click='reroll()') Fortify
       span.gem-cost 4 Gems
 

--- a/views/shared/modals/settings.jade
+++ b/views/shared/modals/settings.jade
@@ -1,35 +1,37 @@
 div(ng-controller='SettingsCtrl')
   div(modal='modals.reset')
     .modal-header
-      h3 Reset
+      h3 Reset Account
     .modal-body
       p This resets your entire account - your tasks will be deleted and your character will start over.
-      p This is highly discouraged because you'll lose historical data, which is useful for graphing your progress over time. However, some people find it useful in the beginning after playing with the app for a while.
+      p.
+        This is highly discouraged because you'll lose historical data, which is useful for graphing your progress over time. However, some people find it useful in the beginning after playing with the app for a while.
     .modal-footer
-      button.btn.btn-default.cancel(ng-click='modals.reset = false') Close
-      button.btn.btn-danger(data-dismiss='modal', ng-click='reset()') Reset
+      button.btn.btn-default.cancel(ng-click='modals.reset = false') Never mind
+      button.btn.btn-danger(data-dismiss='modal', ng-click='reset()') Do it, reset my account!
 
   div(modal='modals.restore')
     .modal-header
-      h3 Restore
+      h3 Fix Values
     .modal-body
-      p HabitRPG is quite Beta-quality at present, and many find they need to restore character attributes as a result. Enter your numbers here and it will be applied automatically to your character. This will be removed once Habit is more stable.
+      p If you've encountered a bug or made a mistake that unfairly changed your character (damage you shouldn't have taken, Gold you didn't really earn, etc.), you can manually correct your numbers here. Yes, this makes it possible to cheat: use this feature wisely, or you'll sabotage your own habit-building!
+      p Note that you cannot restore Streaks on individual tasks here. To do that, edit the Daily and go to Advanced Options, where you will find a Restore Streak field.
       div.restore-options
         form#restore-form.form-horizontal
           h3 Stats
           .option-group.option-medium
             input.option-content(type='number', step="any", data-for='stats.hp', ng-model='restoreValues.stats.hp')
-            span.input-suffix HP
+            span.input-suffix Health
           .option-group.option-medium
             input.option-content(type='number', step="any", data-for='stats.exp', ng-model='restoreValues.stats.exp')
-            span.input-suffix Exp
+            span.input-suffix Experience
           .option-group.option-medium
             input.option-content(type='number', step="any", data-for='stats.gp', ng-model='restoreValues.stats.gp')
-            span.input-suffix GP
+            span.input-suffix Gold
           .option-group.option-medium
             input.option-content(type='number', data-for='stats.lvl', ng-model='restoreValues.stats.lvl')
             span.input-suffix Level
-          h3 Items
+          h3 Equipment
           .option-group.option-medium
             input.option-content(type='number', data-for='items.weapon', ng-model='restoreValues.items.weapon')
             span.input-suffix Weapon
@@ -42,14 +44,15 @@ div(ng-controller='SettingsCtrl')
           .option-group.option-medium
             input.option-content(type='number', data-for='items.shield', ng-model='restoreValues.items.shield')
             span.input-suffix Shield
-          h3 Streak Achievements
+          h3 Achievements
           .option-group.option-medium
             input.option-content(type='number', data-for='achievements.streak', ng-model='restoreValues.achievements.streak')
-            span.input-suffix 21-Day Streak
+            span.input-suffix 21-Day Streaks
         //- This is causing too many problems for users
           h3 Other
           a.btn.btn-small.btn-warning(ng-controller='FooterCtrl', ng-click='addMissedDay()') Trigger New Day
     .modal-footer
+      button.btn.btn-default.cancel(ng-click='modals.restore = false') Discard Changes
       button.btn.btn-primary(ng-click='restore()') Save & Close
 
   div(modal='modals.delete')
@@ -57,9 +60,9 @@ div(ng-controller='SettingsCtrl')
       h3 Delete Account
     .modal-body
       p.
-        Woa woa woa! Are you sure? This will seriously delete your account forever, and it can never be restored. If you're absolutely certain, type <strong>DELETE</strong> into the text-box below.
+        Are you sure? This will delete your account forever, and it can never be restored! You will need to register a new account to use HabitRPG again. Banked or spent Gems will not be refunded. If you're absolutely certain, type <strong>DELETE</strong> into the text box below.
       p
         input(type='text', ng-model='_deleteAccount')
     .modal-footer
-      button.btn.btn-default(ng-click='modals.delete = false') Cancel
-      button.btn.btn-danger.btn-small(ng-disabled='_deleteAccount != "DELETE"', ng-click='delete()') Delete Account
+      button.btn.btn-default(ng-click='modals.delete = false') Never mind
+      button.btn.btn-danger.btn-small(ng-disabled='_deleteAccount != "DELETE"', ng-click='delete()') Do it, delete my account!

--- a/views/shared/tasks/task.jade
+++ b/views/shared/tasks/task.jade
@@ -157,10 +157,10 @@ li(bindonce='list', ng-repeat='task in obj[list.type+"s"]', class='task {{taskCl
             button.task-action-btn.tile(type='button', ng-class='{active: task.priority=="!!"}', ng-click='task.challenge.id || (task.priority="!!")') Medium
             button.task-action-btn.tile(type='button', ng-class='{active: task.priority=="!!!"}', ng-click='task.challenge.id || (task.priority="!!!")') Hard
           //span(ng-if='task.type=="daily" && !task.challenge.id')
-          p
-            span(ng-if='task.type=="daily"')
-              legend.option-title Restore Streak
-              input.option-content(type='number', ng-model='task.streak')
+          br
+          span(ng-if='task.type=="daily"')
+            legend.option-title Restore Streak
+            input.option-content(type='number', ng-model='task.streak')
       button.task-action-btn.tile.spacious(type='submit') Save & Close
 
   div(class='{{obj._id}}{{task.id}}-chart', ng-show='charts[obj._id+task.id]')

--- a/views/shared/tasks/task.jade
+++ b/views/shared/tasks/task.jade
@@ -157,9 +157,10 @@ li(bindonce='list', ng-repeat='task in obj[list.type+"s"]', class='task {{taskCl
             button.task-action-btn.tile(type='button', ng-class='{active: task.priority=="!!"}', ng-click='task.challenge.id || (task.priority="!!")') Medium
             button.task-action-btn.tile(type='button', ng-class='{active: task.priority=="!!!"}', ng-click='task.challenge.id || (task.priority="!!!")') Hard
           //span(ng-if='task.type=="daily" && !task.challenge.id')
-          span(ng-if='task.type=="daily"')
-            legend.option-title Restore Streak
-            input.option-content(type='number', ng-model='task.streak')
+          p
+            span(ng-if='task.type=="daily"')
+              legend.option-title Restore Streak
+              input.option-content(type='number', ng-model='task.streak')
       button.task-action-btn.tile.spacious(type='submit') Save & Close
 
   div(class='{{obj._id}}{{task.id}}-chart', ng-show='charts[obj._id+task.id]')


### PR DESCRIPTION
#1909. User can now keep clicking to their heart's content to sell piles of excess eggs/potions (/food, later). Deselect only occurs once the stack runs out.

Also prettified the alert wording when you fail at egg-hatching.
#1938. Changes "Re-Roll" to "Fortify" and creates a button in Alexander's shop for it to live instead of in the Rewards pane.
#1934. Renames and rearranges the "Reset", "Restore", and "Delete" buttons in Settings for better usability.
