### PR TITLE
Add explicit cancel button to Fortify modal

### DIFF
--- a/views/shared/modals/reroll.jade
+++ b/views/shared/modals/reroll.jade
@@ -10,6 +10,7 @@ div(modal='modals.reroll')
       despair, and the beginning of each new day proves lethal, spend the Gems and catch a reprieve!
 
   .modal-footer
+    button.btn.btn-large.cancel(ng-click='modals.reroll = false') Never mind
     span(ng-if='user.balance < 1')
       a.btn.btn-success.btn-large(ng-click="modals.buyGems = true") Buy More Gems
       span.gem-cost Not enough Gems


### PR DESCRIPTION
Yay, local repo working again... provide a "never mind" button for Fortify in case a user doesn't think to tap outside the modal.
