### PR TITLE
Extend notification time, fix MP alerts

### DIFF
--- a/public/js/controllers/notificationCtrl.js
+++ b/public/js/controllers/notificationCtrl.js
@@ -33,7 +33,7 @@ habitrpg.controller('NotificationCtrl',
 
     $rootScope.$watch('user.stats.mp', function(after,before) {
        if (after == before) return;
-       if (User.user.stats.lvl == 0) return;
+       if (!User.user.flags.classSelected || User.user.preferences.disableClasses) return;
        var mana = after - before;
        Notification.mp(mana);
     });

--- a/public/js/services/notificationServices.js
+++ b/public/js/services/notificationServices.js
@@ -6,11 +6,11 @@ angular.module("notificationServices", [])
     function growl(html, type) {
       $.bootstrapGrowl(html, {
         ele: '#notification-area',
-        type: type, //(null, 'info', 'error', 'success', 'gp', 'xp', 'hp', 'lvl','death')
+        type: type, //(null, 'text', 'error', 'success', 'gp', 'xp', 'hp', 'lvl', 'death', 'mp')
         top_offset: 20,
         align: 'right', //('left', 'right', or 'center')
         width: 250, //(integer, or 'auto')
-        delay: 3000,
+        delay: 7000,
         allow_dismiss: true,
         stackup_spacing: 10 // spacing between consecutive stacecked growls.
       });


### PR DESCRIPTION
Partial fix for #2024: this commit more than doubles the length of time that notifications remain visible, to a lordly 7 seconds.

Also fixes an incidental issue where MP gain alerts would appear even if the user had no interest in them (not having unlocked classes yet, or having opted out of classes).
