### PR TITLE
Spell-casting bug fixes & optimizations

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "expect.js": "~0.2.0",
     "superagent": "~0.15.7",
     "superagent-defaults": "~0.1.5",
-    "git-changelog": "colegleason/git-changelog"
+    "git-changelog": "colegleason/git-changelog",
+    "deep-diff": "~0.1.4"
   }
 }

--- a/public/js/controllers/rootCtrl.js
+++ b/public/js/controllers/rootCtrl.js
@@ -168,9 +168,13 @@ habitrpg.controller("RootCtrl", ['$scope', '$rootScope', '$location', 'User', '$
       if ($scope.spell.target != type) return Notification.text("Invalid target");
       $scope.spell.cast(User.user, target);
       User.save();
+
       var spell = $scope.spell;
-      var targetId = type == 'party' ? '' : type == 'task' ? target.id : target._id;
-      $http.post('/api/v2/user/class/cast/' + spell.key, {params:{targetType:type, targetId:targetId}})
+      var targetId = (type == 'party' || type == 'self') ? '' : type == 'task' ? target.id : target._id;
+      $scope.spell = null;
+      $rootScope.applyingAction = false;
+
+      $http.post('/api/v2/user/class/cast/'+spell.key+'?targetType='+type+'&targetId='+targetId)
       .success(function(){
         var msg = "You cast " + spell.text;
         switch (type) {
@@ -180,8 +184,7 @@ habitrpg.controller("RootCtrl", ['$scope', '$rootScope', '$location', 'User', '$
         }
         Notification.text(msg);
       });
-      $scope.spell = null;
-      $rootScope.applyingAction = false;
+
     }
 
     $rootScope.castCancel = function(){

--- a/public/js/controllers/rootCtrl.js
+++ b/public/js/controllers/rootCtrl.js
@@ -167,9 +167,11 @@ habitrpg.controller("RootCtrl", ['$scope', '$rootScope', '$location', 'User', '$
       $event && ($event.stopPropagation(),$event.preventDefault());
       if ($scope.spell.target != type) return Notification.text("Invalid target");
       $scope.spell.cast(User.user, target);
-      var spell = $scope.spell;
       User.save();
-      $http.post('/api/v2/user/class/cast/' + spell.key, {target:target, type:type}).success(function(){
+      var spell = $scope.spell;
+      var targetId = type == 'party' ? '' : type == 'task' ? target.id : target._id;
+      $http.post('/api/v2/user/class/cast/' + spell.key, {params:{targetType:type, targetId:targetId}})
+      .success(function(){
         var msg = "You cast " + spell.text;
         switch (type) {
           case 'task': msg += ' on ' + target.text;break;

--- a/public/js/controllers/rootCtrl.js
+++ b/public/js/controllers/rootCtrl.js
@@ -163,20 +163,22 @@ habitrpg.controller("RootCtrl", ['$scope', '$rootScope', '$location', 'User', '$
     }
 
     $scope.castEnd = function(target, type, $event){
+      if (!$rootScope.applyingAction) return;
       $event && ($event.stopPropagation(),$event.preventDefault());
       if ($scope.spell.target != type) return Notification.text("Invalid target");
       $scope.spell.cast(User.user, target);
+      var spell = $scope.spell;
       User.save();
-      $http.post('/api/v2/user/class/cast/' + $scope.spell.key, {target:target, type:type}).success(function(){
-        var msg = "You cast " + $scope.spell.text;
+      $http.post('/api/v2/user/class/cast/' + spell.key, {target:target, type:type}).success(function(){
+        var msg = "You cast " + spell.text;
         switch (type) {
           case 'task': msg += ' on ' + target.text;break;
           case 'user': msg += ' on ' + target.profile.name;break;
           case 'party': msg += ' on the Party';break;
         }
         Notification.text(msg);
-        $scope.spell = null;
       });
+      $scope.spell = null;
       $rootScope.applyingAction = false;
     }
 

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -355,7 +355,7 @@ api.cast = function(req, res) {
     case 'user':
       async.waterfall([
         function(cb){
-          Group.findOne({type: 'party', members: {'$in': [user._id]}}).populate('members').exec(cb);
+          Group.findOne({type: 'party', members: {'$in': [user._id]}}).populate('members', 'profile.name stats achievements').exec(cb);
         },
         function(group, cb) {
           // Solo player? let's just create a faux group for simpler code

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -322,14 +322,8 @@ api.buyGemsPaypalIPN = function(req, res, next) {
  */
 api.cast = function(req, res) {
   var user = res.locals.user;
-  var type, target;
-  if (req.body.type) { // this is the method implemented in the app, it's not correct
-    type = req.body.type;
-    target = req.body.target;
-  } else if (req.query.targetType) { // this is the supported API method
-    type = req.query.targetType;
-    target = req.query.targetId;
-  }
+  var targetType = req.query.targetType;
+  var targetId = req.query.targetId;
   var klass = shared.content.spells.special[req.params.spell] ? 'special' : user.stats.class
   var spell = shared.content.spells[klass][req.params.spell];
 
@@ -340,9 +334,9 @@ api.cast = function(req, res) {
     res.json(saved);
   }
 
-  switch (type) {
+  switch (targetType) {
     case 'task':
-      spell.cast(user, user.tasks[target.id]);
+      spell.cast(user, user.tasks[targetId]);
       user.save(done);
       break;
 
@@ -361,20 +355,20 @@ api.cast = function(req, res) {
           // Solo player? let's just create a faux group for simpler code
           var g = group ? group : {members:[user]};
           var series = [], found;
-          if (type == 'party') {
+          if (targetType == 'party') {
             spell.cast(user, g.members);
             series = _.transform(g.members, function(m,v,k){
               m.push(function(cb2){v.save(cb2)});
             });
           } else {
-            found = _.find(g.members, {_id: target._id})
+            found = _.find(g.members, {_id: targetId})
             spell.cast(user, found);
             series.push(function(cb2){found.save(cb2)});
           }
 
           if (group) {
             series.push(function(cb2){
-              var message = '`'+user.profile.name+' casts '+spell.text + (type=='user' ? ' on '+found.profile.name : ' for the party')+'.`';
+              var message = '`'+user.profile.name+' casts '+spell.text + (targetType=='user' ? ' on '+found.profile.name : ' for the party')+'.`';
               group.sendChat(message);
               group.save(cb2);
             })


### PR DESCRIPTION
fix(spells): some $rootScope.applying action fixes so cast-ending is immediate instead of waiting on response. Also, slim down party population to the essentials to avoid RequestEntityTooLarge.

@colegleason @paglias wondering if either of you have experience with Mongoose here. In the past, if I used a projection:

``` coffeescript
User.findById ID, 'profile stats', (err,user)->
  user.stats.hp++
  user.save()
```

It would actually **delete** (from the database) any fields that weren't selected in the query. So like, it would create a "projected document" (slimmed down), but it wasn't smart enough to know not to send those missing fields up as part of the save. As a result, there are many times I use `User.update({_id:ID},MANUAL_UPDATE_OBJECT)` to avoid the scare. 

It doesn't seem to be the issue anymore. I tested this PR a bunch, and everything seems safe. But I'm a bit scared given past experiences. Have you seen this before? Maybe I was doing something wrong in the past? Maybe Mongoose has been updated since to fix that issue?
