### PR TITLE
Fixed header scrollbar being covered by main pane

### DIFF
--- a/public/js/controllers/rootCtrl.js
+++ b/public/js/controllers/rootCtrl.js
@@ -10,6 +10,10 @@ habitrpg.controller("RootCtrl", ['$scope', '$rootScope', '$location', 'User', '$
     var initSticky = _.once(function(){
       if (window.env.IS_MOBILE || User.user.preferences.stickyHeader === false) return;
       $('.header-wrap').sticky({topSpacing:0});
+      // sticky fixes the header's height, but doesn't account for
+      // scrollbars appearing later, so unset it
+      $('.header-wrap').parent().attr("style","height:auto");
+        
     })
     $rootScope.$on('userUpdated',initSticky);
 


### PR DESCRIPTION
Large parties create a horizontal scrollbar in the header; this scrollbar wasn't useable because it was invisibly covered by the main contents of the page. Fixed this.

Tested on Chrome version 31.0.1650.63 and Safari version 5.1.7 under OS X 10.6.8.
