### PR TITLE
Partial implementation of single challenge view.

### DIFF
--- a/public/css/challenges.styl
+++ b/public/css/challenges.styl
@@ -6,7 +6,7 @@ ul.challenge-accordion-header-specs
         margin: 2px 5px
         float:left
 
-#create-challenge-btn
+#back-to-challenges, #create-challenge-btn
 	margin-bottom: 10px
 
 #challenges-filters h3

--- a/public/js/controllers/challengesCtrl.js
+++ b/public/js/controllers/challengesCtrl.js
@@ -1,18 +1,27 @@
 "use strict";
 
-habitrpg.controller("ChallengesCtrl", ['$rootScope','$scope', 'Shared', 'User', 'Challenges', 'Notification', '$compile', 'Groups', '$state',
-  function($rootScope, $scope, Shared, User, Challenges, Notification, $compile, Groups, $state) {
+habitrpg.controller("ChallengesCtrl", ['$rootScope','$scope', 'Shared', 'User', 'Challenges', 'Notification', '$compile', 'Groups', '$state', '$location',
+  function($rootScope, $scope, Shared, User, Challenges, Notification, $compile, Groups, $state, $location) {
 
     // FIXME $scope.challenges needs to be resolved first (see app.js)
     $scope.groups = Groups.Group.query({type:'party,guilds,tavern'});
-    Challenges.Challenge.query(function(challenges){
-      $scope.challenges = challenges;
-      $scope.groupsFilter = _.uniq(_.pluck(challenges, 'group'), function(g){return g._id});
-      $scope.search = {
-        group: _.transform($scope.groups, function(m,g){m[g._id]=true;})
-      };
-    });
-    // we should fix this, that's pretty brittle
+    var cid = $location.path().split("/").pop().match(/([a-f0-9\-])+$/);
+
+    if (! (cid === null || cid[0] === "" || cid[0] === "challenges")) {
+      cid = cid[0];
+      Challenges.Challenge.get({cid: cid}, function(challenge) {
+        $scope.cid = cid;
+        $scope.challenges = [challenge];
+      });
+    } else {
+      Challenges.Challenge.query(function(challenges) {
+        $scope.challenges = challenges;
+        $scope.groupsFilter = _.uniq(_.pluck(challenges, 'group'), function(g){return g._id});
+        $scope.search = {
+          group: _.transform($scope.groups, function(m,g){m[g._id]=true;})
+        };
+      });
+    }
 
     // override score() for tasks listed in challenges-editing pages, so that nothing happens
     $scope.score = function(){}

--- a/public/js/services/challengeServices.js
+++ b/public/js/services/challengeServices.js
@@ -1,27 +1,23 @@
 'use strict';
 
 /**
- * Services that persists and retrieves user from localStorage.
+ * Services that retrieves challenges.
  */
 
 angular.module('challengeServices', ['ngResource']).
     factory('Challenges', ['API_URL', '$resource', 'User', '$q', 'Members',
       function(API_URL, $resource, User, $q, Members) {
         var Challenge = $resource(API_URL + '/api/v2/challenges/:cid',
-          {cid:'@_id'},
+          {cid: '@cid'},
           {
-            //'query': {method: "GET", isArray:false}
             join: {method: "POST", url: API_URL + '/api/v2/challenges/:cid/join'},
             leave: {method: "POST", url: API_URL + '/api/v2/challenges/:cid/leave'},
             close: {method: "POST", params: {uid:''}, url: API_URL + '/api/v2/challenges/:cid/close'},
             getMember: {method: "GET", url: API_URL + '/api/v2/challenges/:cid/member/:uid'}
           });
 
-        //var challenges = [];
-
         return {
           Challenge: Challenge
-          //challenges: challenges
         }
       }
 ]);

--- a/views/options/social/challenges.jade
+++ b/views/options/social/challenges.jade
@@ -66,7 +66,7 @@ script(type='text/ng-template', id='partials/options.social.challenges.detail.ht
 script(type='text/ng-template', id='partials/options.social.challenges.html')
   .container-fluid
     .row
-      .col-md-2.well#challenges-filters
+      .col-md-2.well#challenges-filters(ng-hide="cid")
         h3=env.t('filter') + ':'
         h4=env.t('groups')
         ul.list-unstyled
@@ -91,6 +91,8 @@ script(type='text/ng-template', id='partials/options.social.challenges.html')
             input(type='radio', name='search-participation-radio', ng-click='search._isMember = undefined', checked='checked')
             =env.t('either')
       .col-md-10
+        a.btn.btn-info#back-to-challenges(ng-show="cid", ui-sref='options.social.challenges')
+          | Back to all challenges
         // Creation form
         button.btn.btn-success#create-challenge-btn(ng-click='create()', ng-hide='newChallenge')=env.t('createChallenge')
         .create-challenge-from.well(ng-if='newChallenge')
@@ -162,7 +164,7 @@ script(type='text/ng-template', id='partials/options.social.challenges.html')
                   a.btn.btn-sm.btn-success(ng-hide='challenge._isMember', ng-click='join(challenge)')
                     span.glyphicon.glyphicon-ok
                     =env.t('join')
-              a.accordion-toggle(ng-click='toggle(challenge._id)') {{challenge.name}}
+              a.accordion-toggle(id='{{challenge._id}}', ng-click='toggle(challenge._id)') {{challenge.name}}
             .panel-body(ng-class='{collapse: !$stateParams.cid == challenge._id}')
               .accordion-inner(ng-if='$stateParams.cid == challenge._id')
                 div(ui-view)


### PR DESCRIPTION
So currently, when you click on a specific challenge from a guild/party, it takes you the the top of the list of challenges, as opposed to _just_ the particular challenge you wanted. Hence, to find the challenge that you actually want, you have to scroll down to wherever it is. That's a pain.

---

This pull request solves that by changing the behavior of `/#/options/challenges/:cid` (which I will hereafter call `singleChallPage` for brevity) by only display the selected challenge:

![snapshot5](https://cloud.githubusercontent.com/assets/1936426/2751572/45361204-c8d9-11e3-8934-477a06c6949f.png)

However, there are some breaking changes/unresolved issues that arise because of this, and I'm not sure why some of them happen:
- Can't save changes
- Can't delete challenges
- Can't join challenges
- Newly implemented "Back to Challenges"  button doesn't work, neither does clicking on the 'Challenges' button (on the `singleChallPage`). These buttons do the same thing, but I thought it would be clearer with this bit of redundancy. It can always be removed if needed.

I'm not familiar with 100% of the codebase,, so if someone could give me some pointers, that would be cool :sunglasses: 

---

Also, as a side-effect, I'm certain this PR will reduce server load a _lot_, because now the entire challenge collection doesn't need to be pulled when requesting only a single challenge.
