### PR TITLE
Hide task control buttons during editing

### DIFF
--- a/views/shared/tasks/task.jade
+++ b/views/shared/tasks/task.jade
@@ -52,7 +52,7 @@ li(bindonce='list', bo-id='"task-"+task.id', ng-repeat='task in obj[list.type+"s
       | &nbsp;
 
   // left-hand side checkbox
-  .task-controls.task-primary
+  .task-controls.task-primary(ng-if='!task._editing')
 
     // Habits
     span(bo-if='task.type=="habit"')


### PR DESCRIPTION
Fixes #3481

I thought that fading out the buttons would be the way to go, but the problem is that the UI elsewhere in the app already the paradigm is that faded out means "toggled off" rather than "this button is disabled". It was not at all clear that the button was disabled. I tried adding a tooltip saying something like "Finish editing first", but this was even more kludgey. I even tried adding a not-allowed cursor to it!

In the end, completely hiding the buttons worked best, and I believe it makes sense to the user.
