### PR TITLE
Fix positioning of paw sprites

### DIFF
--- a/public/css/inventory.styl
+++ b/public/css/inventory.styl
@@ -94,6 +94,14 @@ menu.pets .customize-menu
     left: 20%
     height: 5px
 
+  //adjust position of flying pig down to leave some room between rows
+  button[class*="Pet-FlyingPig"]
+    position: relative
+    top: 16px
+    
+    .progress
+      bottom: -9px
+
 .pet-button
     border: none
     background: none white

--- a/public/css/inventory.styl
+++ b/public/css/inventory.styl
@@ -93,14 +93,17 @@ menu.pets .customize-menu
     left: 20%
     height: 5px
 
+  //adjust position of flying pig down to leave some room between rows
+  button[class*="Pet-FlyingPig"]
+    position: relative
+    top: 16px
+    
+    .progress
+      bottom: -9px
+
 .pet-button
     border: none
     background: none white
-
-//adjust position of flying pig down to leave some room between rows
-button[class*="Pet-FlyingPig"]
-    position: relative
-    top: 16px
 
 .pet-not-owned
     width: 81px;


### PR DESCRIPTION
Fixes #2815. 
- Adjusted position of paw sprites using absolute positioning instead of margin-top. 
- Added a class of `pets-rare` to the Rare Pets menu in `stable.jade` in order to target the link around the golden paw sprite.
- Adjusted position of Flying Pig sprites to leave more room between row above. (Don't think they need to look as if they're flying in this view and when you have a whole row of pigs, the gap between rows looks odd).

UUID:1322727e-9911-4ad4-aea9-a5ebd8cba826
User: Pixel
