### PR TITLE
Center text in remove ads popover

### DIFF
--- a/public/css/tasks.styl
+++ b/public/css/tasks.styl
@@ -307,6 +307,11 @@ for $stage in $stages
 .task:hover .task-meta-controls
   opacity: 1
 
+// targets remove ad popover
+span.pull-right
+    .popover
+        text-align: center
+
 .popover
   line-height: 1.5
 

--- a/public/css/tasks.styl
+++ b/public/css/tasks.styl
@@ -307,6 +307,11 @@ for $stage in $stages
 .task:hover .task-meta-controls
   opacity: 1
 
+//targets remove ads popover
+span.pull-right
+    .popover
+        text-align: center
+        
 .popover
   line-height: 1.5
 

--- a/public/css/tasks.styl
+++ b/public/css/tasks.styl
@@ -307,13 +307,13 @@ for $stage in $stages
 .task:hover .task-meta-controls
   opacity: 1
 
-.popover
-  line-height: 1.5
-  
-// specific style to remove ads popover text
+// target remove ad popover
 span.pull-right
     .popover
         text-align: center
+
+.popover
+  line-height: 1.5
 
   // prevent box-shadow from being clipped/overlapped
   margin-bottom: 10px

--- a/public/css/tasks.styl
+++ b/public/css/tasks.styl
@@ -310,7 +310,7 @@ for $stage in $stages
 .popover
   line-height: 1.5
   
-//specific style to remove ads popover text
+// specific style to remove ads popover text
 span.pull-right
     .popover
         text-align: center

--- a/public/css/tasks.styl
+++ b/public/css/tasks.styl
@@ -307,11 +307,6 @@ for $stage in $stages
 .task:hover .task-meta-controls
   opacity: 1
 
-// target remove ad popover
-span.pull-right
-    .popover
-        text-align: center
-
 .popover
   line-height: 1.5
 

--- a/public/css/tasks.styl
+++ b/public/css/tasks.styl
@@ -309,6 +309,11 @@ for $stage in $stages
 
 .popover
   line-height: 1.5
+  
+//specific style to remove ads popover text
+span.pull-right
+    .popover
+        text-align: center
 
   // prevent box-shadow from being clipped/overlapped
   margin-bottom: 10px


### PR DESCRIPTION
**Sorry for the list of commits. I tried cherry picking just the top one, but I'm still learning that function.**

In reference to issue #3414. This was the best way I could target that specific popup. If there is a better way, let me know and I'll fix it.

Result: 
![3414](https://cloud.githubusercontent.com/assets/3391909/3362475/34caae94-fb0a-11e3-8580-0f7adef1a74d.jpg)
