### PR TITLE
explain what clearCompleted does

### DIFF
--- a/views/shared/tasks/lists.jade
+++ b/views/shared/tasks/lists.jade
@@ -108,6 +108,8 @@ script(id='templates/habitrpg-tasks.html', type="text/ng-template")
             div(ng-show='list.showCompleted')
               .alert
                 =env.t('lotOfToDos')
+              .alert
+                =env.t('deleteToDosExplanation')
               button.task-action-btn.tile.spacious.bright(ng-click='user.ops.clearCompleted({})')=env.t('clearCompleted')
             // remaining/completed tabs
             ul.nav.nav-tabs


### PR DESCRIPTION
I'm pretty sure some people don't realise that the "Clear Completed" button permanently deletes all of their completed to-dos. The current wording around the button could be thought to imply that "clear" means "archive immediately". This change makes it obvious what will happen.

See also https://github.com/HabitRPG/habitrpg-shared/pull/241
