### PR TITLE
Prevent users from gaining too much hp and mp

### DIFF
--- a/src/models/user.js
+++ b/src/models/user.js
@@ -403,6 +403,10 @@ UserSchema.pre('save', function(next) {
 
   this.achievements.beastMaster = petCount >= 90;
 
+   //prevent users from gaining too much hp and mp
+  if (this.stats.hp > 50) {this.stats.hp = 50}
+  if (this.stats.mp > this._statsComputed.maxMP) {this.stats.mp = this._statsComputed.maxMP }
+
   //our own version incrementer
   this._v++;
   next();


### PR DESCRIPTION
Intended as a fix for #3660.
Additionally I added a check, that a user does has too much hp. Currently this is done at several places in habitrpg-shared.

By checking both values during each save, it doesn't have to be done each time those values are changed, reducing the code by a few lines and preventing human error by forgetting to add the check.
