### PR TITLE
Organizing the mounts page the same way the pets page has been for a while

### DIFF
--- a/public/css/inventory.styl
+++ b/public/css/inventory.styl
@@ -27,9 +27,17 @@ menu.pets div
   display: inline-block
   padding-top: -30px
 
+menu.mounts div
+  display: inline-block
+  padding-top: -30px
+
 .current-pet
     left: 0px
     bottom: 0px
+
+.current-mount
+	left: 0px
+	bottom: 0px
 
 .item-drop-icon
     float:left

--- a/views/options/inventory/stable.jade
+++ b/views/options/inventory/stable.jade
@@ -52,8 +52,8 @@ script(type='text/ng-template', id='partials/options.inventory.mounts.html')
             each t,k in env.Content.specialMounts
               - var animal = k.split('-')[0], color = k.split('-')[1]
               button(ng-if='user.items.mounts["#{animal}-#{color}"]', class="pet-button Mount_Head_#{animal}-#{color}", ng-class='{active: user.items.currentMount == "#{animal}-#{color}"}', ng-click='chooseMount("#{animal}", "#{color}")', popover=env.t(t), popover-trigger='mouseenter', popover-placement='bottom')
-              // button(class="pet-button pet-not-owned", ng-hide='user.items.mounts["#{mount}"]')
-                // .PixelPaw
+              button(class="pet-button pet-not-owned", ng-hide='user.items.mounts["#{mount}"]')
+                .PixelPaw
 
 
 script(type='text/ng-template', id='partials/options.inventory.pets.html')

--- a/views/options/inventory/stable.jade
+++ b/views/options/inventory/stable.jade
@@ -1,36 +1,3 @@
-script(type='text/ng-template', id='partials/options.inventory.mounts.html')
-  .container-fluid
-    .stable.row
-      .col-md-2
-        div(class="#{env.worldDmg.stables ? 'npc_matt_broken' : 'npc_matt'}")
-      .col-md-10
-        .popover.static-popover.fade.right.in
-          .arrow
-          h3.popover-title
-            a(target='_blank', href='http://www.kickstarter.com/profile/mattboch')=env.t('mattBoch')
-          .popover-content
-            p=env.t('mattShall', {name: "{{user.profile.name}}"})
-            h4= '{{Shared.countMounts(null,User.user.items.mounts) || 0}} / {{totalMounts}} ' + env.t('mountsTamed')
-      .col-md-12
-        menu.pets(type='list')
-          each egg in env.Content.eggs
-            li.customize-menu
-              menu
-                each potion in env.Content.hatchingPotions
-                  - mount = egg.key+"-"+potion.key
-                  div(popover-trigger='mouseenter', popover=env.t('mountName', {potion: potion.text(env.language.code), mount: egg.mountText(env.language.code)}), popover-placement='bottom')
-                    button(class="pet-button Mount_Head_#{mount}", ng-show='user.items.mounts["#{mount}"]', ng-class='{active: user.items.currentMount == "#{mount}"}', ng-click='chooseMount("#{egg.key}", "#{potion.key}")')
-                      //div(class='Mount_Head_{{mount}}')
-                    button(class="pet-button pet-not-owned", ng-hide='user.items.mounts["#{mount}"]')
-                      .PixelPaw
-      .col-md-12
-        h4=env.t('rareMounts')
-        menu
-          div
-            each t,k in env.Content.specialMounts
-              - var animal = k.split('-')[0], color = k.split('-')[1]
-              button(ng-if='user.items.mounts["#{animal}-#{color}"]', class="pet-button Mount_Head_#{animal}-#{color}", ng-class='{active: user.items.currentMount == "#{animal}-#{color}"}', ng-click='chooseMount("#{animal}", "#{color}")', popover=env.t(t), popover-trigger='mouseenter', popover-placement='bottom')
-
 mixin petList(source)
   menu.pets(type='list')
     each egg in source
@@ -45,6 +12,49 @@ mixin petList(source)
               button(class="pet-button pet-not-owned", ng-if='!user.items.pets["#{pet}"]')
                 .PixelPaw
               button(class="pet-evolved pet-button Pet-#{pet}", ng-if='user.items.pets["#{pet}"]<0')
+
+mixin mountList(source)
+  menu.pets(type='list')
+    each egg in env.Content.dropEggs
+      li.customize-menu
+        menu
+          each potion in env.Content.hatchingPotions
+            - mount = egg.key+"-"+potion.key
+            div(popover-trigger='mouseenter', popover=env.t('mountName', {potion: potion.text(env.language.code), mount: egg.mountText(env.language.code)}), popover-placement='bottom')
+              button(class="pet-button Mount_Head_#{mount}", ng-show='user.items.mounts["#{mount}"]', ng-class='{active: user.items.currentMount == "#{mount}"}', ng-click='chooseMount("#{egg.key}", "#{potion.key}")')
+                //div(class='Mount_Head_{{mount}}')
+              button(class="pet-button pet-not-owned", ng-hide='user.items.mounts["#{mount}"]')
+                .PixelPaw
+
+
+script(type='text/ng-template', id='partials/options.inventory.mounts.html')
+  .container-fluid
+    .stable.row
+      .col-md-2
+        div(class="#{env.worldDmg.stables ? 'npc_matt_broken' : 'npc_matt'}")
+      .col-md-10
+        .popover.static-popover.fade.right.in
+          .arrow
+          h3.popover-title
+            a(target='_blank', href='http://www.kickstarter.com/profile/mattboch')=env.t('mattBoch')
+          .popover-content
+            p=env.t('mattShall', {name: "{{user.profile.name}}"})
+            h4= '{{Shared.countMounts(null,User.user.items.mounts) || 0}} / {{totalMounts}} ' + env.t('mountsTamed')
+      .col-md-12
+        +mountList(env.Content.dropEggs)
+      .col-md-12
+        h4=env.t('questMounts')
+        +petList(env.Content.questEggs)
+      .col-md-12
+        h4=env.t('rareMounts')
+        menu
+          div
+            each t,k in env.Content.specialMounts
+              - var animal = k.split('-')[0], color = k.split('-')[1]
+              button(ng-if='user.items.mounts["#{animal}-#{color}"]', class="pet-button Mount_Head_#{animal}-#{color}", ng-class='{active: user.items.currentMount == "#{animal}-#{color}"}', ng-click='chooseMount("#{animal}", "#{color}")', popover=env.t(t), popover-trigger='mouseenter', popover-placement='bottom')
+              // button(class="pet-button pet-not-owned", ng-hide='user.items.mounts["#{mount}"]')
+                // .PixelPaw
+
 
 script(type='text/ng-template', id='partials/options.inventory.pets.html')
   .container-fluid


### PR DESCRIPTION
So this isn't the best code in the world because it's mostly been trial and error, and I felt like I was fumbling around in the dark the whole time. But even if it's not perfect I think it brings a lot more structure to the mounts page than we've had previously. I'm making a pull request in habitrpg-shared as well, to give content.coffee and index.coffee their own mount updates as well.

Commits 2 and 3 here are the same file, with the difference being whether there are paw print icons underneath the Rare Mounts heading. In commit 2 (no paw prints) there are arrows, and in commit 3 there doesn't seem to be a hover balloon with the mount's name, so I think I messed something up. I'll try to fiddle with them some more tomorrow.

and, erm, my UUID is 1534a0ee-2f69-4c2e-9659-0d719ac2ea68 :3
