### PR TITLE
Fix for issue #3477, 'No "Contact Us" at Bottom of the page. Added the n...

### DIFF
--- a/views/shared/footer.jade
+++ b/views/shared/footer.jade
@@ -33,6 +33,8 @@ footer.footer(ng-controller='FooterCtrl')
             a(href='/static/privacy')=env.t('companyPrivacy')
           li
             a(href='/static/terms')=env.t('companyTerms')
+          li
+            a(href='/static/contact')=env.t('contactUs')
       .col-sm-3
         h4=env.t('footerCommunity')
         ul.list-unstyled

--- a/views/static/contact.jade
+++ b/views/static/contact.jade
@@ -1,12 +1,35 @@
 extends ./layout
+//-Trick needed to pass 'env' to ./layout
 block vars
   - var layoutEnv = env
   - var menuItem = 'contact'
+
 block title
-  title=env.t('contact')
+  title=env.t('contactUs')
+
 block content
-  // Probably just add linkks to the respective contact locations?
-  // Bugs? Github
-  // Feature requests? Trello
-  // Enterprise? Click the "pricing" tab
-  /// etc
+  .row
+    .col-md-12
+      .page-header
+        h1=env.t('contactUs')
+      p
+        | Report Account Problems: 
+        a(href='mailto:admin@habitrpg.com') admin&commat;gmail&period;com
+        br
+        | Report a Bug: 
+        a(target='_blank', href='https://github.com/HabitRPG/habitrpg/issues?q=is%3Aopen') Github
+        br
+        | Report Community Issues: 
+        a(href='mailto:leslie@habitrpg.com') leslie&commat;habitrpg&period;com
+        br
+        | General Questions about the Site: 
+        a(target='_blank', href='http://habitrpg.wikia.com/wiki/The_Keep:The_Newbies_Guild') Newbies Guild
+        br
+        | Business Inquiries: 
+        a(href='mailto:vicky@habitrpg.com') vicky&commat;habitrpg&period;com
+        br
+        | Merchandise Inquiries: 
+        a(href='mailto:store@habitrpg.com') store&commat;habitrpg&period;com
+        br
+        | Marketing/Social Media Inquiries: 
+        a(href='mailto:leslie@habitrpg.com') leslie&commat;habitrpg&period;com

--- a/views/static/layout.jade
+++ b/views/static/layout.jade
@@ -38,8 +38,8 @@ html(ng-app='habitrpgStatic')
               a(href='http://blog.habitrpg.com/')=env.t('companyBlog')
             li(class='#{menuItem=="plans" ? "active" : ""}')
               a(href='/static/plans')=env.t('groupPlans')
-            //li(class='#{menuItem=="contact" ? "active" : ""}')
-              a(href='/static/contact')=env.t('contact')
+            li(class='#{menuItem=="contact" ? "active" : ""}')
+              a(href='/static/contact')=env.t('contactUs')
 
           button#header-play-button.btn.btn-primary.navbar-btn.navbar-right(ng-click='playButtonClick()')=env.t('playButton')
 


### PR DESCRIPTION
...ew link and used the existing env.t('contactUs') string so all the translations are correct. Also added the link to layout.jade because that was stubbed out there in comments. Both links go to a new page with other links as described in the issue.
