### PR TITLE
Fixed Windows & UNIX path separators

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Before starting make sure to have [MongoDB](http://www.mongodb.org/), [NodeJS an
 1. Create a config file from the example one:
 `cp config.json.example config.json`
 1. Ensure that Mongo is running and seed the database with initial settings by running: 
-`node .\src\seed.js`.
+`node ./src/seed.js`.
 
 ##  Windows Environment Install
 
@@ -78,7 +78,7 @@ Ignore this error and proceed with the following:
 `copy config.json.example config.json`
 1. Ensure that Mongo is running and seed the database with initial settings by r
 unning:
-`node ./src/seed.js`.
+`node .\src\seed.js`.
 
 # Run HabitRPG
 


### PR DESCRIPTION
Windows: node .\src\seed.js
UNIX: node ./src/seed.js

The readme had it backwards.
