### PR TITLE
Market "Sell..." button: add spaces, remove bracket

### DIFF
--- a/views/options/inventory/inventory.jade
+++ b/views/options/inventory/inventory.jade
@@ -80,21 +80,21 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
                   p
                     button.btn.btn-primary(ng-show='selectedEgg', ng-click='sellInventory()')
                       =env.t('sell')
-                      | {{selectedEgg.key}}
+                      | &nbsp;{{selectedEgg.text}}&nbsp;
                       =env.t('for')
-                      | {{selectedEgg.value}})
+                      | &nbsp;{{selectedEgg.value}}&nbsp;
                       =env.t('gold')
                     button.btn.btn-primary(ng-show='selectedPotion', ng-click='sellInventory()')
                       =env.t('sell')
-                      | {{selectedPotion.key}}
+                      | &nbsp;{{selectedPotion.text}}&nbsp;
                       =env.t('for')
-                      | {{selectedPotion.value}})
+                      | &nbsp;{{selectedPotion.value}}&nbsp;
                       =env.t('gold')
                     button.btn.btn-primary(ng-show='selectedFood', ng-click='sellInventory()')
                       =env.t('sell')
-                      | {{selectedFood.key}}
+                      | &nbsp;{{selectedFood.text}}&nbsp;
                       =env.t('for')
-                      | {{selectedFood.value}})
+                      | &nbsp;{{selectedFood.value}}&nbsp;
                       =env.t('gold')
         menu.inventory-list(type='list')
           li.customize-menu


### PR DESCRIPTION
Fix some text appearance issues:
- Use item.text instead of item.key so that users see "Tiger Cub" rather than "TigerCub".
- Remove unwanted ) from end of gold value so that users see "3 Gold" instead of "3) Gold". Bracket had been left over from the end of the old env.t(...) function call - see https://github.com/HabitRPG/habitrpg/commit/4f07ab39b0868764c665bbf914474745e11ecc32
- Add spaces between words so that users see "Sell Fox for 3 Gold" instead of "SellFoxfor3Gold". There are other shorter/neater ways to insert those spaces, but making them really obvious with nbsp is probably the best way to ensure they don't get accidentally removed again.
