### PR TITLE
improve(profile): reposition the "unlock set" button to the "2 gem/locked" string

### DIFF
--- a/public/css/customizer.styl
+++ b/public/css/customizer.styl
@@ -23,7 +23,11 @@ menu
 
   .cost
     display: block
-    line-height: 2
+    margin-bottom: 5px
+
+    .btn
+      margin-left: 5px
+      vertical-align: baseline
 
 .customize-option
   border: 0px solid grey

--- a/views/options/profile.jade
+++ b/views/options/profile.jade
@@ -2,6 +2,7 @@ mixin twoGem
   small.cost
     | 2 <span class="Pet_Currency_Gem1x inline-gems"></span> /
     = ' ' + env.t('locked')
+    block
 
 script(id='partials/options.profile.avatar.html', type='text/ng-template')
   .row
@@ -21,10 +22,9 @@ script(id='partials/options.profile.avatar.html', type='text/ng-template')
 
           menu(label=env.t('specialShirts'))
             +twoGem()
+              button.btn.btn-xs(ng-hide="user.purchased.shirt.convict && user.purchased.shirt.cross && user.purchased.shirt.fire && user.purchased.shirt.horizon && user.purchased.shirt.ocean && user.purchased.shirt.purple && user.purchased.shirt.rainbow && user.purchased.shirt.redblue && user.purchased.shirt.thunder && user.purchased.shirt.tropical && user.purchased.shirt.zombie", ng-click='unlock("shirt.convict,shirt.cross,shirt.fire,shirt.horizon,shirt.ocean,shirt.purple,shirt.rainbow,shirt.redblue,shirt.thunder,shirt.tropical,shirt.zombie")')!= env.t('unlockSet5') + ' <span class="Pet_Currency_Gem1x inline-gems"/>'
             each shirt in ['convict', 'cross', 'fire', 'horizon', 'ocean', 'purple', 'rainbow', 'redblue', 'thunder', 'tropical', 'zombie']
               button.customize-option(type='button', class='{{user.preferences.size}}_shirt_'+shirt, ng-class='{locked: !user.purchased.shirt.'+shirt+'}', ng-click='unlock("shirt.'+shirt+'")')
-          menu
-            button.btn.btn-sm.btn-primary(ng-hide="user.purchased.shirt.convict && user.purchased.shirt.cross && user.purchased.shirt.fire && user.purchased.shirt.horizon && user.purchased.shirt.ocean && user.purchased.shirt.purple && user.purchased.shirt.rainbow && user.purchased.shirt.redblue && user.purchased.shirt.thunder && user.purchased.shirt.tropical && user.purchased.shirt.zombie", ng-click='unlock("shirt.convict,shirt.cross,shirt.fire,shirt.horizon,shirt.ocean,shirt.purple,shirt.rainbow,shirt.redblue,shirt.thunder,shirt.tropical,shirt.zombie")')!= env.t('unlockSet5') + ' <span class="Pet_Currency_Gem1x inline-gems"/>'
 
 
     .col-md-4
@@ -39,9 +39,9 @@ script(id='partials/options.profile.avatar.html', type='text/ng-template')
                 .label.label-info.pull-right.hint(popover=limited, popover-title=env.t('limitedEdition'), popover-placement='right', popover-trigger='mouseenter')=env.t('limitedEdition')
               menu(label=title)
                 +twoGem()
+                  button.btn.btn-xs(ng-hide='user.purchased.hair.color.#{colors.join(" && user.purchased.hair.color.")}', ng-click='unlock("hair.color.#{colors.join(",hair.color.")}")')!= env.t('unlockSet5') + ' <span class="Pet_Currency_Gem1x inline-gems"/>'
                 each color in colors
                   button(type='button', ng-class='{locked: !user.purchased.hair.color.#{color}}', class='customize-option hair hair_bangs_1_#{color}', ng-click='unlock("hair.color.#{color}")')
-            button.btn.btn-sm.btn-primary(ng-hide='user.purchased.hair.color.#{colors.join(" && user.purchased.hair.color.")}', ng-click='unlock("hair.color.#{colors.join(",hair.color.")}")')!= env.t('unlockSet5') + ' <span class="Pet_Currency_Gem1x inline-gems"/>'
 
           li.customize-menu
             menu(label=env.t('color'))
@@ -63,13 +63,13 @@ script(id='partials/options.profile.avatar.html', type='text/ng-template')
           // Base
           li.customize-menu
             menu(label=env.t('hairBase'))
+              +twoGem()
+                button.btn.btn-xs(ng-hide='user.purchased.hair.base.2 && user.purchased.hair.base.4 && user.purchased.hair.base.5 && user.purchased.hair.base.6 && user.purchased.hair.base.7 && user.purchased.hair.base.8', ng-click='unlock("hair.base.2,hair.base.4,hair.base.5,hair.base.6,hair.base.7,hair.base.8")')!= env.t('unlockSet5') + ' <span class="Pet_Currency_Gem1x inline-gems"/>'
               button(class='head_0 customize-option', type='button', ng-click='set({"preferences.hair.base":0})')
               each v,k in {1:true,2:false,3:true,4:false,5:false,6:false,7:false,8:false}
                 case v
                   when true:  button(class='hair_base_#{k}_{{user.preferences.hair.color}} customize-option', type='button', ng-click='set({"preferences.hair.base":#{k}})')
                   when false: button(class='hair_base_#{k}_{{user.preferences.hair.color}} customize-option', type='button', ng-class='{locked: !user.purchased.hair.base.#{k}}', ng-click='unlock("hair.base.#{k}")')
