### PR TITLE
Fix tier labels no longer providing info on click

### DIFF
--- a/views/options/social/tavern.jade
+++ b/views/options/social/tavern.jade
@@ -48,7 +48,7 @@
               a(target='_blank', href='http://community.habitrpg.com/forum') Community Forum
 
     // Player Tiers
-    .modal(style='position: relative;top: auto;left: auto;right: auto;margin: 0 auto 20px;z-index: 1;max-width: 100%;')
+    .modal(style='position: relative;top: auto;left: auto;right: auto;margin: 0 auto 20px;z-index: 1;max-width: 100%;', popover="Click tier labels for details.", popover-trigger="mouseenter", popover-placement="right")
       .modal-header
         h3 Player Tiers
       .modal-body
@@ -59,7 +59,7 @@
         table.table.table-striped
           tr
             td
-              a.label.label-contributor-1(ng-click='toggleUserTier($event)', tooltip='Click for details') Friend (1-2)
+              a.label.label-contributor-1(ng-click='toggleUserTier($event)') Friend (1-2)
               div(style='display:none;')
                 p.
                   <span class='achievement achievement-firefox'></span> When your <strong>first</strong> submission is deployed, you will receive the HabitRPG Contributor's badge. Your name in Tavern chat will proudly display that you are a contributor. As a bounty for your work, you will also receive <strong>2 Gems</strong>.
@@ -68,7 +68,7 @@
                   <span class='shop_armor_special_1 shop-sprite item-img'></span> When your <strong>second</strong> submission is deployed, the <strong>Crystal Armor</strong> will be available for purchase in the Rewards shop. As a bounty for your continued work, you will also receive <strong>2 Gems</strong>.
           tr
             td
-              a.label.label-contributor-3(ng-click='toggleUserTier($event)', tooltip='Click for details') Elite (3-4)
+              a.label.label-contributor-3(ng-click='toggleUserTier($event)') Elite (3-4)
               div(style='display:none;')
                 p.
                  <span class='shop_head_special_1 shop-sprite item-img'></span> When your <strong>third</strong> submission is deployed, the <strong>Crystal Helmet</strong> will be available for purchase in the Rewards shop. As a bounty for your great work, you will also receive <strong>2 Gems</strong>.
@@ -78,7 +78,7 @@
 
           tr
             td
-              a.label.label-contributor-5(ng-click='toggleUserTier($event)', tooltip='Click for details') Champion (5-6)
+              a.label.label-contributor-5(ng-click='toggleUserTier($event)') Champion (5-6)
               div(style='display:none;')
                 p.
                   <span class='shop_shield_special_1 shop-sprite item-img'></span> When your <em>fifth</em> submission is deployed, the <strong>Crystal Shield</strong> will be available for purchase in the Rewards shop. You will also receive <strong>2 Gems</strong>.
@@ -87,18 +87,18 @@
                  <div class='Pet-Dragon-Hydra pull-left'></div> When your <em>sixth</em> submission is deployed, you will receive a <strong>Hydra Pet</strong>. You will also receive <strong>2 Gems</strong>.
           tr
             td
-              a.label.label-contributor-7(ng-click='toggleUserTier($event)', tooltip='Click for details') Legendary (7)
+              a.label.label-contributor-7(ng-click='toggleUserTier($event)') Legendary (7)
               div(style='display:none;')
                 p.
                   When your <em>seventh</em> submission is deployed, you will receive <strong>2 Gems</strong> and become a member of the honored Contributor's Guild and be privy to the behind-the-scenes details of HabitRPG! Further contributions do not increase your level, but you may continue to earn Gem bounties and titles.
           tr
             td
-              a.label.label-contributor-8(ng-click='toggleUserTier($event)', tooltip='Click for details') Heroic
+              a.label.label-contributor-8(ng-click='toggleUserTier($event)') Heroic
               div(style='display:none;')
                 p The Heroic level contains HabitRPG staff and staff-level contributors. If you have this title, you were appointed to it (or hired!).
           tr
             td
-              a.label.label-npc(ng-click='toggleUserTier($event)', tooltip='Click for details') NPC
+              a.label.label-npc(ng-click='toggleUserTier($event)') NPC
               div(style='display:none;')
                 p NPCs backed HabitRPG's Kickstarter at the highest tier. You can find their avatars watching over site features!
 


### PR DESCRIPTION
It is mysterious to me why adding a tooltip would cause the `ng-click` event to quit firing, but _c'est la vie._ How's this instead...
