### PR TITLE
Fix #2072 (add Mana delta alerts)

### DIFF
--- a/public/css/alerts.styl
+++ b/public/css/alerts.styl
@@ -28,6 +28,8 @@ xpColor = #DCC0FB
 xpText = #635673
 deathColor = #4E4E4E
 deathText = #ABABAB
+mpColor = #c7d3e9
+mpText = #003aa1
 borderDarken = 20%
 
 // alert styles
@@ -56,6 +58,11 @@ borderDarken = 20%
   background-color: deathColor
   border-color: deathColor
   color: deathText
+
+.alert-mp
+  background-color: mpColor
+  border-color: darken(mpColor,borderDarken)
+  color: mpText
 
 // alert icons
 

--- a/public/js/controllers/notificationCtrl.js
+++ b/public/js/controllers/notificationCtrl.js
@@ -31,6 +31,13 @@ habitrpg.controller('NotificationCtrl',
       }
     });
 
+    $rootScope.$watch('user.stats.mp', function(after,before) {
+       if (after == before) return;
+       if (User.user.stats.lvl == 0) return;
+       var mana = after - before;
+       Notification.mp(mana);
+    });
+
     $rootScope.$watch('user._tmp.drop', function(after, before){
       // won't work when getting the same item twice?
       if (after == before || !after) return;

--- a/public/js/services/notificationServices.js
+++ b/public/js/services/notificationServices.js
@@ -65,6 +65,9 @@ angular.module("notificationServices", [])
       },
       error: function(error){
         growl("<i class='icon-exclamation-sign'></i> " + error, "error");
+      },
+      mp: function(val) {
+        growl("<i class='icon-fire'></i> " + sign(val) + " " + round(val) + " MP", 'mp');
       }
     };
   }


### PR DESCRIPTION
Implement a watcher and alert function for Mana. Uses colors based on different saturations of the Mana status bar, which makes it a little similar to the Level Up alert, but the icon helps differentiate.

Tested with cron, spells, and To-Do drip.
