### PR TITLE
Fixed issue with filters div that is bigger than containing div

### DIFF
--- a/public/css/filters.styl
+++ b/public/css/filters.styl
@@ -1,10 +1,11 @@
 .filters
-  padding-top: 1em
-  padding-bottom: 0.618em
-  padding-left: 15px
-  padding-right: 15px
+  padding: 1em 15px 0.382em
   margin-left: 0.382em
   margin-right: 0em
+  &:after
+    content: ""
+    display: table
+    clear: both
   ul
     float: left
     list-style: none

--- a/public/css/filters.styl
+++ b/public/css/filters.styl
@@ -1,6 +1,8 @@
 .filters
   padding-top: 1em
   padding-bottom: 0.618em
+  padding-left: 15px
+  padding-right: 15px
   margin-left: 0.382em
   margin-right: 0em
   ul

--- a/views/main/filters.jade
+++ b/views/main/filters.jade
@@ -1,6 +1,6 @@
 .container-fluid
   .row
-    .filters.col-md-12(ng-controller='FiltersCtrl')
+    .filters(ng-controller='FiltersCtrl')
       ul.filters-controls
         li=env.t('tags')
         //- Edit button


### PR DESCRIPTION
The combination of the col-md-12 class and the margin-left styling on the div with the ng-controller attribute "FiltersCtrl" was causing the width of the div to over-extend the width of the page. You can see it by scrolling to the right on the page, a small gap will appear.

![gap](https://cloud.githubusercontent.com/assets/2916945/3608252/f8ed0fc0-0d5b-11e4-89c7-c644e0ce4b4c.jpg)

It's fixed by removing the col-md-12 class so that the filters class has a width of auto instead of 100% and adding padding-left: 15px and padding-right:15px to make up for the missing padding from that class.
