### PR TITLE
display special negative contribution level in Hall of Heros

### DIFF
--- a/public/css/index.styl
+++ b/public/css/index.styl
@@ -176,3 +176,7 @@ a.label
 
 .white, .white a
   color: #fff !important
+  
+// Override Bootstrap's tiny Emojis
+.emoji
+  font-size: 1.5em;

--- a/src/controllers/hall.js
+++ b/src/controllers/hall.js
@@ -13,7 +13,7 @@ api.ensureAdmin = function(req, res, next) {
 }
 
 api.getHeroes = function(req,res,next) {
-  User.find({'contributor.level':{$gt:0}})
+  User.find({'contributor.level':{$ne:0}})
     .select('contributor backer balance profile.name')
     .sort('-contributor.level')
     .exec(function(err, users){

--- a/src/controllers/hall.js
+++ b/src/controllers/hall.js
@@ -13,7 +13,7 @@ api.ensureAdmin = function(req, res, next) {
 }
 
 api.getHeroes = function(req,res,next) {
-  User.find({'contributor.level':{$ne:0}})
+  User.find({'contributor.level':{$ne:null}})
     .select('contributor backer balance profile.name')
     .sort('-contributor.level')
     .exec(function(err, users){


### PR DESCRIPTION
Changed contributor.level for User.find from $gt:0 to $ne:0 in order to display a special negative contribution level.

This is my first contribution to an open source project and my first real pull request on GitHub. Since you might want to know the reason behind this pull request, I was bantering with one of the admins in the tavern, and this admin (Alys) agreed to give me the title of "Beggar" if I could get the -1 contrib level to show up in the Hall of Heroes.

All I did was change $gt:0 (greater than 0) to $ne:0 (not equal to 0). This is tested and working locally. Negative contrib levels show up in the Hall of Heroes with the plebeian grey that one would expect.

![heroesnot0](https://cloud.githubusercontent.com/assets/5461045/3684851/19dc97c2-1302-11e4-97a0-edc7857bc194.png)

Please accept my pull request so that I can impress Alys! 

If there is anything else that I can do or any changes that I can make, please just let me know! Thanks!
