### PR TITLE
Remove extraneous techy characters from chat notifications

### DIFF
--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -371,7 +371,7 @@ api.cast = function(req, res) {
 
           if (group) {
             series.push(function(cb2){
-              var message = '`'+user.profile.name+' casts '+spell.text + (type=='user' ? ' on @'+found.profile.name : ' for the party')+'.`';
+              var message = '`'+user.profile.name+' casts '+spell.text + (type=='user' ? ' on '+found.profile.name : ' for the party')+'.`';
               group.sendChat(message);
               group.save(cb2);
             })

--- a/src/models/group.js
+++ b/src/models/group.js
@@ -182,7 +182,7 @@ GroupSchema.statics.collectQuest = function(user, progress, cb) {
       return m;
     }, []);
     foundText = foundText ? foundText.join(', ') : 'nothing';
-    group.sendChat("`<" + user.profile.name + "> found "+foundText+".`");
+    group.sendChat("`" + user.profile.name + " found "+foundText+".`");
     group.markModified('quest.progress.collect');
 
     // Still needs completing
@@ -210,7 +210,7 @@ GroupSchema.statics.bossQuest = function(user, progress, cb) {
     var down = progress.down * quest.boss.str; // multiply by boss strength
 
     group.quest.progress.hp -= progress.up;
-    group.sendChat("`<" + user.profile.name + "> attacks <" + quest.boss.name + "> for " + (progress.up.toFixed(1)) + " damage, <" + quest.boss.name + "> attacks party for " + Math.abs(down).toFixed(1) + " damage.`");
+    group.sendChat("`" + user.profile.name + " attacks " + quest.boss.name + " for " + (progress.up.toFixed(1)) + " damage, " + quest.boss.name + " attacks party for " + Math.abs(down).toFixed(1) + " damage.`");
 
     // Everyone takes damage
     var series = [


### PR DESCRIPTION
- Boss and party member names no longer have angle brackets around them during boss fights and collection quests.
- Casting a spell on a targeted party member no longer throws in an @ sign.
