### PR TITLE
Minor fix to chat links; rounded critical hit percentages

### DIFF
--- a/public/js/directives/directives.js
+++ b/public/js/directives/directives.js
@@ -105,7 +105,7 @@ habitrpg.directive('habitrpgSortable', ['User', function(User) {
           .replace(/'/g, '&#39;');
       };
       if (cap[0].charAt(0) !== '!') {
-        return '<a class="markdown-link" href="'
+        return '<a class="markdown-link" target="_blank" href="'
           + escape(link.href)
           + '"'
           + (link.title
@@ -117,7 +117,7 @@ habitrpg.directive('habitrpgSortable', ['User', function(User) {
           + this.output(cap[1])
           + '</a>';
       } else {
-        return '<a class="markdown-img-link" href="'
+        return '<a class="markdown-img-link" target="_blank" href="'
           + escape(link.href)
           + '"'
           + (link.title

--- a/public/js/services/notificationServices.js
+++ b/public/js/services/notificationServices.js
@@ -70,7 +70,7 @@ angular.module("notificationServices", [])
         growl("<i class='icon-fire'></i> " + sign(val) + " " + round(val) + " MP", 'mp');
       },
       crit: function(val) {
-        growl("<i class='icon-certificate'></i> Critical Hit! Bonus: " + val + "%", 'crit');
+        growl("<i class='icon-certificate'></i> Critical Hit! Bonus: " + Math.round(val) + "%", 'crit');
       }
     };
   }

--- a/views/options/social/chat-message.jade
+++ b/views/options/social/chat-message.jade
@@ -2,7 +2,7 @@ li.chat-message(bindonce='group.chat', ng-repeat='message in group.chat', bo-cla
   div(class='scrollable-message')
     a.label.chat-message(class='hidden-label')
       span {{message.user}}&nbsp;
-    markdown(ng-model='message.text',target='_blank', style='padding:0px 3px')
+    markdown(ng-model='message.text', style='padding:0px 3px')
     | -
     span.muted.time(from-now='message.timestamp',style='padding:0px 3px')
     span(style='padding:0px 3px')


### PR DESCRIPTION
Two minor changes:
1. Markdown links in a chat message should open in a new browser tab, but only the first link in a message with multiple links was actually opening in a new tab. Now all chat links open in a new tab.
2. Growl notifications for critical hits were showing some floating point ugliness, e.g.
   ![screen shot 2014-01-08 at 3 44 54 pm](https://f.cloud.github.com/assets/1245093/1873805/c0d1cb2a-78bf-11e3-8858-ae8ed497170f.png)
   I rounded to an integer
   ![screen shot 2014-01-08 at 3 50 02 pm](https://f.cloud.github.com/assets/1245093/1873804/c0cf8cca-78bf-11e3-8574-a9227bc90082.png)
