### PR TITLE
Pin Express to 3.5.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "habitrpg-shared": "git://github.com/HabitRPG/habitrpg-shared#develop",
     "connect-mongo": "*",
-    "express": "*",
+    "express": "3.5.0",
     "gzippo": "*",
     "guid": "*",
     "moment": "~2.4.0",


### PR DESCRIPTION
`*` will grab `4.0.0` which is currently not supported.
