### PR TITLE
Update API footer link

### DIFF
--- a/views/shared/footer.jade
+++ b/views/shared/footer.jade
@@ -37,7 +37,7 @@ footer.footer(ng-controller='FooterCtrl')
           li
             a(target='_blank', href='https://trello.com/c/8gzGlle8')=env.t('communityFeature')
           li
-            a(target='_blank', href='https://github.com/lefnire/habitrpg/wiki/API')=env.t('API')
+            a(target='_blank', href='https://habitrpg.com/static/api')=env.t('API')
           li
             a(href='/static/extensions')=env.t('communityExtensions')
           li


### PR DESCRIPTION
The Wiki page here on Github is quite useless now, the most useful infos are in https://habitrpg.com/static/api and the official Wiki.
