### PR TITLE
allow new tag to have same UUID on client and server - fixes https://github.com/HabitRPG/habitrpg/issues/2856 , fixes https://github.com/HabitRPG/habitrpg/issues/2370

### DIFF
--- a/public/js/controllers/filtersCtrl.js
+++ b/public/js/controllers/filtersCtrl.js
@@ -1,7 +1,7 @@
 "use strict";
 
-habitrpg.controller("FiltersCtrl", ['$scope', '$rootScope', 'User',
-  function($scope, $rootScope, User) {
+habitrpg.controller("FiltersCtrl", ['$scope', '$rootScope', 'User', 'Shared',
+  function($scope, $rootScope, User, Shared) {
     var user = User.user;
     $scope._editing = false;
 
@@ -30,7 +30,7 @@ habitrpg.controller("FiltersCtrl", ['$scope', '$rootScope', 'User',
     };
 
     $scope.createTag = function(name) {
-      User.user.ops.addTag({body:{name:name}});
+      User.user.ops.addTag({body:{name:name, id:Shared.uuid()}});
       $scope._newTag = '';
     };
 }]);


### PR DESCRIPTION
The problem was that addTag() was being run once on the client and then again on the server, and each time it was assigning its own (different) UUID.

This change sets the UUID before addTag() is called.
