### PR TITLE
fix(achievements): Differentiate singular and plural

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -255,3 +255,10 @@ module.exports.locals = function(req, res, next) {
     next();
   });
 }
+
+module.exports.enTranslations = function(stringName, vars){
+  var language = {code:'en'};
+  var string = translations[language.code][stringName];
+  if(!string) return _.template(translations[language.code].stringNotFound, {string: stringName});
+  return vars === undefined ? string : _.template(string, vars);
+};

--- a/views/options/profile.jade
+++ b/views/options/profile.jade
@@ -4,17 +4,21 @@ mixin twoGem
     = ' ' + env.t('locked')
     block
 
-script(id='partials/options.profile.avatar.html', type='text/ng-template')
-  .row
-    .col-md-4
+
+// Make it a mixin so we can call it from mobile
+mixin customizeProfile(mobile)
+  div(class='#{mobile ? "" : "row"}')
+    if mobile
+      .item.item-divider Body
+    .col-md-4.item
       h3=env.t('bodyBody')
 
       menu(type='list')
         li.customize-menu
           menu(label=env.t('bodySize'))
-          .btn-group
-            button.btn.btn-sm.btn-default(ng-class='{active: user.preferences.size=="slim"}', ng-click='set({"preferences.size":"slim"})')=env.t('bodySlim')
-            button.btn.btn-sm.btn-default(ng-class='{active: user.preferences.size=="broad"}', ng-click='set({"preferences.size":"broad"})')=env.t('bodyBroad')
+          .btn-group.button-bar
+            button.button.btn.btn-sm.btn-default(ng-class='{active: user.preferences.size=="slim"}', ng-click='set({"preferences.size":"slim"})')=env.t('bodySlim')
+            button.button.btn.btn-sm.btn-default(ng-class='{active: user.preferences.size=="broad"}', ng-click='set({"preferences.size":"broad"})')=env.t('bodyBroad')
 
         li.customize-menu
           menu(label=env.t('shirts'))
@@ -28,7 +32,9 @@ script(id='partials/options.profile.avatar.html', type='text/ng-template')
               button.customize-option(type='button', class='{{user.preferences.size}}_shirt_'+shirt, ng-class='{locked: !user.purchased.shirt.'+shirt+'}', ng-click='unlock("shirt.'+shirt+'")')
 
 
-    .col-md-4
+    if mobile
+      .item.item-divider Head
+    .col-md-4.item
         h3=env.t('bodyHead')
         menu(type='list')
           // For special events code, see commit dfa27b3
@@ -97,7 +103,9 @@ script(id='partials/options.profile.avatar.html', type='text/ng-template')
               each num in [1,2]
                 button(class='hair_mustache_#{num}_{{user.preferences.hair.color}} customize-option', type='button', ng-class='{locked: !user.purchased.hair.mustache.#{num}}', ng-click='unlock("hair.mustache.#{num}")')
 
-    .col-md-4
+    if mobile
+      .item.item-divider Skin
+    .col-md-4.item
         h3=env.t('bodySkin')
         // skin
         li.customize-menu
@@ -119,6 +127,9 @@ script(id='partials/options.profile.avatar.html', type='text/ng-template')
             menu
               each color in ['monster','pumpkin','skeleton','zombie','ghost','shadow']
                 button.customize-option(type='button', class='skin_#{color}', ng-if='user.purchased.skin.#{color}', ng-click='unlock("skin.#{color}")')
+
+script(id='partials/options.profile.avatar.html', type='text/ng-template')
+  +customizeProfile()
 
 script(id='partials/options.profile.stats.html', type='text/ng-template')
   .container-fluid

--- a/views/options/settings.jade
+++ b/views/options/settings.jade
@@ -20,7 +20,7 @@ script(id='partials/options.settings.html', type="text/ng-template")
       div(ui-view)
 
 script(type='text/ng-template', id='partials/options.settings.settings.html')
-  .containter-fluid
+  .container-fluid
     .row
       .personal-options.col-md-6
         .panel.panel-default
@@ -103,7 +103,7 @@ script(type='text/ng-template', id='partials/options.settings.settings.html')
             a.btn.btn-danger(ng-click='openModal("delete", {controller:"SettingsCtrl"})', popover-trigger='mouseenter', popover=env.t('deleteAccPop'))= env.t('deleteAccount')
 
 script(type='text/ng-template', id='partials/options.settings.coupon.html')
