### PR TITLE
Add Critical Hit notification by watching user._tmp.crit

### DIFF
--- a/public/js/controllers/notificationCtrl.js
+++ b/public/js/controllers/notificationCtrl.js
@@ -38,6 +38,14 @@ habitrpg.controller('NotificationCtrl',
        Notification.mp(mana);
     });
 
+    $rootScope.$watch('user._tmp.crit', function(after, before){
+       if (after == before || !after) return;
+       var amount = User.user._tmp.crit * 100 - 100;
+       // reset the crit counter
+       User.user._tmp.crit = undefined;
+       Notification.text("Critical Hit! Bonus: " + amount + "%");
+    });
+
     $rootScope.$watch('user._tmp.drop', function(after, before){
       // won't work when getting the same item twice?
       if (after == before || !after) return;


### PR DESCRIPTION
Adds a critical hit notification so the user understands why they sometimes get more exp, gold, whatever.

Fixes #2029
