### PR TITLE
New user preference: open new tasks in edit mode

### DIFF
--- a/src/models/user.js
+++ b/src/models/user.js
@@ -227,7 +227,8 @@ var UserSchema = new Schema({
     costume: Boolean,
     sleep: {type: Boolean, 'default': false},
     stickyHeader: {type: Boolean, 'default': true},
-    disableClasses: {type: Boolean, 'default': false}
+    disableClasses: {type: Boolean, 'default': false},
+    newTaskEdit: {type: Boolean, 'default': false}
   },
   profile: {
     blurb: String,

--- a/views/options/settings.jade
+++ b/views/options/settings.jade
@@ -33,12 +33,16 @@ script(type='text/ng-template', id='partials/options.settings.settings.html')
       h4 Misc
       label.checkbox
         input(type='checkbox', ng-click='set({"preferences.hideHeader":user.preferences.hideHeader?false:true})', ng-checked='user.preferences.hideHeader!==true')
-        | Show Header
+        | Show Header&nbsp;
         i.icon-question-sign(popover-trigger='mouseenter', popover-placement='right', popover='Show your avatar, Health/Experience bars, and party.')
       label.checkbox
         input(type='checkbox', ng-click='toggleStickyHeader()', ng-checked='user.preferences.stickyHeader!==false')
-        | Sticky Header
+        | Sticky Header&nbsp;
         i.icon-question-sign(popover-trigger='mouseenter', popover-placement='right', popover='Affix the header to the top of the screen. Unchecked means it scrolls out of view.')
+      label.checkbox
+        input(type='checkbox', ng-model='user.preferences.newTaskEdit', ng-change='set({"preferences.newTaskEdit": user.preferences.newTaskEdit?true: false})')
+        | Open New Tasks in Edit Mode&nbsp;
+        i.icon-question-sign(popover-trigger='mouseenter', popover-placement='right', popover='With this option set, new tasks will immediately open for you to add details like notes and tags.')
       button.btn(ng-click='showTour()', popover-placement='right', popover-trigger='mouseenter', popover='Restart the introductory tour from when you first joined HabitRPG.') Show Tour
       br
       button.btn(ng-click='showBailey()', popover-trigger='mouseenter', popover-placement='right', popover='Bring Bailey the Town Crier out of hiding so you can review past news.') Show Bailey

--- a/views/options/settings.jade
+++ b/views/options/settings.jade
@@ -33,15 +33,15 @@ script(type='text/ng-template', id='partials/options.settings.settings.html')
       h4 Misc
       label.checkbox
         input(type='checkbox', ng-click='set({"preferences.hideHeader":user.preferences.hideHeader?false:true})', ng-checked='user.preferences.hideHeader!==true')
-        | Show Header&nbsp;
+        | Show header&nbsp;
         i.icon-question-sign(popover-trigger='mouseenter', popover-placement='right', popover='Show your avatar, Health/Experience bars, and party.')
       label.checkbox
         input(type='checkbox', ng-click='toggleStickyHeader()', ng-checked='user.preferences.stickyHeader!==false')
-        | Sticky Header&nbsp;
+        | Sticky header&nbsp;
         i.icon-question-sign(popover-trigger='mouseenter', popover-placement='right', popover='Affix the header to the top of the screen. Unchecked means it scrolls out of view.')
       label.checkbox
         input(type='checkbox', ng-model='user.preferences.newTaskEdit', ng-change='set({"preferences.newTaskEdit": user.preferences.newTaskEdit?true: false})')
-        | Open New Tasks in Edit Mode&nbsp;
+        | Open new tasks in edit mode&nbsp;
         i.icon-question-sign(popover-trigger='mouseenter', popover-placement='right', popover='With this option set, new tasks will immediately open for you to add details like notes and tags.')
       button.btn(ng-click='showTour()', popover-placement='right', popover-trigger='mouseenter', popover='Restart the introductory tour from when you first joined HabitRPG.') Show Tour
       br


### PR DESCRIPTION
Adds a new checkbox user preference to Settings > Settings > Misc: "Open new tasks in edit mode".

When this preference is enabled, new tasks the user adds using the Web form will open expanded, with all options visible and ready for editing, instead of the current behavior where the task saves with defaults and requires an additional click or double-click to access extended options.

Meant for power users who like to tweak tags, difficulty, attributes, etc. for most tasks they add, so this defaults to `false`.
