### PR TITLE
new knight player tier added

### DIFF
--- a/public/css/game-pane.styl
+++ b/public/css/game-pane.styl
@@ -84,6 +84,9 @@
   background-color: #7313B4
   color: white
 .label-contributor-8
+  background-color: #cccc00
+  color: white
+.label-contributor-9
   background-color: #ff8000
   color: white
 .label-npc

--- a/views/options/social/tavern.jade
+++ b/views/options/social/tavern.jade
@@ -94,7 +94,7 @@
               div(style='display:none;')
                 p.
                   When your <em>tenth</em> submission is deployed, you will
-                  receive <strong>2 Gems</strong>, and a unique weapon designed
+                  receive <strong>2 Gems</strong>, and a unique gear designed
                   by yourself (or by a volunteer) for you.
           tr
             td

--- a/views/options/social/tavern.jade
+++ b/views/options/social/tavern.jade
@@ -84,13 +84,21 @@
                  <div class='Pet-Dragon-Hydra pull-left'></div> When your <em>sixth</em> submission is deployed, you will receive a <strong>Hydra Pet</strong>. You will also receive <strong>2 Gems</strong>.
           tr
             td
-              a.label.label-contributor-7(ng-click='toggleUserTier($event)') Legendary (7)
+              a.label.label-contributor-7(ng-click='toggleUserTier($event)') Legendary (7-9)
               div(style='display:none;')
                 p.
                   When your <em>seventh</em> submission is deployed, you will receive <strong>2 Gems</strong> and become a member of the honored Contributor's Guild and be privy to the behind-the-scenes details of HabitRPG! Further contributions do not increase your level, but you may continue to earn Gem bounties and titles.
           tr
             td
-              a.label.label-contributor-8(ng-click='toggleUserTier($event)') Heroic
+              a.label.label-contributor-8(ng-click='toggleUserTier($event)') Knight (10+)
+              div(style='display:none;')
+                p.
+                  When your <em>tenth</em> submission is deployed, you will
+                  receive <strong>2 Gems</strong>, and a unique weapon designed
+                  by yourself (or by a volunteer) for you.
+          tr
+            td
+              a.label.label-contributor-9(ng-click='toggleUserTier($event)') Heroic
               div(style='display:none;')
                 p The Heroic level contains HabitRPG staff and staff-level contributors. If you have this title, you were appointed to it (or hired!).
           tr


### PR DESCRIPTION
Right now, only NPC can have custom gears, but it wouldn't cost habitrpg much efforts to give custom gears to some contributors (especially if they design their own custom gear).

![new player tier](http://i.imgur.com/0n7bBsw.png)
