### PR TITLE
fix(vagrant): explicitly call bower install

### DIFF
--- a/vagrant.sh
+++ b/vagrant.sh
@@ -53,6 +53,9 @@ npm install -g grunt-cli bower
 echo Installing HabitRPG
 npm install
 
+echo Installing Bower packages
+sudo -u vagrant bower install -f
+
 echo Seeding Mongodb...
 node ./src/seed.js
 


### PR DESCRIPTION
On some vagrant machines, the bower install process kicked off by `npm install` doesn't complete correctly and a run of `bower install -f` by the user solves it. 
