### PR TITLE
Create QuestRewards

### DIFF
--- a/QuestRewards
+++ b/QuestRewards
@@ -1,0 +1,8 @@
+I didn't receive the rewards after the Spring Spirit quest
+Tried to refresh the browser, waited a cople days but nothing. my Party-mates did receive them.
+
+I log on from Firefox mobile, other Firefox terminals on different machines and from the habitrpg android app
+
+Didn't find any other place where to post a bug so here it is.
+
+cheers


### PR DESCRIPTION
I didn't receive the rewards after the Spring Spirit quest
Tried to refresh the browser, waited a couple days but nothing. my Party-mates did receive them.

I log on from Firefox mobile, other Firefox terminals on different machines and from the habitrpg android app

Didn't find any other place where to post a bug so here it is.
cheers
