### PR TITLE
pull correct information for member modal class

### DIFF
--- a/views/shared/modals/members.jade
+++ b/views/shared/modals/members.jade
@@ -16,7 +16,7 @@ div(ng-controller='MemberModalCtrl')
             li(ng-show='profile.auth.timestamps.loggedin')=env.t('lastLoggedIn')
               | {{timestamp(profile.auth.timestamps.loggedin)}} -
           h3=env.t('stats')
-          .label.label-info {{ {warrior:'Warrior',wizard:'Mage',healer:'Healer',rogue:'Rogue'}[user.stats.class] }}
+          .label.label-info {{ {warrior:'Warrior',wizard:'Mage',healer:'Healer',rogue:'Rogue'}[profile.stats.class] }}
           include ../profiles/stats
         .span6
           include ../header/avatar


### PR DESCRIPTION
Right now, the member modal is pulling from "user.stats.class," which isn't very useful for finding out someone _else_'s class.

(Which is also totally my fault. :P)
