### PR TITLE
feat(attributes): Add backfill button in flat and classbased allocation modes

### DIFF
--- a/views/options/profile.jade
+++ b/views/options/profile.jade
@@ -155,6 +155,11 @@ script(id='partials/options.profile.stats.html', type='text/ng-template')
                   =env.t('taskallocation')
                   &nbsp;
                   i.icon-question-sign(popover-trigger='mouseenter', popover-placement='right', popover=env.t('taskallocationpopover'))
+              div(ng-show='user.preferences.automaticAllocation && !(user.preferences.allocationMode === "taskbased") && (user.stats.points > 0)')
+                a.btn.btn-primary.btn-mini(ng-click='user.ops.allocateNow(user.stats)', popover-trigger='mouseenter', popover-placement='right', popover=env.t('distributepointspopover'))
+                  i.icon-download.icon-white
+                  &nbsp;
+                  =env.t('distributepoints')
         tr
           td= env.t('allocatestr') + ' {{user.stats.str}}'
           td

--- a/views/options/profile.jade
+++ b/views/options/profile.jade
@@ -156,7 +156,7 @@ script(id='partials/options.profile.stats.html', type='text/ng-template')
                   &nbsp;
                   i.icon-question-sign(popover-trigger='mouseenter', popover-placement='right', popover=env.t('taskallocationpopover'))
               div(ng-show='user.preferences.automaticAllocation && !(user.preferences.allocationMode === "taskbased") && (user.stats.points > 0)')
-                a.btn.btn-primary.btn-mini(ng-click='user.ops.allocateNow(user.stats)', popover-trigger='mouseenter', popover-placement='right', popover=env.t('distributepointspopover'))
+                a.btn.btn-primary.btn-mini(ng-click='user.ops.allocateNow({})', popover-trigger='mouseenter', popover-placement='right', popover=env.t('distributepointspopover'))
                   i.icon-download.icon-white
                   &nbsp;
                   =env.t('distributepoints')


### PR DESCRIPTION
Partial implementation of a "distribute points now" button for backfilling accrued Attribute points. Works with flat and classbased allocation so far; taskbased will require much fancier handling.

Requires [this commit in habitrpg-shared](https://github.com/HabitRPG/habitrpg-shared/commit/33222e0f1545afb1c51a68dc185631ce32a519ce).
