### PR TITLE
API rejects spell cast if not enough mana

### DIFF
--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -302,6 +302,7 @@ api.cast = function(req, res, next) {
   var klass = shared.content.spells.special[req.params.spell] ? 'special' : user.stats.class
   var spell = shared.content.spells[klass][req.params.spell];
   if (!spell) return res.json(404, {err: 'Spell "' + req.params.spell + '" not found.'});
+  if (spell.mana > user.stats.mp) return res.json(400, {err: 'Not enough mana to cast spell'});
 
   var done = function(){
     var err = arguments[0];

--- a/test/api.mocha.js
+++ b/test/api.mocha.js
@@ -428,11 +428,14 @@ describe('API', function () {
 
                 // level up user so str is > 0
                 request.put(baseURL+'/user').send({'stats.lvl':5}).end(function(res){
-                  request.post(baseURL+'/user/class/cast/valorousPresence?targetType=party').end(function(res){
-                    request.get(baseURL+'/members/'+member._id).end(function(res){
-                      expect(res.body.stats.buffs.str).to.be.above(0);
-                      expect(diff(res.body,member).length).to.be(1);
-                      done();
+                  // Refill mana so user can cast
+                  request.put(baseURL+'/user').send({'stats.mp':100}).end(function(res){
+                    request.post(baseURL+'/user/class/cast/valorousPresence?targetType=party').end(function(res){
+                      request.get(baseURL+'/members/'+member._id).end(function(res){
+                        expect(res.body.stats.buffs.str).to.be.above(0);
+                        expect(diff(res.body,member).length).to.be(1);
+                        done();
+                      })
                     })
                   })
                 })


### PR DESCRIPTION
Fix #3493 “API does not validate if user has enough mana”

There were a couple different places this validation could be done, but I thought doing it in the API itself was best so that it could return a human-readable error.

(As a sidenote, it likely makes sense to eventually create a canCast method to cut down on the number of places in the code that the mana is checked. Plus, it would open up the possibility of allowing buffs/items that give a mana cost discount.)
