### PR TITLE
Move CSS for pets that have been raised into mounts from stable.jade to inventory.styl

### DIFF
--- a/public/css/inventory.styl
+++ b/public/css/inventory.styl
@@ -97,9 +97,16 @@ menu.pets .customize-menu
 .pet-button
     border: none
     background: none white
+
+//adjust position of flying pig down to leave some room between rows
+button[class*="Pet-FlyingPig"]
+    position: relative
+    top: 16px
+
 .pet-not-owned
     width: 81px;
     height: 99px;
+    position:  relative;
     /* Would use css3 filters and just display the original pet image with a black hue,
        but doesn't seem to work in Firefox or Opera */
     /*filter: brightness(0%)
@@ -107,9 +114,17 @@ menu.pets .customize-menu
     -moz-filter: brightness(0%)
     -o-filter: brightness(0%)
     -ms-filter: brightness(0%)*/
-
-    .PixelPaw
-      margin-top: 36px // align paw with pets, at the bottom of the button
+    
+    // align paw with pets, at the bottom of the button (changing margin-top doesn't work cross-browser)
+    .PixelPaw, .PixelPaw-Gold
+      position: absolute
+      top: 38px
+      left: 16px
+      
+//allow paw alignment to apply correctly to PixelPaw-Gold as it is inside a link
+menu.pets-rare a
+    display: inline-block
+    vertical-align: top
 
 .selectableInventory
   background-color: lightgreen !important

--- a/public/css/inventory.styl
+++ b/public/css/inventory.styl
@@ -114,7 +114,6 @@ menu.pets .customize-menu
 // styles for pets that have been fed until they evolve into a mount
 .pet-evolved
     opacity: 0.1
-    //if this could be changed to the opacity talked about? can't figure it out
 
 .selectableInventory
   background-color: lightgreen !important

--- a/public/css/inventory.styl
+++ b/public/css/inventory.styl
@@ -96,9 +96,16 @@ menu.pets .customize-menu
 .pet-button
     border: none
     background: none white
+
+//adjust position of flying pig down to leave some room between rows
+button[class*="Pet-FlyingPig"]
+    position: relative
+    top: 16px
+
 .pet-not-owned
     width: 81px;
     height: 99px;
+    position:  relative;
     /* Would use css3 filters and just display the original pet image with a black hue,
        but doesn't seem to work in Firefox or Opera */
     /*filter: brightness(0%)
@@ -106,9 +113,17 @@ menu.pets .customize-menu
     -moz-filter: brightness(0%)
     -o-filter: brightness(0%)
     -ms-filter: brightness(0%)*/
-
-    .PixelPaw
-      margin-top: 36px // align paw with pets, at the bottom of the button
+    
+    // align paw with pets, at the bottom of the button (changing margin-top doesn't work cross-browser)
+    .PixelPaw, .PixelPaw-Gold
+      position: absolute
+      top: 38px
+      left: 16px
+      
+//allow paw alignment to apply correctly to PixelPaw-Gold as it is inside a link
+menu.pets-rare a
+    display: inline-block
+    vertical-align: top
 
 .selectableInventory
   background-color: lightgreen !important

--- a/public/css/inventory.styl
+++ b/public/css/inventory.styl
@@ -114,7 +114,6 @@ menu.pets .customize-menu
 // styles for pets that have been fed until they evolve into a mount
 .pet-evolved
     opacity: 0.1
-    -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=10)"
     //if this could be changed to the opacity talked about? can't figure it out
 
 .selectableInventory

--- a/public/css/inventory.styl
+++ b/public/css/inventory.styl
@@ -97,16 +97,9 @@ menu.pets .customize-menu
 .pet-button
     border: none
     background: none white
-
-//adjust position of flying pig down to leave some room between rows
-button[class*="Pet-FlyingPig"]
-    position: relative
-    top: 16px
-
 .pet-not-owned
     width: 81px;
     height: 99px;
-    position:  relative;
     /* Would use css3 filters and just display the original pet image with a black hue,
        but doesn't seem to work in Firefox or Opera */
     /*filter: brightness(0%)
@@ -114,17 +107,15 @@ button[class*="Pet-FlyingPig"]
     -moz-filter: brightness(0%)
     -o-filter: brightness(0%)
     -ms-filter: brightness(0%)*/
-    
-    // align paw with pets, at the bottom of the button (changing margin-top doesn't work cross-browser)
-    .PixelPaw, .PixelPaw-Gold
-      position: absolute
-      top: 38px
-      left: 16px
-      
-//allow paw alignment to apply correctly to PixelPaw-Gold as it is inside a link
-menu.pets-rare a
-    display: inline-block
-    vertical-align: top
+
+    .PixelPaw
+      margin-top: 36px // align paw with pets, at the bottom of the button
+
+// styles for pets that have been fed until they evolve into a mount
+.pet-evolved
+    opacity: 0.1
+    -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=10)"
+    //if this could be changed to the opacity talked about? can't figure it out
 
 .selectableInventory
   background-color: lightgreen !important

--- a/public/css/inventory.styl
+++ b/public/css/inventory.styl
@@ -17,7 +17,8 @@
 
 .equipment-title
   display: inline-block
-  vertical-align: middle
+  vertical-align: bottom
+  margin-right: 20px
 
 .stable .static-popover
   max-width: 550px