-
-          button.btn.btn-sm.btn-primary(ng-hide='user.purchased.hair.base.2 && user.purchased.hair.base.4 && user.purchased.hair.base.5 && user.purchased.hair.base.6 && user.purchased.hair.base.7 && user.purchased.hair.base.8', ng-click='unlock("hair.base.2,hair.base.4,hair.base.5,hair.base.6,hair.base.7,hair.base.8")')!= env.t('unlockSet5') + ' <span class="Pet_Currency_Gem1x inline-gems"/>'
 
           // Flower
           li.customize-menu
@@ -80,10 +80,12 @@ script(id='partials/options.profile.avatar.html', type='text/ng-template')
 
           h5=env.t('bodyFacialHair')
 
+          +twoGem()
+            button.btn.btn-xs(ng-hide='user.purchased.hair.mustache.1 && user.purchased.hair.mustache.2 && user.purchased.hair.beard.1 && user.purchased.hair.beard.2 && user.purchased.hair.beard.3', ng-click='unlock("hair.mustache.1,hair.mustache.2,hair.beard.1,hair.beard.2,hair.beard.3")')!= env.t('unlockSet5') + ' <span class="Pet_Currency_Gem1x inline-gems"/>'
+
           // Beard
           li.customize-menu
             menu(label=env.t('beard'))
-              +twoGem()
               button(class='head_0 customize-option', type='button', ng-click='set({"preferences.hair.beard":0})')
               each num in [1,2,3]
                 button(class='hair_beard_#{num}_{{user.preferences.hair.color}} customize-option', type='button', ng-class='{locked: !user.purchased.hair.beard.#{num}}', ng-click='unlock("hair.beard.#{num}")')
@@ -91,12 +93,9 @@ script(id='partials/options.profile.avatar.html', type='text/ng-template')
           // Mustache
           li.customize-menu
             menu(label=env.t('mustache'))
-              +twoGem()
               button(class='head_0 customize-option', type='button', ng-click='set({"preferences.hair.mustache":0})')
               each num in [1,2]
                 button(class='hair_mustache_#{num}_{{user.preferences.hair.color}} customize-option', type='button', ng-class='{locked: !user.purchased.hair.mustache.#{num}}', ng-click='unlock("hair.mustache.#{num}")')
-
-          button.btn.btn-sm.btn-primary(ng-hide='user.purchased.hair.mustache.1 && user.purchased.hair.mustache.2 && user.purchased.hair.beard.1 && user.purchased.hair.beard.2 && user.purchased.hair.beard.3', ng-click='unlock("hair.mustache.1,hair.mustache.2,hair.beard.1,hair.beard.2,hair.beard.3")')!= env.t('unlockSet5') + ' <span class="Pet_Currency_Gem1x inline-gems"/>'
 
     .col-md-4
         h3=env.t('bodySkin')
@@ -109,11 +108,11 @@ script(id='partials/options.profile.avatar.html', type='text/ng-template')
           // Rainbow Skin
           h5=env.t('rainbowSkins')
           +twoGem()
+            button.btn.btn-xs(ng-hide='user.purchased.skin.eb052b && user.purchased.skin.f69922 && user.purchased.skin.f5d70f && user.purchased.skin.0ff591 && user.purchased.skin.2b43f6 && user.purchased.skin.d7a9f7 && user.purchased.skin.800ed0 && user.purchased.skin.rainbow', ng-click='unlock("skin.eb052b,skin.f69922,skin.f5d70f,skin.0ff591,skin.2b43f6,skin.d7a9f7,skin.800ed0,skin.rainbow")')!= env.t('unlockSet5') + ' <span class="Pet_Currency_Gem1x inline-gems"/>'
           //menu(label='Rainbow Skins (2G / skin)')
           menu
             each color in ['eb052b','f69922','f5d70f','0ff591','2b43f6','d7a9f7','800ed0','rainbow']
               button.customize-option(type='button', class='skin_#{color}', ng-class='{locked: !user.purchased.skin.#{color}}', ng-click='unlock("skin.#{color}")')
-          button.btn.btn-sm.btn-primary(ng-hide='user.purchased.skin.eb052b && user.purchased.skin.f69922 && user.purchased.skin.f5d70f && user.purchased.skin.0ff591 && user.purchased.skin.2b43f6 && user.purchased.skin.d7a9f7 && user.purchased.skin.800ed0 && user.purchased.skin.rainbow', ng-click='unlock("skin.eb052b,skin.f69922,skin.f5d70f,skin.0ff591,skin.2b43f6,skin.d7a9f7,skin.800ed0,skin.rainbow")')!= env.t('unlockSet5') + ' <span class="Pet_Currency_Gem1x inline-gems"/>'
 
           // Special Events
           // restore to d4df481 to see purchasing + "limited edition" code


### PR DESCRIPTION
Here's the current layout:
![3](https://cloud.githubusercontent.com/assets/113721/2567153/9ed40efa-b8d1-11e3-9eb8-ea3a5a6e9dd9.png)

This pull request changes it to the following:
![1](https://cloud.githubusercontent.com/assets/113721/2567154/aafee40c-b8d1-11e3-9115-afdd302f00c8.png)

There is an option of keeping the button blue, but the intensity of the colour seems too much in the new position:
![2](https://cloud.githubusercontent.com/assets/113721/2567158/bde41a38-b8d1-11e3-931f-618bf08f5698.png)
