### PR TITLE
Make habit +/- buttons fill height and vertically centered

### DIFF
--- a/public/css/tasks.styl
+++ b/public/css/tasks.styl
@@ -174,7 +174,7 @@ for $stage in $stages
 .task-action-btn
   display: inline-block
   width: 2.12765em
-  height: 2.12765em
+  height: 100%
   padding: 0
   font-size: 1.41em
   line-height: 2.12765

--- a/public/css/tasks.styl
+++ b/public/css/tasks.styl
@@ -188,6 +188,17 @@ for $stage in $stages
     color: #222
     text-decoration: none
 
+// Use table-style vertical aligning to vertically align in a
+// fluid height container
+.task-action-lbl
+  display: table
+  height: 100%
+  width: 100%
+
+.task-action-lbl-cell
+  display: table-cell
+  vertical-align: middle
+
 // checkbox
 .task-checker input[type=checkbox]
   margin: 0

--- a/views/shared/tasks/task.jade
+++ b/views/shared/tasks/task.jade
@@ -57,8 +57,12 @@ li(bindonce='list', bo-id='"task-"+task.id', ng-repeat='task in obj[list.type+"s
     // Habits
     span(bo-if='task.type=="habit"')
       // score() is overridden in challengesCtrl to do nothing
-      a.task-action-btn(ng-if='task.up', ng-click='score(task,"up")') +
-      a.task-action-btn(ng-if='task.down', ng-click='score(task,"down")') -
+      a.task-action-btn(ng-if='task.up', ng-click='score(task,"up")')
+        div.task-action-lbl
+          div.task-action-lbl-cell +
+      a.task-action-btn(ng-if='task.down', ng-click='score(task,"down")')
+        div.task-action-lbl
+          div.task-action-lbl-cell -
 
     // Rewards
     span(ng-show='task.type=="reward"')


### PR DESCRIPTION
Plus/minus buttons had a fixed height, but that was inconsistent with all other task types. This patch makes the buttons fill the full height, as well as centers the labels vertically.

Discussion of this change in pull request #3509
## Before

![screenshot 2014-05-21 14 44 51](https://cloud.githubusercontent.com/assets/44676/3047129/cb1ee2d6-e131-11e3-8414-606cd08f8fdd.png)
## After

![screenshot 2014-05-21 18 35 30](https://cloud.githubusercontent.com/assets/44676/3048900/64e3fa40-e151-11e3-8187-f2a9f6352665.png)
