### PR TITLE
manual username & password input

### DIFF
--- a/public/js/controllers/authCtrl.js
+++ b/public/js/controllers/authCtrl.js
@@ -62,8 +62,8 @@ habitrpg.controller("AuthCtrl", ['$scope', '$rootScope', 'User', '$http', '$loca
 
     $scope.auth = function() {
       var data = {
-        username: $scope.loginUsername,
-        password: $scope.loginPassword
+        username: $scope.loginUsername || $('#login-tab input[name="username"]').val(),
+        password: $scope.loginPassword || $('#login-tab input[name="password"]').val()
       };
       if ($scope.useUUID) {
         runAuth($scope.loginUsername, $scope.loginPassword);


### PR DESCRIPTION
fixes #2295
when using browser/plugin auto-complete from what I understand certain browser events
are not emmited and thus angular never picks up the new values.

This patch adds a fallback using jQuery to set the username & password if the angular
properties are not set.

see: https://github.com/angular/angular.js/issues/1460
