### PR TITLE
fix(notifications): eliminate blank notifications

### DIFF
--- a/public/js/services/notificationServices.js
+++ b/public/js/services/notificationServices.js
@@ -58,7 +58,9 @@ angular.module("notificationServices", [])
         notify(sign(val) + " " + coins(val - bonus), 'gp');
       },
       text: function(val){
-        notify(val, 'info');
+        if (val) {
+          notify(val, 'info');
+        }
       },
       lvl: function(){
         notify(window.env.t('levelUp'), 'lvl', 'glyphicon glyphicon-chevron-up');


### PR DESCRIPTION
There's two ways to fix this, but this covers any null message sent through Notification.text().

The other way is to add a message here (which opens up a translation can of worms):
https://github.com/HabitRPG/habitrpg-shared/blob/develop/script/index.coffee#L618

Addresses: #3183
