### PR TITLE
display backgrounds in reverse chronological order (most recent at top)

### DIFF
--- a/views/options/profile.jade
+++ b/views/options/profile.jade
@@ -238,7 +238,11 @@ script(id='partials/options.profile.profile.html', type='text/ng-template')
 script(type='text/ng-template', id='partials/options.profile.backgrounds.html')
   .container-fluid
     menu(type='list')
-      each bgs,k in env.Content.backgrounds
+      // backgrounds are listed in content file in chronological order, but
+      // we want to display them with most recent at top (reversed)
+      - var bgsKeys = Object.keys(env.Content.backgrounds);
+      - for (var i = bgsKeys.length-1; i >= 0; i--) {
+        - var k = bgsKeys[i], bgs = env.Content.backgrounds[k];
         li.customize-menu
           menu(label=env.t(k))
             +gemCost(7)
@@ -246,6 +250,7 @@ script(type='text/ng-template', id='partials/options.profile.backgrounds.html')
               button.btn.btn-xs(ng-hide="ownsSet('background',#{JSON.stringify(bgs)})",ng-click="unlock(setKeys('background',#{JSON.stringify(bgs)}))")!= env.t('unlockSet',{cost:15}) + ' <span class="Pet_Currency_Gem1x inline-gems"/>'
             each bg,k in bgs
               button.customize-option(type='button',class='background_#{k}',ng-click='unlock("background.#{k}")',popover-title=bg.text(),popover=bg.notes(),popover-trigger='mouseenter')
+      - }
 
 script(id='partials/options.profile.html', type="text/ng-template")
   ul.options-menu


### PR DESCRIPTION
Currently, on the User -> Backgrounds page, the newest backgrounds are at the bottom of the page, where they are harder to see. The August backgrounds will be under the fold. This change reverses their order so that the newest will be at the top - see image below. Advantages for this order:
- Increases usability for users who buy all/most of the backgrounds since they are probably more likely to want to equip the recent ones.
- Makes it obvious that new backgrounds exist, even for users who missed the notification.
- MIght encourage more purchases when the new ones are easier to see.

@lemoness, you might want to comment on this. It's okay if you disapprove. :)

Regarding the code: There might have been a neater way to do this, in which case I'd love to be taught about it (feel free to point me at docs or sample code rather than explaining in detail). One alternative would of course be to simply reorder the items in content.coffee, however I'm guessing that for the people who add new items, it will be more intuitive to add them at the bottom, which is what's done for several other things in that file (quests, mystery, events).

BTW... The old code and my new code assume that the items in env.Content.backgrounds will always be returned in the same order. Is that reliable, even when env.Content.backgrounds has become very large? If not, then a fully reliable sort order could be easily enforced if the keys were changed from backgrounds062014 to backgrounds20140620 (yyyymmdd). The century is not necessary of course but 2014 is more recognisable as a year than 14, so it's more user-friendly for the admins adding the data. If we're going to do that, then now would be the best time when there are only two keys to change. I am happy to do all the changes required (excluding the uploads to Transifex), if I'm given the go-ahead by someone in command. :)  In fact, if Matteo is busy, I could even have a go at uploading to Transifex. I'm aware that renaming keys would require database changes to update everyone's ownerships and their currently equipped backgrounds, which is a little scary but I know there's migration scripts in the repo so I could copy one of them. But all of that would be done in a different PR than this one.

![screen shot 2014-07-27 at 2 52 14 pm](https://cloud.githubusercontent.com/assets/1495809/3713101/32511c9a-154d-11e4-85b9-fd7972a20e5b.png)
