### PR TITLE
Fix #2048 (streak bonuses not appearing to add up)

### DIFF
--- a/public/js/controllers/notificationCtrl.js
+++ b/public/js/controllers/notificationCtrl.js
@@ -19,10 +19,10 @@ habitrpg.controller('NotificationCtrl',
       if (after == before) return;
       if (User.user.stats.lvl == 0) return;
       var money = after - before;
-      Notification.gp(money);
+      var bonus = User.user._tmp.streakBonus;
+      Notification.gp(money, bonus || 0);
 
       //Append Bonus
-      var bonus = User.user._tmp.streakBonus;
 
       if ((money > 0) && !!bonus) {
         if (bonus < 0.01) bonus = 0.01;

--- a/public/js/services/notificationServices.js
+++ b/public/js/services/notificationServices.js
@@ -51,8 +51,8 @@ angular.module("notificationServices", [])
         if (val < -50) return; // don't show when they level up (resetting their exp)
         growl("<i class='icon-star'></i> " + sign(val) + " " + round(val) + " XP", 'xp');
       },
-      gp: function(val) {
-        growl(sign(val) + " " + coins(val), 'gp');
+      gp: function(val, bonus) {
+        growl(sign(val) + " " + coins(val - bonus), 'gp');
       },
       text: function(val){
         growl(val);


### PR DESCRIPTION
Addresses the issue of misleading streak notifications, by making the "gp" notification style take two arguments: value and bonus. (It's thus important to pass a 0 if we're not dealing with a streak. If there's a better way to handle that, I'm all for it!) The GP notification subtracts off the bonus before displaying, resulting in an alert that contains only the pre-streak total. When we then add the "+X Streak Bonus!" notification, the total list of alerts correctly adds up to the amount of GP gained, where previously the streak bonus was getting double-listed.

If you watch very closely, totaling up every alert you get, there will be discrepancies of a few Silver due to rounding. But you'll be much closer than you previously would, where you'd seem to be short several Gold!
