### PR TITLE
Implement "Change username" feature

### DIFF
--- a/public/js/controllers/settingsCtrl.js
+++ b/public/js/controllers/settingsCtrl.js
@@ -65,6 +65,20 @@ habitrpg.controller('SettingsCtrl',
       $rootScope.$state.go('tasks');
     }
 
+    $scope.changeUsername = function(changeUser){
+      if (!changeUser.newUsername || !changeUser.password) {
+        return alert(window.env.t('fillAll'));
+      }
+      $http.post(API_URL + '/api/v2/user/change-username', changeUser)
+        .success(function(){
+          alert(window.env.t('usernameSuccess'));
+          $scope.changeUser = {};
+        })
+        .error(function(data){
+          alert(data);
+        });
+    }
+
     $scope.changePassword = function(changePass){
       if (!changePass.oldPassword || !changePass.newPassword || !changePass.confirmNewPassword) {
         return alert(window.env.t('fillAll'));

--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -195,6 +195,31 @@ api.resetPassword = function(req, res, next){
   });
 };
 
+api.changeUsername = function(req, res, next) {
+  var user = res.locals.user,
+    password = req.body.password
+    newUsername = req.body.newUsername;
+
+  User.findOne({'auth.local.username': newUsername}, function(err, result) {
+    if (err) next(err);
+
+    if(result)
+        return res.json(401, {err: "Username already taken"});
+
+    var salt = user.auth.local.salt,
+      hashed_password = utils.encryptPassword(password, salt);
+
+    if (hashed_password !== user.auth.local.hashed_password)
+      return res.json(401, {err:"Incorrect password"});
+
+    user.auth.local.username = newUsername;
+    user.save(function(err, saved){
+        if (err) next(err);
+        res.send(200);
+    })
+  });
+}
+
 api.changePassword = function(req, res, next) {
   var user = res.locals.user,
     oldPassword = req.body.oldPassword,

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -10,6 +10,7 @@ router.post('/api/v2/user/auth/local', i18n.getUserLanguage, auth.loginLocal);
 router.post('/api/v2/user/auth/facebook', i18n.getUserLanguage, auth.loginFacebook);
 router.post('/api/v2/user/reset-password', i18n.getUserLanguage, auth.resetPassword);
 router.post('/api/v2/user/change-password', i18n.getUserLanguage, auth.auth, auth.changePassword);
+router.post('/api/v2/user/change-username', i18n.getUserLanguage, auth.auth, auth.changeUsername);
 
 router.post('/api/v1/register', i18n.getUserLanguage, auth.registerUser);
 router.post('/api/v1/user/auth/local', i18n.getUserLanguage, auth.loginLocal);

--- a/views/options/settings.jade
+++ b/views/options/settings.jade
@@ -79,6 +79,18 @@ script(type='text/ng-template', id='partials/options.settings.settings.html')
               input.form-control(type='text', ng-model='_couponCode', placeholder='Enter Coupon Code')
               button.btn.btn-primary(type='submit') Submit
 
+        div(ng-if='user.auth.local.username')
+          .panel.panel-default
+            .panel-heading
+              span=env.t('changeUsername')
+            .panel-body
+              form(ng-submit='changeUsername(changeUser)', ng-show='user.auth.local')
+                .form-group
+                  input.form-control(type='text', placeholder=env.t('newUsername'), ng-model='changeUser.newUsername', required)
+                .form-group
+                  input.form-control(type='password', placeholder=env.t('password'), ng-model='changeUser.password', required)
+                input.btn.btn-default(type='submit', value=env.t('submit'))
+
         //- Why is ng-if='user.auth.local' validating for users *without* user.auth.local (facebook users)? adding .username here for extra
         div(ng-if='user.auth.local.username')
           .panel.panel-default


### PR DESCRIPTION
Implements the "Change username" feature ([Trello Link](https://trello.com/c/9nwlCiXs/164-change-password-email-username)) in a panel on the settings page.

Some questions (Not all completely related):
1. ~~Should we have a "Current password" field as added security in the "Change username" form?~~ Added.
2. I've based this on the "Change password" code, which triggers a JS `alert` on success/error, is this a temporary placeholder?
3. A continuation of 2. Errors return a 404, but this shows on the client side as "Error (please reload): <error message> (Check developer console)" I take it this is also temporary?

Related habitrpg-shared changes: https://github.com/HabitRPG/habitrpg-shared/pull/226
