### PR TITLE
Add mention of Health refill to Fortify

### DIFF
--- a/views/options/inventory/inventory.jade
+++ b/views/options/inventory/inventory.jade
@@ -105,6 +105,6 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
             menu.pets-menu(label='Services')
               div
                 // Once grunt-spritesmith is merged, let's use https://github.com/browserquest/BrowserQuest/blob/master/client/img/1/item-firepotion.png
-                button.btn(popover='Return all tasks to neutral value (yellow color).', popover-title=env.t('rerollName'), popover-trigger='mouseenter', popover-placement='left', ng-click='modals.reroll = true')
+                button.btn(popover='Return all tasks to neutral value (yellow color), and restore all lost Health.', popover-title=env.t('rerollName'), popover-trigger='mouseenter', popover-placement='left', ng-click='modals.reroll = true')
                   | Fortify 4
                   span.Pet_Currency_Gem1x.inline-gems

--- a/views/shared/modals/reroll.jade
+++ b/views/shared/modals/reroll.jade
@@ -5,9 +5,9 @@ div(modal='modals.reroll')
   .modal-body
     include ../gems
     p.
-      Fortify will return all your tasks to a neutral (yellow) state, as if you'd just added them. Consider
-      this an option of last resort! Red tasks provide good incentive to improve. But if all that red fills you with
-      despair, and the beginning of each new day proves lethal, spend the Gems and catch a reprieve!
+      Fortify will return all your tasks to a neutral (yellow) state, as if you'd just added them, and top your Health
+      off to full. Consider this an option of last resort! Red tasks provide good incentive to improve. But if all that
+      red fills you with despair, and the beginning of each new day proves lethal, spend the Gems and catch a reprieve!
 
   .modal-footer
     button.btn.btn-large.cancel(ng-click='modals.reroll = false') Never mind


### PR DESCRIPTION
I was surprised to find, when the other day I decided to purchase a Fortify (fka Re-Roll), that it filled me up to 50 Health. By a look at the code, this is absolutely intentional, so I thought it would make sense to include that feature in the description of the service.
