### PR TITLE
fix(profile): body and facial hair elements fix

### DIFF
--- a/views/options/profile.jade
+++ b/views/options/profile.jade
@@ -52,16 +52,16 @@ script(id='partials/options.profile.avatar.html', type='text/ng-template')
           +colorSelection(['rainbow','yellow','green','purple','blue','TRUred'],env.t('rainbowColors'))
           +colorSelection(['pblue','pgreen','porange','ppink','ppurple','pyellow'],"Pastel Hair",env.t('limited30Apr'))
 
-          h5=env.t('bodyHair')
-          // Bangs
           li.customize-menu
+            h5=env.t('bodyHair')
+
+            // Bangs
             menu(label=env.t('hairBangs'))
               button(class='head_0 customize-option', type='button', ng-click='set({"preferences.hair.bangs":0})')
               each num in [1,2,3]
                 button(class='hair_bangs_#{num}_{{user.preferences.hair.color}} customize-option', type='button', ng-click='set({"preferences.hair.bangs":#{num}})')
 
-          // Base
-          li.customize-menu
+            // Base
             menu(label=env.t('hairBase'))
               +twoGem()
                 button.btn.btn-xs(ng-hide='user.purchased.hair.base.2 && user.purchased.hair.base.4 && user.purchased.hair.base.5 && user.purchased.hair.base.6 && user.purchased.hair.base.7 && user.purchased.hair.base.8', ng-click='unlock("hair.base.2,hair.base.4,hair.base.5,hair.base.6,hair.base.7,hair.base.8")')!= env.t('unlockSet5') + ' <span class="Pet_Currency_Gem1x inline-gems"/>'
@@ -78,20 +78,19 @@ script(id='partials/options.profile.avatar.html', type='text/ng-template')
               each num in [1,2,3,4,5,6]
                 button(class='hair_flower_#{num} customize-option', type='button', ng-click='set({"preferences.hair.flower":#{num}})')
 
-          h5=env.t('bodyFacialHair')
-
-          +twoGem()
-            button.btn.btn-xs(ng-hide='user.purchased.hair.mustache.1 && user.purchased.hair.mustache.2 && user.purchased.hair.beard.1 && user.purchased.hair.beard.2 && user.purchased.hair.beard.3', ng-click='unlock("hair.mustache.1,hair.mustache.2,hair.beard.1,hair.beard.2,hair.beard.3")')!= env.t('unlockSet5') + ' <span class="Pet_Currency_Gem1x inline-gems"/>'
-
-          // Beard
           li.customize-menu
+            h5=env.t('bodyFacialHair')
+
+            +twoGem()
+              button.btn.btn-xs(ng-hide='user.purchased.hair.mustache.1 && user.purchased.hair.mustache.2 && user.purchased.hair.beard.1 && user.purchased.hair.beard.2 && user.purchased.hair.beard.3', ng-click='unlock("hair.mustache.1,hair.mustache.2,hair.beard.1,hair.beard.2,hair.beard.3")')!= env.t('unlockSet5') + ' <span class="Pet_Currency_Gem1x inline-gems"/>'
+
+            // Beard
             menu(label=env.t('beard'))
               button(class='head_0 customize-option', type='button', ng-click='set({"preferences.hair.beard":0})')
               each num in [1,2,3]
                 button(class='hair_beard_#{num}_{{user.preferences.hair.color}} customize-option', type='button', ng-class='{locked: !user.purchased.hair.beard.#{num}}', ng-click='unlock("hair.beard.#{num}")')
 
-          // Mustache
-          li.customize-menu
+            // Mustache
             menu(label=env.t('mustache'))
               button(class='head_0 customize-option', type='button', ng-click='set({"preferences.hair.mustache":0})')
               each num in [1,2]


### PR DESCRIPTION
New structure is valid HTML.
It makes more semantic sense, as the selection
of all hair is a single list-item, and can possibly
be styled as a group, consider adding a "well" class
on the container to group bangs and base menus together.

As a side effect, this fixes whitespace styling in this tiny case:

![1](https://cloud.githubusercontent.com/assets/113721/2778674/9cbe80de-caf4-11e3-8822-dfce9f19b17f.png) ![2](https://cloud.githubusercontent.com/assets/113721/2778675/9cc15804-caf4-11e3-886e-d310857f5bfa.png)