-  .containter-fluid
+  .container-fluid
     .row
       .col-md-6
         h2 Coupon
@@ -127,7 +127,7 @@ script(type='text/ng-template', id='partials/options.settings.coupon.html')
 
 
 script(type='text/ng-template', id='partials/options.settings.api.html')
-  .containter-fluid
+  .container-fluid
     .row
       .col-md-6
         h2=env.t('API')
@@ -140,7 +140,7 @@ script(type='text/ng-template', id='partials/options.settings.api.html')
         img(src='https://chart.googleapis.com/chart?cht=qr&chs=200x200&chl=%7B%22address%22%3A%22https%3A%2F%2Fhabitrpg.com%22%2C%22user%22%3A%22{{user.id}}%22%2C%22key%22%3A%22{{user.apiToken}}%22%7D&choe=UTF-8&chld=L', alt='qrcode')
 
 script(id='partials/options.settings.export.html', type="text/ng-template")
-  .containter-fluid
+  .container-fluid
     .row
       .col-md-6
         h2=env.t('dataExport')
@@ -183,26 +183,26 @@ script(id='partials/feature-matrix-check.html',type='text/ng-template')
     label
 
 script(id='partials/options.settings.subscription.html',type='text/ng-template')
-
-  .well
-    h2=env.t('individualSub')
-    div(ng-if='!user.purchased.plan.customerId')
-      div(ng-include="'partials/options.settings.subscription.perks.html'")
-      p
-        small.muted Payment Methods:
-      .btn.btn-primary(ng-click='showStripe(true)') Card
-      //-small.muted PayPal coming soon.
-      //a.btn.btn-warning(ng-click='paypalSubscribe()') PayPal
-      a.btn.btn-warning(href='/paypal/subscribe?_id={{user._id}}&apiToken={{user.apiToken}}') PayPal
-
-    div(ng-if='user.purchased.plan.customerId')
-      .well
-        p.lead
-          =env.t('subscribed')
-          | &nbsp;
-          span.glyphicon.glyphicon-ok
-        div(ng-include="'partials/options.settings.subscription.perks.html'")
-      .btn.btn-sm.btn-danger(ng-click='cancelSubscription()')=env.t('cancelSub')
-      p
-        small.muted Unsubscribing removes subscriber perks (<a href='https://github.com/HabitRPG/habitrpg/issues/3180' target='_blank'>read more here</a>). We're working on persisting subscriber perks through a canceled plan's billing cycle, but for now be sure to open your mystery box before unsubscribing!
-
+  .container-fluid
+    .row
+      .col-md-6
+        .well
+          h2=env.t('individualSub')
+          div(ng-if='!user.purchased.plan.customerId')
+            div(ng-include="'partials/options.settings.subscription.perks.html'")
+            p
+              small.muted Payment Methods:
+              .btn.btn-primary(ng-click='showStripe(true)') Card
+                //-small.muted PayPal coming soon.
+                //a.btn.btn-warning(ng-click='paypalSubscribe()') PayPal
+              a.btn.btn-warning(href='/paypal/subscribe?_id={{user._id}}&apiToken={{user.apiToken}}') PayPal
+            div(ng-if='user.purchased.plan.customerId')
+              .well
+                p.lead
+                  =env.t('subscribed')
+                  | &nbsp;
+                  span.glyphicon.glyphicon-ok
+                div(ng-include="'partials/options.settings.subscription.perks.html'")
+              .btn.btn-sm.btn-danger(ng-click='cancelSubscription()')=env.t('cancelSub')
+              p
+                small.muted Unsubscribing removes subscriber perks (<a href='https://github.com/HabitRPG/habitrpg/issues/3180' target='_blank'>read more here</a>). We're working on persisting subscriber perks through a canceled plan's billing cycle, but for now be sure to open your mystery box before unsubscribing!

--- a/views/shared/profiles/achievements.jade
+++ b/views/shared/profiles/achievements.jade
@@ -41,19 +41,25 @@ div(ng-if='profile.backer.tier')
 div(ng-if='profile.achievements.streak || user._id == profile._id')
   .achievement.achievement-thermometer(ng-show='profile.achievements.streak')
   div(ng-class='{muted: !profile.achievements.streak}')
-    h5 
+    h5(ng-show='{profile.achievements.streak > 1 || !profile.achievements.streak}')
       |{{profile.achievements.streak || 0 }}&nbsp;
       =env.t('streakName')
