### PR TITLE
Add .idea and .git to nodemon ignore list

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -57,7 +57,7 @@ module.exports = function(grunt) {
 
     nodemon: {
       dev: {
-        ignoredFiles: ['public/*', 'Gruntfile.js', 'views/*', 'build/*']
+        ignoredFiles: ['public/*', 'Gruntfile.js', 'views/*', 'build/*', '.idea*', '.git*']
       }
     },
 


### PR DESCRIPTION
Dramatically reduces unnecessary server bounces during development.
