### PR TITLE
feat(readme): dependencies badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-HabitRPG [![Build Status](https://travis-ci.org/HabitRPG/habitrpg.png?branch=develop)](https://travis-ci.org/HabitRPG/habitrpg) [![Code Climate](https://codeclimate.com/github/HabitRPG/habitrpg.png)](https://codeclimate.com/github/HabitRPG/habitrpg)
+HabitRPG [![Build Status](https://travis-ci.org/HabitRPG/habitrpg.png?branch=develop)](https://travis-ci.org/HabitRPG/habitrpg) [![Code Climate](https://codeclimate.com/github/HabitRPG/habitrpg.png)](https://codeclimate.com/github/HabitRPG/habitrpg) [![Dependency Status](https://gemnasium.com/HabitRPG/habitrpg.svg)](https://gemnasium.com/HabitRPG/habitrpg)
 ===============
 
 [HabitRPG](https://habitrpg.com) is an open source habit building program which treats your life like a Role Playing Game. Level up as you succeed, lose HP as you fail, earn money to buy weapons and armor.


### PR DESCRIPTION
If you [login to Gemnasium](https://gemnasium.com/login), and [add a project](https://gemnasium.com/projects/new_from_github), we can have a nice badge and a web visual to all dependencies, which would be nice, in my opinion.

It would look something like this:
![up-to-date](http://img.shields.io/badge/dependencies-up--to--date-brightgreen.svg)
![out](http://img.shields.io/badge/dependencies-out--of--date-yellow.svg)
![update](http://img.shields.io/badge/dependencies-update!-red.svg)
