### PR TITLE
Menu line compromise built with css borders

### DIFF
--- a/public/css/header.styl
+++ b/public/css/header.styl
@@ -39,6 +39,22 @@
 .user-reporter:after
   content: '▾'
   float: right
+  
+.border-menu {
+  position: relative;
+  padding-left: 1.25em;
+}
+.border-menu:after {
+  content: "";
+  position: absolute;
+  top: 0.5em;
+  left: 0.1em;
+  width: 0.9em;
+  height: 0.2em;
+  padding-bottom: 0.15em;
+  border-top: 0.1em solid #3e5555;
+  border-bottom: 0.35em double #3e5555;
+}
 
 
 /* flyout navigation pattern

--- a/views/shared/header/menu.jade
+++ b/views/shared/header/menu.jade
@@ -2,7 +2,7 @@ nav.toolbar(ng-controller='AuthCtrl')
   ul.toolbar-mobile-nav
     li.toolbar-mobile
       a(ng-click='expandMenu("mobile")', ng-class='{active: _expandedMenu=="mobile"}')
-        span  &#9776;
+        span.border-menu
       div(ng-if='_expandedMenu=="mobile"', ng-click='expandMenu(null)')
         h4=env.t('menu')
         div
@@ -49,7 +49,7 @@ nav.toolbar(ng-controller='AuthCtrl')
       a(ui-sref='options.profile.avatar')
         span=env.t('user')
       a(ng-click='expandMenu("avatar")', ng-class='{active: _expandedMenu == "avatar"}')
-        span &#9776;
+        span.border-menu
       div(ng-if='_expandedMenu == "avatar"')
         ul.toolbar-submenu(ng-click='expandMenu(null)')
           li
@@ -62,7 +62,7 @@ nav.toolbar(ng-controller='AuthCtrl')
       a(ui-sref='options.social.tavern')
         span=env.t('social')
       a(ng-click='expandMenu("social")', ng-class='{active: _expandedMenu == "social"}')
-        span &#9776;
+        span.border-menu
       div(ng-if='_expandedMenu == "social"')
         ul.toolbar-submenu(ng-click='expandMenu(null)')
           li
@@ -79,7 +79,7 @@ nav.toolbar(ng-controller='AuthCtrl')
       a(ui-sref='options.inventory.drops')
         span=env.t('inventory')
       a(ng-click='expandMenu("inventory")', ng-class='{active: _expandedMenu == "inventory"}')
-        span  &#9776;
+        span.border-menu
       div(ng-if='_expandedMenu == "inventory"')
         ul.toolbar-submenu(ng-click='expandMenu(null)')
           li


### PR DESCRIPTION
The previous TRIGRAM FOR HEAVEN, though elegant-looking, wasn't supported on all browsers.  See discussion here:   [https://github.com/HabitRPG/habitrpg/pull/3412](https://github.com/HabitRPG/habitrpg/pull/3412)

New solution à la this guide:  [http://css-tricks.com/three-line-menu-navicon/](http://css-tricks.com/three-line-menu-navicon/)

Here's what it looks like: 
![capture decran 2014-05-06 a 11 36 21 am](https://cloud.githubusercontent.com/assets/7093793/2891604/80ef6284-d534-11e3-9b43-c40d5d2a5bd5.png)
