### PR TITLE
Member modal spacing

### DIFF
--- a/views/shared/modals/members.jade
+++ b/views/shared/modals/members.jade
@@ -13,11 +13,11 @@ script(type='text/ng-template', id='modals/member.html')
             li {{profile._id}}
             li(ng-show='profile.auth.timestamps.created')
               |&nbsp;
-              =env.t('memberSince')
+              =env.t('memberSince') + '&nbsp;'
               | {{timestamp(profile.auth.timestamps.created)}} -
             li(ng-show='profile.auth.timestamps.loggedin')
               |&nbsp;
-              =env.t('lastLoggedIn')
+              =env.t('lastLoggedIn') + '&nbsp;'
               | {{timestamp(profile.auth.timestamps.loggedin)}} -
           h3=env.t('stats')
           .label.label-info {{ {warrior:'Warrior',wizard:'Mage',healer:'Healer',rogue:'Rogue'}[profile.stats.class] }}


### PR DESCRIPTION
Updated member modal to add spaces between (Member since|Last logged in) and the respective dates (untracked in issue #2582). 
