### PR TITLE
Revert "Made incorrect username and password show the same error, for se...

### DIFF
--- a/public/js/controllers/authCtrl.js
+++ b/public/js/controllers/authCtrl.js
@@ -41,6 +41,8 @@ angular.module('authCtrl', [])
       };
 
       $scope.register = function() {
+        // As soon as a CAPTCHA of some sorts is added to this registration form,
+        // please revert commit e3efab2 for extra security benefit.
         /*TODO highlight invalid inputs
          we have this as a workaround for https://github.com/HabitRPG/habitrpg-mobile/issues/64
          */

--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -108,14 +108,14 @@ api.loginLocal = function(req, res, next) {
   if (!(username && password)) return res.json(401, {err:'Missing :username or :password in request body, please provide both'});
   User.findOne({'auth.local.username': username}, function(err, user){
     if (err) return next(err);
-    if (!user) return res.json(401, {err:"Username or password incorrect. Click 'Forgot Password' for help with either. (Note: usernames are case-sensitive)"});
+    if (!user) return res.json(401, {err:"Username '" + username + "' not found. Usernames are case-sensitive, click 'Forgot Password' if you can't remember the capitalization."});
     // We needed the whole user object first so we can get his salt to encrypt password comparison
     User.findOne({
       'auth.local.username': username,
       'auth.local.hashed_password': utils.encryptPassword(password, user.auth.local.salt)
     }, function(err, user){
       if (err) return next(err);
-      if (!user) return res.json(401,{err:"Username or password incorrect. Click 'Forgot Password' for help with either. (Note: usernames are case-sensitive)"});
+      if (!user) return res.json(401,{err:'Incorrect password'});
       res.json({id: user._id,token: user.apiToken});
     });
   });


### PR DESCRIPTION
...curity purposes."

This reverts commit 8d03cfc6b59b82900badbc9b4397f079e11ee2e1.

The security of obscuring usernames on the login form is useless
when the registration form interface is not protected.

The usability disadvantage of not showing a proper error is real, however.
