### PR TITLE
Some work on demystification of RPG elements

### DIFF
--- a/views/options/profile.jade
+++ b/views/options/profile.jade
@@ -138,13 +138,17 @@ script(id='partials/options.profile.stats.html', type='text/ng-template')
     .border-right(ng-class='user.flags.classSelected && !user.preferences.disableClasses ? "span4" : "span6"')
       include ../shared/profiles/stats
     .span4.border-right.allocate-stats(ng-if='user.flags.classSelected && !user.preferences.disableClasses')
-      h4
-        | {{user.stats.class}}&nbsp;
+      h3 Character Build
+      h4 Class:&nbsp;
+        span(ng-show="user.stats.class == 'warrior'") Warrior&nbsp;
+        span(ng-show="user.stats.class == 'wizard'") Mage&nbsp;
+        span(ng-show="user.stats.class == 'healer'") Healer&nbsp;
+        span(ng-show="user.stats.class == 'rogue'") Rogue&nbsp;
         a.btn.btn-danger.btn-mini(ng-click='changeClass(null)')
-          | Change & Re-Roll&nbsp;
+          | Change Class, Refund Attribute Points&nbsp;
         small 3 <span class="Pet_Currency_Gem1x inline-gems"/>
 
-      h6 Points: {{user.stats.points}}
+      h5 Unallocated Attribute Points: {{user.stats.points}}
       fieldset.auto-allocate
         label.checkbox
           input(type='checkbox', ng-model='user.preferences.automaticAllocation', ng-change='set({"preferences.automaticAllocation": user.preferences.automaticAllocation?true: false})')

--- a/views/shared/modals/classes.jade
+++ b/views/shared/modals/classes.jade
@@ -1,6 +1,6 @@
 .modal(ng-if='!user.flags.classSelected && user.stats.lvl >= 10', data-backdrop=true, ng-controller='UserCtrl')
   .modal-header
-    h3 Class System Unlocked!
+    h3 Choose Your Class!
   .modal-body.select-class
     p Select your class. Click each class for more information. See <a href="http://habitrpg.wikia.com/wiki/Class_System" target="_blank">Wikia</a> for thorough details.
     .row-fluid
@@ -19,7 +19,7 @@
             span(class='shield_warrior_5')
             span(class='weapon_warrior_6')
       .span3(ng-click='selectedClass = "wizard"')
-        h5 Wizard
+        h5 Mage
         figure.herobox(ng-class='{"selected-class": selectedClass=="wizard"}')
           .character-sprites
             span(class='skin_{{user.preferences.skin}}')
@@ -62,7 +62,7 @@
             span(class='weapon_healer_6')
     br
     .well(ng-show='selectedClass=="warrior"') Warriors deal damage to tasks (reducing redness), have moderate defense, and improved critical hits.
-    .well(ng-show='selectedClass=="wizard"') Wizards deal damage to tasks (reducing redness), can debuff tasks, and they gain experience rapidly.
+    .well(ng-show='selectedClass=="wizard"') Mages deal damage to tasks (reducing redness), can debuff tasks, and they gain experience rapidly.
     .well(ng-show='selectedClass=="rogue"') Rogues finds more drops and gold. They can also "go stealth" to avoid damage at the end of a day.
     .well(ng-show='selectedClass=="healer"') Healers have high defense against damage, and can heal themselves and other players in the party, as well as buff players.
 

--- a/views/shared/profiles/stats.jade
+++ b/views/shared/profiles/stats.jade
@@ -3,7 +3,7 @@ table.table.table-striped
   tr(ng-repeat='(k,v) in user.items.gear.equipped', ng-init='piece=Content.gear.flat[v]', ng-show='piece')
     td
       strong {{piece.text}}:&nbsp;
-      span(ng-repeat='stat in ["str","con","per","int"]', ng-show='piece[stat]') {{piece[stat]}}{{stat}}&nbsp;
+      span(ng-repeat='stat in ["str","con","per","int"]', ng-show='piece[stat]') {{piece[stat]}} {{stat.toUpperCase()}}&nbsp;
 
 h4 Stats
 table.table.table-striped
@@ -31,19 +31,25 @@ table.table.table-striped
       strong {{v}}: {{profile._statsComputed[k]}}
     td
       ul
