### PR TITLE
RPG demystification, cont'd

### DIFF
--- a/views/options/profile.jade
+++ b/views/options/profile.jade
@@ -154,25 +154,25 @@ script(id='partials/options.profile.stats.html', type='text/ng-template')
       table.table.table-striped
         tr
           td
-            i.icon-question-sign(popover-title='Strength', popover='Strength increases damage you inflict to tasks (reducing redness), and increases critical hit chance.', popover-trigger='mouseenter')
+            i.icon-question-sign(popover-title='Strength', popover='Strength reduces task threat (redness), increases the Gold and Experience boost from random "critical hits," and helps deal damage to boss monsters.', popover-trigger='mouseenter')
             | &nbsp;STR: {{user.stats.str}}
           td
             a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("str")') +
         tr
           td
-            i.icon-question-sign(popover-title='Constitution', popover='Constitution decreases damage inflicted by tasks, and increases the effectiveness of healing and buff spells.', popover-trigger='mouseenter')
+            i.icon-question-sign(popover-title='Constitution', popover='Constitution reduces the damage you take, whether from negative Habits, missed Dailies, or the attacks of boss monsters.', popover-trigger='mouseenter')
             | &nbsp;CON: {{user.stats.con}}
           td
             a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("con")') +
         tr
           td
-            i.icon-question-sign(popover-title='Perception', popover='Perception increases drops and gold, and can help with critical hits by spells.', popover-trigger='mouseenter')
+            i.icon-question-sign(popover-title='Perception', popover='Perception increases how much Gold you earn, and increases the chance of finding items when scoring tasks.', popover-trigger='mouseenter')
             | &nbsp;PER: {{user.stats.per}}
           td
             a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("per")') +
         tr
           td
-            i.icon-question-sign(popover-title='Intelligence', popover='Intelligence increases your overall mana, spell effectiveness, and experience gain.', popover-trigger='mouseenter')
+            i.icon-question-sign(popover-title='Intelligence', popover='Intelligence increases how much Experience you earn, and determines your maximum Mana available for class abilities.', popover-trigger='mouseenter')
             | &nbsp;INT: {{user.stats.int}}
           td
             a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("int")') +

--- a/views/shared/modals/classes.jade
+++ b/views/shared/modals/classes.jade
@@ -1,11 +1,10 @@
 .modal(ng-if='!user.flags.classSelected && user.stats.lvl >= 10', data-backdrop=true, ng-controller='UserCtrl')
   .modal-header
-    h3 Choose Your Class!
+    h3 Choose Your <a href='http://habitrpg.wikia.com/wiki/Class_System' target='_blank'>Class</a>!
   .modal-body.select-class
-    p Select your class. Click each class for more information. See <a href="http://habitrpg.wikia.com/wiki/Class_System" target="_blank">Wikia</a> for thorough details.
     .row-fluid
       .span3(ng-click='selectedClass = "warrior"')
-        h5 Warrior
+        h5 <a href='http://habitrpg.wikia.com/wiki/Warrior' target='_blank'>Warrior</a>
         figure.herobox(ng-class='{"selected-class": selectedClass=="warrior"}')
           .character-sprites
             span(class='skin_{{user.preferences.skin}}')
@@ -19,7 +18,7 @@
             span(class='shield_warrior_5')
             span(class='weapon_warrior_6')
       .span3(ng-click='selectedClass = "wizard"')
-        h5 Mage
+        h5 <a href='http://habitrpg.wikia.com/wiki/Mage' target='_blank'>Mage</a>
         figure.herobox(ng-class='{"selected-class": selectedClass=="wizard"}')
           .character-sprites
             span(class='skin_{{user.preferences.skin}}')
@@ -33,7 +32,7 @@
             span(class='shield_wizard_5')
             span(class='weapon_wizard_6')
       .span3(ng-click='selectedClass = "rogue"')
-        h5 Rogue
+        h5 <a href='http://habitrpg.wikia.com/wiki/Rogue' target='_blank'>Rogue</a>
         figure.herobox(ng-class='{"selected-class": selectedClass=="rogue"}')
           .character-sprites
             span(class='skin_{{user.preferences.skin}}')
@@ -47,7 +46,7 @@
             span(class='shield_rogue_6')
             span(class='weapon_rogue_6')
       .span3(ng-click='selectedClass = "healer"')
-        h5 Healer
+        h5 <a href='http://habitrpg.wikia.com/wiki/Healer' target='_blank'>Healer</a>
         figure.herobox(ng-class='{"selected-class": selectedClass=="healer"}')
           .character-sprites
             span(class='skin_{{user.preferences.skin}}')
@@ -61,10 +60,10 @@
             span(class='shield_healer_5')
             span(class='weapon_healer_6')
     br
