### PR TITLE
Added Vagrant for unified, portable dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ newrelic_agent.log
 .bower-tmp
 .bower-registry
 .bower-cache
+.vagrant
 
 *.log
 src/*/*.map

--- a/VAGRANT.md
+++ b/VAGRANT.md
@@ -1,0 +1,26 @@
+Vagrant
+===============
+
+Vagrant is a system to create reproducible and portable development
+environments. Because of the variety of systems used for HabitRPG
+development and the various issues developers may encounter setting up
+HabitRPG on them, vagrant can provide a single development environment
+no matter the developer's platform.
+
+To use Vagrant, go to [their downloads
+page](http://www.vagrantup.com/downloads.html) and download and install
+the software appropriate for your system.
+
+Once Vagrant has been installed, issue the following commands to get the
+environment up and running:
+
+1. Download the vagrant box:
+`vagrant box add habitrpg http://dl.dropboxusercontent.com/u/4309797/devel/habitrpg/package.box`
+2. Initialize the vagrant box:
+`vagrant init`
+3. Boot up and provision the software on the box:
+`vagrant up`
+4. Login to the environment:
+`vagrant ssh`
+
+The HabitRPG files will be located under `/vagrant' on the filesystem.

--- a/VAGRANT.md
+++ b/VAGRANT.md
@@ -16,11 +16,9 @@ environment up and running:
 
 1. Download the vagrant box:
 `vagrant box add habitrpg http://dl.dropboxusercontent.com/u/4309797/devel/habitrpg/package.box`
-2. Initialize the vagrant box:
-`vagrant init`
-3. Boot up and provision the software on the box:
+2. Boot up the box:
 `vagrant up`
-4. Login to the environment:
+3. Login to the environment:
 `vagrant ssh`
 
 The HabitRPG files will be located under `/vagrant' on the filesystem.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,11 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# The vagrant config for HabitRPG. Requires vagrant on your local machine.
+# The box fetched will be precise64 located:
+#    http://files.vagrantup.com/precise64.box
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "habitrpg"
+  config.vm.network "forwarded_port", guest: 3000, host: 3000
+end


### PR DESCRIPTION
Created a vagrant file and some supporting documentation. I've gotten `npm start`/`grunt run:dev` up and running, and I'm hoping I can pass the baton off to folks with more experience in the actual HabitRPG code. 

I've uploaded the vagrant box to my dropbox, which totals about 745MB. Ideally, we'd host the file elsewhere. 
