### PR TITLE
Show number of tamed mounts under Profile/Stats & Achievements

### DIFF
--- a/public/js/controllers/inventoryCtrl.js
+++ b/public/js/controllers/inventoryCtrl.js
@@ -13,7 +13,7 @@ habitrpg.controller("InventoryCtrl", ['$rootScope', '$scope', '$window', 'User',
     // count egg, food, hatchingPotion stack totals
     var countStacks = function(items) { return _.reduce(items,function(m,v){return m+v;},0);}
 
-    $scope.$watch('user.items.mounts', function(mounts){ $scope.mountCount = $rootScope.countExists(mounts); }, true);
+    $scope.$watch('user.items.mounts', function(mounts){ $rootScope.mountCount = $rootScope.countExists(mounts); }, true);
     $scope.$watch('user.items.eggs', function(eggs){ $scope.eggCount = countStacks(eggs); }, true);
     $scope.$watch('user.items.hatchingPotions', function(pots){ $scope.potCount = countStacks(pots); }, true);
     $scope.$watch('user.items.food', function(food){ $scope.foodCount = countStacks(food); }, true);

--- a/views/shared/profiles/stats.jade
+++ b/views/shared/profiles/stats.jade
@@ -62,9 +62,8 @@ table.table.table-striped
   tr
     td
       strong Pets Found
-      | : {{profile.petCount}}
-// Dunno why this doesn't work //
-//  tr
+      | : {{petCount}}
+  tr
     td
       strong Mounts Tamed
-      | : {{profile.mountCount}} //
+      | : {{mountCount}} 

--- a/views/shared/profiles/stats.jade
+++ b/views/shared/profiles/stats.jade
@@ -62,7 +62,7 @@ table.table.table-striped
   tr
     td
       strong Pets Found
-      | : {{petCount}}
+      | : {{profile.petCount}}
   tr
     td
       strong Mounts Tamed


### PR DESCRIPTION
@snicker issued #1936 which changed `line 65` from `{{petCount}}` to `{{profile.petCount}}`. I don't know if that's the way it should be and if the problem is somewhere else but I switched it back as it wasn't displaying the correct number of pets. Also, on `stables.jade` both pets and mounts are `{{petCount}}` and `{{mountCount}}`.

And `inventoryCtrl.js` makes it display the amount of mounts tamed now but I don't know if that's correct.
