### PR TITLE
Add information to quests on the Market before you buy them

### DIFF
--- a/public/js/controllers/inventoryCtrl.js
+++ b/public/js/controllers/inventoryCtrl.js
@@ -141,7 +141,7 @@ habitrpg.controller("InventoryCtrl", ['$rootScope', '$scope', '$window', 'User',
       var item = Content.quests[quest];
       var completedPrevious = !item.previous || (User.user.achievements.quests && User.user.achievements.quests[item.previous]);
       if (!completedPrevious)
-        return alert("You must first complete " + $rootScope.Content.quests[item.previous].text + '.');
+        return $scope.purchase("quests", item);
       if (item.lvl && item.lvl > user.stats.lvl)
         return alert("You must be level " + item.lvl + '.');
       $rootScope.selectedQuest = item;

--- a/public/js/controllers/inventoryCtrl.js
+++ b/public/js/controllers/inventoryCtrl.js
@@ -129,12 +129,18 @@ habitrpg.controller("InventoryCtrl", ['$rootScope', '$scope', '$window', 'User',
     $scope.closeQuest = function(){
       $rootScope.selectedQuest = undefined;
       $rootScope.modals.showQuest = false;
+      $rootScope.modals.buyQuest = false;
     }
     $scope.questInit = function(){
       $rootScope.party.$questAccept({key:$scope.selectedQuest.key}, function(){
         $rootScope.party.$get();
       });
       $scope.closeQuest();
+    }
+    $scope.buyQuest = function(quest) {
+      var item = Content.quests[quest];
+      $rootScope.selectedQuest = item;
+      $rootScope.modals.buyQuest = true;
     }
   }
 ]);

--- a/public/js/controllers/inventoryCtrl.js
+++ b/public/js/controllers/inventoryCtrl.js
@@ -142,8 +142,6 @@ habitrpg.controller("InventoryCtrl", ['$rootScope', '$scope', '$window', 'User',
       var completedPrevious = !item.previous || (User.user.achievements.quests && User.user.achievements.quests[item.previous]);
       if (!completedPrevious)
         return $scope.purchase("quests", item);
-      if (item.lvl && item.lvl > user.stats.lvl)
-        return alert("You must be level " + item.lvl + '.');
       $rootScope.selectedQuest = item;
       $rootScope.modals.buyQuest = true;
     }

--- a/public/js/controllers/inventoryCtrl.js
+++ b/public/js/controllers/inventoryCtrl.js
@@ -139,6 +139,11 @@ habitrpg.controller("InventoryCtrl", ['$rootScope', '$scope', '$window', 'User',
     }
     $scope.buyQuest = function(quest) {
       var item = Content.quests[quest];
+      var completedPrevious = !item.previous || (User.user.achievements.quests && User.user.achievements.quests[item.previous]);
+      if (!completedPrevious)
+        return alert("You must first complete " + $rootScope.Content.quests[item.previous].text + '.');
+      if (item.lvl && item.lvl > user.stats.lvl)
+        return alert("You must be level " + item.lvl + '.');
       $rootScope.selectedQuest = item;
       $rootScope.modals.buyQuest = true;
     }

--- a/views/options/inventory/inventory.jade
+++ b/views/options/inventory/inventory.jade
@@ -47,7 +47,7 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
             p.muted(ng-show='questCount < 1')=env.t('noScrolls')
             p.muted!=env.t('scrollsText1') + ' <a href="/#/options/groups/party">' + env.t('scrollsText2') + '</a>'
             div(ng-repeat='(quest_key,points) in ownedItems(user.items.quests)', ng-init='quest = Content.quests[quest_key]')
-              button.customize-option(popover='{{quest.previous && !user.achievements.quests[quest.previous] ? "You need to complete the previous quest to start this one!" : quest.notes}}', popover-title='{{quest.text}}', popover-trigger='mouseenter', popover-placement='right', ng-click='showQuest(quest_key)', class='inventory_quest_scroll', ng-class='{locked: quest.previous && !user.achievements.quests[quest.previous]}')
+              button.customize-option(popover="{{quest.previous && !user.achievements.quests[quest.previous] ? env.t('scrollsPre') : quest.notes}}", popover-title='{{quest.text}}', popover-trigger='mouseenter', popover-placement='right', ng-click='showQuest(quest_key)', class='inventory_quest_scroll', ng-class='{locked: quest.previous && !user.achievements.quests[quest.previous]}')
                 .badge.badge-info.stack-count {{points}}
 
         li.customize-menu
@@ -125,7 +125,7 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
             menu.pets-menu(label=env.t('quests'))
               p.muted!=env.t('scrollsText1') + ' <a href="/#/options/groups/party">' + env.t('scrollsText2') + '</a>'
               div(ng-repeat='quest in Content.quests')
-                button.customize-option(popover='{{quest.previous && !user.achievements.quests[quest.previous] ? "You need to complete the previous quest to start this one!" : quest.notes}}', popover-title='{{quest.text}}', popover-trigger='mouseenter', popover-placement='left', ng-click='buyQuest(quest.key)', class='inventory_quest_scroll', ng-class='{locked: quest.previous && !user.achievements.quests[quest.previous]}')
+                button.customize-option(popover="{{quest.previous && !user.achievements.quests[quest.previous] ? env.t('scrollsPre') : quest.notes}}", popover-title='{{quest.text}}', popover-trigger='mouseenter', popover-placement='left', ng-click='buyQuest(quest.key)', class='inventory_quest_scroll', ng-class='{locked: quest.previous && !user.achievements.quests[quest.previous]}')
                 p
                   |  {{quest.value}}
                   span.Pet_Currency_Gem1x.inline-gems

--- a/views/options/inventory/inventory.jade
+++ b/views/options/inventory/inventory.jade
@@ -47,7 +47,7 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
             p.muted(ng-show='questCount < 1')=env.t('noScrolls')
             p.muted!=env.t('scrollsText1') + ' <a href="/#/options/groups/party">' + env.t('scrollsText2') + '</a>'
             div(ng-repeat='(quest_key,points) in ownedItems(user.items.quests)', ng-init='quest = Content.quests[quest_key]')
-              button.customize-option(popover=('{{quest.previous && !user.achievements.quests[quest.previous] ? "' + env.t('scrollsPre') + '" : quest.notes}}'), popover-title='{{quest.text}}', popover-trigger='mouseenter', popover-placement='right', ng-click='showQuest(quest_key)', class='inventory_quest_scroll', ng-class='{locked: quest.previous && !user.achievements.quests[quest.previous]}')
+              button.customize-option(popover="{{quest.previous && !user.achievements.quests[quest.previous] ? env.t('scrollsPre') : quest.notes}}", popover-title='{{quest.text}}', popover-trigger='mouseenter', popover-placement='right', ng-click='showQuest(quest_key)', class='inventory_quest_scroll', ng-class='{locked: quest.previous && !user.achievements.quests[quest.previous]}')
                 .badge.badge-info.stack-count {{points}}
 
         li.customize-menu

--- a/views/options/inventory/inventory.jade
+++ b/views/options/inventory/inventory.jade
@@ -47,7 +47,7 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
             p.muted(ng-show='questCount < 1')=env.t('noScrolls')
             p.muted!=env.t('scrollsText1') + ' <a href="/#/options/groups/party">' + env.t('scrollsText2') + '</a>'
             div(ng-repeat='(quest_key,points) in ownedItems(user.items.quests)', ng-init='quest = Content.quests[quest_key]')
-              button.customize-option(popover="{{quest.previous && !user.achievements.quests[quest.previous] ? env.t('scrollsPre') : quest.notes}}", popover-title='{{quest.text}}', popover-trigger='mouseenter', popover-placement='right', ng-click='showQuest(quest_key)', class='inventory_quest_scroll', ng-class='{locked: quest.previous && !user.achievements.quests[quest.previous]}')
+              button.customize-option(popover=('{{quest.previous && !user.achievements.quests[quest.previous] ? "' + env.t('scrollsPre') + '" : quest.notes}}'), popover-title='{{quest.text}}', popover-trigger='mouseenter', popover-placement='right', ng-click='showQuest(quest_key)', class='inventory_quest_scroll', ng-class='{locked: quest.previous && !user.achievements.quests[quest.previous]}')
                 .badge.badge-info.stack-count {{points}}
 
         li.customize-menu
@@ -125,7 +125,7 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
             menu.pets-menu(label=env.t('quests'))
               p.muted!=env.t('scrollsText1') + ' <a href="/#/options/groups/party">' + env.t('scrollsText2') + '</a>'
               div(ng-repeat='quest in Content.quests')
-                  button.customize-option(popover='{{quest.text}}', popover-trigger='mouseenter', popover-placement='left', ng-click='purchase("quests", quest)', class='inventory_quest_scroll', ng-class='{locked: quest.previous && !user.achievements.quests[quest.previous]}')
+                  button.customize-option(popover='{{quest.notes}}', popover-title='{{quest.text}}', popover-trigger='mouseenter', popover-placement='left', ng-click='buyQuest(quest.key)', class='inventory_quest_scroll', ng-class='{locked: quest.previous && !user.achievements.quests[quest.previous]}')
                   p
                     |  {{quest.value}}
                     span.Pet_Currency_Gem1x.inline-gems

--- a/views/options/inventory/inventory.jade
+++ b/views/options/inventory/inventory.jade
@@ -47,7 +47,7 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
             p.muted(ng-show='questCount < 1')=env.t('noScrolls')
             p.muted!=env.t('scrollsText1') + ' <a href="/#/options/groups/party">' + env.t('scrollsText2') + '</a>'
             div(ng-repeat='(quest_key,points) in ownedItems(user.items.quests)', ng-init='quest = Content.quests[quest_key]')
-              button.customize-option(popover="{{quest.previous && !user.achievements.quests[quest.previous] ? env.t('scrollsPre') : quest.notes}}", popover-title='{{quest.text}}', popover-trigger='mouseenter', popover-placement='right', ng-click='showQuest(quest_key)', class='inventory_quest_scroll', ng-class='{locked: quest.previous && !user.achievements.quests[quest.previous]}')
+              button.customize-option(popover='{{quest.previous && !user.achievements.quests[quest.previous] ? "You need to complete the previous quest to start this one!" : quest.notes}}', popover-title='{{quest.text}}', popover-trigger='mouseenter', popover-placement='right', ng-click='showQuest(quest_key)', class='inventory_quest_scroll', ng-class='{locked: quest.previous && !user.achievements.quests[quest.previous]}')
                 .badge.badge-info.stack-count {{points}}
 
         li.customize-menu
@@ -125,7 +125,7 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
             menu.pets-menu(label=env.t('quests'))
               p.muted!=env.t('scrollsText1') + ' <a href="/#/options/groups/party">' + env.t('scrollsText2') + '</a>'
               div(ng-repeat='quest in Content.quests')
-                button.customize-option(popover='{{quest.text}}', popover-trigger='mouseenter', popover-placement='left', ng-click='buyQuest(quest.key)', class='inventory_quest_scroll', ng-class='{locked: quest.previous && !user.achievements.quests[quest.previous]}')
+                button.customize-option(popover='{{quest.previous && !user.achievements.quests[quest.previous] ? "You need to complete the previous quest to start this one!" : quest.notes}}', popover-title='{{quest.text}}', popover-trigger='mouseenter', popover-placement='left', ng-click='buyQuest(quest.key)', class='inventory_quest_scroll', ng-class='{locked: quest.previous && !user.achievements.quests[quest.previous]}')
                 p
                   |  {{quest.value}}
                   span.Pet_Currency_Gem1x.inline-gems

--- a/views/options/inventory/inventory.jade
+++ b/views/options/inventory/inventory.jade
@@ -125,10 +125,10 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
             menu.pets-menu(label=env.t('quests'))
               p.muted!=env.t('scrollsText1') + ' <a href="/#/options/groups/party">' + env.t('scrollsText2') + '</a>'
               div(ng-repeat='quest in Content.quests')
-                  button.customize-option(popover='{{quest.notes}}', popover-title='{{quest.text}}', popover-trigger='mouseenter', popover-placement='left', ng-click='buyQuest(quest.key)', class='inventory_quest_scroll', ng-class='{locked: quest.previous && !user.achievements.quests[quest.previous]}')
-                  p
-                    |  {{quest.value}}
-                    span.Pet_Currency_Gem1x.inline-gems
+                button.customize-option(popover='{{quest.text}}', popover-trigger='mouseenter', popover-placement='left', ng-click='buyQuest(quest.key)', class='inventory_quest_scroll', ng-class='{locked: quest.previous && !user.achievements.quests[quest.previous]}')
+                p
+                  |  {{quest.value}}
+                  span.Pet_Currency_Gem1x.inline-gems
 
           li.customize-menu
             menu.pets-menu(label=env.t('special'))

--- a/views/shared/modals/quests.jade
+++ b/views/shared/modals/quests.jade
@@ -45,7 +45,7 @@ div(modal='modals.buyQuest', ng-controller='InventoryCtrl')
     quest-rewards(key='{{selectedQuest.key}}')
   .modal-footer
     button.btn.btn-large.cancel(ng-click='closeQuest()')=env.t('neverMind')
-    button.btn.btn-default.btn-large.btn-primary(ng-click='purchase("quests", quest)')=env.t('buyQuest')
+    button.btn.btn-default.btn-large.btn-primary(ng-click='purchase("quests", quest);closeQuest()')=env.t('buyQuest')
 
 div(modal='party.quest.key && !party.quest.active && !questHold && party.quest.members[user._id] == undefined')
   .modal-header

--- a/views/shared/modals/quests.jade
+++ b/views/shared/modals/quests.jade
@@ -36,6 +36,17 @@ div(modal='modals.showQuest', ng-controller='InventoryCtrl')
     button.btn.btn-default.btn-small.btn-cancel(ng-click='closeQuest()')=env.t('cancel')
     button.btn.btn-default.btn-primary(ng-click='questInit()')=env.t('inviteParty')
 
+div(modal='modals.buyQuest', ng-controller='InventoryCtrl')
+  .modal-header
+    h3 {{selectedQuest.text}}
+  .modal-body
+    .pull-right(class='quest_{{selectedQuest.key}}')
+    p {{selectedQuest.notes}}
+    quest-rewards(key='{{selectedQuest.key}}')
+  .modal-footer
+    button.btn.btn-large.cancel(ng-click='closeQuest()')=env.t('neverMind')
+    button.btn.btn-default.btn-large.btn-primary(ng-click='purchase("quests", quest)')=env.t('buyQuest')
+
 div(modal='party.quest.key && !party.quest.active && !questHold && party.quest.members[user._id] == undefined')
   .modal-header
     h3=env.t('questInvitation')


### PR DESCRIPTION
Add popover quest description to quests in the Market and add buyQuest modal to show text and rewards before purchasing the quest.

This was suggested by Ryan on [this trello card](https://trello.com/c/XzWhIu3S/349-add-quests-ideas-here) and I thought I could handle it. I don't know if it's the best approach but it's working. It can help users see what the quest it like before they purchase it.

The picture is the modal when you click on the quest.

![buyquest1](https://f.cloud.github.com/assets/6205335/1987514/dd07c000-845a-11e3-81a1-3884b72eb2f8.png)
