### PR TITLE
Fix link to wiki LFG board

### DIFF
--- a/views/options/social/tavern.jade
+++ b/views/options/social/tavern.jade
@@ -27,7 +27,7 @@
         table.table.table-striped
           tr
             td
-              a(target='_blank', href='http://habitrpg.wikia.com/wiki/Board:LFG_Board') Looking for Group (Party Wanted) Posts
+              a(target='_blank', href='http://habitrpg.wikia.com/wiki/Board:Looking_for_a_Group_(LFG)') Looking for Group (Party Wanted) Posts
           tr
             td
               a(target='_blank', href='https://vimeo.com/57654086') Tutorial


### PR DESCRIPTION
I changed the name of wiki forum so it didn't display as "LFG Board board" which broke the link.
