### PR TITLE
fix(profile): rainbow skin elements consistent with the rest

### DIFF
--- a/views/options/profile.jade
+++ b/views/options/profile.jade
@@ -106,11 +106,9 @@ script(id='partials/options.profile.avatar.html', type='text/ng-template')
               button.customize-option(type='button', class='skin_#{color}', ng-click='set({"preferences.skin":"#{color}"})')
 
           // Rainbow Skin
-          h5=env.t('rainbowSkins')
-          +twoGem()
-            button.btn.btn-xs(ng-hide='user.purchased.skin.eb052b && user.purchased.skin.f69922 && user.purchased.skin.f5d70f && user.purchased.skin.0ff591 && user.purchased.skin.2b43f6 && user.purchased.skin.d7a9f7 && user.purchased.skin.800ed0 && user.purchased.skin.rainbow', ng-click='unlock("skin.eb052b,skin.f69922,skin.f5d70f,skin.0ff591,skin.2b43f6,skin.d7a9f7,skin.800ed0,skin.rainbow")')!= env.t('unlockSet5') + ' <span class="Pet_Currency_Gem1x inline-gems"/>'
-          //menu(label='Rainbow Skins (2G / skin)')
-          menu
+          menu(label=env.t('rainbowSkins'))
+            +twoGem()
+              button.btn.btn-xs(ng-hide='user.purchased.skin.eb052b && user.purchased.skin.f69922 && user.purchased.skin.f5d70f && user.purchased.skin.0ff591 && user.purchased.skin.2b43f6 && user.purchased.skin.d7a9f7 && user.purchased.skin.800ed0 && user.purchased.skin.rainbow', ng-click='unlock("skin.eb052b,skin.f69922,skin.f5d70f,skin.0ff591,skin.2b43f6,skin.d7a9f7,skin.800ed0,skin.rainbow")')!= env.t('unlockSet5') + ' <span class="Pet_Currency_Gem1x inline-gems"/>'
             each color in ['eb052b','f69922','f5d70f','0ff591','2b43f6','d7a9f7','800ed0','rainbow']
               button.customize-option(type='button', class='skin_#{color}', ng-class='{locked: !user.purchased.skin.#{color}}', ng-click='unlock("skin.#{color}")')
 


### PR DESCRIPTION
Again fixing inconsistency in elements.
Note that styling fixes are a positive side-effect, but are not the main intent of the pull request.

Before (look at the title "Rainbox skins"):
![6](https://cloud.githubusercontent.com/assets/113721/2778715/f686d8f0-caf4-11e3-972f-f8b09761c04d.png)

After:
![5](https://cloud.githubusercontent.com/assets/113721/2778714/f66b6ab6-caf4-11e3-8d88-b911a06df3a2.png)

_(Please do not take pull request spamming negatively. These three could be a single pull request with three commits, but I also could see you accepting or rejecting them separately. And to me, the more independent, the better.)_