-    .well(ng-show='selectedClass=="warrior"') Warriors deal damage to tasks (reducing redness), have moderate defense, and improved critical hits.
-    .well(ng-show='selectedClass=="wizard"') Mages deal damage to tasks (reducing redness), can debuff tasks, and they gain experience rapidly.
-    .well(ng-show='selectedClass=="rogue"') Rogues finds more drops and gold. They can also "go stealth" to avoid damage at the end of a day.
-    .well(ng-show='selectedClass=="healer"') Healers have high defense against damage, and can heal themselves and other players in the party, as well as buff players.
+    .well(ng-show='selectedClass=="warrior"') Warriors keep tasks in line, each success making later slip-ups less harsh. They also score impressive "critical hits," which randomly give bonus Gold and Experience for scoring a task. Play a Warrior if you don't want to be punished too hard for inconsistency, or if you find strong motivation from unpredictable jackpot-style rewards!
+    .well(ng-show='selectedClass=="wizard"') Mages learn swiftly, gaining Experience and Levels faster than other classes. They also get a great deal of Mana for using special abilities. Play a Mage if you enjoy the tactical game aspects of Habit, or if you are strongly motivated by leveling up and unlocking advanced features!
+    .well(ng-show='selectedClass=="rogue"') Rogues love to accumulate wealth, gaining more Gold than anyone else, and are adept at finding random items. Their iconic Stealth ability lets them duck the consequences of missed Dailies. Play a Rogue if you find strong motivation from Rewards and Achievements, striving for loot and badges!
+    .well(ng-show='selectedClass=="healer"') Healers stand impervious against harm, and extend that protection to others. Missed Dailies and bad Habits don't faze them much, and they have ways to recover Health from failure. Play a Healer if you enjoy assisting others in your Party, or if the idea of cheating Death through hard work inspires you!
 
   .modal-footer
     button.btn.btn-small.btn-danger.cancel(ng-click='user.ops.disableClasses({})', popover-placement='top', popover-trigger='mouseenter', popover="Can't be bothered with classes? Opt out - you'll be a warrior and your points handled automatically. You can enable classes later under Settings") Opt Out

--- a/views/shared/profiles/stats.jade
+++ b/views/shared/profiles/stats.jade
@@ -39,7 +39,7 @@ table.table.table-striped
           |  Equipment: {{Content.gear.flat[profile.items.gear.equipped.weapon][k] + Content.gear.flat[profile.items.gear.equipped.armor][k] + Content.gear.flat[profile.items.gear.equipped.head][k] + Content.gear.flat[profile.items.gear.equipped.shield][k] || 0}}&nbsp;
         li
           i.icon-question-sign(popover-title='Class Equipment Bonus', popover-trigger='mouseenter', popover-placement='top', popover="Your class uses its own equipment more effectively than gear from other classes. Equipped gear from your current class gets a 50% boost to the attribute bonus it grants.")
-          |  Class Equip Bonus: {{profile._statsComputed[k] - profile.stats.buffs[k] - ((profile.stats.lvl - 1) / 2) - Content.gear.flat[profile.items.gear.equipped.weapon][k] - Content.gear.flat[profile.items.gear.equipped.armor][k] - Content.gear.flat[profile.items.gear.equipped.head][k] - Content.gear.flat[profile.items.gear.equipped.shield][k]}}&nbsp;
+          |  Class Equip Bonus: {{profile._statsComputed[k] - profile.stats.buffs[k] - ((profile.stats.lvl - 1) / 2) - Content.gear.flat[profile.items.gear.equipped.weapon][k] - Content.gear.flat[profile.items.gear.equipped.armor][k] - Content.gear.flat[profile.items.gear.equipped.head][k] - Content.gear.flat[profile.items.gear.equipped.shield][k] - profile.stats[k]}}&nbsp;
         li
           i.icon-question-sign(popover-title='Allocated Points', popover-trigger='mouseenter', popover-placement='top', popover="Attribute points you've earned and assigned. Assign points using the Character Build column.")
           |  Allocated: {{profile.stats[k] || 0}}&nbsp;

--- a/views/shared/profiles/stats.jade
+++ b/views/shared/profiles/stats.jade
@@ -30,17 +30,22 @@ table.table.table-striped
     td
       strong {{v}}: {{profile._statsComputed[k]}}
     td
