### PR TITLE
Client side of Rebirth-related fix: don't remove Wolf Eggs upon unlock

### DIFF
--- a/public/js/services/guideServices.js
+++ b/public/js/services/guideServices.js
@@ -127,7 +127,9 @@ angular.module('guideServices', []).
     $rootScope.$watch('user.flags.dropsEnabled', function(after, before) {
       if (alreadyShown(before, after)) return;
       var eggs = User.user.items.eggs || {};
-      eggs['Wolf'] = 1; // This is also set on the server
+      if (!eggs) {
+        eggs['Wolf'] = 1; // This is also set on the server
+      }
       $rootScope.modals.dropsEnabled = true;
     });
 


### PR DESCRIPTION
Previously, if user had >1 Wolf Egg, performed a Rebirth, then unlocked drops again, they would be reset to 1 Wolf Egg. Now Habit checks to see if they have some Wolf Eggs already, and if so, gives them one instead of setting the quantity to one.

Server op from the `$watch` happens first, so guideservices.js just skips if there are already eggs around. I tried doing a `eggs['Wolf']++` here as well, but that caused doubling-up (looked like the user received two eggs, until refresh). That may mean this bit isn't needed at all, in practice.
