### PR TITLE
Mark collected items in collection quests

### DIFF
--- a/public/css/index.styl
+++ b/public/css/index.styl
@@ -27,6 +27,7 @@
 @import "./npcs.styl"
 @import "./challenges.styl"
 @import "./classes.styl"
+@import "./quests.styl"
 
 // fix exploding to very wide for some reason
 .datepicker

--- a/public/css/quests.styl
+++ b/public/css/quests.styl
@@ -1,0 +1,3 @@
+.quest_collected_true
+  color: #ccc
+  text-decoration:line-through

--- a/views/options/social/group.jade
+++ b/views/options/social/group.jade
@@ -45,7 +45,7 @@ a.pull-right.gem-wallet(popover-trigger='mouseenter', popover-title=env.t('guild
           div(ng-if='Content.quests[group.quest.key].collect')
             h4=env.t('collected') + ':'
             table.table.table-striped
-              tr(ng-repeat='(k,v) in group.quest.progress.collect')
+              tr(ng-repeat='(k,v) in group.quest.progress.collect', class='quest_collected_{{v >= Content.quests[group.quest.key].collect[k].count}}')
                 td
                   div(class='quest_{{group.quest.key}}_{{k}}') {{Content.quests[group.quest.key].collect[k].text}}
                 td


### PR DESCRIPTION
When you collect enough of a item in a collection quest, that item is shown differently:

![items](https://f.cloud.github.com/assets/1175986/2000597/654ad08c-8560-11e3-8eb6-93d649596938.png)

This should close #2409.
