### PR TITLE
More UI demystification

### DIFF
--- a/views/options/profile.jade
+++ b/views/options/profile.jade
@@ -145,7 +145,7 @@ script(id='partials/options.profile.stats.html', type='text/ng-template')
           | Change Class, Refund Attribute Points&nbsp;
         small 3 <span class="Pet_Currency_Gem1x inline-gems"/>
 
-      h5 Unallocated Attribute Points: {{user.stats.points}}
+      h5(popover-trigger='mouseenter', popover-placement='left', popover="Each level earns you one point to assign to an attribute of your choice. You can do so manually, or let the game decide for you using one of the Automatic Allocation options.") Unallocated Attribute Points: {{user.stats.points}}&nbsp;
       fieldset.auto-allocate
         label.checkbox
           input(type='checkbox', ng-model='user.preferences.automaticAllocation', ng-change='set({"preferences.automaticAllocation": user.preferences.automaticAllocation?true: false})', ng-click='set({"preferences.allocationMode":"taskbased"})')
@@ -166,29 +166,21 @@ script(id='partials/options.profile.stats.html', type='text/ng-template')
               i.icon-question-sign(popover-trigger='mouseenter', popover-placement='right', popover="Assigns points based on the Physical (STR), Mental (INT), Social (CON), and Other (PER) categories associated with the tasks you complete.")
       table.table.table-striped
         tr
+          td Points allocated to STR: {{user.stats.str}}
           td
-            i.icon-question-sign(popover-title='Strength', popover='Strength reduces task threat (redness), increases the Gold and Experience boost from random "critical hits," and helps deal damage to boss monsters.', popover-trigger='mouseenter')
-            | &nbsp;STR: {{user.stats.str}}
-          td
-            a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("str")') +
+            a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("str")', popover-trigger='mouseenter', popover-placement='right', popover="Add a point to Strength") +
         tr
+          td Points allocated to CON: {{user.stats.con}}
           td
-            i.icon-question-sign(popover-title='Constitution', popover='Constitution reduces the damage you take, whether from negative Habits, missed Dailies, or the attacks of boss monsters.', popover-trigger='mouseenter')
-            | &nbsp;CON: {{user.stats.con}}
-          td
-            a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("con")') +
+            a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("con")', popover-trigger='mouseenter', popover-placement='right', popover="Add a point to Constitution") +
         tr
+          td Points allocated to PER: {{user.stats.per}}
           td
-            i.icon-question-sign(popover-title='Perception', popover='Perception increases how much Gold you earn, and increases the chance of finding items when scoring tasks.', popover-trigger='mouseenter')
-            | &nbsp;PER: {{user.stats.per}}
-          td
-            a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("per")') +
+            a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("per")', popover-trigger='mouseenter', popover-placement='right', popover="Add a point to Perception") +
         tr
+          td Points allocated to INT: {{user.stats.int}}
           td
-            i.icon-question-sign(popover-title='Intelligence', popover='Intelligence increases how much Experience you earn, and determines your maximum Mana available for class abilities.', popover-trigger='mouseenter')
-            | &nbsp;INT: {{user.stats.int}}
-          td
-            a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("int")') +
+            a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("int")', popover-trigger='mouseenter', popover-placement='right', popover="Add a point to Intelligence") +
     div(ng-class='user.flags.classSelected && !user.preferences.disableClasses ? "span4" : "span6"')
       include ../shared/profiles/achievements
 

--- a/views/options/social/tavern.jade
+++ b/views/options/social/tavern.jade
@@ -53,52 +53,52 @@
         h3 Player Tiers
       .modal-body
         small.
-          Click tier labels below for more information. <br />
+          <a href='/#/options/groups/hall'>Visit the Hall of Heroes (contributors and backers)</a> <br />
           <a href='http://habitrpg.wikia.com/wiki/Contributor_Rewards' target='_blank'>Learn more about contributor rewards</a> <br />
           <a href='http://habitrpg.wikia.com/wiki/Contributing_to_HabitRPG' target='_blank'>Learn how to contribute to HabitRPG</a>
         table.table.table-striped
           tr
             td
