### PR TITLE
Make better use of space for customizations and Market

### DIFF
--- a/public/css/customizer.styl
+++ b/public/css/customizer.styl
@@ -10,7 +10,7 @@ menu
 
 .customize-menu
   padding: 0;
-  width: 70%;
+  width: 100%;
   list-style: none;
   padding-bottom: 10px
   

--- a/public/css/inventory.styl
+++ b/public/css/inventory.styl
@@ -99,8 +99,7 @@ menu.pets div
 
 // This adds feeding progress bars to pets. If we have any issues with `menu.pets > button`, revisit
 menu.pets .customize-menu
-  width: 100%
-  
+
   button
     position: relative
   .progress


### PR DESCRIPTION
With how many different customizations and items we have available these days, throwing away a chunk of space in each column seems wasteful, leading to unnecessary scrolling. This commit changes the `customize-menu` style to 100% width, allowing T-shirts, hairstyles, drops in inventory, and Market items to use whatever room the browser has available.

Previously this was implemented only for the list of pets, so I've removed the redundant setting there.
