### PR TITLE
Increase max-width of food-tray to 17em

### DIFF
--- a/public/css/inventory.styl
+++ b/public/css/inventory.styl
@@ -45,7 +45,7 @@ menu.pets div
   right: 15px
   bottom: 0px
   width: 30%
-  max-width: 15em;
+  max-width: 17em;
   height: 50%
   overflow-y: auto
   z-index: 1


### PR DESCRIPTION
Increase max-width of food-tray to 17em to allow for scrollbar when necessary.

Issue: https://github.com/HabitRPG/habitrpg/issues/3628