@@ -96,16 +97,9 @@ menu.pets .customize-menu
 .pet-button
     border: none
     background: none white
-
-//adjust position of flying pig down to leave some room between rows
-button[class*="Pet-FlyingPig"]
-    position: relative
-    top: 16px
-
 .pet-not-owned
     width: 81px;
     height: 99px;
-    position:  relative;
     /* Would use css3 filters and just display the original pet image with a black hue,
        but doesn't seem to work in Firefox or Opera */
     /*filter: brightness(0%)
@@ -113,17 +107,15 @@ button[class*="Pet-FlyingPig"]
     -moz-filter: brightness(0%)
     -o-filter: brightness(0%)
     -ms-filter: brightness(0%)*/
-    
-    // align paw with pets, at the bottom of the button (changing margin-top doesn't work cross-browser)
-    .PixelPaw, .PixelPaw-Gold
-      position: absolute
-      top: 38px
-      left: 16px
-      
-//allow paw alignment to apply correctly to PixelPaw-Gold as it is inside a link
-menu.pets-rare a
-    display: inline-block
-    vertical-align: top
+
+    .PixelPaw
+      margin-top: 36px // align paw with pets, at the bottom of the button
+
+// styles for pets that have been fed until they evolve into a mount
+.pet-evolved
+    opacity: 0.1
+    -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=10)"
+    //if this could be changed to the opacity talked about? can't figure it out
 
 .selectableInventory
   background-color: lightgreen !important

--- a/views/options/inventory/stable.jade
+++ b/views/options/inventory/stable.jade
@@ -58,9 +58,7 @@ script(type='text/ng-template', id='partials/options.inventory.pets.html')
                     .progress-bar.progress-bar-success(style="width:{{user.items.pets[pet]/.5}}%")
                 button(class="pet-button pet-not-owned", ng-if='!user.items.pets[pet]')
                   .PixelPaw
-                // How to apply this style in stylus files?
-                button(class="pet-button Pet-{{pet}}" ng-if='user.items.pets[pet]<0',style='opacity:0.1;filter:alpha(opacity=10)')
-                  //if this could be changed to the opacity talked about? can't figure it out
+                button(class="pet-evolved pet-button Pet-{{pet}}", ng-if='user.items.pets[pet]<0')
       .col-md-12
         h4=env.t('questPets')
         menu.pets(type='list')
@@ -72,11 +70,11 @@ script(type='text/ng-template', id='partials/options.inventory.pets.html')
                     .progress-bar.progress-bar-success(style="width:{{user.items.pets[pet]/.5}}%")
                 button(class="pet-button pet-not-owned", ng-if='!user.items.pets[pet]')
                   .PixelPaw
-                button(class="pet-button Pet-{{pet}}" ng-if='user.items.pets[pet]<0',style='opacity:0.1;filter:alpha(opacity=10)')
+                button(class="pet-evolved pet-button Pet-{{pet}}", ng-if='user.items.pets[pet]<0')
 
       .col-md-12
         h4=env.t('rarePets')
-        menu.pets-rare
+        menu
           div
             button(ng-if='user.items.pets["Wolf-Veteran"]', class="pet-button Pet-Wolf-Veteran", ng-class='{active: user.items.currentPet == "Wolf-Veteran"}', ng-click='choosePet("Wolf", "Veteran")', popover=env.t('veteranWolf'), popover-trigger='mouseenter', popover-placement='bottom')
             button(ng-if='user.items.pets["Wolf-Cerberus"]', class="pet-button Pet-Wolf-Cerberus", ng-class='{active: user.items.currentPet == "Wolf-Cerberus"}', ng-click='choosePet("Wolf", "Cerberus")', popover=env.t('cerberusPup'), popover-trigger='mouseenter', popover-placement='bottom')

--- a/views/options/inventory/stable.jade
+++ b/views/options/inventory/stable.jade
@@ -76,7 +76,7 @@ script(type='text/ng-template', id='partials/options.inventory.pets.html')
 
       .col-md-12
         h4=env.t('rarePets')
-        menu
+        menu.pets-rare
           div
             button(ng-if='user.items.pets["Wolf-Veteran"]', class="pet-button Pet-Wolf-Veteran", ng-class='{active: user.items.currentPet == "Wolf-Veteran"}', ng-click='choosePet("Wolf", "Veteran")', popover=env.t('veteranWolf'), popover-trigger='mouseenter', popover-placement='bottom')
             button(ng-if='user.items.pets["Wolf-Cerberus"]', class="pet-button Pet-Wolf-Cerberus", ng-class='{active: user.items.currentPet == "Wolf-Cerberus"}', ng-click='choosePet("Wolf", "Cerberus")', popover=env.t('cerberusPup'), popover-trigger='mouseenter', popover-placement='bottom')


### PR DESCRIPTION
`stable.jade`
- Added a class of `.pet-evolved` for pets that have been raised into mounts. 
- Removed inline styles

`inventory.styl > .pet-evolved`
- Added styles from `stable.jade`
- Changed the opacity method for IE as Stylus was choking on `filter: alpha(opacity=10)`. Since this method targets IE7, it seemed obsolete anyway
- I didn’t understand the comment “if this could be changed to the opacity talked about? can't figure it out”, so I kept it, but moved it from `stable.jade` to keep it with the CSS.

UUID:1322727e-9911-4ad4-aea9-a5ebd8cba826
User: Pixel
