### PR TITLE
Ticking all checkboxes will complete a Daily/To-do

### DIFF
--- a/public/js/controllers/tasksCtrl.js
+++ b/public/js/controllers/tasksCtrl.js
@@ -44,7 +44,14 @@ habitrpg.controller("TasksCtrl", ['$scope', '$location', 'User','Notification', 
 
     $scope.saveTask = function(task, stayOpen) {
       if (task.checklist)
+      {
         task.checklist = _.filter(task.checklist,function(i){return !!i.text});
+        if (task.completed == false &&
+            task.checklist.length == $scope.checklistCompletion(task.checklist)) {
+          task.completed = true;
+          $scope.changeCheck(task);
+        }
+      }
       User.user.ops.updateTask({params:{id:task.id},body:task});
       if (!stayOpen) task._editing = false;
     };


### PR DESCRIPTION
When the user ticks the last checkbox for an as yet uncompleted Daily or To-do, the task will now automatically register as completed. The reverse logic (i.e., unchecking a checkbox resulting in "un-completing" the task) is not implemented because I couldn't figure out a good way to do it.
