### PR TITLE
fix(readme): build status for the develop branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-HabitRPG [![Build Status](https://travis-ci.org/HabitRPG/habitrpg.png?branch=master)](https://travis-ci.org/HabitRPG/habitrpg)
+HabitRPG [![Build Status](https://travis-ci.org/HabitRPG/habitrpg.png?branch=develop)](https://travis-ci.org/HabitRPG/habitrpg)
 ===============
 
 [HabitRPG](https://habitrpg.com) is an open source habit building program which treats your life like a Role Playing Game. Level up as you succeed, lose HP as you fail, earn money to buy weapons and armor.


### PR DESCRIPTION
Your main development branch is `develop`.
It is usually only interesting to follow the status of the branch in development.
Of course `master` branch will almost always be passing.
Ironically, now it isn't, because our build fixes are on `develop`,
so it's another reason to switch.
