### PR TITLE
allow notifications icon to go grey when all messages have been seen - fixes https://github.com/HabitRPG/habitrpg/issues/3270

### DIFF
--- a/migrations/20140823_remove_undefined_and_false_notifications.js
+++ b/migrations/20140823_remove_undefined_and_false_notifications.js
@@ -1,0 +1,13 @@
+db.users.find({}).forEach(function(user){
+  var newNewMessages = {};
+
+ for(var key in user.newMessages) {
+    var val = user.newMessages[key];
+    // print("\n" + key + " " + val);
+    if(key != "undefined" && val['value']){
+      newNewMessages[key] = val;
+    }
+ }
+
+  db.users.update({_id: user._id}, {$set: {'newMessages': newNewMessages}});
+});

--- a/public/js/services/groupServices.js
+++ b/public/js/services/groupServices.js
@@ -47,7 +47,7 @@ angular.module('groupServices', ['ngResource']).
           // On enter, set chat message to "seen"
           seenMessage: function(gid){
             $http.post('/api/v2/groups/'+gid+'/chat/seen');
-            if (User.user.newMessages) User.user.newMessages[gid] = false;
+            if (User.user.newMessages) delete User.user.newMessages[gid];
           },
 
           // Pass reference to party, myGuilds, publicGuilds, tavern; inside data in order to

--- a/src/controllers/groups.js
+++ b/src/controllers/groups.js
@@ -257,8 +257,8 @@ api.seenMessage = function(req,res,next){
   // Skip the auth step, we want this to be fast. If !found with uuid/token, then it just doesn't save
   // Check for req.params.gid to exist
   if(req.params.gid){
-    var update = {$set:{}};
-    update['$set']['newMessages.'+req.params.gid+'.value'] = false;
+    var update = {$unset:{}};
+    update['$unset']['newMessages.'+req.params.gid] = '';
     User.update({_id:req.headers['x-api-user'], apiToken:req.headers['x-api-key']},update).exec();
   }
   res.send(200);


### PR DESCRIPTION
@lefnire : migrations/20140823_remove_undefined_and_false_notifications.js needs to be run when this goes live.

Explanation: https://github.com/HabitRPG/habitrpg/issues/3270#issuecomment-51696497

This also prevents the "undefined" guild from reappearing (https://github.com/HabitRPG/habitrpg/issues/3270#issuecomment-41032939) because that was happening when `$http.post('/api/v2/groups/'+gid+'/chat/seen');` was called with no gid (i.e., every time you visited the party page). Now that the api is deleting seen message data instead of setting it to false, it never incorrectly creates the undefined entry.
