### PR TITLE
Fix food tray z-index

### DIFF
--- a/public/css/inventory.styl
+++ b/public/css/inventory.styl
@@ -46,6 +46,7 @@ menu.pets div
   width:30%
   height: 50%
   overflow-y: scroll
+  z-index: 1
 
 .inventory-list
   p


### PR DESCRIPTION
In the pet tab, the food tray is inheriting #wrap’s negative z-index, causing it to become obscured by the footer if you scroll to the bottom of the page. Increased the z-index to 1.

“Fixing HabitRPG one line at at time”
UUID: 1322727e-9911-4ad4-aea9-a5ebd8cba826
