### PR TITLE
Update Request Feature link

### DIFF
--- a/views/shared/footer.jade
+++ b/views/shared/footer.jade
@@ -34,7 +34,7 @@ footer.footer(ng-controller='FooterCtrl')
           li
             a(target='_blank', href='https://github.com/HabitRPG/habitrpg/issues') Submit Bug
           li
-            a(target='_blank', href='https://trello.com/board/habitrpg/50e5d3684fe3a7266b0036d6') Request Feature
+            a(target='_blank', href='https://trello.com/c/8gzGlle8') Request Feature
           li
             a(target='_blank', href='https://github.com/lefnire/habitrpg/wiki/API') API
           li


### PR DESCRIPTION
Link now goes directly to How to Submit a New Request card. Previously it was linking to the Trello board (not the card).
