### PR TITLE
remove beta from api call examples

### DIFF
--- a/views/static/api.jade
+++ b/views/static/api.jade
@@ -80,7 +80,7 @@ html
       h2 Extensions / Scripts
       p HabitRPG has a simple API for up-scoring and down-scoring third party Habits: <code>POST /api/v2/user/tasks/{id}/{direction}</code> (headers <code>x-api-user</code> and <code>x-api-key</code> required).
       h4 Example
-      p <code>curl -X POST -H "x-api-key: YOUR_API_TOKEN" -H "x-api-user: YOUR_USER_ID" https://beta.habitrpg.com/api/v2/user/tasks/productivity/up</code>
+      p <code>curl -X POST -H "x-api-key: YOUR_API_TOKEN" -H "x-api-user: YOUR_USER_ID" https://habitrpg.com/api/v2/user/tasks/productivity/up</code>
       p Note: You may need to add <code>--compressed -H "Content-Type:application/json"</code> to your curl if you get errors.
       ul
         li POST to the URL <code>/api/v2/user/tasks/{id}/{direction}</code>
@@ -91,7 +91,7 @@ html
       h2 Full API
       p All API requests should be prefaced by <code>https://habitrpg.com</code>. Every authenticated request should include two headers. Your api key (<code>x-api-key</code>) and your user id (<code>x-api-user</code>). Do not include <code>{}</code> braces in your header (<code>-H 'x-api-user: a94b6d9d-6b64-43ae-856c-2c3f211bd426'</code>)
       h2 Requirements:
-      p The base-url for all routes is /api/v2. So /user actions will be at https://beta.habitrpg.com/api/v2/user/*. You need to send x-api-user and x-api-key headers for each request.
+      p The base-url for all routes is /api/v2. So /user actions will be at https://habitrpg.com/api/v2/*. You need to send x-api-user and x-api-key headers for each request.
       p For create & edit paths (PUT & POST), you'll need to know the schema of the object you're trying to create or edit. See Schema <a href='https://github.com/HabitRPG/habitrpg/tree/develop/src/models' target="_blank">definitions here</a>
       p If any of the documentation is lacking or you're having trouble with it, please post an issue to <a href='https://github.com/HabitRPG/habitrpg/issues' target='_blank'>Github</a>
     #message-bar.swagger-ui-wrap


### PR DESCRIPTION
The API documentation examples used beta.habitrpg.com as url. Additionally, the base URL was specified including "/user/". removed both to avoid confusion and make copy-paste easier
