### PR TITLE
fix Guild Gems strings on the party tab

### DIFF
--- a/views/options/social/group.jade
+++ b/views/options/social/group.jade
@@ -1,4 +1,4 @@
-a.pull-right.gem-wallet(popover-trigger='mouseenter', popover-title=env.t('guildBankPop1'), popover=env.t('guildBankPop2'), popover-placement='left', popover-html='true')
+a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter', popover-title=env.t('guildBankPop1'), popover=env.t('guildBankPop2'), popover-placement='left', popover-html='true')
   // <span class="task-action-btn tile flush bright add-gems-btn">＋</span>
   span.task-action-btn.tile.flush.neutral
     .Pet_Currency_Gem2x.Gems


### PR DESCRIPTION
The Guild Gems strings should say Party Gems instead.
