### PR TITLE
Fixes #3260: Buttonless habits full width

### DIFF
--- a/public/css/tasks.styl
+++ b/public/css/tasks.styl
@@ -147,6 +147,8 @@ for $stage in $stages
 
 .habit-wide .task-text
   padding-left: 7em
+.habit-narrow .task-text
+  padding-left: 0.75em
 
 // when a task is being dragged
 .task.ui-sortable-helper


### PR DESCRIPTION
When the user has neither a plus nor a minus button on
one of their habits, the habit’s title will now span the entire
width of the task div instead of having a gap to the left.
