### PR TITLE
Toggling header does not adjust other UI elements until refresh

### DIFF
--- a/public/js/controllers/settingsCtrl.js
+++ b/public/js/controllers/settingsCtrl.js
@@ -15,7 +15,7 @@ habitrpg.controller('SettingsCtrl',
 //        });
 //    }
 
-	  $scope.hideHeader = function(){
+    $scope.hideHeader = function(){
       User.set({"preferences.hideHeader":!User.user.preferences.hideHeader})
       if (User.user.preferences.hideHeader && User.user.preferences.stickyHeader){
         User.set({"preferences.stickyHeader":false});

--- a/public/js/controllers/settingsCtrl.js
+++ b/public/js/controllers/settingsCtrl.js
@@ -15,6 +15,16 @@ habitrpg.controller('SettingsCtrl',
 //        });
 //    }
 
+	  $scope.hideHeader = function(){
+      User.set({"preferences.hideHeader":!User.user.preferences.hideHeader})
+      if (User.user.preferences.hideHeader && User.user.preferences.stickyHeader){
+        User.set({"preferences.stickyHeader":false});
+        $rootScope.$on('userSynced', function(){
+          window.location.reload();
+        });           
+      }
+  	}
+
     $scope.toggleStickyHeader = function(){
       $rootScope.$on('userSynced', function(){
         window.location.reload();

--- a/views/options/settings.jade
+++ b/views/options/settings.jade
@@ -38,7 +38,7 @@ script(type='text/ng-template', id='partials/options.settings.settings.html')
                 span.hint(popover-trigger='mouseenter', popover-placement='right', popover=env.t('showHeaderPop'))=env.t('showHeader')
             .checkbox
               label
-                input(type='checkbox', ng-click='toggleStickyHeader()', ng-checked='user.preferences.stickyHeader!==false')
+                input(type='checkbox', ng-click='toggleStickyHeader()', ng-checked='user.preferences.stickyHeader!==false', ng-disabled="user.preferences.hideHeader!==false")
                 span.hint(popover-trigger='mouseenter', popover-placement='right', popover=env.t('stickyHeaderPop'))=env.t('stickyHeader')
             .checkbox
               label

--- a/views/options/settings.jade
+++ b/views/options/settings.jade
@@ -34,7 +34,7 @@ script(type='text/ng-template', id='partials/options.settings.settings.html')
 
             .checkbox
               label
-                input(type='checkbox', ng-click='hideHeader()', ng-checked='user.preferences.hideHeader!==true')
+                input(type='checkbox', ng-click='hideHeader() ', ng-checked='user.preferences.hideHeader!==true')
                 span.hint(popover-trigger='mouseenter', popover-placement='right', popover=env.t('showHeaderPop'))=env.t('showHeader')
             .checkbox
               label

--- a/views/options/settings.jade
+++ b/views/options/settings.jade
@@ -34,7 +34,7 @@ script(type='text/ng-template', id='partials/options.settings.settings.html')
 
             .checkbox
               label
-                input(type='checkbox', ng-click='set({"preferences.hideHeader":user.preferences.hideHeader?false:true})', ng-checked='user.preferences.hideHeader!==true')
+                input(type='checkbox', ng-click='hideHeader()', ng-checked='user.preferences.hideHeader!==true')
                 span.hint(popover-trigger='mouseenter', popover-placement='right', popover=env.t('showHeaderPop'))=env.t('showHeader')
             .checkbox
               label


### PR DESCRIPTION
Changing settingsCtrl.js and settings.jade to solve issue #3510:
1) When Show Header is checked, Sticky Header is enabled.
2) When Show Header is not checked, Sticky Header is disabled and not checked. I think there's no reason to enable it when you don't have a header to stick.
3) When show header is checked & sticky header is checked too, when you check Show Header browser will refresh and sticky header will go off.
