### PR TITLE
add vagrant installation steps to prevent warnings and errors

### DIFF
--- a/vagrant.sh
+++ b/vagrant.sh
@@ -27,8 +27,23 @@ function autostart_habitrpg {
 echo Setting up HabitRPG...
 echo cd /vagrant >> /home/vagrant/.bashrc
 
+# Prevent warnings: "dpkg-preconfigure: unable to re-open stdin ..."
+export DEBIAN_FRONTEND=noninteractive
+
 echo Updating repositories...
 apt-get update -qq
+
+echo Installing Unix build tools - needed for node-gyp to use make...
+apt-get install -qq build-essential
+
+echo Installing GraphicsMagick - provides gm and convert...
+apt-get install -qq graphicsmagick
+
+echo Installing phantomjs and dependency...
+apt-get install -qq phantomjs libicu48
+
+echo Installing requirements for grunt-spritesmith...
+apt-get install -qq pkg-config libcairo2-dev libjpeg-dev
 
 echo Installing Mongodb...
 apt-get install -qq mongodb
@@ -54,7 +69,7 @@ echo Installing HabitRPG
 npm install
 
 echo Installing Bower packages
-sudo -u vagrant bower install -f
+sudo -H -u vagrant bower --config.interactive=false install -f
 
 echo Seeding Mongodb...
 node ./src/seed.js


### PR DESCRIPTION
Do not merge this until it's been reviewed by someone who knows what they're doing, such as @thepeopleseason. Don't rely on me knowing what I'm doing - I'm new to vagrant.

I've been having a lot of trouble getting my local vagrant install working properly and I've found that these changes help. Some just remove warnings or non-fatal errors (e.g., for software that I think isn't essential for common development tasks) but I wanted to clear away as many of those as possible, so I could better see what the important errors were. The most important fixes seemed to be:
- installing build-essential (without that, some of the steps related to kerberos modules would often hang for many minutes or even hours occasionally!) 
- adding the -H flag to the bower install command (without that it always tried to put temporary files under /root, even though it was sudo'ed to the vagrant user).

I have no idea why these errors were fatal for me when they clearly aren't for anyone else - maybe vagrant behaves differently under MacOS???

The rest of this comment lists each of my changes in turn, describing the reason for each and, where appropriate, giving the errors that it fixes. For some of the errors that I've pasted in, I've also included the preceding one or two lines of non-error text, just to give context.

---

```
# Prevent warnings: "dpkg-preconfigure: unable to re-open stdin ..."
export DEBIAN_FRONTEND=noninteractive
```

That merely removes a few unnecessary warnings (helpful to stop new users from worrying about them).

---

```
echo Installing Unix build tools - needed for node-gyp to use make...
apt-get install -qq build-essential
```

That allows this step to work:

```
==> default: 
==> default: > kerberos@0.0.3 install /vagrant/node_modules/connect-mongo/node_modules/mongodb/node_modules/kerberos
==> default: > (node-gyp rebuild 2> builderror.log) || (exit 0)
==> default: 
```

Before build-essential was installed, this was being written into builderror.log ("not found: make" is the critical part):

```
gyp WARN EACCES attempting to reinstall using temporary dev dir "/vagrant/node_modules/connect-mongo/node_modules/mongodb/node_modules/kerberos/.node-gyp"
gyp ERR! build error 
gyp ERR! stack Error: not found: make
gyp ERR! stack     at F (/usr/lib/node_modules/npm/node_modules/which/which.js:43:28)
gyp ERR! stack     at E (/usr/lib/node_modules/npm/node_modules/which/which.js:46:29)
gyp ERR! stack     at /usr/lib/node_modules/npm/node_modules/which/which.js:57:16
gyp ERR! stack     at Object.oncomplete (fs.js:107:15)
gyp ERR! System Linux 3.2.0-23-generic
gyp ERR! command "node" "/usr/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /vagrant/node_modules/connect-mongo/node_modules/mongodb/node_modules/kerberos
gyp ERR! node -v v0.10.29
gyp ERR! node-gyp -v v0.13.1
gyp ERR! not ok 
```

The software being built with "make" might not be important, but before build-essential was installed, this part of the install process would often hang. I could start "vagrant up" before bedtime, and in the morning, sometimes it would still be stuck on this step! That hasn't happened at all since I installed build-essential.

---

```
echo Installing GraphicsMagick - provides gm and convert...
apt-get install -qq graphicsmagick
```

prevents this:

```
==> default: > gmsmith@0.4.2 preinstall /vagrant/node_modules/habitrpg-shared/node_modules/grunt-spritesmith/node_modules/spritesmith/node_modules/gmsmith
==> default: > gm -version || convert -version
==> default: sh: 1: 
==> default: gm: not found
==> default: sh: 1: 
==> default: convert: not found
==> default: npm
==> default:  WARN optional dep failed, continuing gmsmith@0.4.2
```

---

```
echo Installing phantomjs and dependency...
apt-get install -qq phantomjs libicu48
```

phantomjs prevents this:

```
==> default: > phantomjssmith@0.4.0 preinstall /vagrant/node_modules/habitrpg-shared/node_modules/grunt-spritesmith/node_modules/spritesmith/node_modules/phantomjssmith
==> default: > phantomjs --version
==> default: sh: 1: 
==> default: phantomjs: not found
==> default: npm
==> default:  
==> default: WARN
==> default:  
==> default: optional dep failed, continuing
==> default:  phantomjssmith@0.4.0
```

libicu48 prevents this:

```
==> default: > phantomjssmith@0.4.0 preinstall /vagrant/node_modules/habitrpg-shared/node_modules/grunt-spritesmith/node_modules/spritesmith/node_modules/phantomjssmith
==> default: > phantomjs --version
==> default: 2014-07-25T07:21:31 [WARNING] Unable to load library icui18n "Cannot load library icui18n: (libicui18n.so.48: cannot open shared object file: No such file or directory)" 
```

---

```
echo Installing requirements for grunt-spritesmith...
apt-get install -qq pkg-config libcairo2-dev
```

pkg-config prevents this:

```
==> default:  attempting to reinstall using temporary dev dir "/vagrant/node_modules/habitrpg-shared/node_modules/grunt-spritesmith/node_modules/spritesmith/node_modules/canvassmith/node_modules/canvas/.node-gyp"
==> default: ./util/has_cairo_freetype.sh: line 4: pkg-config: command not found
==> default: gyp: Call to './util/has_cairo_freetype.sh' returned exit status 0. while trying to load binding.gyp
```

libcairo2-dev prevents this:

```
==> default: Package cairo was not found in the pkg-config search path.
==> default: Perhaps you should add the directory containing `cairo.pc'
==> default: to the PKG_CONFIG_PATH environment variable
==> default: No package 'cairo' found
==> default: gyp: Call to './util/has_cairo_freetype.sh' returned exit status 0. while trying to load binding.gyp
```

libjpeg-dev prevents this:

```
==> default: In file included from ../src/Canvas.cc:19:0:
==> default: ../src/JPEGStream.h:10:21: fatal error: jpeglib.h: No such file or directory
==> default: compilation terminated.
==> default: make: *** [Release/obj.target/canvas/src/Canvas.o] Error 1
==> default: make: Leaving directory `/vagrant/node_modules/habitrpg-shared/node_modules/grunt-spritesmith/node_modules/spritesmith/node_modules/canvassmith/node_modules/canvas/bui
```

---

```
sudo -H -u vagrant bower --config.interactive=false install -f
```

The --config.interactive=false flag doesn't seem to be necessary currently, but might be in future (thepeopleseason's idea from https://github.com/HabitRPG/habitrpg/pull/3771).

The -H flag prevents this:

```
==> default: Installing Bower packages
==> default: bower                           EACCES EACCES, permission denied '/root/.local/share/bower/empty'
```

From "man sudo": "The -H (HOME) option requests that the security policy set the HOME environment variable to the home directory of the target user".
