### PR TITLE
API: get a list of buyable gear

### DIFF
--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -161,6 +161,12 @@ api.getTask = function(req, res, next) {
 */
 // api.buy // handled in Shard.ops
 
+api.getBuyList = function (req, res, next) {
+   var list = shared.updateStore(res.locals.user);
+
+   return res.json(200, list);
+};
+
 /*
   ------------------------------------------------------------------------
   User

--- a/src/routes/apiv2.coffee
+++ b/src/routes/apiv2.coffee
@@ -152,6 +152,11 @@ module.exports = (swagger, v2) ->
 
 
     # Inventory
+    "/user/inventory/buy":
+      spec:
+         description: "Get a list of buyable gear"
+      action: user.getBuyList
+
     "/user/inventory/buy/{key}":
       spec:
         method: 'POST'


### PR DESCRIPTION
Well that was easy to add. :)

This could be useful for 3rd party developers which don't / can't use the shared scripts.

To my surprise the new API-Route also showed up on Swagger UI, very nice^^
