### PR TITLE
Edit stripe cc subscriptions

### DIFF
--- a/public/js/controllers/rootCtrl.js
+++ b/public/js/controllers/rootCtrl.js
@@ -121,6 +121,26 @@ habitrpg.controller("RootCtrl", ['$scope', '$rootScope', '$location', 'User', '$
       });
     }
 
+    $rootScope.showStripeEdit = function(){
+      StripeCheckout.open({
+        key: window.env.STRIPE_PUB_KEY,
+        address: false,
+        name: 'Update',
+        description: 'Update the card to be charged for your subscription',
+        panelLabel: 'Update Card',
+        token: function(data) {
+          var url = '/stripe/subscribe/edit?plan=basic_earned';
+          $scope.$apply(function(){
+            $http.post(url, data).success(function() {
+              window.location.reload(true);
+            }).error(function(err) {
+              alert(err);
+            });
+          })
+        }
+      });
+    }
+
     $rootScope.cancelSubscription = function(){
       if (!confirm(window.env.t('sureCancelSub'))) return;
       window.location.href = '/' + user.purchased.plan.paymentMethod.toLowerCase() + '/subscribe/cancel?_id=' + user._id + '&apiToken=' + user.apiToken;

--- a/src/routes/payments.js
+++ b/src/routes/payments.js
@@ -13,6 +13,7 @@ router.get('/paypal/subscribe/cancel', auth.authWithUrl, i18n.getUserLanguage, p
 router.post('/paypal/ipn', i18n.getUserLanguage, payments.paypalIPN); // misc ipn handling
 
 router.post("/stripe/checkout", auth.auth, i18n.getUserLanguage, payments.stripeCheckout);
+router.post("/stripe/subscribe/edit", auth.auth, i18n.getUserLanguage, payments.stripeSubscribeEdit)
 //router.get("/stripe/subscribe", auth.authWithUrl, i18n.getUserLanguage, payments.stripeSubscribe); // checkout route is used (above) with ?plan= instead
 router.get("/stripe/subscribe/cancel", auth.authWithUrl, i18n.getUserLanguage, payments.stripeSubscribeCancel);
 

--- a/views/options/settings.jade
+++ b/views/options/settings.jade
@@ -207,4 +207,5 @@ script(id='partials/options.settings.subscription.html',type='text/ng-template')
               | &nbsp;
               span.glyphicon.glyphicon-ok
             div(ng-include="'partials/options.settings.subscription.perks.html'")
+            .btn.btn-primary(ng-if='!user.purchased.plan.dateTerminated', ng-click='showStripeEdit()') Update Card
             .btn.btn-sm.btn-danger(ng-if='!user.purchased.plan.dateTerminated', ng-click='cancelSubscription()')=env.t('cancelSub')


### PR DESCRIPTION
To test locally, be sure to create a stripe account, create a stripe subscription plan "basic_earned", update the stripe API keys in config.json. Users who have purchased with Stripe will have a button for 'Update card', which changes the default card in stripe to be charged the next time their subscription is due.

I'm not sure how to test what happens with paypal.
