### PR TITLE
add Enable Class System button to User -> Stats when user has opted out

### DIFF
--- a/views/options/profile.jade
+++ b/views/options/profile.jade
@@ -194,6 +194,8 @@ mixin profileStats
             
            
       div(ng-class='user.flags.classSelected && !user.preferences.disableClasses ? "col-md-4" : "col-md-6"')
+        button.btn.btn-default(ng-if='user.preferences.disableClasses', ng-click='user.ops.changeClass({})', popover-trigger='mouseenter', popover-placement='right', popover=env.t('enableClassPop'))= env.t('enableClass')
+        hr(ng-if='user.preferences.disableClasses')
         include ../shared/profiles/achievements
 
 script(id='partials/options.profile.stats.html', type='text/ng-template')


### PR DESCRIPTION
Users often have trouble opting in to the class system because they don't think to look for the "Enable Class System" button under Settings. This change copies the button to the User -> Stats page ("Stats & Achievements").

I have not removed the button from Settings (maybe in future we can).

Here is what it looks like when the user has opted out:
![screen shot 2014-09-02 at 2 54 32 pm](https://cloud.githubusercontent.com/assets/1495809/4114278/a7bc4138-3264-11e4-9b67-894928a8990c.png)

And when the user hovers over the button:
![screen shot 2014-09-02 at 2 56 55 pm](https://cloud.githubusercontent.com/assets/1495809/4114281/b905f5ec-3264-11e4-9280-4aa4828b27f8.png)

When a player has opted-in, the page looks the same as it always did:
![screen shot 2014-09-02 at 2 53 33 pm](https://cloud.githubusercontent.com/assets/1495809/4114285/dbcf7d32-3264-11e4-9aa8-496e0aa3cc36.png)
