### PR TITLE
Changed pet/mount count in stats page to include all pets/mounts

### DIFF
--- a/views/shared/profiles/stats.jade
+++ b/views/shared/profiles/stats.jade
@@ -38,27 +38,27 @@ table.table.table-striped
       ul(style='list-style-type:none')
         li(ng-show='profile.stats.lvl > 1')
           span.glyphicon.glyphicon-question-sign(popover-title=env.t('levelBonus'), popover-trigger='mouseenter', popover-placement='top', popover=env.t('levelBonusText'))
-          | 
+          |
           =env.t('level')
           |: {{(profile.stats.lvl - 1) / 2}}&nbsp;
         li(ng-show='Content.gear.flat[profile.items.gear.equipped.weapon][k] + Content.gear.flat[profile.items.gear.equipped.armor][k] + Content.gear.flat[profile.items.gear.equipped.head][k] + Content.gear.flat[profile.items.gear.equipped.shield][k] > 0')
           span.glyphicon.glyphicon-question-sign(popover-title=env.t('equipment'), popover-trigger='mouseenter', popover-placement='top', popover=env.t('equipmentBonusText'))
-          | 
+          |
           =env.t('equipment')
           |: {{Content.gear.flat[profile.items.gear.equipped.weapon][k] + Content.gear.flat[profile.items.gear.equipped.armor][k] + Content.gear.flat[profile.items.gear.equipped.head][k] + Content.gear.flat[profile.items.gear.equipped.shield][k] || 0}}&nbsp;
         li(ng-show='profile._statsComputed[k] - profile.stats.buffs[k] - ((profile.stats.lvl - 1) / 2) - Content.gear.flat[profile.items.gear.equipped.weapon][k] - Content.gear.flat[profile.items.gear.equipped.armor][k] - Content.gear.flat[profile.items.gear.equipped.head][k] - Content.gear.flat[profile.items.gear.equipped.shield][k] - profile.stats[k] > 0')
           span.glyphicon.glyphicon-question-sign(popover-title=env.t('classBonus'), popover-trigger='mouseenter', popover-placement='top', popover=env.t('classBonusText'))
-          | 
+          |
           =env.t('classEquipBonus')
           |: {{profile._statsComputed[k] - profile.stats.buffs[k] - ((profile.stats.lvl - 1) / 2) - Content.gear.flat[profile.items.gear.equipped.weapon][k] - Content.gear.flat[profile.items.gear.equipped.armor][k] - Content.gear.flat[profile.items.gear.equipped.head][k] - Content.gear.flat[profile.items.gear.equipped.shield][k] - profile.stats[k]}}&nbsp;
         li(ng-show='profile.stats[k] > 0')
           span.glyphicon.glyphicon-question-sign(popover-title=env.t('allocatedPoints'), popover-trigger='mouseenter', popover-placement='top', popover=env.t('allocatedPointsText'))
-          | 
+          |
           =env.t('allocated')
           |: {{profile.stats[k] || 0}}&nbsp;
         li(ng-show='profile.stats.buffs[k] > 0')
           span.glyphicon.glyphicon-question-sign(popover-title=env.t('buffs'), popover-trigger='mouseenter', popover-placement='top', popover=env.t('buffsText'))
-          | 
+          |
           =env.t('buffs')
           |: {{profile.stats.buffs[k] || 0}}&nbsp;
   tr(ng-if='profile.stats.buffs.stealth')
@@ -80,9 +80,7 @@ table.table.table-striped(ng-show='user.flags.dropsEnabled')
   tr
     td
       strong=env.t('petsFound')
-      | : {{profile.petCount}}
-// Dunno why this doesn't work //
-// tr
+      | : {{_.size(user.items.pets)}}
     td
       strong=env.t('mountsTamed')
-      | : {{profile.mountCount}} //
+      | : {{_.size(user.items.mounts)}}


### PR DESCRIPTION
It was making me sad that there was nowhere that listed ALL my pets, after my last pull request. Also fixed some code for mount count on the same page that was commented out, and set that to include all mounts, so now the stats page can list the grand total of pets and mounts you've found/bought/stolen, which seems appropriate.
