### PR TITLE
Additional Profile Options

### DIFF
--- a/src/models/user.js
+++ b/src/models/user.js
@@ -237,6 +237,13 @@ var UserSchema = new Schema({
     blurb: String,
     imageUrl: String,
     name: String,
+    github: String,
+    trello: String,
+    wikia: String,
+    contact: String,
+    gitPrivacy: {type: Boolean, 'default': true},
+    trelloPrivacy: {type: Boolean, 'default': true},
+    wikiaPrivacy: {type: Boolean, 'default': true},
   },
   stats: {
     hp: {type: Number, 'default': 50},

--- a/views/options/inventory/stable.jade
+++ b/views/options/inventory/stable.jade
@@ -55,6 +55,9 @@ script(type='text/ng-template', id='partials/options.inventory.pets.html')
                 .bar(style="width: {{user.items.pets[pet]/.5}}%;")
             button(class="pet-button pet-not-owned", ng-if='!user.items.pets[pet]')
               .PixelPaw
+            button(class="pet-button pet-not-owned" ng-if='user.items.pets[pet]<0')
+              .PixelPaw
+              //if this could be changed to the opacity talked about?
 
     h4 Rare Pets
     menu

--- a/views/options/profile.jade
+++ b/views/options/profile.jade
@@ -176,11 +176,33 @@ script(id='partials/options.profile.profile.html', type='text/ng-template')
     span.muted(ng-hide='profile.profile.blurb') - None -
     //{{profile.profile.blurb | linky:'_blank'}}
 
+    h4 Contact Info
+    markdown(ng-show='profile.profile.contact', ng-model='profile.profile.contact')
+    span.muted(ng-hide='profile.profile.contact') - None -
+
+    h4 Github
+    p
+      span(ng-show='profile.profile.github') {{profile.profile.github}}
+      span(ng-show='profile.profile.gitPrivacy')  (private)
+    span.muted(ng-hide='profile.profile.github') - None -
+
+    h4 Trello
+    p
+      span(ng-show='profile.profile.trello') {{profile.profile.trello}}
+      span(ng-show='profile.profile.trelloPrivacy')  (private)
+    span.muted(ng-hide='profile.profile.trello') - None -
+
+    h4 Wikia
+    p
+      span(ng-show='profile.profile.wikia') {{profile.profile.wikia}}
+      span(ng-show='profile.profile.wikiaPrivacy')  (private)
+    span.muted(ng-hide='profile.profile.wikia') - None -
+
   div.whatever-options(ng-show='_editing.profile')
     // TODO use photo-upload instead: https://groups.google.com/forum/?fromgroups=#!topic/derbyjs/xMmADvxBOak
     .control-group.option-large
-      label.control-label Display Name
-      input.option-content(type='text', placeholder='Full Name', ng-model='editingProfile.name')
+      label.control-label Display Name (Maximum of 20 Characters)
+      input.option-content(type='text', placeholder='Full Name', ng-model='editingProfile.name', ng-maxlength="20")
     .control-group.option-large
       label.control-label Photo Url
       input.option-content(type='url', ng-model='editingProfile.imageUrl', placeholder='Image Url')
@@ -188,6 +210,31 @@ script(id='partials/options.profile.profile.html', type='text/ng-template')
       label.control-label Blurb
       textarea.option-content(style='height:15em;', placeholder='Blurb', ng-model='editingProfile.blurb')
       include ../shared/formatting-help
+    .control-group.option-large
+      label.control-label Contact Info
+      textarea.option-content(style='height:10em;', placeholder='Email, instant messengers, or other ways for users to contact you privately.', ng-model='editingProfile.contact')
+      include ../shared/formatting-help
+    
+    h5 Sharing this information can help hRPG staff connect your account and your contributions.
+    
+    .control-group.option-large
+      label.control-label Github
+      p
+        input.option-content(type='checkbox', ng-model='editingProfile.gitPrivacy')
+        |  Private
+      input.option-content(type='text', placeholder='Github Username', ng-model='editingProfile.github')
+    .control-group.option-large
+      label.control-label Trello
+      p
+        input.option-content(type='checkbox', ng-model='editingProfile.trelloPrivacy')
+        |  Private
+      input.option-content(type='text', placeholder='Trello Username', ng-model='editingProfile.trello')
+    .control-group.option-large
+      label.control-label Wikia
+      p
+        input.option-content(type='checkbox', ng-model='editingProfile.wikiaPrivacy')
+        |  Private
+      input.option-content(type='text', placeholder='Wikia Username', ng-model='editingProfile.wikia')
 
 script(id='partials/options.profile.html', type="text/ng-template")
   ul.nav.nav-tabs

--- a/views/shared/modals/members.jade
+++ b/views/shared/modals/members.jade
@@ -8,7 +8,24 @@ div(ng-controller='MemberModalCtrl')
       .row-fluid
         .span6
           img(ng-show='profile.profile.imageUrl', ng-src='{{profile.profile.imageUrl}}')
+          h3 About Me
           markdown(ng-show='profile.profile.blurb', ng-model='profile.profile.blurb')
+          h4 Contact Info
+          markdown(ng-show='profile.profile.contact', ng-model='profile.profile.contact')
+          span(ng-if='!profile.profile.gitPrivacy'||'!profile.profile.trelloPrivacy'||'!profile.profile.wikiaPrivacy')
+            h4 External Accounts
+          span(ng-if='!profile.profile.gitPrivacy')
+            strong Github: 
+            {{profile.profile.github}}
+            br
+          span(ng-if='!profile.profile.trelloPrivacy')
+            strong Trello: 
+            {{profile.profile.trello}}
+            br
+          span(ng-if='!profile.profile.wikiaPrivacy')
+            strong Wikia: 
+            {{profile.profile.wikia}}
+            br
           ul.muted.unstyled(ng-if='profile.auth.timestamps', style='margin-top:10px;')
             li {{profile._id}}
             li(ng-show='profile.auth.timestamps.created') - Member since {{timestamp(profile.auth.timestamps.created)}} -

--- a/views/static/front.jade
+++ b/views/static/front.jade
@@ -10,15 +10,38 @@ block content
   div(ng-app='habitrpgStatic')
     #wrap(ng-controller='AuthCtrl')
       //-include ./header
-      .jumbotron.masthead
-        .container
-          h1
-            img(src='/bower_components/habitrpg-shared/img/logo/habitrpg_pixel.png', alt='HabitRPG')
-          p=env.t('synopsis')
-          a.btn.btn-primary.btn-small(ng-click='playButtonClick()')=env.t('playButton')
       .container
-        p(style='height:600;')
-          iframe(src='//player.vimeo.com/video/76557040', width='100%', height='539', frameborder='0', webkitallowfullscreen='', mozallowfullscreen='', allowfullscreen='')
+        //we need to use something that's not jumbotron for this, but still keep it centered
+        //could someone write something else to make it pretty?
+        img(src='/bower_components/habitrpg-shared/img/logo/habitrpg_pixel.png', alt='HabitRPG logo')
+        //this image needs to be replaced by something more enticing, that shows off the features of hRPG
+        //while acting similarly to a logo
+        h1=env.t('tagline')
+        //we'd want the tagline centered, for sure, and a bit more pop, but without using jumbotron
+        //it could also be part of the image, as long as the alt text included it
+        //in fact, I think I really want it on the image, rather than as text, but language issues
+        br
+        p=env.t('landingp1')
+        h3=env.t('landingp2header')
+        //images in these parts could be useful, too
+        //if there's a language workaround, image headers?
+        p=env.t('landingp2')
+        h3=env.t('landingp3header')
+        //I'm not sold on "Consquences as the title here. Anyone got a better idea?
+        p=env.t('landingp3')
+        h3=env.t('landingp4header')
+        p=env.t('landingp4')
+        h3=env.t('landingend')
+        p
+          =env.t('landingend2')
+          a(href="FEATURESPAGEHERE")=env.t('landingfeatureslink')
+          //need the link, obv
+          =env.t('landingend3')
+          a(href="ENTERPRISEPAGEHERE")=env.t('landingadminlink')
+          //need the link, obv
+          =env.t('landingend4')
+        a.btn.btn-primary.btn-small(ng-click='playButtonClick()')=env.t('playButton')
+        //play button needs to be moved into a footer and be size fixed, due to no jumbotron
 
       .modal.fade#login-modal(style='display:none')
         .modal-dialog
@@ -29,6 +52,7 @@ block content
             .modal-body
               a(href='/auth/facebook')
                     img(src='/bower_components/habitrpg-shared/img/facebook-login-register.jpeg', alt=env.t('loginFacebookAlt'))
+              //can we add in google auth? I like google auth
               h3 Or
               ul.nav.nav-tabs
                 li.active


### PR DESCRIPTION
Adds a contact field to profiles, encouraging users to share info on how others can reach them. Adds fields for external accounts, with the option to set them private. Updates the modal to show contact info and any public accounts. Oh, and display names are limited to 20 characters.
