### PR TITLE
Update API Parameter documentation for Equip call

### DIFF
--- a/src/routes/apiv2.coffee
+++ b/src/routes/apiv2.coffee
@@ -193,7 +193,7 @@ module.exports = (swagger, v2) ->
         method: 'POST'
         description: "Equip an item (either pets, mounts, or gear)"
         parameters: [
-          path 'type',"Type to equip",'string',['pets','mounts','gear']
+          path 'type',"Type to equip",'string',['pet','mount','equipped', 'costume']
           path 'key',"The object key you're equipping (call /content route for available keys)",'string'
         ]
       action: user.equip


### PR DESCRIPTION
the function that is called actually expects different values than specified in the documentation.

This is related to #3525.
The API itself works, it just does no validation of the input and the documentation is wrong, which is why I used it wrong.

Having some kind of validation would probably still a good idea.
