### PR TITLE
apply contributor tier color to avatar name - fixes https://github.com/HabitRPG/habitrpg/issues/3735

### DIFF
--- a/public/css/avatar.styl
+++ b/public/css/avatar.styl
@@ -48,12 +48,20 @@ future re: pets and whatnot, this is just temporary.
 
 // info revealed on hover/focus for party
 // always visible on the user's own avatar
+// except that the user's own name is hidden
+// if the user has a mount or background
 .herobox:after
 	opacity: 0
-.herobox.isUser:not(.hasMount):after
+.herobox.isUser.notBackground:not(.hasMount):after
 	opacity: 1
 	// make it a bit special
 	hrpg-label-color-mixin(darken($color-herobox, 16.18%))
+
+// when a buff/rebirth exists, add space between the icon and the level
+.glyphicon-circle-arrow-up
+	padding-right: 4px
+.glyphicon-plus-sign
+	padding-left: 4px
 
 .character-sprites span
     position: absolute

--- a/public/css/avatar.styl
+++ b/public/css/avatar.styl
@@ -13,12 +13,6 @@ future re: pets and whatnot, this is just temporary.
     width:560px
     margin: 0px auto
 
-.avatar-level
-    position: absolute
-    bottom: 2px
-    right: 2px
-    @extend $hrpg-label
-
 // basic herobox styles
 .herobox
 	height: 10.5em // higher to acct for the name area
@@ -34,28 +28,27 @@ future re: pets and whatnot, this is just temporary.
 	outline: 1px solid rgba(0,0,0,0.1)
 // padding: 0 // push down the sprite
 
-// the hero's info frame
-.herobox:after
-	content: attr(data-name) //" – " "lvl " attr(data-level) // " " attr(data-class)
+// herobox avatar level (always visible) and name (hidden by default)
+.herobox .avatar-level
 	position: absolute
-	top: 0
-	display: block
-	margin: 2px
-	text-align: left
+	bottom: 2px
+	right: 2px
 	@extend $hrpg-label
-	hrpg-label-color-mixin(darken($good, 15%))
-	transition: opacity 0.2s ease-out
-
-// info revealed on hover/focus for party
-// always visible on the user's own avatar
-// except that the user's own name is hidden
-// if the user has a mount or background
-.herobox:after
+.herobox .avatar-name
+	position: absolute
+	top:  2px
+	left: 2px
+	@extend $hrpg-label
 	opacity: 0
-.herobox.isUser.notBackground:not(.hasMount):after
+	transition: opacity 0.2s ease-out
+// user's own name is visible if not using mount or background
+.herobox.isUser.notBackground:not(.hasMount) .avatar-name
 	opacity: 1
-	// make it a bit special
-	hrpg-label-color-mixin(darken($color-herobox, 16.18%))
+// avatar name becomes visible on hover
+.herobox:hover .avatar-name, .herobox:focus .avatar-name
+	opacity: 1
+.herobox.noBackgroundImage:hover, .herobox.noBackgroundImage:focus
+	background: lighten($color-herobox, 30%)
 
 // when a buff/rebirth exists, add space between the icon and the level
 .glyphicon-circle-arrow-up
@@ -64,16 +57,16 @@ future re: pets and whatnot, this is just temporary.
 	padding-left: 4px
 
 .character-sprites span
-    position: absolute
+	position: absolute
 
 #profileStable
-    .active
-        border 1px solid black
+	.active
+		border 1px solid black
 
 // if not user's avatar, remove lines for party unity
 .herobox.noBackgroundImage:not(.isUser)
-  outline: 0
-  background-color: darken($color-herobox, 8%)
+	outline: 0
+	background-color: darken($color-herobox, 8%)
 
 // vertically center avatar sprite depending on if they have a pet
 .herobox.hasPet
@@ -82,14 +75,6 @@ future re: pets and whatnot, this is just temporary.
 	padding-top: 2em
 .herobox.hasMount
     padding-top:0em
-
-// expose hero info on hover, taking
-// into account the extra pet space
-.herobox:hover, .herobox:focus
-  &:after
-    opacity: 1
-.herobox.noBackgroundImage:hover, .herobox.noBackgroundImage:focus
-  background: lighten($color-herobox, 30%)
 
 // positioning the sprites, etc
 .herobox

