### PR TITLE
Fix hurts the boss

### DIFF
--- a/test/api.mocha.js
+++ b/test/api.mocha.js
@@ -545,8 +545,9 @@ describe('API', function () {
                         // Tavern Boss
                         function(cb2){
                           Group.findById('habitrpg',function(err,tavern){
-                            expect(_.isEmpty(tavern.quest)).to.be(true);
                             expect(user.items.pets['MantisShrimp-Base']).to.be(true);
+                            //use an explicit get because mongoose wraps the null in an object
+                            expect(_.isEmpty(tavern.get('quest'))).to.be(true);
                             expect(user.items.mounts['MantisShrimp-Base']).to.be(true);
                             expect(user.items.eggs.Dragon).to.be(2);
                             expect(user.items.hatchingPotions.Shade).to.be(2);
@@ -556,7 +557,8 @@ describe('API', function () {
 
                         // Party Boss
                         function(cb2){
-                          expect(_.isEmpty(_group.quest)).to.be(true);
+                          //use an explicit get because mongoose wraps the null in an object
+                          expect(_.isEmpty(_group.get('quest'))).to.be(true);
                           expect(user.items.gear.owned.weapon_special_2).to.be(true);
                           expect(user.items.eggs.Dragon).to.be(2);
                           expect(user.items.hatchingPotions.Shade).to.be(2);

--- a/test/api.mocha.js
+++ b/test/api.mocha.js
@@ -564,18 +564,27 @@ describe('API', function () {
                           expect(user.items.hatchingPotions.Shade).to.be(2);
 
                           // need to fetch users to get updated data
-                          User.findById(party[0].id,function(err,mbr){
-                            expect(mbr.items.gear.owned.weapon_special_2).to.be(true);
-                          });
-                          User.findById(party[1].id,function(err,mbr){
-                            expect(mbr.items.gear.owned.weapon_special_2).to.be(true);
-                          });
-                          User.findById(party[2].id,function(err,mbr){
-                            expect(mbr.items.gear.owned.weapon_special_2).to.not.be.ok();
-                          });
-                          cb2()
+                          async.parallel([
+                            function(cb3){
+                              User.findById(party[0].id,function(err,mbr){
+                                expect(mbr.items.gear.owned.weapon_special_2).to.be(true);
+                                cb3();
+                              });
+                            },
+                            function(cb3){
+                              User.findById(party[1].id,function(err,mbr){
+                                expect(mbr.items.gear.owned.weapon_special_2).to.be(true);
+                                cb3();
+                              });
+                            },
+                            function(cb3){
+                              User.findById(party[2].id,function(err,mbr){
+                                expect(mbr.items.gear.owned.weapon_special_2).to.not.be.ok();
+                                cb3();
+                              });
+                            }
+                          ], cb2);
                         }
-
                       ],cb)
                     }
                   ],done);

--- a/test/api.mocha.js
+++ b/test/api.mocha.js
@@ -562,9 +562,17 @@ describe('API', function () {
                           expect(user.items.gear.owned.weapon_special_2).to.be(true);
                           expect(user.items.eggs.Dragon).to.be(2);
                           expect(user.items.hatchingPotions.Shade).to.be(2);
-                          expect(_.find(_group.members,{_id:party[0]._id}).items.gear.owned.weapon_special_2).to.be(true);
-                          expect(_.find(_group.members,{_id:party[1]._id}).items.gear.owned.weapon_special_2).to.be(true);
-                          expect(_.find(_group.members,{_id:party[2]._id}).items.gear.owned.weapon_special_2).to.not.be.ok();
+
+                          // need to fetch users to get updated data
+                          User.findById(party[0].id,function(err,mbr){
+                            expect(mbr.items.gear.owned.weapon_special_2).to.be(true);
+                          });
+                          User.findById(party[1].id,function(err,mbr){
+                            expect(mbr.items.gear.owned.weapon_special_2).to.be(true);
+                          });
+                          User.findById(party[2].id,function(err,mbr){
+                            expect(mbr.items.gear.owned.weapon_special_2).to.not.be.ok();
+                          });
                           cb2()
                         }
 

--- a/test/api.mocha.js
+++ b/test/api.mocha.js
@@ -545,9 +545,9 @@ describe('API', function () {
                         // Tavern Boss
                         function(cb2){
                           Group.findById('habitrpg',function(err,tavern){
-                            expect(user.items.pets['MantisShrimp-Base']).to.be(true);
                             //use an explicit get because mongoose wraps the null in an object
                             expect(_.isEmpty(tavern.get('quest'))).to.be(true);
+                            expect(user.items.pets['MantisShrimp-Base']).to.be(5);
                             expect(user.items.mounts['MantisShrimp-Base']).to.be(true);
                             expect(user.items.eggs.Dragon).to.be(2);
                             expect(user.items.hatchingPotions.Shade).to.be(2);


### PR DESCRIPTION
This modifies the failing tests under "Hurts the boss"
- Quest is empty test failed because quest = null which Mongoose was wrapping.  An explicit get fixes the issue with the test.
- The Mantis Pet test should be looking for 5 not true
- Tests on the Group members fail because _group.members is an array of ids not user objects. Fixed by retrieving each and running tests.

UserID: 7941e218-7b6e-42b7-989d-8b040c65aa17
