### PR TITLE
split Player Tiers table into entries for individual tiers

### DIFF
--- a/public/css/game-pane.styl
+++ b/public/css/game-pane.styl
@@ -131,6 +131,9 @@ hrpg-contributor-label-mixin($hrpg-contributor-color)
   hrpg-contributor-label-mixin($color-contributor-seven)
 .label-contributor-8
   hrpg-contributor-label-mixin($color-contributor-staff)
+  // FOR NEW MOD LEVEL: line above will change from -staff to -mod
+.label-contributor-9
+  hrpg-contributor-label-mixin($color-contributor-staff)
 .label-npc
   hrpg-contributor-label-mixin($color-contributor-npc)
   color: #00FF00 !important

--- a/views/options/social/tavern.jade
+++ b/views/options/social/tavern.jade
@@ -75,46 +75,62 @@
           table.table.table-striped.panel-tiers
             tr
               td
-                a.label.label-contributor-1(ng-click='toggleUserTier($event)')=env.t('friend') + ' (1-2)'
+                a.label.label-contributor-1(ng-click='toggleUserTier($event)')=env.t('tier') + ' 1 (' + env.t('friend') + ')'
                 div
                   p
                     span.achievement.achievement-firefox
                     !=env.t('friendFirst')
-                  hr
+            tr
+              td
+                a.label.label-contributor-2(ng-click='toggleUserTier($event)')=env.t('tier') + ' 2 (' + env.t('friend') + ')'
+                div
                   p
                     span.shop-sprite.item-img(class='shop_armor_special_1')
                     !=env.t('friendSecond')
             tr
               td
-                a.label.label-contributor-3(ng-click='toggleUserTier($event)')=env.t('elite') + ' (3-4)'
+                a.label.label-contributor-3(ng-click='toggleUserTier($event)')=env.t('tier') + ' 3 (' + env.t('elite') + ')'
                 div
                   p
                     span.shop-sprite.item-img(class='shop_head_special_1')
                     !=env.t('eliteThird')
-                  hr
+            tr
+              td
+                a.label.label-contributor-4(ng-click='toggleUserTier($event)')=env.t('tier') + ' 4 (' + env.t('elite') + ')'
+                div
                   p
                     span.shop-sprite.item-img(class='shop_weapon_special_1')
                     !=env.t('eliteFourth')
             tr
               td
-                a.label.label-contributor-5(ng-click='toggleUserTier($event)')=env.t('champion') + ' (5-6)'
+                a.label.label-contributor-5(ng-click='toggleUserTier($event)')=env.t('tier') + ' 5 (' + env.t('champion') + ')'
                 div
                   p
                     span.shop-sprite.item-img(class='shop_shield_special_1')
                     !=env.t('championFifth')
-                  hr
+            tr
+              td
+                a.label.label-contributor-6(ng-click='toggleUserTier($event)')=env.t('tier') + ' 6 (' + env.t('champion') + ')'
+                div
                   p
                     div(class='Pet-Dragon-Hydra pull-left')
                     !=env.t('championSixth')
             tr
               td
-                a.label.label-contributor-7(ng-click='toggleUserTier($event)')=env.t('legendary') + ' (7)'
+                a.label.label-contributor-7(ng-click='toggleUserTier($event)')=env.t('tier') + ' 7 (' + env.t('legendary') + ')'
                 div
                   p
-                    !=env.t('legSeventh')
+                  !=env.t('legSeventh')
             tr
               td
-                a.label.label-contributor-8(ng-click='toggleUserTier($event)')=env.t('heroic')
+                a.label.label-contributor-7(ng-click='toggleUserTier($event)')=env.t('moderator') + ' (' + env.t('guardian') + ')'
+                // FOR NEW MOD LEVEL: line above will change from -7 to -8
+                div
+                  p=env.t('guardianText')
+                  // FOR NEW MOD LEVEL: edit guardianText to remove this: "Not all Tier 7 contributors are moderators. All current moderators are listed below the Tavern chat box."
+            tr
+              td
+                a.label.label-contributor-9(ng-click='toggleUserTier($event)')=env.t('staff') + ' (' + env.t('heroic') + ')'
                 div
                   p=env.t('heroicText')
             tr


### PR DESCRIPTION
Changes Player Tiers table on Tavern page FROM this:
![screen shot 2014-08-02 at 8 13 49 am](https://cloud.githubusercontent.com/assets/1495809/3785723/298ea2d2-19c9-11e4-9a1e-732f827a05fa.png)

TO THIS:
![screen shot 2014-08-02 at 10 42 37 am](https://cloud.githubusercontent.com/assets/1495809/3786639/eb6cdb5c-19de-11e4-8e46-16c8efdc9f6c.png)

When expanded those sections look like this:
![screen shot 2014-08-02 at 10 44 32 am](https://cloud.githubusercontent.com/assets/1495809/3786644/00eb766e-19df-11e4-896d-9e6636ecf96a.png)
![screen shot 2014-08-02 at 10 44 43 am](https://cloud.githubusercontent.com/assets/1495809/3786645/00ec1b5a-19df-11e4-9e2f-e0aae997052b.png)
![screen shot 2014-08-02 at 10 44 50 am](https://cloud.githubusercontent.com/assets/1495809/3786646/00ef7a34-19df-11e4-89e3-2a5559a585d5.png)

@Lemoness, note the new text for Moderators in the image just above. Do you want changes? When the new Tiers are fully implemented, I will be proposing that the final two sentences be deleted (i.e., delete "Not all Tier 7 contributors are moderators. All current moderators are listed below the Tavern chat box.")

FYI, all the colours for the new tiers are already in HabitRPG/habitrpg/develop, as shown by the test of the chat function below (all my test users have profile names that indicate their levels). Therefore I believe this PR can be safely merged.
![screen shot 2014-08-02 at 10 43 25 am](https://cloud.githubusercontent.com/assets/1495809/3786653/58b53da8-19df-11e4-8a01-ba2303cb9fe7.png)

This PR also has a little code that partially implements the new numbering system for moderators and staff (Tiers 8 and 9) but that's still invisible to the users.