-        li Allocated: {{profile.stats[k] || 0}}
-        li
-          | Gear: {{Content.gear.flat[profile.items.gear.equipped.weapon][k] + Content.gear.flat[profile.items.gear.equipped.armor][k] + Content.gear.flat[profile.items.gear.equipped.head][k] + Content.gear.flat[profile.items.gear.equipped.shield][k] || 0}}&nbsp;
-          i.icon-question-sign(popover-title='Class Gear', popover-trigger='mouseenter', popover-placement='right', popover="Wearing your class's gear gives that stat a 1.5% bonus, in addition to this number.")
-        li Level: {{(profile.stats.lvl - 1) / 2}}
-        li Buffs: {{profile.stats.buffs[k] || 0}}
+        li Level: {{(profile.stats.lvl - 1) / 2}}&nbsp;
+          i.icon-question-sign(popover-title='Level Bonus', popover-trigger='mouseenter', popover-placement='right', popover="Each attribute gets a bonus equal to half your Level.")
+        li Equipment: {{Content.gear.flat[profile.items.gear.equipped.weapon][k] + Content.gear.flat[profile.items.gear.equipped.armor][k] + Content.gear.flat[profile.items.gear.equipped.head][k] + Content.gear.flat[profile.items.gear.equipped.shield][k] || 0}}&nbsp;
+          i.icon-question-sign(popover-title='Equipment', popover-trigger='mouseenter', popover-placement='right', popover="Attribute bonuses provided by your equipped battle gear. See the Equipment tab under Inventory to select your battle gear.")
+        li Class Equip Bonus: {{profile._statsComputed[k] - profile.stats.buffs[k] - ((profile.stats.lvl - 1) / 2) - Content.gear.flat[profile.items.gear.equipped.weapon][k] - Content.gear.flat[profile.items.gear.equipped.armor][k] - Content.gear.flat[profile.items.gear.equipped.head][k] - Content.gear.flat[profile.items.gear.equipped.shield][k]}}&nbsp;
+          i.icon-question-sign(popover-title='Class Equipment Bonus', popover-trigger='mouseenter', popover-placement='right', popover="Your class uses its own equipment more effectively than gear from other classes. Equipped gear from your current class gets a 50% boost to the attribute bonus it grants.")
+        li Allocated: {{profile.stats[k] || 0}}&nbsp;
+          i.icon-question-sign(popover-title='Allocated Points', popover-trigger='mouseenter', popover-placement='right', popover="Attribute points you've earned and assigned. Assign points using the Character Build column.")
+        li Buffs: {{profile.stats.buffs[k] || 0}}&nbsp;
+          i.icon-question-sign(popover-title='Buffs', popover-trigger='mouseenter', popover-placement='right', popover="Attribute bonuses provided by abilities you or your party members have used. The abilities you can use are found in the Rewards column on your Tasks page.")
   tr(ng-if='profile.stats.buffs.stealth')
     td
-      strong Stealth: {{profile.stats.buffs.stealth}}
+      strong Stealth: {{profile.stats.buffs.stealth}}&nbsp;
+        i.icon-question-sign(popover-title='Stealth', popover-trigger='mouseenter', popover-placement='right', popover="When a new day begins, you will avoid damage from this many missed Dailies.")
     td
   tr(ng-if='profile.stats.buffs.streaks')
     td
-      strong Frozen Streaks: true
+      strong Streaks Frozen&nbsp;
+        i.icon-question-sign(popover-title='Streaks Frozen', popover-trigger='mouseenter', popover-placement='right', popover="Streaks on missed Dailies will not reset at the end of the day.")
     td
 
 h4 Pets
@@ -52,3 +58,8 @@ table.table.table-striped
     td
       strong Pets Found
       | : {{profile.petCount}}
+// Dunno why this doesn't work //
+//  tr
+    td
+      strong Mounts Tamed
+      | : {{profile.mountCount}} //


### PR DESCRIPTION
- Added a bunch more ? bubbles with basic explanations of attribute boosts and buffs.
- Added an explicit line in the stats list for bonus from class-matched equipment.
- Added a "Character Build" header to the attribute assignment and class change area.
- Changed the latest "Re-Roll" to "Refund Attribute Points" (so @lefnire will punch me in the face if we ever meet in person)
- Changed display of "Wizard" to "Mage" in stats page and class select modal.
- Changed "Class System Unlocked!" modal header to be more universal, so it still makes sense if e.g. you're changing classes.
- Mild beautification of attribute boosts from gear: add space between value and attribute, use uppercase attribute abbreviation.

Still to do:
- More robust and accurate descriptions of classes.
- More robust and accurate descriptions of attributes.
- Find more places where "wizard" is used and change it over to "Mage".
- Get the mounts count in there? I tried, but the binding wouldn't return anything.
