### PR TITLE
Fix #399 (fussy popover target)

### DIFF
--- a/public/css/tasks.styl
+++ b/public/css/tasks.styl
@@ -119,6 +119,11 @@ for $stage in $stages
   line-height: 1.4
   word-wrap: break-word
 
+  span.emoji
+    width:1.5em
+    height:1.5em
+    background-size:1.5em
+
 // task due date (for to-dos)
 .task-date
   font-size: 70%

--- a/public/js/controllers/userCtrl.js
+++ b/public/js/controllers/userCtrl.js
@@ -3,6 +3,7 @@
 habitrpg.controller("UserCtrl", ['$rootScope', '$scope', '$location', 'User', '$http', '$state',
   function($rootScope, $scope, $location, User, $http, $state) {
     $scope.profile = User.user;
+    $scope.profile.petCount = $rootScope.Shared.countPets(null, $scope.profile.items.pets);
     $scope.hideUserAvatar = function() {
       $(".userAvatar").hide();
     };

--- a/public/js/filters/filters.js
+++ b/public/js/filters/filters.js
@@ -11,7 +11,7 @@ angular.module('habitrpg')
   })
   .filter('completedFilter', function(){
     return function(tasks,_showCompleted) {
-      if (tasks[0].type != 'todo') return tasks;
+      if (!tasks[0] || tasks[0].type != 'todo') return tasks;
       return _.where(tasks, {completed:!!_showCompleted});
     }
   })

--- a/public/js/filters/filters.js
+++ b/public/js/filters/filters.js
@@ -9,3 +9,9 @@ angular.module('habitrpg')
       return Math.floor((gp - Math.floor(gp))*100);
     }
   })
+  .filter('completedFilter', function(){
+    return function(tasks,_showCompleted) {
+      if (tasks[0].type != 'todo') return tasks;
+      return _.where(tasks, {completed:!!_showCompleted});
+    }
+  })

