### PR TITLE
Fix npm postinstall error ("not a recognized command" running `bower install`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "scripts": {
     "test": "./test/run_tests.sh",
     "start": "grunt run:dev",
-    "postinstall": "./node_modules/bower/bin/bower install -f"
+    "postinstall": "bower install -f"
   },
   "devDependencies": {
     "protractor": "~0.14.0",


### PR DESCRIPTION
As mentioned in the wiki article "[Setting up HabitRPG locally](http://habitrpg.wikia.com/wiki/Setting_up_HabitRPG_locally#Install_Node.js_.28includes_npm.29)", `npm install` fails on Windows with the following error:

```
'.' is not recognized as an internal or external command, operable program or batch file.
```

Because the Windows command line sees forward slashes as beginning a command argument, it believes `.` is the name of the executable.  This can be worked around simply by removing the explicit path to Bower.  (npm automatically places commands provided by dependencies in the install environment's `PATH`, so this works even when Bower is not installed globally.)
