### PR TITLE
Create drop notification Growl style

### DIFF
--- a/public/css/alerts.styl
+++ b/public/css/alerts.styl
@@ -30,8 +30,10 @@ deathColor = #4E4E4E
 deathText = #ABABAB
 mpColor = #c7d3e9
 mpText = #003aa1
-critColor = #ffe3bf
+critColor = #fce5cd
 critText = #dc5000
+dropColor = #d9ead3
+dropText = #415838
 borderDarken = 20%
 
 // alert styles
@@ -70,6 +72,11 @@ borderDarken = 20%
   background-color: critColor
   border-color: darken(critColor,borderDarken)
   color: critText
+
+.alert-drop
+  background-color: dropColor
+  border-color: darken(dropColor,borderDarken)
+  color: dropText
 
 // alert icons
 

--- a/public/js/controllers/notificationCtrl.js
+++ b/public/js/controllers/notificationCtrl.js
@@ -56,7 +56,7 @@ habitrpg.controller('NotificationCtrl',
         User.user.items[type][after.key] = 0;
       }
       User.user.items[type][after.key]++;
-      Notification.text(User.user._tmp.drop.dialog);
+      Notification.drop(User.user._tmp.drop.dialog);
     });
 
     $rootScope.$watch('user.achievements.streak', function(after, before){

--- a/public/js/services/notificationServices.js
+++ b/public/js/services/notificationServices.js
@@ -71,6 +71,9 @@ angular.module("notificationServices", [])
       },
       crit: function(val) {
         growl("<i class='icon-certificate'></i> Critical Hit! Bonus: " + Math.round(val) + "%", 'crit');
+      },
+      drop: function(val) {
+        growl("<i class='icon-gift'></i> " + val, 'drop');
       }
     };
   }


### PR DESCRIPTION
Implements a unique notification style for drop alerts, using a green color scheme and a "gift" glyph icon. Temporary until we get a more robust drop notification in place.

Realized I'd missed a trick by not having the crit notification color match orange tasks, so tweaked that too (drops match green tasks). Just for unity of color scheme.
