### PR TITLE
Fixed UI issues when editing checklists

### DIFF
--- a/public/js/controllers/tasksCtrl.js
+++ b/public/js/controllers/tasksCtrl.js
@@ -43,7 +43,7 @@ habitrpg.controller("TasksCtrl", ['$scope', '$rootScope', '$location', 'User','N
     };
 
     $scope.saveTask = function(task, stayOpen) {
-      if (task.checklist && task.checklist[0])
+      if (task.checklist)
         task.checklist = _.filter(task.checklist,function(i){return !!i.text});
       User.user.ops.updateTask({params:{id:task.id},body:task});
       if (!stayOpen) task._editing = false;

--- a/public/js/controllers/tasksCtrl.js
+++ b/public/js/controllers/tasksCtrl.js
@@ -92,7 +92,10 @@ habitrpg.controller("TasksCtrl", ['$scope', '$rootScope', '$location', 'User','N
       focusChecklist(task,0);
     }
     $scope.addChecklistItem = function(task,$event,$index) {
-      if ($index == task.checklist.length-1){
+      if (!task.checklist[$index].text) {
+        // Don't allow creation of an empty checklist item
+        // TODO Provide UI feedback that this item is still blank
+      } else if ($index == task.checklist.length-1){
         User.user.ops.updateTask({params:{id:task.id},body:task}); // don't preen the new empty item
         task.checklist.push({completed:false,text:''});
         focusChecklist(task,task.checklist.length-1);
@@ -101,13 +104,21 @@ habitrpg.controller("TasksCtrl", ['$scope', '$rootScope', '$location', 'User','N
         focusChecklist(task,$index+1);
       }
     }
-    $scope.removeChecklistItem = function(task,$index,force){
-      var backspaced = !force && !task.checklist[$index].text
-      if (force || backspaced) {
+    $scope.removeChecklistItem = function(task,$event,$index,force){
+      // Remove item if clicked on trash icon
+      if (force) {
         task.checklist.splice($index,1);
         $scope.saveTask(task,true);
-        if (backspaced) focusChecklist(task,$index-1);
-      }
+      } else if (!task.checklist[$index].text) {
+        // User deleted all the text and is now wishing to delete the item
+        // saveTask will prune the empty item
+        $scope.saveTask(task,true);
+        // Move focus if the list is still non-empty
+        if ($index > 0)
+          focusChecklist(task,$index-1);
+        // Don't allow the backspace key to navigate back now that the field is gone
+        $event.preventDefault();
+      } 
     }
     $scope.navigateChecklist = function(task,$index,$event){
       focusChecklist(task, $event.keyCode == '40' ? $index+1 : $index-1);

--- a/views/shared/tasks/task.jade
+++ b/views/shared/tasks/task.jade
@@ -120,10 +120,10 @@ li(bindonce='list', bo-id='"task-"+task.id', ng-repeat='task in obj[list.type+"s
               i.icon.icon-question-sign(popover=env.t('checklistText'),popover-trigger='mouseenter',popover-placement='bottom')
             ul.unstyled
               li(ng-repeat='item in task.checklist')
-                a.pull-right.checklist-icons(ng-click='removeChecklistItem(task,$index,true)')
+                a.pull-right.checklist-icons(ng-click='removeChecklistItem(task,$event,$index,true)')
                   i.icon-trash(tooltip=env.t('delete'))
                 input(type='checkbox',ng-model='item.completed',ng-change='saveTask(task,true)')
-                input.inline-edit(type='text',ng-model='item.text',ui-keyup="{13:'addChecklistItem(task,$event,$index)','8 49':'removeChecklistItem(task,$index)','38 40':'navigateChecklist(task,$index,$event)'}")//-,ng-blur='saveTask(task,true)')
+                input.inline-edit(type='text',ng-model='item.text',ui-keydown="{'8 46':'removeChecklistItem(task,$event,$index)'}",ui-keyup="{'13':'addChecklistItem(task,$event,$index)','38 40':'navigateChecklist(task,$index,$event)'}")//-,ng-blur='saveTask(task,true)')
 
 
       form(ng-submit='saveTask(task)')


### PR DESCRIPTION
Fixes #2182 and #2197. In short:
1. Fixed issue where removeChecklistItem() was leaving the "Checklist:" label after removing the last item.
2. Fixed issue where removeChecklistItem() tried to give focus to an item in an empty list.
2. Fixed keycode typo. The keycode 49 (for the numeral 1) was being used instead of the keycode 46 (for the delete key). 

Slightly new behavior introduced:
1. addChecklistItem no longer allows the user to create an empty checklist item.
2. backspace and delete previously removed a list item as soon as it contained no text, making it hard for the user to, for example, correct typos that start at the beginning of the string. Now backspace and delete only remove a list item when either key is pressed in a list item that already contains no text. Delete all the text, then hit delete one more time to back up to the previous list item. This seems more intuitive.

It might be nice in a future commit to add visual cues (like those for the task text) that indicate an empty checklist item (red) or a checklist item that has focus (blue). 
