### PR TITLE
Prevent popover shadows from being clipped/overlapped

### DIFF
--- a/public/css/tasks.styl
+++ b/public/css/tasks.styl
@@ -284,6 +284,10 @@ for $stage in $stages
 .popover
   line-height: 1.5
 
+  // prevent box-shadow from being clipped/overlapped
+  margin-bottom: 10px
+  margin-right: 5px
+
 // task editing
 // ------------
 form


### PR DESCRIPTION
Bootstrap's popovers don't add any extra space for their box shadows, which makes it possible for them to be clipped or overlapped (this can currently be seen on the Pets tab).

This PR adds bottom and right margins to popovers equal to the spread of their box-shadows.  Doing so prevents the clipping currently seen on the Pets tab, but does not have a negative impact on other popovers in the application.