-              a.label.label-contributor-1(ng-click='toggleUserTier($event)') Friend (1-2)
+              a.label.label-contributor-1(ng-click='toggleUserTier($event)', tooltip='Click for details') Friend (1-2)
               div(style='display:none;')
                 p.
                   <span class='achievement achievement-firefox'></span> When your <strong>first</strong> submission is deployed, you will receive the HabitRPG Contributor's badge. Your name in Tavern chat will proudly display that you are a contributor. As a bounty for your work, you will also receive <strong>2 Gems</strong>.
                 hr
                 p.
-                  <span class='shop_armor_special_1 shop-sprite item-img'></span> When your <strong>second</strong> submission is deployed, the <strong>Crystal Armor</strong> will be available for purchase in the Rewards shop after the Golden Armor. As a bounty for your continued work, you will also receive <strong>2 Gems</strong>.
+                  <span class='shop_armor_special_1 shop-sprite item-img'></span> When your <strong>second</strong> submission is deployed, the <strong>Crystal Armor</strong> will be available for purchase in the Rewards shop. As a bounty for your continued work, you will also receive <strong>2 Gems</strong>.
           tr
             td
-              a.label.label-contributor-3(ng-click='toggleUserTier($event)') Elite (3-4)
+              a.label.label-contributor-3(ng-click='toggleUserTier($event)', tooltip='Click for details') Elite (3-4)
               div(style='display:none;')
                 p.
-                 <span class='shop_head_special_1 shop-sprite item-img'></span> When your <strong>third</strong> submission is deployed, the <strong>Crystal Helmet</strong> will be available for purchase in the Rewards shop after the Golden Helmet. As a bounty for your great work, you will also receive <strong>2 Gems</strong>.
+                 <span class='shop_head_special_1 shop-sprite item-img'></span> When your <strong>third</strong> submission is deployed, the <strong>Crystal Helmet</strong> will be available for purchase in the Rewards shop. As a bounty for your great work, you will also receive <strong>2 Gems</strong>.
                 hr
                 p.
-                  <span class='shop_weapon_special_1 shop-sprite item-img'></span> When your <strong>fourth</strong> submission is deployed, the <strong>Crystal Sword</strong> will be available for purchase in the Rewards shop after the Golden Sword. You will once again receive a bounty of <strong>2 Gems</strong>.
+                  <span class='shop_weapon_special_1 shop-sprite item-img'></span> When your <strong>fourth</strong> submission is deployed, the <strong>Crystal Sword</strong> will be available for purchase in the Rewards shop. You will once again receive a bounty of <strong>2 Gems</strong>.
 
           tr
             td
-              a.label.label-contributor-5(ng-click='toggleUserTier($event)') Champion (5-6)
+              a.label.label-contributor-5(ng-click='toggleUserTier($event)', tooltip='Click for details') Champion (5-6)
               div(style='display:none;')
                 p.
-                  <span class='shop_shield_special_1 shop-sprite item-img'></span> When your <em>fifth</em> submission is deployed, the <strong>Crystal Shield</strong> will be available for purchase in the Reward shop after the Golden Shield. You will also receive <strong>2 Gems</strong>.
+                  <span class='shop_shield_special_1 shop-sprite item-img'></span> When your <em>fifth</em> submission is deployed, the <strong>Crystal Shield</strong> will be available for purchase in the Rewards shop. You will also receive <strong>2 Gems</strong>.
                 hr
                 p.
                  <div class='Pet-Dragon-Hydra pull-left'></div> When your <em>sixth</em> submission is deployed, you will receive a <strong>Hydra Pet</strong>. You will also receive <strong>2 Gems</strong>.
           tr
             td
