### PR TITLE
Fix #2277: make Automatic Allocation checkbox set "task activity" mode

### DIFF
--- a/views/options/profile.jade
+++ b/views/options/profile.jade
@@ -148,7 +148,7 @@ script(id='partials/options.profile.stats.html', type='text/ng-template')
       h5 Unallocated Attribute Points: {{user.stats.points}}
       fieldset.auto-allocate
         label.checkbox
-          input(type='checkbox', ng-model='user.preferences.automaticAllocation', ng-change='set({"preferences.automaticAllocation": user.preferences.automaticAllocation?true: false})')
+          input(type='checkbox', ng-model='user.preferences.automaticAllocation', ng-change='set({"preferences.automaticAllocation": user.preferences.automaticAllocation?true: false})', ng-click='set({"preferences.allocationMode":"taskbased"})')
           | Automatic Allocation&nbsp;
           i.icon-question-sign(popover-trigger='mouseenter', popover-placement='right', popover="Places points into attributes according to your preferences, when you level up.")
           form(ng-show='user.preferences.automaticAllocation')


### PR DESCRIPTION
Clicks on the "Automatic Allocation" checkbox also force the allocation mode preference to "distribute attribute points based on task activity", hopefully addressing #2277 and maintaining close to old behavior for users accustomed to the original auto-allocation setting.

@lefnire: This feels like a hella weird solution, throwing both `ng-change` and `ng-click` on the same element, but doing an `&&` in the `set` caused the `automaticAllocation` preference to stop saving to the user. Shrug!
