### PR TITLE
Fix (apparent) misalignment of paws on pets/mounts grids

### DIFF
--- a/public/css/inventory.styl
+++ b/public/css/inventory.styl
@@ -123,6 +123,9 @@ menu.pets .customize-menu
     -o-filter: brightness(0%)
     -ms-filter: brightness(0%)*/
 
+    .PixelPaw
+      margin-top: 36px // align paw with pets, at the bottom of the button
+
 .selectableInventory
   background-color: lightgreen !important
   border-radius: 50%


### PR DESCRIPTION
The current alignment of the pets and mounts grids makes it look like owned and unowned creatures don't line up.  This is because pets (with the exception of flying pigs) have their icons aligned to the bottom of the images which contain them, while the paw icon is aligned to the center of its button.

This PR adds extra space to the top of the `PixelPaw` image when it is displayed for unowned creatures, pushing it back into apparent alignment with pet icons (again, with the exception of flying pigs, which are _supposed_ to look like they're higher than the rest).