-              a.label.label-contributor-7(ng-click='toggleUserTier($event)') Legendary (7)
+              a.label.label-contributor-7(ng-click='toggleUserTier($event)', tooltip='Click for details') Legendary (7)
               div(style='display:none;')
                 p.
                   When your <em>seventh</em> submission is deployed, you will receive <strong>2 Gems</strong> and become a member of the honored Contributor's Guild and be privy to the behind-the-scenes details of HabitRPG! Further contributions do not increase your level, but you may continue to earn Gem bounties and titles.
           tr
             td
-              a.label.label-contributor-8(ng-click='toggleUserTier($event)') Heroic
+              a.label.label-contributor-8(ng-click='toggleUserTier($event)', tooltip='Click for details') Heroic
               div(style='display:none;')
                 p The Heroic level contains HabitRPG staff and staff-level contributors. If you have this title, you were appointed to it (or hired!).
           tr
             td
-              a.label.label-npc(ng-click='toggleUserTier($event)') NPC
+              a.label.label-npc(ng-click='toggleUserTier($event)', tooltip='Click for details') NPC
               div(style='display:none;')
                 p NPCs backed HabitRPG's Kickstarter at the highest tier. You can find their avatars watching over site features!
 

--- a/views/shared/profiles/stats.jade
+++ b/views/shared/profiles/stats.jade
@@ -17,8 +17,8 @@ table.table.table-striped
       strong Experience
       | : {{profile.stats.exp | number:0}} / {{Shared.tnl(profile.stats.lvl)}}
 
-h4.stats-equipment Equipment
-table.table.table-striped
+h4.stats-equipment(ng-show='user.flags.itemsEnabled') Equipment
+table.table.table-striped(ng-show='user.flags.itemsEnabled')
   // FIXME this isn't refreshing properly. On first party modal, correct. Second party modal click gives the previous gear. It's always one behind.
   tr(ng-repeat='(k,v) in profile.items.gear.equipped', ng-init='piece=Content.gear.flat[v]', ng-show='piece')
     td
@@ -27,25 +27,29 @@ table.table.table-striped
 
 h4 Attributes
 table.table.table-striped
-  tr(ng-repeat='(k,v) in {str:"Strength",int:"Intelligence",con:"Constitution",per:"Perception"}')
+  tr(ng-repeat='(k,v) in {str:"Strength (STR)",int:"Intelligence (INT)",con:"Constitution (CON)",per:"Perception (PER)"}')
     td
+      i.icon-question-sign(ng-show='k=="str"', popover-title='Strength', popover-placement='right', popover='Strength reduces task threat (redness), increases the Gold and Experience boost from random "critical hits," and helps deal damage to boss monsters.', popover-trigger='mouseenter', style='margin-right:3px')
+      i.icon-question-sign(ng-show='k=="con"', popover-title='Constitution', popover-placement='right', popover='Constitution reduces the damage you take, whether from negative Habits, missed Dailies, or the attacks of boss monsters.', popover-trigger='mouseenter', style='margin-right:3px')
+      i.icon-question-sign(ng-show='k=="per"', popover-title='Perception', popover-placement='right', popover='Perception increases how much Gold you earn, and starting at level 4, increases the chance of finding items when scoring tasks.', popover-trigger='mouseenter', style='margin-right:3px')
+      i.icon-question-sign(ng-show='k=="int"', popover-title='Intelligence', popover-placement='right', popover='Intelligence increases how much Experience you earn, and once you\'ve unlocked Classes, determines your maximum Mana available for class abilities.', popover-trigger='mouseenter', style='margin-right:3px')
       strong {{v}}: {{profile._statsComputed[k]}}
     td
       ul(style='list-style-type:none')
         li
-          i.icon-question-sign(popover-title='Level Bonus', popover-trigger='mouseenter', popover-placement='top', popover="Each attribute gets a bonus equal to half your Level.")
+          i.icon-question-sign(popover-title='Level Bonus', popover-trigger='mouseenter', popover-placement='top', popover="Each attribute gets a bonus equal to half of (your Level minus 1).")
           |  Level: {{(profile.stats.lvl - 1) / 2}}&nbsp;
