### PR TITLE
make location of habitrpg box more generic

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "thepeopleseason/habitrpg"
+  config.vm.box = "habitrpg"
   config.ssh.forward_agent = true
 
   config.vm.hostname = "habitrpg"


### PR DESCRIPTION
@thepeopleseason :

I'm guessing this is probably a good change to make, although it's entirely possible that I still don't know what I'm doing. :)

Related to this change... When I destroyed every trace of my local vagrant install and started completely from scratch, I found that the instructions at http://habitrpg.wikia.com/wiki/Setting_up_HabitRPG_locally#Vagrant weren't sufficient. I had to go back to [your original blog post](http://habitrpg.wikia.com/wiki/User_blog:Thepeopleseason/Vagrant_install_of_HabitRPG_now_available) and run this:
    $ vagrant box add habitrpg http://dl.dropboxusercontent.com/u/4309797/devel/habitrpg/habitrpg.box

Although to be honest, I actually used a previously-downloaded copy of habitrpg.box to save on download time, so I can't say whether the dropbox URL still works.

Should the habitrpg.box file be imported to upstream/develop and should "$ vagrant box add habitrpg habitrpg.box" be added to the official instructions on the wiki? Or am I missing something fundamental that means this isn't necessary?
