### PR TITLE
add Help menu - fixes UI Trello card: Help/FAQs

### DIFF
--- a/public/css/menu.styl
+++ b/public/css/menu.styl
@@ -74,6 +74,7 @@
   hrpg-button-color-mixin($color-toolbar)
 // Top level menu items: Tasks – User – Social – Inventory
 .toolbar-nav
+  white-space: nowrap
   float:left;
   padding: 0.618em
   @media screen and (max-width:768px)

--- a/views/shared/header/menu.jade
+++ b/views/shared/header/menu.jade
@@ -43,11 +43,28 @@ nav.toolbar(ng-controller='AuthCtrl', ng-class='{active: isToolbarHidden}')
                 a(ui-sref='options.inventory.mounts')=env.t('mounts')
               li
                 a(ui-sref='options.inventory.equipment')=env.t('equipment')
+
+            ul.toolbar-submenu
+              li
+                a(target="_blank" href='http://habitrpg.wikia.com/wiki/FAQ')=env.t('FAQ')
+              li
+                a(target="_blank" href='https://github.com/HabitRPG/habitrpg/issues/2760')=env.t('reportBug')
+              li
+                a(target="_blank" href='https://habitrpg.com/#/options/groups/guilds/5481ccf3-5d2d-48a9-a871-70a7380cee5a')=env.t('askQuestion')
+              li
+                a(target="_blank" href='https://trello.com/c/odmhIqyW/440-read-first-table-of-contents')=env.t('requestAF')
+              li
+                a(target="_blank" href='http://habitrpg.wikia.com/wiki/Contributing_to_HabitRPG')=env.t('contributeToHRPG')
+              li
+                a(target="_blank" href='http://habitrpg.wikia.com/wiki/')=env.t('overview')
+
           ul.toolbar-controls
             li.toolbar-subscribe-button
               button(ng-if='!user.purchased.plan.customerId',ui-sref='options.settings.subscription',popover-trigger='mouseenter',popover-placement='bottom',popover-title=env.t('subscriptions'),popover=env.t('subDescription'),popover-append-to-body='true')=env.t('subscribe')
             li.toolbar-controls-button
               a(ng-click='expandMenu(null)')=env.t('close')
+
+
     ul.toolbar-nav
       li.toolbar-button
         a(ui-sref='tasks')
@@ -99,6 +116,27 @@ nav.toolbar(ng-controller='AuthCtrl', ng-class='{active: isToolbarHidden}')
               a(ui-sref='options.inventory.mounts')=env.t('mounts')
             li
               a(ui-sref='options.inventory.equipment')=env.t('equipment')
+
+      li.toolbar-button-dropdown
+        a(target="_blank" href='http://habitrpg.wikia.com/wiki/')
+          span=env.t('help')
+        a(ng-click='expandMenu("help")', ng-class='{active: _expandedMenu == "help"}')
+          span  &#9776;
+        div(ng-if='_expandedMenu == "help"')
+          ul.toolbar-submenu(ng-click='expandMenu(null)')
+            li
+              a(target="_blank" href='http://habitrpg.wikia.com/wiki/FAQ')=env.t('FAQ')
+            li
+              a(target="_blank" href='https://github.com/HabitRPG/habitrpg/issues/2760')=env.t('reportBug')
+            li
+              a(target="_blank" href='https://habitrpg.com/#/options/groups/guilds/5481ccf3-5d2d-48a9-a871-70a7380cee5a')=env.t('askQuestion')
+            li
+              a(target="_blank" href='https://trello.com/c/odmhIqyW/440-read-first-table-of-contents')=env.t('requestAF')
+            li
+              a(target="_blank" href='http://habitrpg.wikia.com/wiki/Contributing_to_HabitRPG')=env.t('contributeToHRPG')
+            li
+              a(target="_blank" href='http://habitrpg.wikia.com/wiki/')=env.t('overview')
+
     ul.toolbar-subscribe(ng-if='!user.purchased.plan.customerId')
       li.toolbar-subscribe-button
         button(ui-sref='options.settings.subscription',popover-trigger='mouseenter',popover-placement='bottom',popover-title=env.t('subscriptions'),popover=env.t('subDescription'),popover-append-to-body='true')=env.t('subscribe')

