### PR TITLE
Translation loader now ignores non-directories

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -17,7 +17,7 @@ var loadTranslations = function(locale){
 loadTranslations('en');
 
 fs.readdirSync(path.join(__dirname, "/../node_modules/habitrpg-shared/locales/")).forEach(function(file) {
-  if(file === 'en' || file === 'README.md') return;
+  if(file === 'en' || file === 'README.md' || file.indexOf('.') === 0) return;
   loadTranslations(file);
   // Merge missing strings from english
   _.defaults(translations[file], translations.en);

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -5,19 +5,21 @@ var fs = require('fs'),
     shared = require('habitrpg-shared'),
     translations = {};
 
+var localePath = path.join(__dirname, "/../node_modules/habitrpg-shared/locales/")
+
 var loadTranslations = function(locale){
-  var files = fs.readdirSync(path.join(__dirname, "/../node_modules/habitrpg-shared/locales/", locale));
+  var files = fs.readdirSync(path.join(localePath, locale));
   translations[locale] = {};
   _.each(files, function(file){
-    _.merge(translations[locale], require(path.join(__dirname, "/../node_modules/habitrpg-shared/locales/", locale, file)));
+    _.merge(translations[locale], require(path.join(localePath, locale, file)));
   });
 };
 
 // First fetch english so we can merge with missing strings in other languages
 loadTranslations('en');
 
-fs.readdirSync(path.join(__dirname, "/../node_modules/habitrpg-shared/locales/")).forEach(function(file) {
-  if(file === 'en' || file === 'README.md' || file.indexOf('.') === 0) return;
+fs.readdirSync(localePath).forEach(function(file) {
+  if(file === 'en' || fs.statSync(path.join(localePath, file)).isDirectory() === false) return;
   loadTranslations(file);
   // Merge missing strings from english
   _.defaults(translations[file], translations.en);

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -11,6 +11,7 @@ var loadTranslations = function(locale){
   var files = fs.readdirSync(path.join(localePath, locale));
   translations[locale] = {};
   _.each(files, function(file){
+    if(path.extname(file) !== '.json') return;
     _.merge(translations[locale], require(path.join(localePath, locale, file)));
   });
 };


### PR DESCRIPTION
I was having an issue with habitrpg failing to load when OSX created a .DS_Store file in the locales directory. This code fixes that by ignoring all ~~hidden files (files that start with “.”)~~ non-directories.

Edit: new summary of the entire pull request:
- Locale loader will ignore anything that's not a directory (previously the entire program would crash on load if there was a file in ./locales)
- When loading individual translations, only json files will be used to import the strings
