### PR TITLE
Columns were made longer by hovering over the last task in the list

### DIFF
--- a/public/css/tasks.styl
+++ b/public/css/tasks.styl
@@ -127,7 +127,7 @@ for $stage in $stages
   position: relative
   &:hover
     cursor: move
-  &:last-child
+  :last-child
     margin-bottom: 0
 
   label


### PR DESCRIPTION
This PR fixes an issue where hovering over the last item in a column would cause the column to lengthen if the item contained an Extra Notes bubble. This issue also applied to rewards, equipment, and spells.
