### PR TITLE
add list of moderators to top of Tavern chat

### DIFF
--- a/views/options/social/tavern.jade
+++ b/views/options/social/tavern.jade
@@ -129,6 +129,6 @@
       h3=env.t('tavernTalk')
       include ./chat-box
       .alert.alert-info.alert-sm
-        != ' ' + env.t('tavernAlert1') + ' <a href="https://github.com/HabitRPG/habitrpg/issues/2760" target="_blank">' + env.t('tavernAlert2') + '</a>.'
+        != ' ' + env.t('tavernAlert1') + ' <a href="https://github.com/HabitRPG/habitrpg/issues/2760" target="_blank">' + env.t('tavernAlert2') + '</a>.<br />' + env.t('moderatorIntro1') + env.t('moderatorList') + env.t('moderatorIntro2') 
       ul.list-unstyled.tavern-chat
         include ./chat-message


### PR DESCRIPTION
Uses "moderatorList" in the a moderatorList.json file, and uses moderatorIntro1 and moderatorIntro2 (in groups.json) for associated text.

See https://github.com/HabitRPG/habitrpg-shared/pull/239 for the JSON data that this uses.

I've done this in the most basic, simple way possible since it's likely that this message won't be needed for long but I can pretty it up if you want me to.

Ref: https://plus.google.com/u/0/112627489415765168293/posts/ZRn4EMFU3HQ  - discusses upcoming changes that will make moderators more obvious without this text, and the last few comments are about making this change as a stop-gap measure.
