### PR TITLE
Fixed unnecessary margin on button group buttons

### DIFF
--- a/public/css/index.styl
+++ b/public/css/index.styl
@@ -181,6 +181,10 @@ a
 .btn 
   margin-right: 5px
 
+// Buttons in groups should not have a 5px margin between them; suppress margin for buttons in groups.
+.btn-group .btn
+  margin-right: 0px
+
 .modal-indented-list
   margin-left: 10px;
   padding-left: 10px;


### PR DESCRIPTION
Buttons in groups in bootstrap are styled to touch on inside edges to
appear joined, so should not have a 5 px margin between them.