--- a/views/shared/header/menu.jade
+++ b/views/shared/header/menu.jade
@@ -43,7 +43,6 @@ nav.toolbar(ng-controller='AuthCtrl', ng-class='{active: isToolbarHidden}')
                 a(ui-sref='options.inventory.mounts')=env.t('mounts')
               li
                 a(ui-sref='options.inventory.equipment')=env.t('equipment')
-
             ul.toolbar-submenu
               li
                 a(target="_blank" href='http://habitrpg.wikia.com/wiki/FAQ')=env.t('FAQ')
@@ -57,14 +56,11 @@ nav.toolbar(ng-controller='AuthCtrl', ng-class='{active: isToolbarHidden}')
                 a(target="_blank" href='http://habitrpg.wikia.com/wiki/Contributing_to_HabitRPG')=env.t('contributeToHRPG')
               li
                 a(target="_blank" href='http://habitrpg.wikia.com/wiki/')=env.t('overview')
-
           ul.toolbar-controls
             li.toolbar-subscribe-button
               button(ng-if='!user.purchased.plan.customerId',ui-sref='options.settings.subscription',popover-trigger='mouseenter',popover-placement='bottom',popover-title=env.t('subscriptions'),popover=env.t('subDescription'),popover-append-to-body='true')=env.t('subscribe')
             li.toolbar-controls-button
               a(ng-click='expandMenu(null)')=env.t('close')
-
-
     ul.toolbar-nav
       li.toolbar-button
         a(ui-sref='tasks')
@@ -116,7 +112,6 @@ nav.toolbar(ng-controller='AuthCtrl', ng-class='{active: isToolbarHidden}')
               a(ui-sref='options.inventory.mounts')=env.t('mounts')
             li
               a(ui-sref='options.inventory.equipment')=env.t('equipment')
-
       li.toolbar-button-dropdown
         a(target="_blank" href='http://habitrpg.wikia.com/wiki/')
           span=env.t('help')
@@ -136,7 +131,6 @@ nav.toolbar(ng-controller='AuthCtrl', ng-class='{active: isToolbarHidden}')
               a(target="_blank" href='http://habitrpg.wikia.com/wiki/Contributing_to_HabitRPG')=env.t('contributeToHRPG')
             li
               a(target="_blank" href='http://habitrpg.wikia.com/wiki/')=env.t('overview')
-
     ul.toolbar-subscribe(ng-if='!user.purchased.plan.customerId')
       li.toolbar-subscribe-button
         button(ui-sref='options.settings.subscription',popover-trigger='mouseenter',popover-placement='bottom',popover-title=env.t('subscriptions'),popover=env.t('subDescription'),popover-append-to-body='true')=env.t('subscribe')


### PR DESCRIPTION
Requires https://github.com/HabitRPG/habitrpg-shared/pull/298

As requested by @lemoness in [UI Trello card: Help/FAQs](https://trello.com/c/qU5U2ILc/8-help-faqs), this adds a help menu to the site when viewed in a browser on a PC and in a browser on a mobile device. This does NOT add the menu to the mobile apps.

All links open in a new tab. They point to:
- Help: http://habitrpg.wikia.com/wiki/HabitRPG_Wiki [CHANGE THAT? Maybe point to FAQ?]
- FAQ: http://habitrpg.wikia.com/wiki/FAQ
- Report a Bug: https://github.com/HabitRPG/habitrpg/issues/2760
- Ask a Question: https://habitrpg.com/#/options/groups/guilds/5481ccf3-5d2d-48a9-a871-70a7380cee5a (Newbies guild)
- Request a Feature: https://trello.com/c/odmhIqyW/440-read-first-how-to-request-a-feature-table-of-contents
- Contribute to HabitRPG: http://habitrpg.wikia.com/wiki/Contributing_to_HabitRPG
- Overview for New Users: http://habitrpg.wikia.com/wiki/HabitRPG_Wiki

The top-level "Help" item and "Overview for New Users" currently point to the same place. Tell me if you want "Help" changed. Note that at the moment, "Help" does not appear in the mobile browser version for consistency with how the other menus are handled.

Screenshots on PC and mobile browser:
![screen shot 2014-09-05 at 8 48 56 pm](https://cloud.githubusercontent.com/assets/1495809/4163825/fa8dcc68-34eb-11e4-94f6-d4680cf8ef89.png)
![screenshot_2014-09-05-20-51-20](https://cloud.githubusercontent.com/assets/1495809/4163858/6b0a5b82-34ec-11e4-8c8f-7610f8fc0158.png)
