### PR TITLE
Transcribed old wiki information to api.jade

### DIFF
--- a/views/static/api.jade
+++ b/views/static/api.jade
@@ -72,8 +72,23 @@ html
         //.input
           a#explore(href='#') Explore
       br
+      h2 Two API Types
+      p HabitRPG's API is meant for two different audiences: (1) extensions and scripts, and (2) full-fledged applications. Extensions and scripts can utilize Habit's up/down scoring for individual tasks. An example of this in action is the <a href="https://chrome.google.com/webstore/detail/habitrpg/pidkmpibnnnhneohdgjclfdjpijggmjj?hl=en-US">Chrome Extension</a>, which up-scores you for visiting productive websites, and down-scores you for visiting procrastination websites. Other examples currently in use are Pomodoro, Anki, and Github scripts - which up-score you for good behavior and downscore you for bad behavior - <a href="http://habitrpg.wikia.com/wiki/App_and_Extension_Integrations">see the list</a>. The second API consumer is for full-fledge applications, which need read / write access to the entire user document. An example of this would be Mobile Apps or Desktop application.
+      h2 Extensions / Scripts
+      p HabitRPG has a simple API for up-scoring and down-scoring third party Habits: <code>POST /api/v2/user/tasks/{id}/{direction}</code> (headers <code>x-api-user</code> and <code>x-api-key</code> required).
+      h4 Example
+      p <code>curl -X POST -H "x-api-key: YOUR_API_TOKEN" -H "x-api-user: YOUR_USER_ID" https://beta.habitrpg.com/api/v2/user/tasks/productivity/up</code>
+      p Note: You may need to add <code>--compressed -H "Content-Type:application/json"</code> to your curl if you get errors.
+      ul
+        li POST to the URL <code>/api/v2/user/tasks/{id}/{direction}</code>
+          ul
+           li <code>{direction}</code> is 'up' or 'down'
+           li <code>{id}</code> is a unique identifier for a task, which you make up, consisting of lowercase letters. Try to make it something common, like 'productivity' or 'fitness' - because other services may piggy-back off <em>your</em> task. For example, the Chrome extension down-scores a <code>productivity</code> task when you visit vice websites (reddit, 9gag, etc). However, Pomodoro up-scores <code>productivity</code> when you complete a task. So the two services share a single task to score your overall productivity. If the task doesn't yet exist, it is created the first time you POST to this URL.
+           li <code>apiToken</code> (POST body) <em>required</em>
+      h2 Full API
+      p All API requests should be prefaced by <code>https://habitrpg.com</code>. Every authenticated request should include two headers. Your api key (<code>x-api-key</code>) and your user id (<code>x-api-user</code>). Do not include <code>{}</code> braces in your header (<code>-H 'x-api-user: a94b6d9d-6b64-43ae-856c-2c3f211bd426'</code>)
       h2 Requirements:
-      p The base-url for all routes is /api/v2. So /user actions will be at https://beta.habitrpg.com/api/v2/user/*. You need to send x-api-user and x-api-key headers for each request, <a href='https://github.com/HabitRPG/habitrpg/wiki/API' target='_blank'>read more here</a>. (TODO: We need to move that Wiki document into <a href='https://github.com/HabitRPG/habitrpg/blob/develop/views/static/api.jade' target='_blank'>this file</a> and delete the Wiki)
+      p The base-url for all routes is /api/v2. So /user actions will be at https://beta.habitrpg.com/api/v2/user/*. You need to send x-api-user and x-api-key headers for each request.
       p For create & edit paths (PUT & POST), you'll need to know the schema of the object you're trying to create or edit. See Schema <a href='https://github.com/HabitRPG/habitrpg/tree/develop/src/models' target="_blank">definitions here</a>
       p If any of the documentation is lacking or you're having trouble with it, please post an issue to <a href='https://github.com/HabitRPG/habitrpg/issues' target='_blank'>Github</a>
     #message-bar.swagger-ui-wrap


### PR DESCRIPTION
Old API wiki page information has been transcribed into api.jade (as requested https://github.com/HabitRPG/habitrpg/wiki/API and https://habitrpg.com/static/api), as well as copied to http://habitrpg.wikia.com/wiki/API.
