### PR TITLE
Tweak to boss victory text

### DIFF
--- a/src/models/group.js
+++ b/src/models/group.js
@@ -222,7 +222,7 @@ GroupSchema.statics.bossQuest = function(user, progress, cb) {
 
     // Boss slain, finish quest
     if (group.quest.progress.hp <= 0) {
-      group.sendChat('`' + quest.boss.name + ' has been slain! Party has received their rewards.`');
+      group.sendChat('`You defeated ' + quest.boss.name + '! Questing party members receive the rewards of victory.`');
       // Participants: Grant rewards & achievements, finish quest
       series.push(function(cb2){
         group.finishQuest(quest,cb2);


### PR DESCRIPTION
A lot of the quest text being written (including Trapper Santa, the only boss monster currently fightable) has the party members driving off the baddie without killing it. While I'm sure there will be some dragon-slayin' eventually, this commit makes the text appropriate regardless of the quest conclusion content.

And also spices up the rest of the line, because y'know, I can't resist.
