### PR TITLE
Change link for Tavern Request a Feature

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -40,12 +40,6 @@
     "sticky": "*",
     "bootstrap-tour": "~0.8.0"
   },
-  "resolutions": {
-    "jquery": "~2.0.3",
-    "bootstrap": "v2.3.2",
-    "angular": "~1.2.1",
-    "bootstrap-tour": "~0.8.0"
-  },
   "devDependencies": {
     "angular-mocks": "~1.2.1"
   }

--- a/views/options/social/tavern.jade
+++ b/views/options/social/tavern.jade
@@ -42,7 +42,7 @@
               a(target='_blank', href='https://github.com/HabitRPG/habitrpg/issues') Report a Problem
           tr
             td
-              a(target='_blank', href='https://trello.com/board/habitrpg/50e5d3684fe3a7266b0036d6') Request a Feature
+              a(target='_blank', href='https://trello.com/c/8gzGlle8') Request a Feature
           tr
             td
               a(target='_blank', href='http://community.habitrpg.com/forum') Community Forum


### PR DESCRIPTION
Tavern "Request a Feature" now links directly to Trello "How to submit a feature request" card. 

IGNORE commit 98dd655. Not sure how those changes happened. From fresh install?
