### PR TITLE
Member modal spacing fix's fix.

### DIFF
--- a/views/shared/modals/members.jade
+++ b/views/shared/modals/members.jade
@@ -13,11 +13,13 @@ script(type='text/ng-template', id='modals/member.html')
             li {{profile._id}}
             li(ng-show='profile.auth.timestamps.created')
               |&nbsp;
-              =env.t('memberSince') + '&nbsp;'
+              =env.t('memberSince')
+              |&nbsp;
               | {{timestamp(profile.auth.timestamps.created)}} -
             li(ng-show='profile.auth.timestamps.loggedin')
               |&nbsp;
-              =env.t('lastLoggedIn') + '&nbsp;'
+              =env.t('lastLoggedIn')
+              |&nbsp;
               | {{timestamp(profile.auth.timestamps.loggedin)}} -
           h3=env.t('stats')
           .label.label-info {{ {warrior:'Warrior',wizard:'Mage',healer:'Healer',rogue:'Rogue'}[profile.stats.class] }}


### PR DESCRIPTION
Fixing escaped &nbsp;s from #2987. 

For expediency, I've tested various different ways of fixing this via the jade-lang.com online demo. Given my inexperience with jade, I'm going with this fix because it interacts the least with functions and locals.

Again, sorry for the bad fix. 
