### PR TITLE
Don't show Streak achievement modal on Fix Character Values if it was undefined

### DIFF
--- a/public/js/controllers/notificationCtrl.js
+++ b/public/js/controllers/notificationCtrl.js
@@ -60,7 +60,7 @@ habitrpg.controller('NotificationCtrl',
     });
 
     $rootScope.$watch('user.achievements.streak', function(after, before){
-      if(after == before || after < before) return;
+      if(before == undefined || after == before || after < before) return;
       $rootScope.modals.achievements.streak = true;
     });
 


### PR DESCRIPTION
Fix for #2236.
