### PR TITLE
Updated width and positioning of pnotify items

### DIFF
--- a/public/js/services/notificationServices.js
+++ b/public/js/services/notificationServices.js
@@ -3,12 +3,18 @@
  */
 angular.module("notificationServices", [])
   .factory("Notification", [function() {
+    var stack_topright = {"dir1": "down", "dir2": "left", "spacing1": 15, "spacing2": 15, "firstpos1": 60};
     function notify(html, type, icon) {
       var notice = $.pnotify({
         type: type || 'warning', //('info', 'text', 'warning', 'success', 'gp', 'xp', 'hp', 'lvl', 'death', 'mp', 'crit')
 	    text: html,
-        opacity: 1,
+        opacity: .75,
         addclass: 'alert-' + type,
+        delay: 7000,
+        hide: (type == 'error') ? false : true,
+        mouse_reset: false,
+        width: "250px",
+        stack: stack_topright,
         icon: icon || false
       }).click(function() { notice.pnotify_remove() });
     };


### PR DESCRIPTION
Addressing @SabreCat's issues with #3237:
- Notifications moved down to 60 pixels from top of page. 
- Width set to 250px

Other changes: 
- Notifications are now translucent. 
- Delay set to former value of 7 seconds. 
- Notifications persist if type == error
- Mousing over a notification will not extend the time before it disappears.
- Notifications are now spaced 15px apart.
