### PR TITLE
docs(rebirth): Bullet point about repurchase of limited ed gear after Rebirth

### DIFF
--- a/views/shared/modals/rebirth.jade
+++ b/views/shared/modals/rebirth.jade
@@ -18,7 +18,6 @@ div(modal='modals.rebirth')
         .rebirth_orb.pull-left(style='margin-right: 5px')
         p=env.t('rebirthStartOver')
         br
-        p=env.t('rebirthAdventure')
         .unordered
             li=env.t('rebirthAdvList1')
             li=env.t('rebirthAdvList2')
@@ -31,6 +30,7 @@ div(modal='modals.rebirth')
             li=env.t('rebirthInList2')
             li=env.t('rebirthInList3')
             li=env.t('rebirthInList4')
+            li=env.t('rebirthInList5')
         br
         .achievement-sun.pull-left(style='margin-right: 5px')
         p=env.t('rebirthEarnAchievement')


### PR DESCRIPTION
Requires [this commit on habitrpg-shared](https://github.com/HabitRPG/habitrpg-shared/commit/667a4264c594066b99fc0d9ad189602329c10e43). Adds a line to the Rebirth modal informing users that limited edition gear can be repurchased after Rebirth. Removed a line from the top of the modal to make room, preventing scrolling at ordinary resolutions--I'm open to suggestions if we think that line is crucial.
