### PR TITLE
Only refund quest scroll to leader if quest was active

### DIFF
--- a/src/controllers/groups.js
+++ b/src/controllers/groups.js
@@ -610,7 +610,7 @@ api.questAbort = function(req, res, next){
       if (group.quest.active) {
         var update = {$inc:{}};
         update['$inc']['items.quests.' + group.quest.key] = 1;
-        User.update({_id:group.quest.leader}, update, cb);
+        User.update({_id:group.quest.leader}, update);
       }
       group.quest = {key:null,progress:{},leader:null};
       group.markModified('quest');

--- a/src/controllers/groups.js
+++ b/src/controllers/groups.js
@@ -607,11 +607,11 @@ api.questAbort = function(req, res, next){
     },
     // Refund party leader quest scroll
     function(cb){
-      var update = {$inc:{}};
-      update['$inc']['items.quests.' + group.quest.key] = 1;
-      User.update({_id:group.quest.leader}, update, cb);
-    },
-    function(cb) {
+      if (group.quest.active) {
+        var update = {$inc:{}};
+        update['$inc']['items.quests.' + group.quest.key] = 1;
+        User.update({_id:group.quest.leader}, update, cb);
+      }
       group.quest = {key:null,progress:{},leader:null};
       group.markModified('quest');
       group.save(cb);


### PR DESCRIPTION
otherwise quest leader gets more quest scrolls than they had to begin with.