-      ul
-        li Level: {{(profile.stats.lvl - 1) / 2}}&nbsp;
-          i.icon-question-sign(popover-title='Level Bonus', popover-trigger='mouseenter', popover-placement='right', popover="Each attribute gets a bonus equal to half your Level.")
-        li Equipment: {{Content.gear.flat[profile.items.gear.equipped.weapon][k] + Content.gear.flat[profile.items.gear.equipped.armor][k] + Content.gear.flat[profile.items.gear.equipped.head][k] + Content.gear.flat[profile.items.gear.equipped.shield][k] || 0}}&nbsp;
-          i.icon-question-sign(popover-title='Equipment', popover-trigger='mouseenter', popover-placement='right', popover="Attribute bonuses provided by your equipped battle gear. See the Equipment tab under Inventory to select your battle gear.")
-        li Class Equip Bonus: {{profile._statsComputed[k] - profile.stats.buffs[k] - ((profile.stats.lvl - 1) / 2) - Content.gear.flat[profile.items.gear.equipped.weapon][k] - Content.gear.flat[profile.items.gear.equipped.armor][k] - Content.gear.flat[profile.items.gear.equipped.head][k] - Content.gear.flat[profile.items.gear.equipped.shield][k]}}&nbsp;
-          i.icon-question-sign(popover-title='Class Equipment Bonus', popover-trigger='mouseenter', popover-placement='right', popover="Your class uses its own equipment more effectively than gear from other classes. Equipped gear from your current class gets a 50% boost to the attribute bonus it grants.")
-        li Allocated: {{profile.stats[k] || 0}}&nbsp;
-          i.icon-question-sign(popover-title='Allocated Points', popover-trigger='mouseenter', popover-placement='right', popover="Attribute points you've earned and assigned. Assign points using the Character Build column.")
-        li Buffs: {{profile.stats.buffs[k] || 0}}&nbsp;
-          i.icon-question-sign(popover-title='Buffs', popover-trigger='mouseenter', popover-placement='right', popover="Attribute bonuses provided by abilities you or your party members have used. The abilities you can use are found in the Rewards column on your Tasks page.")
+      ul(style='list-style-type:none')
+        li
+          i.icon-question-sign(popover-title='Level Bonus', popover-trigger='mouseenter', popover-placement='top', popover="Each attribute gets a bonus equal to half your Level.")
+          |  Level: {{(profile.stats.lvl - 1) / 2}}&nbsp;
+        li
+          i.icon-question-sign(popover-title='Equipment', popover-trigger='mouseenter', popover-placement='top', popover="Attribute bonuses provided by your equipped battle gear. See the Equipment tab under Inventory to select your battle gear.")
+          |  Equipment: {{Content.gear.flat[profile.items.gear.equipped.weapon][k] + Content.gear.flat[profile.items.gear.equipped.armor][k] + Content.gear.flat[profile.items.gear.equipped.head][k] + Content.gear.flat[profile.items.gear.equipped.shield][k] || 0}}&nbsp;
+        li
+          i.icon-question-sign(popover-title='Class Equipment Bonus', popover-trigger='mouseenter', popover-placement='top', popover="Your class uses its own equipment more effectively than gear from other classes. Equipped gear from your current class gets a 50% boost to the attribute bonus it grants.")
+          |  Class Equip Bonus: {{profile._statsComputed[k] - profile.stats.buffs[k] - ((profile.stats.lvl - 1) / 2) - Content.gear.flat[profile.items.gear.equipped.weapon][k] - Content.gear.flat[profile.items.gear.equipped.armor][k] - Content.gear.flat[profile.items.gear.equipped.head][k] - Content.gear.flat[profile.items.gear.equipped.shield][k]}}&nbsp;
+        li
+          i.icon-question-sign(popover-title='Allocated Points', popover-trigger='mouseenter', popover-placement='top', popover="Attribute points you've earned and assigned. Assign points using the Character Build column.")
+          |  Allocated: {{profile.stats[k] || 0}}&nbsp;
+        li
+          i.icon-question-sign(popover-title='Buffs', popover-trigger='mouseenter', popover-placement='top', popover="Attribute bonuses provided by abilities you or your party members have used. The abilities you can use are found in the Rewards column on your Tasks page.")
+          |  Buffs: {{profile.stats.buffs[k] || 0}}&nbsp;
   tr(ng-if='profile.stats.buffs.stealth')
     td
       strong Stealth: {{profile.stats.buffs.stealth}}&nbsp;


### PR DESCRIPTION
- Major beautification of the help bubbles for attribute bonuses added in commit 2f79472. They now serve as the bullets in the `ul` rather than staggering along the right side.
- Updated help bubble descriptions of attributes for accuracy (though see to-dos, below)
- Added direct Wikia links for all classes displayed in the class selection modal, and turned part of the header into a link to the class system wiki page.
- Updated class descriptions to provide more of an end-user experience perspective.

Still to do / consider:
- The "Stats & Achievements" page is ungainly right now, with a huge left-hand column, not very much in the center, and a wildly variable right side depending on the user's Achievements rap sheet. What do people think about splitting this into a "Character" tab with all the game-mechanics stuff, and an "Achievements" tab with information about the user's accomplishments like pet counts and badges? This would also give us room to put in some truly detailed descriptions of the attributes, which I tried but didn't look good in help-bubble popovers.
- I noticed a `[user.stats.class]` (resulting in "wizard" etc.) in the post-class-selection Justin tour, but injecting the same bit of Angular binding there as used elsewhere threw errors or showed up as raw text, depending on the syntax I used. @lefnire might know better how to fix that?
- I'm not 100% sold on how text-bare the "Choose Your Class" modal is when it first pops up, could be a little disorienting. So I'd be cool with putting some form of the one-liner back in at the top, the unfortunate side-effect being that it gives you ugly scrollbars on the longer class descriptions. Maybe another wordsmith might know how to curtail my verbosity :cat::sweat_drops:
