### PR TITLE
Misc UI fixes

### DIFF
--- a/views/options/profile.jade
+++ b/views/options/profile.jade
@@ -126,19 +126,19 @@ script(id='partials/options.profile.stats.html', type='text/ng-template')
           input(type='checkbox', ng-model='user.preferences.automaticAllocation', ng-change='set({"preferences.automaticAllocation": user.preferences.automaticAllocation?true: false})', ng-click='set({"preferences.allocationMode":"taskbased"})')
           | Automatic Allocation&nbsp;
           i.icon-question-sign(popover-trigger='mouseenter', popover-placement='right', popover="Places points into attributes according to your preferences, when you level up.")
-          form(ng-show='user.preferences.automaticAllocation')
-            label.radio
-              input(type='radio', name='allocationMode', value='flat', ng-model='user.preferences.allocationMode', ng-change='set({"preferences.allocationMode": "flat"})')
-              | Distribute attribute points evenly&nbsp;
-              i.icon-question-sign(popover-trigger='mouseenter', popover-placement='right', popover="Assigns the same number of points to each attribute.")
-            label.radio
-              input(type='radio', name='allocationMode', value='classbased', ng-model='user.preferences.allocationMode', ng-change='set({"preferences.allocationMode": "classbased"})')
-              | Distribute attribute points based on Class&nbsp;
-              i.icon-question-sign(popover-trigger='mouseenter', popover-placement='right', popover="Assigns more points to the attributes important to your Class.")
-            label.radio
-              input(type='radio', name='allocationMode', value='taskbased', ng-model='user.preferences.allocationMode', ng-change='set({"preferences.allocationMode": "taskbased"})')
-              | Distribute attribute points based on task activity&nbsp;
-              i.icon-question-sign(popover-trigger='mouseenter', popover-placement='right', popover="Assigns points based on the Physical (STR), Mental (INT), Social (CON), and Other (PER) categories associated with the tasks you complete.")
+        form(ng-show='user.preferences.automaticAllocation',style='margin-left:1em')
+          label.radio
+            input(type='radio', name='allocationMode', value='flat', ng-model='user.preferences.allocationMode', ng-change='set({"preferences.allocationMode": "flat"})')
+            | Distribute attribute points evenly&nbsp;
+            i.icon-question-sign(popover-trigger='mouseenter', popover-placement='right', popover="Assigns the same number of points to each attribute.")
+          label.radio
+            input(type='radio', name='allocationMode', value='classbased', ng-model='user.preferences.allocationMode', ng-change='set({"preferences.allocationMode": "classbased"})')
+            | Distribute attribute points based on Class&nbsp;
+            i.icon-question-sign(popover-trigger='mouseenter', popover-placement='right', popover="Assigns more points to the attributes important to your Class.")
+          label.radio
+            input(type='radio', name='allocationMode', value='taskbased', ng-model='user.preferences.allocationMode', ng-change='set({"preferences.allocationMode": "taskbased"})')
+            | Distribute attribute points based on task activity&nbsp;
+            i.icon-question-sign(popover-trigger='mouseenter', popover-placement='right', popover="Assigns points based on the Physical (STR), Mental (INT), Social (CON), and Other (PER) categories associated with the tasks you complete.")
       table.table.table-striped
         tr
           td Points allocated to STR: {{user.stats.str}}

--- a/views/shared/tasks/task.jade
+++ b/views/shared/tasks/task.jade
@@ -193,15 +193,15 @@ li(bindonce='list', bo-id='"task-"+task.id', ng-repeat='task in obj[list.type+"s
               legend.option-title.pull-left=env.t('restoreStreak')
               input.option-content(type='number', ng-model='task.streak')
 
-            div(ng-if='user.preferences.allocationMode == "taskbased" || $state.is("options.social.challenges")')
-              legend.option-title=env.t('attributes')
-              .task-controls.tile-group
-              button.task-action-btn.tile(type='button', ng-class='{active: task.attribute=="str"}', ng-click='task.attribute="str"')=env.t('physical')
-              button.task-action-btn.tile(type='button', ng-class='{active: task.attribute=="int"}', ng-click='task.attribute="int"')=env.t('mental')
-              button.task-action-btn.tile(type='button', ng-class='{active: task.attribute=="con"}', ng-click='task.attribute="con"')=env.t('social')
-              button.task-action-btn.tile(type='button', ng-class='{active: task.attribute=="per"}', ng-click='task.attribute="per"', popover=env.t('otherExamples'), popover-trigger='mouseenter', popover-placement='top')=env.t('other')
-                | 
-                i.icon-question-sign
+            div(ng-if='(user.preferences.allocationMode == "taskbased" && user.preferences.automaticAllocation) || $state.is("options.social.challenges")')
+              legend.option-title.pull-left=env.t('attributes')
+              .task-controls.tile-group(style='text-align:left')
+                button.task-action-btn.tile(type='button', ng-class='{active: task.attribute=="str"}', ng-click='task.attribute="str"')=env.t('physical')
+                button.task-action-btn.tile(type='button', ng-class='{active: task.attribute=="int"}', ng-click='task.attribute="int"')=env.t('mental')
+                button.task-action-btn.tile(type='button', ng-class='{active: task.attribute=="con"}', ng-click='task.attribute="con"')=env.t('social')
+                button.task-action-btn.tile(type='button', ng-class='{active: task.attribute=="per"}', ng-click='task.attribute="per"', popover=env.t('otherExamples'), popover-trigger='mouseenter', popover-placement='top')=env.t('other')
+                  |&nbsp;
+                  i.icon-question-sign
 
         button.task-action-btn.tile.spacious(type='submit')=env.t('saveAndClose')
 


### PR DESCRIPTION
Fixes three things:
1. In Firefox, clicking allocation mode radio buttons was causing auto-allocate overall to toggle.
2. In Firefox, task attributes weren't pulling left correctly (similar to something that was previously happening with Restore Streak)
3. In all browsers, task attributes were showing up with automatic allocation turned off, because of the `taskbased` default behind the scenes.

Fixing 1-2 caused some other oddities in Chrome, so I needed to make some light tweaks to compensate, but now things align properly in both of those browsers. Safari folks, everything look OK?
