### PR TITLE
updated migration script to allow notifications icons to go grey

### DIFF
--- a/migrations/20140823_remove_undefined_and_false_notifications.js
+++ b/migrations/20140823_remove_undefined_and_false_notifications.js
@@ -1,13 +1,45 @@
-db.users.find({}).forEach(function(user){
-  var newNewMessages = {};
+//  node .migrations/20140823_remove_undefined_and_false_notifications.js
 
- for(var key in user.newMessages) {
-    var val = user.newMessages[key];
-    // print("\n" + key + " " + val);
+var migrationName = '20140823_remove_undefined_and_false_notifications';
+
+var authorName = 'Alys'; // in case script author needs to know when their ...
+var authorUuid = 'd904bd62-da08-416b-a816-ba797c9ee265'; //... own data is done
+
+/**
+ * https://github.com/HabitRPG/habitrpg/pull/3907
+ */
+
+var mongo = require('mongoskin');
+var _ = require('lodash');
+
+// XXX @lefnire, choose wisely:
+// var liveUsers = mongo.db('lefnire:mAdn3s5s@charlotte.mongohq.com:10015/habitrpg_large?auto_reconnect').collection('users');
+// var liveUsers = mongo.db('localhost:27017/habitrpg_old?auto_reconnect').collection('users');
+
+// For local testing by script author:
+// var liveUsers = mongo.db('localhost:27017/habitrpg?auto_reconnect').collection('users');
+
+
+var fields = {migration:1,newMessages:1};
+var progressCount = 1000;
+// var progressCount = 1;
+var count = 0;
+liveUsers.findEach({migration: {$ne:migrationName}}, fields, {batchSize:250}, function(err, user){
+  count++;
+  if (!user) err = '!user';
+  if (err) {return console.error(err);}
+
+ var newNewMessages = {};
+  _.each(user.newMessages,function(val,key){
+    // console.log(key + " " + val.name);
     if(key != "undefined" && val['value']){
       newNewMessages[key] = val;
     }
- }
+  })
 
-  db.users.update({_id: user._id}, {$set: {'newMessages': newNewMessages}});
+  liveUsers.update({_id:user._id}, {$set:{newMessages:newNewMessages, migration:migrationName}, $inc:{_v:1}});
+
+  if (count%progressCount == 0) console.log(count + ' ' + user._id);
+  if (user._id == '9') console.log('lefnire processed');
+  if (user._id == authorUuid) console.log(authorName + ' processed');
 });


### PR DESCRIPTION
Same script as in https://github.com/HabitRPG/habitrpg/pull/3907 but updated to use a node.js stream-based migration as described in https://github.com/HabitRPG/habitrpg/pull/3907#issuecomment-53522251

This script modifies all users' newMessages object to remove all guilds with the "undefined" key and all guilds with the false value for new messages.

@lefnire, this definitely needs you to check it before it's used. I was making it up as I went along. :) Note the "XXX" comment where you have to choose a database.

If this script is close to what you're after, I'll likely use it as a template for future scripts, so IFF you have time, I'd appreciate any comments you want to make.
