### PR TITLE
feat(emoji): using at.js for emoji selection

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -40,7 +40,8 @@
     "swagger-ui": "git://github.com/wordnik/swagger-ui.git",
     "ngInfiniteScroll": "1.0.0",
     "jquery-colorbox": "~1.4.36",
-    "pnotify": "~1.3.1"
+    "pnotify": "~1.3.1",
+    "jquery.atwho": "~0.4.11"
   },
   "devDependencies": {
     "angular-mocks": "~1.2.12"

--- a/public/js/directives/directives.js
+++ b/public/js/directives/directives.js
@@ -130,4 +130,29 @@ habitrpg.directive('questRewards', ['$rootScope', function($rootScope){
       scope.quest = $rootScope.Content.quests[attrs.key];
     }
   }
-}])
+}]);
+
+habitrpg.directive('atEmoji', function($rootScope, $timeout){
+  var emojis = [], emoji_config;
+
+  return {
+    restrict: 'A',
+    link: function(scope, element, attrs){
+      $timeout(function(){
+        if($rootScope._.isEmpty(emojis)){
+          $rootScope._.forEach(emoji.map.colons, function(key, value){
+            emojis.push(value);
+          });
+
+          emoji_config = {
+            at: ":",
+            data: emojis,
+            tpl:"<li data-value=':${name}:'>${name} <img src='bower_components/habitrpg-shared/img/emoji/${name}.png'  height='20' width='20' /></li>"
+          };
+        }
+
+        $(element).atwho(emoji_config);
+      }, 500);
+    }
+  }
+});

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -6,6 +6,8 @@
             "bower_components/pnotify/jquery.pnotify.min.js",
             "bower_components/bootstrap-growl/jquery.bootstrap-growl.js",
             "bower_components/bootstrap-tour/build/js/bootstrap-tour.js",
+            "bower_components/Caret.js/dist/jquery.caret.min.js",
+            "bower_components/jquery.atwho/dist/js/jquery.atwho.min.js",
             "bower_components/angular/angular.js",
             "bower_components/angular-sanitize/angular-sanitize.js",
             "bower_components/marked/lib/marked.js",
@@ -21,7 +23,6 @@
             "bower_components/ngInfiniteScroll/build/ng-infinite-scroll.min.js",
             "bower_components/select2/select2.js",
             "bower_components/angular-ui-select2/src/select2.js",
-
             "bower_components/angular-bootstrap/ui-bootstrap.js",
             "bower_components/angular-bootstrap/ui-bootstrap-tpls.js",
             "bower_components/bootstrap/dist/js/bootstrap.js",
@@ -69,7 +70,8 @@
             "app.css",
             "bower_components/pnotify/jquery.pnotify.default.css",
             "bower_components/pnotify/jquery.pnotify.default.icons.css",
-            "bower_components/habitrpg-shared/dist/habitrpg-shared.css"
+            "bower_components/habitrpg-shared/dist/habitrpg-shared.css",
+            "bower_components/jquery.atwho/dist/css/jquery.atwho.min.css"
         ]
     },
     "static": {

--- a/views/main/filters.jade
+++ b/views/main/filters.jade
@@ -25,7 +25,7 @@
         li.filters-edit(bindonce='user.tags', ng-class='{active: user.filters[tag.id]}', ng-repeat='tag in user.tags')
           //- Edit tags
           form.hrpg-input-group(ng-show='_editing')
-            input(type='text', ng-model='tag.name')
+            input(type='text', ng-model='tag.name', at-emoji)
             button(ng-click='user.ops.deleteTag({params:{id:tag.id}})')
               span.glyphicon.glyphicon-trash
           //- List of Tags

--- a/views/shared/tasks/lists.jade
+++ b/views/shared/tasks/lists.jade
@@ -25,7 +25,7 @@ script(id='templates/habitrpg-tasks.html', type="text/ng-template")
           // Add New
           form.addtask-form.form-inline.new-task-form(name='new{{list.type}}form', ng-hide='obj._locked || (list.showCompleted && list.type=="todo")', ng-submit='addTask(obj[list.type+"s"],list)')
             span.addtask-field
-              input(type='text', ng-model='list.newTask', placeholder='{{list.placeHolder}}', required)
+              input(type='text', ng-model='list.newTask', placeholder='{{list.placeHolder}}', required, at-emoji)
             input.addtask-btn(type='submit', value='＋', ng-disabled='new{{list.type}}form.$invalid')
           hr
 

--- a/views/shared/tasks/task.jade
+++ b/views/shared/tasks/task.jade
@@ -138,7 +138,7 @@ li(bindonce='list', bo-id='"task-"+task.id', ng-repeat='task in obj[list.type+"s
         // text & notes
         fieldset.option-group
           label.option-title=env.t('text')
-          input.option-content(type='text', ng-model='task.text', required, ng-disabled='task.challenge.id')
+          input.option-content(type='text', ng-model='task.text', required, ng-disabled='task.challenge.id', at-emoji)
 
           label.option-title=env.t('extraNotes')
           textarea.option-content(rows='3', ng-model='task.notes')


### PR DESCRIPTION
I really needed some auto completion for emojis :smile:

Why at.js/caret.js and not angular-at-directive:
- at.js repo is newer and tested
- easier to add data than in at-directive
- with the at-directive every textarea would had to add an ul-List for each item

I could add my "at-emoji" directive to:
- Tag Creation / Edit
- New/edit habits/dailies/tasks/rewards 

The Tavern / Guild / Party Chats didn't work every time, so I removed them from this checkin.

So ... have fun using Emoji's easier than before :tongue: 
