### PR TITLE
Fix gem text alignment on the menubar.

### DIFF
--- a/public/css/menu.styl
+++ b/public/css/menu.styl
@@ -105,7 +105,7 @@
     span
       display:inline-block
       vertical-align:top
-      padding-top: 0.382em
+      padding-top: 0.236em
 .toolbar-currency
   padding-top: 0.236em
   padding-bottom: 0.236em


### PR DESCRIPTION
I'm not much of a frontend guy so I'm not sure if there was some reason
for this one being different, but it throws the alignment off so I
assume it was a mistake.

Fixes #3855
