### PR TITLE
show more avatar background (remove Lvl, hide avatar name)

### DIFF
--- a/public/css/avatar.styl
+++ b/public/css/avatar.styl
@@ -48,12 +48,20 @@ future re: pets and whatnot, this is just temporary.
 
 // info revealed on hover/focus for party
 // always visible on the user's own avatar
+// except that the user's own name is hidden
+// if the user has a mount or background
 .herobox:after
 	opacity: 0
-.herobox.isUser:not(.hasMount):after
+.herobox.isUser.notBackground:not(.hasMount):after
 	opacity: 1
 	// make it a bit special
 	hrpg-label-color-mixin(darken($color-herobox, 16.18%))
+
+// when a buff/rebirth exists, add space between the icon and the level
+.glyphicon-circle-arrow-up
+	padding-right: 4px
+.glyphicon-plus-sign
+	padding-left: 4px
 
 .character-sprites span
     position: absolute

--- a/views/shared/header/avatar.jade
+++ b/views/shared/header/avatar.jade
@@ -77,8 +77,5 @@ mixin herobox(opts)
     +avatar(opts)
     .avatar-level(ng-class='userLevelStyle(profile)')
       span.glyphicon.glyphicon-circle-arrow-up(ng-show='profile.stats.buffs.str || profile.stats.buffs.per || profile.stats.buffs.con || profile.stats.buffs.int || profile.stats.buffs.stealth', tooltip=env.t('buffed'))
-      |&nbsp;&nbsp;
-      =env.t('lvl')
-      |&nbsp;{{profile.stats.lvl}}
-      |&nbsp;
+      span(tooltip=env.t('level')){{profile.stats.lvl}}
       span.glyphicon.glyphicon-plus-sign(ng-show='profile.achievements.rebirths', tooltip=env.t('reborn', {reLevel: "{{profile.achievements.rebirthLevel}}"}))


### PR DESCRIPTION
@benmanley, @lemoness. Partial fix for https://github.com/HabitRPG/habitrpg/issues/3565#issuecomment-48515870 and later comments.

When the user has a background in place, the user's name is now hidden until the user hovers over their avatar (in exactly the same way as their name is already hidden when they have a mount).

"Lvl" has been removed from the level indicator at the bottom of the avatar and a "Level" tooltip has been added (with internationalisation).

The nbsp spaces have been removed from the level indicator and padding has been used instead.

These changes help to show more of the user's background. They also sometimes help to show more of the mermaid tail, depending on the users current condition.

![screen shot 2014-07-27 at 8 45 40 am](https://cloud.githubusercontent.com/assets/1495809/3712485/9cf35ada-1517-11e4-9638-2ff1ad6f85ee.png)
![screen shot 2014-07-27 at 8 47 57 am](https://cloud.githubusercontent.com/assets/1495809/3712486/aa763d80-1517-11e4-83c4-53e2929a93b9.png)
![screen shot 2014-07-27 at 8 57 39 am](https://cloud.githubusercontent.com/assets/1495809/3712504/538137ae-1518-11e4-80e3-c3f450ae7379.png)
![screen shot 2014-07-27 at 8 29 24 am](https://cloud.githubusercontent.com/assets/1495809/3712505/592a244a-1518-11e4-8c21-0366558f73f6.png)
