### PR TITLE
Remove padding from <li> when used in Markdown

### DIFF
--- a/public/css/game-pane.styl
+++ b/public/css/game-pane.styl
@@ -70,6 +70,8 @@
 
     li
       border:0
+      padding-top:0px
+      padding-bottom:0px
 
 // Name tags
 .label-contributor-1, .label-contributor-2


### PR DESCRIPTION
Fixes Markdown list items ending up looking like this:

![screenclip](https://f.cloud.github.com/assets/4501321/1814892/57fea5e4-6f07-11e3-8922-3db134ac622f.png)

Padding is preserved for party chat items overall, but when nested in a message, they should go line by line without padding, to reduce scrolling.
