### PR TITLE
Align pets

### DIFF
--- a/public/css/inventory.styl
+++ b/public/css/inventory.styl
@@ -25,7 +25,7 @@
 
 menu.pets div 
   display: inline-block
-  padding-top: -30px
+  vertical-align: top
 
 .current-pet
     left: 0px


### PR DESCRIPTION
Padding can't be negative, so I replaced `padding-top: -30px` by `vertical-align: top`, which is the right way to align inline-block displayed items :) (default is baseline and it's why it was shifted)
