### PR TITLE
move Level tooltip back to Level element to avoid Buffed/Rebirth tooltip glitches

### DIFF
--- a/views/shared/header/avatar.jade
+++ b/views/shared/header/avatar.jade
@@ -77,7 +77,7 @@ mixin herobox(opts)
     .avatar-name(ng-class='userLevelStyle(profile)')
       |{{profile.profile.name}}
     +avatar(opts)
-    .avatar-level(ng-class='userLevelStyle(profile)',tooltip=env.t('level'))
+    .avatar-level(ng-class='userLevelStyle(profile)')
       span.glyphicon.glyphicon-circle-arrow-up(ng-show='profile.stats.buffs.str || profile.stats.buffs.per || profile.stats.buffs.con || profile.stats.buffs.int || profile.stats.buffs.stealth', tooltip=env.t('buffed'))
-      span() {{profile.stats.lvl}}
+      span(tooltip=env.t('level')) {{profile.stats.lvl}}
       span.glyphicon.glyphicon-plus-sign(ng-show='profile.achievements.rebirths', tooltip=env.t('reborn', {reLevel: "{{profile.achievements.rebirthLevel}}"}))


### PR DESCRIPTION
This reverts https://github.com/HabitRPG/habitrpg/pull/3920 (although I do want to fix that problem again!) because #3920 causes the level tooltip to obscure the Buffed and Rebirth tooltips when you hover over the Buffed/Rebirth icons:
![screen shot 2014-08-26 at 3 37 07 pm](https://cloud.githubusercontent.com/assets/1495809/4040508/4102ba36-2ce6-11e4-9c28-daf2894950fb.png)
The "Level" tooltip needs to apply to the level itself, not to the whole box, to avoid this problem.

I think the unpleasant effect shown in #3920 is less critical than obscuring the other tooltips, especially the Buffed one. New users are often buffed due to Perfect Days (they haven't set up many dailies yet) and they sometimes ask questions about what the buffed icon means. If they can see the tooltip for it, they'll know to search the wiki for "Buffed" or ask what that word means in the Tavern. With the tooltip hidden, it'll be harder for them to describe what they're confused about.

I'm going to keep working on a fix for the issue shown in #3920, although I'm a bit worried that it might be a Bootstrap bug/inconsistency because it happens in Firefox but not in Chrome.
