### PR TITLE
Fix display of static new-stuff page

### DIFF
--- a/views/static/new-stuff.jade
+++ b/views/static/new-stuff.jade
@@ -15,6 +15,6 @@ html(ng-app='habitrpgStatic')
     meta(name='viewport', content='width=device-width, initial-scale=1.0')
 
     != env.getManifestFiles("static")
-
+    != env.getManifestFiles("app")
   body
     include ../shared/new-stuff


### PR DESCRIPTION
I noticed, that the app css file was missing, which caused the first news items and bailey to not display.
