### PR TITLE
fix(footer): correct logic to show debug panel

### DIFF
--- a/views/shared/footer.jade
+++ b/views/shared/footer.jade
@@ -65,7 +65,7 @@ footer.footer(ng-controller='FooterCtrl')
               tr
                 td
                   a.addthis_button_google_plusone(g:plusone:size='medium')
-        else if(env.NODE_ENV != 'production' && !env.isStaticPage)
+        else if(env.NODE_ENV === 'development' && !env.isStaticPage)
           h4 Debug
           .btn-group-vertical
             a.btn.btn-default(ng-click='addMissedDay()') +1 Missed Day


### PR DESCRIPTION
In the controller, the actions behind the buttons are only defined in development.
As a result, if the environment is neither production, nor development,
the buttons would show up but do nothing.

After this fix, the buttons only show up in development.