--- a/views/options/social/group.jade
+++ b/views/options/social/group.jade
@@ -21,7 +21,7 @@ a.pull-right.gem-wallet(popover-trigger='mouseenter', popover-title='Guild Bank'
           hr
           .npc_ian.pull-left
           p Once all members have either accepted or rejected, the quest begins. Only those that clicked "accept" will be able to participate in the quest and recieve the drops. If members are pending too long (inactive?), you can start without them by clicking "Begin".
-          button.btn.btn-small.btn-warning(ng-if='group.quest.leader==user._id || group.leader==user._id', ng-click='party.$questAccept({"force":true})') Begin
+          button.btn.btn-small.btn-warning(ng-if='!group.quest.leader || group.quest.leader==user._id', ng-click='party.$questAccept({"force":true})') Begin
           //-TODO Cancel button
           //-TODO Both force-start & cancel should only be available to quest-initiator
 
@@ -71,7 +71,7 @@ a.pull-right.gem-wallet(popover-trigger='mouseenter', popover-title='Guild Bank'
             p Only participants can collect items and share in the quest loot. If you die during a quest, you get booted from the quest. If everyone dies once, the quest fails.
 
 
-          button.btn.btn-mini.btn-danger(ng-if='group.quest.leader==user._id || group.leader==user._id', ng-click='questAbort()') Abort
+          button.btn.btn-mini.btn-danger(ng-if='!group.quest.leader || group.quest.leader==user._id', ng-click='questAbort()') Abort
 
     // ------ Information -------
     .modal.inline-modal

--- a/views/shared/modals/members.jade
+++ b/views/shared/modals/members.jade
@@ -14,6 +14,7 @@ div(ng-controller='MemberModalCtrl')
             li(ng-show='profile.auth.timestamps.created') - Member since {{timestamp(profile.auth.timestamps.created)}} -
             li(ng-show='profile.auth.timestamps.loggedin') - Last logged in {{timestamp(profile.auth.timestamps.loggedin)}} -
           h3 Stats
+          .label.label-info {{profile.stats.class}}
           p.alert.alert-info Coming back soon!
             //-include ../profiles/stats
         .span6

--- a/views/shared/tasks/lists.jade
+++ b/views/shared/tasks/lists.jade
@@ -46,7 +46,7 @@ script(id='templates/habitrpg-tasks.html', type="text/ng-template")
 
         // Static Rewards
         ul.items.rewards(ng-if='main && list.type=="reward" && user.flags.itemsEnabled')
-          li.task.reward-item(ng-repeat='item in itemStore')
+          li.task.reward-item(ng-repeat='item in itemStore', popover-trigger='mouseenter', popover-placement='top', popover-title='{{item.text}}', popover='{{item.notes}}')
             // right-hand side control buttons
             .task-meta-controls
               span.task-notes
@@ -57,12 +57,12 @@ script(id='templates/habitrpg-tasks.html', type="text/ng-template")
                 span.reward-cost {{item.value}}
                 span.shop_gold
             // main content
-            span(popover-trigger='mouseenter', popover-placement='top', popover-title='{{item.text}}', popover='{{item.notes}}', bo-class='{"shop_{{item.key}} shop-sprite item-img": true}')
-            span.task-text(popover-trigger='mouseenter', popover-placement='top', popover-title='{{item.text}}', popover='{{item.notes}}') {{item.text}}
+            span(bo-class='{"shop_{{item.key}} shop-sprite item-img": true}')
+            span.task-text {{item.text}}
 
         // Winter Event
         ul.items.rewards(ng-if='main && list.type=="reward" && (user.items.special.snowball>0 || user.stats.buffs.snowball)')
-          li.task.reward-item(ng-if='user.items.special.snowball>0')
+          li.task.reward-item(popover-trigger='mouseenter', popover-placement='top', popover='{{Content.spells.special.snowball.notes}}', popover-title='{{Content.spells.special.snowball.text}}', ng-if='user.items.special.snowball>0')
             .task-meta-controls
               span.task-notes
                 i.icon-comment
@@ -72,8 +72,8 @@ script(id='templates/habitrpg-tasks.html', type="text/ng-template")
                 span.reward-cost {{user.items.special.snowball}}
                 span.shop_snowball(style='display:inline-block;vertical-align:top;')
             // main content
-            span.task-text(popover-trigger='mouseenter', popover-placement='top', popover='{{Content.spells.special.snowball.notes}}', popover-title='{{Content.spells.special.snowball.text}}') {{Content.spells.special.snowball.text}}
-          li.task.reward-item(ng-if='user.stats.buffs.snowball')
+            span.task-text {{Content.spells.special.snowball.text}}
+          li.task.reward-item(popover-trigger='mouseenter', popover-placement='top', popover='{{Content.spells.special.salt.notes}}', popover-title='{{Content.spells.special.salt.text}}', ng-if='user.stats.buffs.snowball')
             .task-meta-controls
               span.task-notes
                 i.icon-comment
@@ -84,10 +84,10 @@ script(id='templates/habitrpg-tasks.html', type="text/ng-template")
                 span.shop_gold
             // main content
             span.shop_salt.shop-sprite.item-img
-            span.task-text(popover-trigger='mouseenter', popover-placement='top', popover='{{Content.spells.special.salt.notes}}', popover-title='{{Content.spells.special.salt.text}}') {{Content.spells.special.salt.text}}
+            span.task-text {{Content.spells.special.salt.text}}
 
         // Spells
-        ul.items(ng-if='main && list.type=="reward" && user.stats.class && !user.preferences.disableClasses')
+        ul.items(popover-trigger='mouseenter', popover-placement='top', popover='{{spell.notes}}', popover-title='{{spell.text}}', ng-if='main && list.type=="reward" && user.stats.class && !user.preferences.disableClasses')
           li.task.reward-item(ng-repeat='(k,spell) in Content.spells[user.stats.class]', ng-show='user.stats.lvl >= spell.lvl')
             .task-meta-controls
               span.task-notes
@@ -100,7 +100,7 @@ script(id='templates/habitrpg-tasks.html', type="text/ng-template")
                   | &nbsp;MP
             // main content
             span(ng-class='{"shop_{{spell.key}} shop-sprite item-img": true}')
-            span.task-text(popover-trigger='mouseenter', popover-placement='top', popover='{{spell.notes}}', popover-title='{{spell.text}}') {{spell.text}}
+            span.task-text {{spell.text}}
 
         br
 

--- a/views/shared/tasks/lists.jade
+++ b/views/shared/tasks/lists.jade
@@ -87,8 +87,8 @@ script(id='templates/habitrpg-tasks.html', type="text/ng-template")
             span.task-text {{Content.spells.special.salt.text}}
 
         // Spells
-        ul.items(popover-trigger='mouseenter', popover-placement='top', popover='{{spell.notes}}', popover-title='{{spell.text}}', ng-if='main && list.type=="reward" && user.stats.class && !user.preferences.disableClasses')
-          li.task.reward-item(ng-repeat='(k,spell) in Content.spells[user.stats.class]', ng-show='user.stats.lvl >= spell.lvl')
+        ul.items(ng-if='main && list.type=="reward" && user.stats.class && !user.preferences.disableClasses')
+          li.task.reward-item(popover-trigger='mouseenter', popover-placement='top', popover='{{spell.notes}}', popover-title='{{spell.text}}', ng-repeat='(k,spell) in Content.spells[user.stats.class]', ng-show='user.stats.lvl >= spell.lvl')
             .task-meta-controls
               span.task-notes
                 i.icon-comment

--- a/views/shared/tasks/lists.jade
+++ b/views/shared/tasks/lists.jade
@@ -49,7 +49,7 @@ script(id='templates/habitrpg-tasks.html', type="text/ng-template")
           li.task.reward-item(ng-repeat='item in itemStore')
             // right-hand side control buttons
             .task-meta-controls
-              span.task-notes(popover-trigger='mouseenter', popover-placement='left', popover='{{item.notes}}', popover-title='{{item.text}}')
+              span.task-notes
                 i.icon-comment
             //left-hand size commands
             .task-controls
@@ -57,14 +57,14 @@ script(id='templates/habitrpg-tasks.html', type="text/ng-template")
                 span.reward-cost {{item.value}}
                 span.shop_gold
             // main content
-            span(bo-class='{"shop_{{item.key}} shop-sprite item-img": true}')
-            p.task-text {{item.text}}
+            span(popover-trigger='mouseenter', popover-placement='top', popover-title='{{item.text}}', popover='{{item.notes}}', bo-class='{"shop_{{item.key}} shop-sprite item-img": true}')
+            span.task-text(popover-trigger='mouseenter', popover-placement='top', popover-title='{{item.text}}', popover='{{item.notes}}') {{item.text}}
 
         // Winter Event
         ul.items.rewards(ng-if='main && list.type=="reward" && (user.items.special.snowball>0 || user.stats.buffs.snowball)')
           li.task.reward-item(ng-if='user.items.special.snowball>0')
             .task-meta-controls
-              span.task-notes(popover-trigger='mouseenter', popover-placement='left', popover='{{Content.spells.special.snowball.notes}}', popover-title='{{Content.spells.special.snowball.text}}')
+              span.task-notes
                 i.icon-comment
             //left-hand size commands
             .task-controls
@@ -72,10 +72,10 @@ script(id='templates/habitrpg-tasks.html', type="text/ng-template")
                 span.reward-cost {{user.items.special.snowball}}
                 span.shop_snowball(style='display:inline-block;vertical-align:top;')
             // main content
-            p.task-text {{Content.spells.special.snowball.text}}
+            span.task-text(popover-trigger='mouseenter', popover-placement='top', popover='{{Content.spells.special.snowball.notes}}', popover-title='{{Content.spells.special.snowball.text}}') {{Content.spells.special.snowball.text}}
           li.task.reward-item(ng-if='user.stats.buffs.snowball')
             .task-meta-controls
-              span.task-notes(popover-trigger='mouseenter', popover-placement='left', popover='{{Content.spells.special.salt.notes}}', popover-title='{{Content.spells.special.salt.text}}')
+              span.task-notes
                 i.icon-comment
             //left-hand size commands
             .task-controls
@@ -84,13 +84,13 @@ script(id='templates/habitrpg-tasks.html', type="text/ng-template")
                 span.shop_gold
             // main content
             span.shop_salt.shop-sprite.item-img
-            p.task-text {{Content.spells.special.salt.text}}
+            span.task-text(popover-trigger='mouseenter', popover-placement='top', popover='{{Content.spells.special.salt.notes}}', popover-title='{{Content.spells.special.salt.text}}') {{Content.spells.special.salt.text}}
 
         // Spells
         ul.items(ng-if='main && list.type=="reward" && user.stats.class && !user.preferences.disableClasses')
           li.task.reward-item(ng-repeat='(k,spell) in Content.spells[user.stats.class]', ng-show='user.stats.lvl >= spell.lvl')
             .task-meta-controls
-              span.task-notes(popover-trigger='mouseenter', popover-placement='left', popover='{{spell.notes}}', popover-title='{{spell.text}}')
+              span.task-notes
                 i.icon-comment
             //left-hand size commands
             .task-controls
@@ -100,7 +100,7 @@ script(id='templates/habitrpg-tasks.html', type="text/ng-template")
                   | &nbsp;MP
             // main content
             span(ng-class='{"shop_{{spell.key}} shop-sprite item-img": true}')
-            p.task-text {{spell.text}}
+            span.task-text(popover-trigger='mouseenter', popover-placement='top', popover='{{spell.notes}}', popover-title='{{spell.text}}') {{spell.text}}
 
         br
 

--- a/views/shared/tasks/task.jade
+++ b/views/shared/tasks/task.jade
@@ -1,4 +1,4 @@
-li(bindonce='list', ng-repeat='task in obj[list.type+"s"]', class='task {{Shared.taskClasses(task, user.filters, user.preferences.dayStart, user.lastCron, list.showCompleted, main)}}', ng-click='spell && castEnd(task, "task", $event)', ng-class='{"cast-target":spell}')
+li(bindonce='list', ng-repeat='task in obj[list.type+"s"] | completedFilter: list.showCompleted', class='task {{Shared.taskClasses(task, user.filters, user.preferences.dayStart, user.lastCron, list.showCompleted, main)}}', ng-click='spell && castEnd(task, "task", $event)', ng-class='{"cast-target":spell}')
   // right-hand side control buttons
   .task-meta-controls
 

--- a/views/shared/tasks/task.jade
+++ b/views/shared/tasks/task.jade
@@ -1,4 +1,4 @@
-li(bindonce='list', ng-repeat='task in obj[list.type+"s"] | completedFilter: list.showCompleted', class='task {{Shared.taskClasses(task, user.filters, user.preferences.dayStart, user.lastCron, list.showCompleted, main)}}', ng-click='spell && castEnd(task, "task", $event)', ng-class='{"cast-target":spell}')
+li(bindonce='list', ng-repeat='task in obj[list.type+"s"] | completedFilter: list.showCompleted', class='task {{Shared.taskClasses(task, user.filters, user.preferences.dayStart, user.lastCron, list.showCompleted, main)}}', ng-click='spell && castEnd(task, "task", $event)', ng-class='{"cast-target":spell}', popover-trigger='mouseenter', popover-placement='top', popover='{{task.notes}}', popover-title='{{task.text}}')
   // right-hand side control buttons
   .task-meta-controls
 

--- a/views/shared/tasks/task.jade
+++ b/views/shared/tasks/task.jade
@@ -62,6 +62,7 @@ li(bindonce='list', ng-repeat='task in obj[list.type+"s"] | completedFilter: lis
   // main content
   p.task-text
     markdown(ng-model='task.text',target='_blank')
+    //-| {{task.text}}
 
   // edit/options dialog
   div(ng-if='task._editing')

--- a/views/shared/tasks/task.jade
+++ b/views/shared/tasks/task.jade
@@ -64,113 +64,114 @@ li(bindonce='list', ng-repeat='task in obj[list.type+"s"] | completedFilter: lis
     | {{task.text}}
 
   // edit/options dialog
-  .task-options(ng-show='task._editing')
+  div(ng-if='task._editing')
+    .task-options
 
-    // Broken Challenge
-    .well(ng-if='task.challenge.broken')
-      div(ng-if='task.challenge.broken=="TASK_DELETED"')
-        p Broken Challenge Link: this task was part of a challenge, but has been removed from it. What would you like to do?
-        p
-          a(ng-click='unlink(task, "keep")') Keep It
-          | &nbsp;|&nbsp;
-          a(ng-click="removeTask(obj[list.type+'s'], $index)") Remove It
-      div(ng-if='task.challenge.broken=="CHALLENGE_DELETED"')
-        p Broken Challenge Link: this task was part of a challenge, but the challenge (or group) has been deleted. What to do with the orphan tasks?
-        p
-          a(ng-click='unlink(task, "keep-all")') Keep Them
-          | &nbsp;|&nbsp;
-          a(ng-click='unlink(task, "remove-all")') Remove Them
-      div(ng-if='task.challenge.broken=="CHALLENGE_CLOSED"')
-        p.
-          This challenge has been completed, and the winner was <span class='badge'>{{task.challenge.winner}}</span>! What to do with the orphan tasks?
-        p
-          a(ng-click='unlink(task, "keep-all")') Keep Them
-          | &nbsp;|&nbsp;
-          a(ng-click='unlink(task, "remove-all")') Remove Them
-      //div(ng-if='task.challenge.broken=="UNSUBSCRIBED"')
-        p Broken Challenge Link: this task was part of a challenge, but you have unsubscribed from the challenge. What to do with the orphan tasks?
-        p
-          a(ng-click="unlink(task, 'keep-all')") Keep Them
-          | &nbsp;|&nbsp;
-          a(ng-click="unlink(task, 'remove-all')") Remove Them
+      // Broken Challenge
+      .well(ng-if='task.challenge.broken')
+        div(ng-if='task.challenge.broken=="TASK_DELETED"')
+          p Broken Challenge Link: this task was part of a challenge, but has been removed from it. What would you like to do?
+          p
+            a(ng-click='unlink(task, "keep")') Keep It
+            | &nbsp;|&nbsp;
+            a(ng-click="removeTask(obj[list.type+'s'], $index)") Remove It
+        div(ng-if='task.challenge.broken=="CHALLENGE_DELETED"')
+          p Broken Challenge Link: this task was part of a challenge, but the challenge (or group) has been deleted. What to do with the orphan tasks?
+          p
+            a(ng-click='unlink(task, "keep-all")') Keep Them
+            | &nbsp;|&nbsp;
+            a(ng-click='unlink(task, "remove-all")') Remove Them
+        div(ng-if='task.challenge.broken=="CHALLENGE_CLOSED"')
+          p.
+            This challenge has been completed, and the winner was <span class='badge'>{{task.challenge.winner}}</span>! What to do with the orphan tasks?
+          p
+            a(ng-click='unlink(task, "keep-all")') Keep Them
+            | &nbsp;|&nbsp;
+            a(ng-click='unlink(task, "remove-all")') Remove Them
+        //div(ng-if='task.challenge.broken=="UNSUBSCRIBED"')
+          p Broken Challenge Link: this task was part of a challenge, but you have unsubscribed from the challenge. What to do with the orphan tasks?
+          p
+            a(ng-click="unlink(task, 'keep-all')") Keep Them
+            | &nbsp;|&nbsp;
+            a(ng-click="unlink(task, 'remove-all')") Remove Them
 
-    form(ng-submit='saveTask(task)')
-      // text & notes
-      fieldset.option-group
-        label.option-title Text
-        input.option-content(type='text', ng-model='task.text', required, ng-disabled='task.challenge.id')
+      form(ng-submit='saveTask(task)')
+        // text & notes
+        fieldset.option-group
+          label.option-title Text
+          input.option-content(type='text', ng-model='task.text', required, ng-disabled='task.challenge.id')
 
-        label.option-title Extra Notes
-        textarea.option-content(rows='3', ng-model='task.notes', ng-disabled='task.challenge.id')
+          label.option-title Extra Notes
+          textarea.option-content(rows='3', ng-model='task.notes', ng-disabled='task.challenge.id')
 
-      // if Habit, plus/minus command options
-      fieldset.option-group(ng-if='task.type=="habit" && !task.challenge.id')
-        legend.option-title Direction/Actions
-        span.task-checker.action-plusminus.select-toggle
-          input.visuallyhidden.focusable(id='{{obj._id}}_{{task.id}}-option-plus', type='checkbox', ng-model='task.up')
-          label(for='{{obj._id}}_{{task.id}}-option-plus')
-        span.task-checker.action-plusminus.select-toggle
-          input.visuallyhidden.focusable(id='{{obj._id}}_{{task.id}}-option-minus', type='checkbox', ng-model='task.down')
-          label(for='{{obj._id}}_{{task.id}}-option-minus')
+        // if Habit, plus/minus command options
+        fieldset.option-group(ng-if='task.type=="habit" && !task.challenge.id')
+          legend.option-title Direction/Actions
+          span.task-checker.action-plusminus.select-toggle
+            input.visuallyhidden.focusable(id='{{obj._id}}_{{task.id}}-option-plus', type='checkbox', ng-model='task.up')
+            label(for='{{obj._id}}_{{task.id}}-option-plus')
+          span.task-checker.action-plusminus.select-toggle
+            input.visuallyhidden.focusable(id='{{obj._id}}_{{task.id}}-option-minus', type='checkbox', ng-model='task.down')
+            label(for='{{obj._id}}_{{task.id}}-option-minus')
 
-      // if Daily, calendar
-      fieldset(bo-if='task.type=="daily"', class="option-group")
-        legend.option-title Repeat
-        .task-controls.tile-group.repeat-days(bindonce)
-          // note, does not use  data-toggle="buttons-checkbox" - it would interfere with our own click binding
-          button.task-action-btn.tile(ng-class='{active: task.repeat.su}',  type='button', ng-click='task.challenge.id || (task.repeat.su = !task.repeat.su)', bo-text='moment.weekdaysMin(0)')
-          button.task-action-btn.tile(ng-class='{active: task.repeat.m}',   type='button', ng-click='task.challenge.id || (task.repeat.m = !task.repeat.m)', bo-text='moment.weekdaysMin(1)')
-          button.task-action-btn.tile(ng-class='{active: task.repeat.t}',   type='button', ng-click='task.challenge.id || (task.repeat.t = !task.repeat.t)', bo-text='moment.weekdaysMin(2)')
-          button.task-action-btn.tile(ng-class='{active: task.repeat.w}',   type='button', ng-click='task.challenge.id || (task.repeat.w = !task.repeat.w)', bo-text='moment.weekdaysMin(3)')
-          button.task-action-btn.tile(ng-class='{active: task.repeat.th}',  type='button', ng-click='task.challenge.id || (task.repeat.th = !task.repeat.th)', bo-text='moment.weekdaysMin(4)')
-          button.task-action-btn.tile(ng-class='{active: task.repeat.f}',   type='button', ng-click='task.challenge.id || (task.repeat.f= !task.repeat.f)', bo-text='moment.weekdaysMin(5)')
-          button.task-action-btn.tile(ng-class='{active: task.repeat.s}',   type='button', ng-click='task.challenge.id || (task.repeat.s = !task.repeat.s)', bo-text='moment.weekdaysMin(6)')
+        // if Daily, calendar
+        fieldset(bo-if='task.type=="daily"', class="option-group")
+          legend.option-title Repeat
+          .task-controls.tile-group.repeat-days(bindonce)
+            // note, does not use  data-toggle="buttons-checkbox" - it would interfere with our own click binding
+            button.task-action-btn.tile(ng-class='{active: task.repeat.su}',  type='button', ng-click='task.challenge.id || (task.repeat.su = !task.repeat.su)', bo-text='moment.weekdaysMin(0)')
+            button.task-action-btn.tile(ng-class='{active: task.repeat.m}',   type='button', ng-click='task.challenge.id || (task.repeat.m = !task.repeat.m)', bo-text='moment.weekdaysMin(1)')
+            button.task-action-btn.tile(ng-class='{active: task.repeat.t}',   type='button', ng-click='task.challenge.id || (task.repeat.t = !task.repeat.t)', bo-text='moment.weekdaysMin(2)')
+            button.task-action-btn.tile(ng-class='{active: task.repeat.w}',   type='button', ng-click='task.challenge.id || (task.repeat.w = !task.repeat.w)', bo-text='moment.weekdaysMin(3)')
+            button.task-action-btn.tile(ng-class='{active: task.repeat.th}',  type='button', ng-click='task.challenge.id || (task.repeat.th = !task.repeat.th)', bo-text='moment.weekdaysMin(4)')
+            button.task-action-btn.tile(ng-class='{active: task.repeat.f}',   type='button', ng-click='task.challenge.id || (task.repeat.f= !task.repeat.f)', bo-text='moment.weekdaysMin(5)')
+            button.task-action-btn.tile(ng-class='{active: task.repeat.s}',   type='button', ng-click='task.challenge.id || (task.repeat.s = !task.repeat.s)', bo-text='moment.weekdaysMin(6)')
 
-      // if Reward, pricing
-      fieldset.option-group.option-short(ng-if='task.type=="reward" && !task.challenge.id')
-        legend.option-title Price
-        input.option-content(type='number', size='16', min='0', step="any", ng-model='task.value')
-        .money.input-suffix
-          span.shop_gold
+        // if Reward, pricing
+        fieldset.option-group.option-short(ng-if='task.type=="reward" && !task.challenge.id')
+          legend.option-title Price
+          input.option-content(type='number', size='16', min='0', step="any", ng-model='task.value')
+          .money.input-suffix
+            span.shop_gold
 
-      // if Todos, the due date
-      fieldset.option-group(ng-if='task.type=="todo" && !task.challenge.id')
-        legend.option-title Due Date
-        input.option-content.datepicker(type='text', data-date-format='mm/dd/yyyy', ng-model='task.date')
+        // if Todos, the due date
+        fieldset.option-group(ng-if='task.type=="todo" && !task.challenge.id')
+          legend.option-title Due Date
+          input.option-content.datepicker(type='text', data-date-format='mm/dd/yyyy', ng-model='task.date')
 
-      fieldset.option-group(ng-if='!$state.includes("options.social.challenges")')
-        legend.option-title Tags
-        label.checkbox(ng-repeat='tag in user.tags')
-          input(type='checkbox', ng-model='task.tags[tag.id]')
-          | {{tag.name}}
+        fieldset.option-group(ng-if='!$state.includes("options.social.challenges")')
+          legend.option-title Tags
+          label.checkbox(ng-repeat='tag in user.tags')
+            input(type='checkbox', ng-model='task.tags[tag.id]')
+            | {{tag.name}}
 
-      // Advanced Options
-      span(bo-if='task.type!="reward"')
-        p.option-title.mega(ng-click='task._advanced = !task._advanced') Advanced Options
-        fieldset.option-group.advanced-option(ng-class="{visuallyhidden: !task._advanced}")
-          legend.option-title
-            a.priority-multiplier-help(href='https://trello.com/card/priority-multiplier/50e5d3684fe3a7266b0036d6/17', target='_blank', popover-title='How difficult is this task?', popover-trigger='mouseenter', popover="This multiplies its point value. Use sparingly, rely instead on our organic value-adjustment algorithms. But some tasks are grossly more valuable (Write Thesis vs Floss Teeth). Click for more info.")
-              i.icon-question-sign
-            | Difficulty
-          .task-controls.tile-group.priority-multiplier
-            button.task-action-btn.tile(type='button', ng-class='{active: task.priority==1 || !task.priority}', ng-click='task.challenge.id || (task.priority=1)') Easy
-            button.task-action-btn.tile(type='button', ng-class='{active: task.priority==1.5}', ng-click='task.challenge.id || (task.priority=1.5)') Medium
-            button.task-action-btn.tile(type='button', ng-class='{active: task.priority==2}', ng-click='task.challenge.id || (task.priority=2)') Hard
-          //span(ng-if='task.type=="daily" && !task.challenge.id')
-          br
-          span(ng-if='task.type=="daily"')
-            legend.option-title Restore Streak
-            input.option-content(type='number', ng-model='task.streak')
+        // Advanced Options
+        span(bo-if='task.type!="reward"')
+          p.option-title.mega(ng-click='task._advanced = !task._advanced') Advanced Options
+          fieldset.option-group.advanced-option(ng-class="{visuallyhidden: !task._advanced}")
+            legend.option-title
+              a.priority-multiplier-help(href='https://trello.com/card/priority-multiplier/50e5d3684fe3a7266b0036d6/17', target='_blank', popover-title='How difficult is this task?', popover-trigger='mouseenter', popover="This multiplies its point value. Use sparingly, rely instead on our organic value-adjustment algorithms. But some tasks are grossly more valuable (Write Thesis vs Floss Teeth). Click for more info.")
+                i.icon-question-sign
+              | Difficulty
+            .task-controls.tile-group.priority-multiplier
+              button.task-action-btn.tile(type='button', ng-class='{active: task.priority==1 || !task.priority}', ng-click='task.challenge.id || (task.priority=1)') Easy
+              button.task-action-btn.tile(type='button', ng-class='{active: task.priority==1.5}', ng-click='task.challenge.id || (task.priority=1.5)') Medium
+              button.task-action-btn.tile(type='button', ng-class='{active: task.priority==2}', ng-click='task.challenge.id || (task.priority=2)') Hard
+            //span(ng-if='task.type=="daily" && !task.challenge.id')
+            br
+            span(ng-if='task.type=="daily"')
+              legend.option-title Restore Streak
+              input.option-content(type='number', ng-model='task.streak')
 
-          legend.option-title Attributes
-          .task-controls.tile-group
-            button.task-action-btn.tile(type='button', ng-class='{active: task.attribute=="str"}', ng-click='task.attribute="str"') Physical
-            button.task-action-btn.tile(type='button', ng-class='{active: task.attribute=="int"}', ng-click='task.attribute="int"') Mental
-            button.task-action-btn.tile(type='button', ng-class='{active: task.attribute=="con"}', ng-click='task.attribute="con"') Social
-            button.task-action-btn.tile(type='button', ng-class='{active: task.attribute=="per"}', ng-click='task.attribute="per"')
-              | Other&nbsp;
-              i.icon-question-sign(popover='Eg, professional pursuits, hobbies, financial, etc.', popover-trigger='mouseenter', popover-placement='top')
+            legend.option-title Attributes
+            .task-controls.tile-group
+              button.task-action-btn.tile(type='button', ng-class='{active: task.attribute=="str"}', ng-click='task.attribute="str"') Physical
+              button.task-action-btn.tile(type='button', ng-class='{active: task.attribute=="int"}', ng-click='task.attribute="int"') Mental
+              button.task-action-btn.tile(type='button', ng-class='{active: task.attribute=="con"}', ng-click='task.attribute="con"') Social
+              button.task-action-btn.tile(type='button', ng-class='{active: task.attribute=="per"}', ng-click='task.attribute="per"')
+                | Other&nbsp;
+                i.icon-question-sign(popover='Eg, professional pursuits, hobbies, financial, etc.', popover-trigger='mouseenter', popover-placement='top')
 
-      button.task-action-btn.tile.spacious(type='submit') Save & Close
+        button.task-action-btn.tile.spacious(type='submit') Save & Close
 
   div(class='{{obj._id}}{{task.id}}-chart', ng-show='charts[obj._id+task.id]')

--- a/views/shared/tasks/task.jade
+++ b/views/shared/tasks/task.jade
@@ -61,7 +61,7 @@ li(bindonce='list', ng-repeat='task in obj[list.type+"s"] | completedFilter: lis
       label(for='box-{{obj._id}}_{{task.id}}')
   // main content
   p.task-text
-    | {{task.text}}
+    markdown(ng-model='task.text',target='_blank')
 
   // edit/options dialog
   div(ng-if='task._editing')

--- a/views/shared/tasks/task.jade
+++ b/views/shared/tasks/task.jade
@@ -36,7 +36,7 @@ li(bindonce='list', ng-repeat='task in obj[list.type+"s"] | completedFilter: lis
     a(ng-show='task.history', ng-click='toggleChart(obj._id+task.id, task)', tooltip='Progress')
       i.icon-signal
     // notes
-    span.task-notes(ng-show='task.notes && !task._editing', popover-trigger='mouseenter', popover-placement='left', popover='{{task.notes}}', popover-title='{{task.text}}')
+    span.task-notes(ng-show='task.notes && !task._editing')
       i.icon-comment
 
   // left-hand side checkbox

--- a/views/shared/tasks/task.jade
+++ b/views/shared/tasks/task.jade
@@ -36,7 +36,7 @@ li(bindonce='list', ng-repeat='task in obj[list.type+"s"]', class='task {{Shared
     a(ng-show='task.history', ng-click='toggleChart(obj._id+task.id, task)', tooltip='Progress')
       i.icon-signal
     // notes
-    span.task-notes(ng-show='task.notes && !task._editing', popover-trigger='mouseenter', popover-placement='left', popover='{{task.notes}}', popover-title='{{task.text}}')
+    span.task-notes(ng-show='task.notes && !task._editing')
       i.icon-comment
 
   // left-hand side checkbox
@@ -60,8 +60,7 @@ li(bindonce='list', ng-repeat='task in obj[list.type+"s"]', class='task {{Shared
       input.visuallyhidden.focusable(ng-if='!$state.includes("tasks")', id='box-{{obj._id}}_{{task.id}}', type='checkbox')
       label(for='box-{{obj._id}}_{{task.id}}')
   // main content
-  p.task-text
-    | {{task.text}}
+  span.task-text(popover-trigger='mouseenter', popover-placement='top', popover='{{task.notes}}', popover-title='{{task.text}}') {{task.text}}
 
   // edit/options dialog
   .task-options(ng-show='task._editing')


### PR DESCRIPTION
Some shuffling of task popover functionality to address the difficulty of targeting the "notes" speech bubble icon.
- The icon itself no longer has any popover. It simply cues the user that more detail is available.
- Popovers now appear when you mouse over the task text. For equipment Rewards, mousing over the shop sprite also works.
- Implemented and tested for tasks, static rewards, spells, and Winter special spells.
- Tested with drag-drop sort operations. Looks a little funky, but works fine.
