### PR TITLE
Cap food-try max width to 15em

### DIFF
--- a/public/css/inventory.styl
+++ b/public/css/inventory.styl
@@ -45,6 +45,7 @@ menu.pets div
   right: 15px
   bottom: 0px
   width: 30%
+  max-width: 15em;
   height: 50%
   overflow-y: auto
   z-index: 1


### PR DESCRIPTION
Fix for https://github.com/HabitRPG/habitrpg/issues/3628, which caps the max-width in .food-tray to 15em.
