### PR TITLE
Don't need angle brackets anymore for party cast notifications

### DIFF
--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -370,7 +370,7 @@ api.cast = function(req, res) {
 
           if (group) {
             series.push(function(cb2){
-              var message = '`<'+user.profile.name+'> casts '+spell.text + (type=='user' ? ' on @'+found.profile.name : ' for the party')+'.`';
+              var message = '`'+user.profile.name+' casts '+spell.text + (type=='user' ? ' on @'+found.profile.name : ' for the party')+'.`';
               group.sendChat(message);
               group.save(cb2);
             })


### PR DESCRIPTION
With the casting notifications no longer originating from a user in normal chat-message style, the angle brackets are no longer needed. Will look better without them.
