### PR TITLE
add correct styling to moderator names in message above Tavern chat

### DIFF
--- a/src/models/user.js
+++ b/src/models/user.js
@@ -446,5 +446,9 @@ module.exports.schema = UserSchema;
 module.exports.model = mongoose.model("User", UserSchema);
 
 mongoose.model("User").find({'contributor.admin':true},function(err,mods){
-  module.exports.mods = _.map(mods,function(m){return ' '+ m.profile.name});
+  module.exports.mods = _.map(mods,function(m){
+    var lvl = (m.backer && m.backer.npc) ? 'label-npc' :
+        'label-contributor-' + m.contributor.level;
+    return ' <span class="label ' + lvl + '">'+ m.profile.name + '</span>'
+  });
 });


### PR DESCRIPTION
changes the message above Tavern chat so that the moderator's names have the standard styles applied. 

Old appearance:
![screen shot 2014-08-02 at 7 28 04 am](https://cloud.githubusercontent.com/assets/1495809/3785419/d98603a2-19c3-11e4-93b3-2ced97e5c1ba.png)

New appearance:
![screen shot 2014-08-02 at 7 27 46 am](https://cloud.githubusercontent.com/assets/1495809/3785420/e0a287a0-19c3-11e4-8fb2-1f676ca8c912.png)

Obviously the correct people's names will appear ("admin-level-7", etc are just the profile names of my test users).

An NPC such as It's Bailey would appear in the list ONLY if they had been given moderator privileges with the "admin" flag (so when this goes live, Bailey will NOT appear in the list); the code for NPCs is just future-proofing.
