### PR TITLE
Add missing `angular-ui` dependency.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,7 @@
     "jquery.cookie": "~1.4.0",
     "jquery-ui": "~1.10.3",
     "angular": "~1.2.12",
+    "angular-ui": "~0.4.0",
     "angular-sanitize": "~1.2.12",
     "angular-resource": "~1.2.12",
     "angular-ui-utils": "~0.1.0",


### PR DESCRIPTION
When I was setting up HabitRPG locally, I noticed that this dependency was 404ing. This fixes it.
