### PR TITLE
Replace growl with pnotify

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -38,7 +38,8 @@
     "sticky": "*",
     "swagger-ui": "git://github.com/wordnik/swagger-ui.git",
     "ngInfiniteScroll": "~1.0.0",
-    "jquery-colorbox": "~1.4.36"
+    "jquery-colorbox": "~1.4.36",
+    "pnotify": "~1.3.1"
   },
   "devDependencies": {
     "angular-mocks": "~1.2.12"

--- a/public/js/services/notificationServices.js
+++ b/public/js/services/notificationServices.js
@@ -3,17 +3,14 @@
  */
 angular.module("notificationServices", [])
   .factory("Notification", [function() {
-    function growl(html, type) {
-      $.bootstrapGrowl(html, {
-        ele: '#notification-area',
+    function notify(html, type, icon) {
+      var notice = $.pnotify({
         type: type || 'warning', //('info', 'text', 'warning', 'success', 'gp', 'xp', 'hp', 'lvl', 'death', 'mp', 'crit')
-        top_offset: 60,
-        align: 'right', //('left', 'right', or 'center')
-        width: 250, //(integer, or 'auto')
-        delay: (type=='error') ? 0 : 7000,
-        allow_dismiss: true,
-        stackup_spacing: 10 // spacing between consecutive stacked growls.
-      });
+	    text: html,
+        opacity: 1,
+        addclass: 'alert-' + type,
+        icon: icon || false
+      }).click(function() { notice.pnotify_remove() });
     };
 
     /**
@@ -45,32 +42,32 @@ angular.module("notificationServices", [])
       coins: coins,
       hp: function(val) {
         // don't show notifications if user dead
-        growl("<span class='glyphicon glyphicon-heart'></span>&nbsp; " + sign(val) + " " + round(val) + " " + window.env.t('hp'), 'hp');
+        notify(sign(val) + " " + round(val) + " " + window.env.t('hp'), 'hp', 'glyphicon glyphicon-heart');
       },
       exp: function(val) {
         if (val < -50) return; // don't show when they level up (resetting their exp)
-        growl("<span class='glyphicon glyphicon-star'></span>&nbsp; " + sign(val) + " " + round(val) + " " + window.env.t('xp'), 'xp');
+        notify(sign(val) + " " + round(val) + " " + window.env.t('xp'), 'xp', 'glyphicon glyphicon-star');
       },
       gp: function(val, bonus) {
-        growl(sign(val) + " " + coins(val - bonus), 'gp');
+        notify(sign(val) + " " + coins(val - bonus), 'gp');
       },
       text: function(val){
-        growl(val);
+        notify(val, 'info');
       },
       lvl: function(){
-        growl('<span class="glyphicon glyphicon-chevron-up"></span>&nbsp;' + window.env.t('levelUp'), 'lvl');
+        notify(window.env.t('levelUp'), 'lvl', 'glyphicon glyphicon-chevron-up');
       },
       error: function(error){
-        growl("<span class='glyphicon glyphicon-exclamation-sign'></span>&nbsp; " + error, "danger");
+        notify(error, "danger", 'glyphicon glyphicon-exclamation-sign');
       },
       mp: function(val) {
-        growl("<span class='glyphicon glyphicon-fire'></span>&nbsp; " + sign(val) + " " + round(val) + " " + window.env.t('mp'), 'mp');
+        notify(sign(val) + " " + round(val) + " " + window.env.t('mp'), 'mp', 'glyphicon glyphicon-fire');
       },
       crit: function(val) {
-        growl("<span class='glyphicon glyphicon-certificate'></span>&nbsp;" + window.env.t('critBonus') + Math.round(val) + "%", 'crit');
+        notify(window.env.t('critBonus') + Math.round(val) + "%", 'crit', 'glyphicon glyphicon-certificate');
       },
       drop: function(val) {
-        growl("<span class='glyphicon glyphicon-gift'></span>&nbsp; " + val, 'drop');
+        notify(val, 'drop', 'glyphicon glyphicon-gift');
       }
     };
   }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,6 +3,7 @@
         "js": [
             "bower_components/jquery/dist/jquery.min.js",
             "bower_components/jquery.cookie/jquery.cookie.js",
+            "bower_components/pnotify/jquery.pnotify.min.js",
             "bower_components/bootstrap-growl/jquery.bootstrap-growl.js",
             "bower_components/bootstrap-tour/build/js/bootstrap-tour.js",
             "bower_components/angular/angular.js",
@@ -66,6 +67,8 @@
         "css": [
             "bower_components/bootstrap/dist/css/bootstrap.css",
             "app.css",
+            "bower_components/pnotify/jquery.pnotify.default.css",
+            "bower_components/pnotify/jquery.pnotify.default.icons.css",
             "bower_components/habitrpg-shared/dist/habitrpg-shared.css"
         ]
     },


### PR DESCRIPTION
Re: #2924

This is a preliminary code review pull request. There are a few issues with the code as-is:
- Alerts do not have a close 'X' icon, but you can click them to get rid of them (this behavior can be changed).
-  Alerts stay on page longer than the growl alerts did. 
- Code has not been run through the unit test suite because I'm experiencing issues running the tests (selenium won't start).
- Pnotify's facility to redisplay either the most recent or all the alerts since page load is obscured by the toolbar (see the upper right corner of http://sciactive.com/pnotify/ for this in action). I believe someone better versed in interface design would probably want to tackle this, especially since the default interface uses the same chevron as the toolbar expander.

I decided to submit this pull request because I think someone else can probably run with this, while I try to tackle issues with the vagrant image. 
