### PR TITLE
changing order of stats in character build

### DIFF
--- a/views/options/profile.jade
+++ b/views/options/profile.jade
@@ -161,21 +161,22 @@ script(id='partials/options.profile.stats.html', type='text/ng-template')
                   &nbsp;
                   =env.t('distributePoints')
         tr
-          td= env.t('allocateStr') + ' {{user.stats.str}}'
-          td
-            a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("str")', popover-trigger='mouseenter', popover-placement='right', popover=env.t('allocateStrPop')) +
-        tr
           td= env.t('allocateCon') + ' {{user.stats.con}}'
           td
             a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("con")', popover-trigger='mouseenter', popover-placement='right', popover=env.t('allocateConPop')) +
+         tr
+          td= env.t('allocateInt') + ' {{user.stats.int}}'
+          td
+            a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("int")', popover-trigger='mouseenter', popover-placement='right', popover=env.t('allocateIntPop')) +
         tr
           td= env.t('allocatePer') + ' {{user.stats.per}}'
           td
             a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("per")', popover-trigger='mouseenter', popover-placement='right', popover=env.t('allocatePerPop')) +
         tr
-          td= env.t('allocateInt') + ' {{user.stats.int}}'
+          td= env.t('allocateStr') + ' {{user.stats.str}}'
           td
-            a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("int")', popover-trigger='mouseenter', popover-placement='right', popover=env.t('allocateIntPop')) +
+            a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("str")', popover-trigger='mouseenter', popover-placement='right', popover=env.t('allocateStrPop')) +
+         
     div(ng-class='user.flags.classSelected && !user.preferences.disableClasses ? "span4" : "span6"')
       include ../shared/profiles/achievements
 


### PR DESCRIPTION
User pointed out  nicely that on the stats page, the Attributes and Character build had the stats in different order, which continually led to her accidentally adding points to the wrong stat. This reorders the character build stats to match the attribute stats.