--- a/views/shared/header/avatar.jade
+++ b/views/shared/header/avatar.jade
@@ -77,8 +77,5 @@ mixin herobox(opts)
     +avatar(opts)
     .avatar-level(ng-class='userLevelStyle(profile)')
       span.glyphicon.glyphicon-circle-arrow-up(ng-show='profile.stats.buffs.str || profile.stats.buffs.per || profile.stats.buffs.con || profile.stats.buffs.int || profile.stats.buffs.stealth', tooltip=env.t('buffed'))
-      |&nbsp;&nbsp;
-      =env.t('lvl')
-      |&nbsp;{{profile.stats.lvl}}
-      |&nbsp;
+      span(tooltip=env.t('level')){{profile.stats.lvl}}
       span.glyphicon.glyphicon-plus-sign(ng-show='profile.achievements.rebirths', tooltip=env.t('reborn', {reLevel: "{{profile.achievements.rebirthLevel}}"}))

--- a/views/shared/header/avatar.jade
+++ b/views/shared/header/avatar.jade
@@ -74,6 +74,8 @@ mixin avatar(opts)
 mixin herobox(opts)
   - if (!opts) {opts = {minimal:false,main:false}}
   figure.herobox(ng-click='spell ? castEnd(profile, "user", $event) : clickMember(profile._id)', data-name='{{profile.profile.name}}', class='background_{{profile.preferences.background}} #{opts.main ? "isUser" : ""} #{opts.minimal ? "minimal" : ""}', ng-class='{hasPet: (#{!opts.minimal} && profile.items.currentPet), hasMount: (#{!opts.minimal} && profile.items.currentMount), notBackground: !profile.preferences.background, "cast-target": applyingAction, isLeader: party.leader==profile._id}')
+    .avatar-name(ng-class='userLevelStyle(profile)')
+      {{profile.profile.name}}
     +avatar(opts)
     .avatar-level(ng-class='userLevelStyle(profile)')
       span.glyphicon.glyphicon-circle-arrow-up(ng-show='profile.stats.buffs.str || profile.stats.buffs.per || profile.stats.buffs.con || profile.stats.buffs.int || profile.stats.buffs.stealth', tooltip=env.t('buffed'))


### PR DESCRIPTION
Do not merge this until https://github.com/HabitRPG/habitrpg/pull/3792 ["show more avatar background (remove Lvl, hide avatar name)"] has been merged!  I based this branch on the branch for that change, since the same code is being modified. If https://github.com/HabitRPG/habitrpg/pull/3792 is rejected, I can re-do this change.

Note: Ben suggested (sensibly) that the level indicators should NOT have the tier colour, since level and tier aren't related, but I've left the colour on the levels because I think it looks nice with the name and level matching, and I thought the aesthetics might be more important than logic in this case. See the final screenshot for what it's like with grey levels. If you prefer grey levels, it's a very simple fix - in views/shared/header/avatar.jade change .avatar-level(ng-class='userLevelStyle(profile)') to .avatar-level

@benmanley: I changed the way that the avatar names are inserted into the page. Instead of .herobox:after with a "content" attribute, it's now .avatar-name (very similar to the pre-existing .avatar-level code), but maybe there was a good reason for using .herobox:after? I've also reorderd the various styles to put all name/level styles together and simplified the comments. If any of that isn't okay, I can re-do the change. I also made whitespace more consistent in a couple of unrelated places (tabs, not spaces).

**default state (user is not hovering):**
![1](https://cloud.githubusercontent.com/assets/1495809/3728632/93a4e8c6-16ad-11e4-9e0c-d1e96a31c685.png)

**user hovers over a party member to show name:**
![2](https://cloud.githubusercontent.com/assets/1495809/3728633/93bbf7dc-16ad-11e4-85a0-ada9cc59ac36.png)

**user has a background so name is hidden by default (user is not hovering) - see https://github.com/HabitRPG/habitrpg/pull/3792 for details:**
![3](https://cloud.githubusercontent.com/assets/1495809/3728634/93bccafe-16ad-11e4-9e9f-568096d23579.png)

**user hovers over own avatar to show name:**
![4](https://cloud.githubusercontent.com/assets/1495809/3728635/93bef8e2-16ad-11e4-835d-7e011fa3be9a.png)

**what it looks like when levels are grey:**
![5](https://cloud.githubusercontent.com/assets/1495809/3728631/939ed116-16ad-11e4-8534-09ea134a1160.png)
