### PR TITLE
Update npcs.styl

### DIFF
--- a/public/css/npcs.styl
+++ b/public/css/npcs.styl
@@ -23,7 +23,7 @@
   margin-bottom: 5px
 
 .static-popover
-  z-index 0
+  z-index 1
   display block
   position:relative
 


### PR DESCRIPTION
I'm sure it's better to have the popover box visible when the screen gets wider and the columns get near, but still don't collapse to a new row. This small change makes the box visible over the content and not the content visible over the popover box and avoids the problem of going over the header when scrolling.
