### PR TITLE
fix(profile): body size elements consistent with the rest

### DIFF
--- a/views/options/profile.jade
+++ b/views/options/profile.jade
@@ -9,12 +9,13 @@ script(id='partials/options.profile.avatar.html', type='text/ng-template')
     .col-md-4
       h3=env.t('bodyBody')
 
-      h5=env.t('bodySize')
-      .btn-group
-        button.btn.btn-sm.btn-default(ng-class='{active: user.preferences.size=="slim"}', ng-click='set({"preferences.size":"slim"})')=env.t('bodySlim')
-        button.btn.btn-sm.btn-default(ng-class='{active: user.preferences.size=="broad"}', ng-click='set({"preferences.size":"broad"})')=env.t('bodyBroad')
-
       menu(type='list')
+        li.customize-menu
+          menu(label=env.t('bodySize'))
+          .btn-group
+            button.btn.btn-sm.btn-default(ng-class='{active: user.preferences.size=="slim"}', ng-click='set({"preferences.size":"slim"})')=env.t('bodySlim')
+            button.btn.btn-sm.btn-default(ng-class='{active: user.preferences.size=="broad"}', ng-click='set({"preferences.size":"broad"})')=env.t('bodyBroad')
+
         li.customize-menu
           menu(label=env.t('shirts'))
             each shirt in ['black', 'blue', 'green', 'pink', 'white', 'yellow']


### PR DESCRIPTION
Before this change body size selector had inconsistent code
with the rest of the profile customization.
This also led to an inconsistent styling of the menu label.

Compare the styling of label "Size" before and after:
![4](https://cloud.githubusercontent.com/assets/113721/2778699/c69b4bda-caf4-11e3-9fa0-f9bd1669443d.png)  ....    ![3](https://cloud.githubusercontent.com/assets/113721/2778700/c69d702c-caf4-11e3-8e0f-12cc9603049a.png)
