### PR TITLE
Minimal fix for #2092

### DIFF
--- a/public/js/controllers/notificationCtrl.js
+++ b/public/js/controllers/notificationCtrl.js
@@ -41,7 +41,7 @@ habitrpg.controller('NotificationCtrl',
         User.user.items[type][after.key] = 0;
       }
       User.user.items[type][after.key]++;
-      $rootScope.modals.drop = true;
+      Notification.text(User.user._tmp.drop.dialog);
     });
 
     $rootScope.$watch('user.achievements.streak', function(after, before){


### PR DESCRIPTION
This removes the modal for drops and throws it into a Growl notification instead. Absolute minimal fix for issue #2092, and has much room for improvement:

The message is kinda verbose to read in the time it's visible, so I'd love to instead have "You found an item!" with a picture of the specific drop. But I'm having a devil of a time getting a dynamically-formed icon style to show up in the notification... I can get one to show up if I manually specify it, but none of the dozen methods I tried for splicing in the type and key of the drop worked.
