### PR TITLE
Finish up @wc8 suggested user preferences: tags and Advanced Options

### DIFF
--- a/public/js/directives/directives.js
+++ b/public/js/directives/directives.js
@@ -175,6 +175,8 @@ habitrpg
       controller: ['$scope', '$rootScope', function($scope, $rootScope){
         $scope.editTask = function(task){
           task._editing = !task._editing;
+          task._tags = User.user.preferences.tagsCollapsed;
+          task._advanced = User.user.preferences.advancedCollapsed;
           if($rootScope.charts[task.id]) $rootScope.charts[task.id] = false;
         };
       }],

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -228,7 +228,9 @@ var UserSchema = new Schema({
     sleep: {type: Boolean, 'default': false},
     stickyHeader: {type: Boolean, 'default': true},
     disableClasses: {type: Boolean, 'default': false},
-    newTaskEdit: {type: Boolean, 'default': false}
+    newTaskEdit: {type: Boolean, 'default': false},
+    tagsCollapsed: {type: Boolean, 'default': false},
+    advancedCollapsed: {type: Boolean, 'default': false}
   },
   profile: {
     blurb: String,

--- a/views/options/settings.jade
+++ b/views/options/settings.jade
@@ -43,6 +43,14 @@ script(type='text/ng-template', id='partials/options.settings.settings.html')
         input(type='checkbox', ng-model='user.preferences.newTaskEdit', ng-change='set({"preferences.newTaskEdit": user.preferences.newTaskEdit?true: false})')
         | Open new tasks in edit mode&nbsp;
         i.icon-question-sign(popover-trigger='mouseenter', popover-placement='right', popover='With this option set, new tasks will immediately open for you to add details like notes and tags.')
+      label.checkbox
+        input(type='checkbox', ng-model='user.preferences.tagsCollapsed', ng-change='set({"preferences.tagsCollapsed": user.preferences.tagsCollapsed?true: false})')
+        | Tag list in tasks starts collapsed&nbsp;
+        i.icon-question-sign(popover-trigger='mouseenter', popover-placement='right', popover='With this option set, the list of task tags will be hidden when you first open a task for editing.')
+      label.checkbox
+        input(type='checkbox', ng-model='user.preferences.advancedCollapsed', ng-change='set({"preferences.advancedCollapsed": user.preferences.advancedCollapsed?true: false})')
+        | Advanced Options in tasks start collapsed&nbsp;
+        i.icon-question-sign(popover-trigger='mouseenter', popover-placement='right', popover='With this option set, Advanced Options will be hidden when you first open a task for editing.')
       button.btn(ng-click='showTour()', popover-placement='right', popover-trigger='mouseenter', popover='Restart the introductory tour from when you first joined HabitRPG.') Show Tour
       br
       button.btn(ng-click='showBailey()', popover-trigger='mouseenter', popover-placement='right', popover='Bring Bailey the Town Crier out of hiding so you can review past news.') Show Bailey

--- a/views/shared/tasks/task.jade
+++ b/views/shared/tasks/task.jade
@@ -170,9 +170,10 @@ li(bindonce='list', bo-id='"task-"+task.id', ng-repeat='task in obj[list.type+"s
           legend.option-title=env.t('dueDate')
           input.option-content.datepicker(type='text', datepicker-popup='MM/dd/yyyy', ng-model='task.date')
 
+        // Tags
         fieldset.option-group(ng-if='!$state.includes("options.social.challenges")')
-          legend.option-title=env.t('tags')
-          label.checkbox(ng-repeat='tag in user.tags')
+          p.option-title.mega(ng-click='task._tags = !task._tags')=env.t('tags')
+          label.checkbox(ng-repeat='tag in user.tags', ng-class="{visuallyhidden: task._tags}")
             input(type='checkbox', ng-model='task.tags[tag.id]')
             markdown(ng-model='tag.name')
 


### PR DESCRIPTION
Last two user preferences in my mini-project about them!
- User can now show and hide tag list in task edit mode via click, just like Advanced Options.
- New user preference to have tags start off hidden when user first creates/edits a task.
- New user preference to have Advanced Options start off hidden when user first creates/edits a task.

The options default to `false` since they add extra clicks in many cases. The hidden-tags option is useful for power users who have lots of tags, and use the _secret technique_ of creating tasks with filters active to assign tags. The hidden Advanced Options preference is useful for users who frequently make use of Extra Notes, checklists, and so on, but seldom use difficulties or attributes.