-    small=env.t('streakText', {streaks: "{{profile.achievements.streak || 0 }}"})
+    small(ng-show='{profile.achievements.streak > 1 || !profile.achievements.streak}')=env.t('streakText', {streaks: "{{profile.achievements.streak || 0 }}"})
+    h5(ng-show='{profile.achievements.streak == 1}')
+      =env.t('streakSingular')
+    small(ng-show='{profile.achievements.streak == 1')=env.t('streakSingularText')
   hr
 
 div(ng-if='profile.achievements.perfect || user._id == profile._id')
   .achievement.achievement-perfect(ng-show='profile.achievements.perfect')
   div(ng-class='{muted: !profile.achievements.perfect}')
-    h5 
+    h5(ng-show='{profile.achievements.perfect > 1 || !profile.achievements.perfect}')
       |{{profile.achievements.perfect || 0 }}&nbsp;
       =env.t('perfectName')
-    small=env.t('perfectText', {perfects: "{{profile.achievements.perfect || 0 }}"})
+    small(ng-show='{profile.achievements.perfect > 1 || !profile.achievements.perfect}')=env.t('perfectText', {perfects: "{{profile.achievements.perfect || 0 }}"})
+    h5(ng-show='{profile.achievements.perfect == 1}')
+      =env.t('perfectSingular')
+    small(ng-show='{profile.achievements.perfect == 1}')=env.t('perfectSingularText')
   hr
 
 //-div(ng-if='profile.achievements.ultimateGear || user._id == profile._id')

--- a/views/shared/profiles/achievements.jade
+++ b/views/shared/profiles/achievements.jade
@@ -41,25 +41,25 @@ div(ng-if='profile.backer.tier')
 div(ng-if='profile.achievements.streak || user._id == profile._id')
   .achievement.achievement-thermometer(ng-show='profile.achievements.streak')
   div(ng-class='{muted: !profile.achievements.streak}')
-    h5(ng-show='{profile.achievements.streak > 1 || !profile.achievements.streak}')
+    h5(ng-show='profile.achievements.streak > 1 || !profile.achievements.streak')
       |{{profile.achievements.streak || 0 }}&nbsp;
       =env.t('streakName')
-    small(ng-show='{profile.achievements.streak > 1 || !profile.achievements.streak}')=env.t('streakText', {streaks: "{{profile.achievements.streak || 0 }}"})
-    h5(ng-show='{profile.achievements.streak == 1}')
+    small(ng-show='profile.achievements.streak > 1 || !profile.achievements.streak')=env.t('streakText', {streaks: "{{profile.achievements.streak || 0 }}"})
+    h5(ng-show='profile.achievements.streak == 1')
       =env.t('streakSingular')
-    small(ng-show='{profile.achievements.streak == 1')=env.t('streakSingularText')
+    small(ng-show='profile.achievements.streak == 1')=env.t('streakSingularText')
   hr
 
 div(ng-if='profile.achievements.perfect || user._id == profile._id')
   .achievement.achievement-perfect(ng-show='profile.achievements.perfect')
   div(ng-class='{muted: !profile.achievements.perfect}')
-    h5(ng-show='{profile.achievements.perfect > 1 || !profile.achievements.perfect}')
+    h5(ng-show='profile.achievements.perfect > 1 || !profile.achievements.perfect')
       |{{profile.achievements.perfect || 0 }}&nbsp;
       =env.t('perfectName')
-    small(ng-show='{profile.achievements.perfect > 1 || !profile.achievements.perfect}')=env.t('perfectText', {perfects: "{{profile.achievements.perfect || 0 }}"})
-    h5(ng-show='{profile.achievements.perfect == 1}')
+    small(ng-show='profile.achievements.perfect > 1 || !profile.achievements.perfect')=env.t('perfectText', {perfects: "{{profile.achievements.perfect || 0 }}"})
+    h5(ng-show='profile.achievements.perfect == 1')
       =env.t('perfectSingular')
-    small(ng-show='{profile.achievements.perfect == 1}')=env.t('perfectSingularText')
+    small(ng-show='profile.achievements.perfect == 1')=env.t('perfectSingularText')
   hr
 
 //-div(ng-if='profile.achievements.ultimateGear || user._id == profile._id')


### PR DESCRIPTION
Allows Streak and Perfect Day achievements to dynamically show a singular or plural version of their text based on how many achievements the viewed profile has stacked.

BREAKING CHANGE: Will lead to 'string not found' errors until the singular version strings are implemented in all locales on habitrpg-shared.
