### PR TITLE
Clear up some confusion caused by AngularJS number filter

### DIFF
--- a/public/js/controllers/headerCtrl.js
+++ b/public/js/controllers/headerCtrl.js
@@ -3,6 +3,7 @@
 habitrpg.controller("HeaderCtrl", ['$scope', 'Groups', 'User',
   function($scope, Groups, User) {
 
+    $scope.Math = window.Math;
 
     $scope.party = Groups.party(function(){
       $scope.partyMinusSelf = _.sortBy(

--- a/views/shared/header/header.jade
+++ b/views/shared/header/header.jade
@@ -14,12 +14,12 @@
         .bar(style='width: {{Shared.percent(user.stats.hp, 50)}}%;')
         span.meter-text
           i.icon-heart
-          | {{user.stats.hp | number:0}} / 50
+          | {{Math.ceil(user.stats.hp)}} / 50
       .meter.experience(title='Experience')
         .bar(style='width: {{Shared.percent(user.stats.exp,Shared.tnl(user.stats.lvl))}}%;')
         span.meter-text
           i.icon-star
-          | {{user.stats.exp | number:0}} / {{Shared.tnl(user.stats.lvl) | number:0}}
+          | {{Math.floor(user.stats.exp)}} / {{Shared.tnl(user.stats.lvl) | number:0}}
           // FIXME doesn't look great here, but the "Experience" CSS title rollover covers it where it was before
           span(ng-show='user.history.exp')
             a(ng-click='toggleChart("exp")', tooltip='Progress')
@@ -28,7 +28,7 @@
         .bar(style='width: {{user.stats.mp / user._statsComputed.maxMP * 100}}%;')
         span.meter-text
           i.icon-fire
-          | {{user.stats.mp || 0 | number:0}} / {{user._statsComputed.maxMP}}
+          | {{Math.floor(user.stats.mp)}} / {{user._statsComputed.maxMP}}
 
     // party
     span(ng-controller='PartyCtrl')


### PR DESCRIPTION
Implement `floor` rounding for Mana, so users don't get "Not enough Mana" errors for trying to spend 30 out of 29.8 points. (They'll see 29 instead of 30.) 

Implement `ceil` rounding for Health, so users don't look like they should be dead when they're at .3 HP. (They'll see 1.)

Implement `floor` rounding for Experience, so it doesn't look like the user ought to have leveled up when they're at 639.7 out of 640. (They'll see 639.)
