### PR TITLE
Minor Text Update to Class Tour

### DIFF
--- a/public/js/services/guideServices.js
+++ b/public/js/services/guideServices.js
@@ -174,7 +174,7 @@ angular.module('guideServices', []).
         }, {
           element: ".meter.mana",
           title: "Spells",
-          content: "You can now unlock class-specific spells. You'll see your first at level 6. Your mana replenishes 10 points per day, plus 1 point per completed <a target='_blank' href='http://habitrpg.wikia.com/wiki/Todos'>To-Do</a>."
+          content: "You can now unlock class-specific spells. You'll see your first at level 11. Your mana replenishes 10 points per day, plus 1 point per completed <a target='_blank' href='http://habitrpg.wikia.com/wiki/Todos'>To-Do</a>."
         }, {
           orphan: true,
           title: "Read More",


### PR DESCRIPTION
Spells now happen at level 11 rather than 6.

Reflects change from https://github.com/HabitRPG/habitrpg/issues/2096