-        li
+        li(ng-show='user.flags.itemsEnabled')
           i.icon-question-sign(popover-title='Equipment', popover-trigger='mouseenter', popover-placement='top', popover="Attribute bonuses provided by your equipped battle gear. See the Equipment tab under Inventory to select your battle gear.")
           |  Equipment: {{Content.gear.flat[profile.items.gear.equipped.weapon][k] + Content.gear.flat[profile.items.gear.equipped.armor][k] + Content.gear.flat[profile.items.gear.equipped.head][k] + Content.gear.flat[profile.items.gear.equipped.shield][k] || 0}}&nbsp;
-        li
-          i.icon-question-sign(popover-title='Class Equipment Bonus', popover-trigger='mouseenter', popover-placement='top', popover="Your class uses its own equipment more effectively than gear from other classes. Equipped gear from your current class gets a 50% boost to the attribute bonus it grants.")
+        li(ng-show='user.flags.itemsEnabled')
+          i.icon-question-sign(popover-title='Class Equipment Bonus', popover-trigger='mouseenter', popover-placement='top', popover="Your class (Warrior, if you haven't unlocked or selected another class) uses its own equipment more effectively than gear from other classes. Equipped gear from your current class gets a 50% boost to the attribute bonus it grants.")
           |  Class Equip Bonus: {{profile._statsComputed[k] - profile.stats.buffs[k] - ((profile.stats.lvl - 1) / 2) - Content.gear.flat[profile.items.gear.equipped.weapon][k] - Content.gear.flat[profile.items.gear.equipped.armor][k] - Content.gear.flat[profile.items.gear.equipped.head][k] - Content.gear.flat[profile.items.gear.equipped.shield][k] - profile.stats[k]}}&nbsp;
-        li
+        li(ng-show='user.flags.classSelected && !user.preferences.disableClasses')
           i.icon-question-sign(popover-title='Allocated Points', popover-trigger='mouseenter', popover-placement='top', popover="Attribute points you've earned and assigned. Assign points using the Character Build column.")
           |  Allocated: {{profile.stats[k] || 0}}&nbsp;
         li
-          i.icon-question-sign(popover-title='Buffs', popover-trigger='mouseenter', popover-placement='top', popover="Attribute bonuses provided by abilities you or your party members have used. The abilities you can use are found in the Rewards column on your Tasks page.")
+          i.icon-question-sign(popover-title='Buffs', popover-trigger='mouseenter', popover-placement='top', popover="Attribute bonuses provided by abilities you or your party members have used. Starting at level 11, the abilities you can use are found in the Rewards column on your Tasks page.")
           |  Buffs: {{profile.stats.buffs[k] || 0}}&nbsp;
   tr(ng-if='profile.stats.buffs.stealth')
     td
@@ -58,8 +62,8 @@ table.table.table-striped
         i.icon-question-sign(popover-title='Streaks Frozen', popover-trigger='mouseenter', popover-placement='right', popover="Streaks on missed Dailies will not reset at the end of the day.")
     td
 
-h4 Pets
-table.table.table-striped
+h4(ng-show='user.flags.dropsEnabled') Pets
+table.table.table-striped(ng-show='user.flags.dropsEnabled')
   tr
     td
       strong Pets Found


### PR DESCRIPTION
Let's see if I can remember all the stuff I doofed around with here. Overall focus was on having things show up _where_ and _when_ the user first needs to deal with them, and not before.
- Moves the explanations of attributes from the Character Build section of Stats & Achievements to the Attributes section.
- Makes explicit that the Character Build points are allocated points, not total STR/CON/etc.
- Hides various pieces of Stats & Achievements if the user has not unlocked relevant features yet. For instance, Equipment and Class Equip Bonus are not displayed until the player unlocks the Item Store.
- Added a popover to describe what "unallocated attribute points" are. **Caveat**: I could not for the life of me get Jade to give me a ? bubble on the same line as the `h5` without its text becoming h5-styled as well. So the text itself provides the popover, which is inconsistent; a user will probably find it only by accident. :confused:
- Tavern: brings the descriptions of contributor gear up to date, and adds a link to the new Hall of Heroes.
