### PR TITLE
allow bower install to run without asking for permission to collect stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "scripts": {
     "test": "./test/run_tests.sh",
     "start": "grunt run:dev",
-    "postinstall": "./node_modules/bower/bin/bower install -f"
+    "postinstall": "./node_modules/bower/bin/bower --config.interactive=false install -f"
   },
   "devDependencies": {
     "protractor": "~0.14.0",


### PR DESCRIPTION
@lefnire, you'll probably want to approve/reject this one.

A change to bower earlier this year causes it to ask, during the installation process, for permission to send stats back to bower. This is annoying because it halts the local install process until a response is given.

Adding --config.interactive=false prevents this. Reference: https://github.com/bower/bower/issues/1162
