### PR TITLE
ngRepeat with track by

### DIFF
--- a/views/options/social/challenges.jade
+++ b/views/options/social/challenges.jade
@@ -50,7 +50,7 @@ script(type='text/ng-template', id='partials/options.social.challenges.detail.ht
       =env.t('exportChallengeCSV')
     h3=env.t('hows')
     menu
-      button.customize-option(ng-repeat='member in challenge.members', ng-click='toggleMember(challenge._id, member._id)') {{member.profile.name}}
+      button.customize-option(ng-repeat='member in challenge.members track by member._id', ng-click='toggleMember(challenge._id, member._id)') {{member.profile.name}}
   div(ui-view)
 
   // Accordion version if we choose that instead
@@ -135,7 +135,7 @@ script(type='text/ng-template', id='partials/options.social.challenges.html')
 
         // Challenges list
         .panel-group
-          .panel.panel-default(ng-repeat='challenge in challenges|filter:filterChallenges')
+          .panel.panel-default(ng-repeat='challenge in challenges|filter:filterChallenges track by challenge._id ')
             .panel-heading
               ul.pull-right.challenge-accordion-header-specs
                 li(ng-if='challenge.official')

--- a/views/options/social/chat-message.jade
+++ b/views/options/social/chat-message.jade
@@ -1,4 +1,4 @@
-li.chat-message(ng-repeat='message in group.chat', ng-class=':: {highlight: isUserMentioned(user,message) || message.uuid=="system", "own-message": user._id == message.uuid}')
+li.chat-message(ng-repeat='message in group.chat track by message.id', ng-class=':: {highlight: isUserMentioned(user,message) || message.uuid=="system", "own-message": user._id == message.uuid}')
   .scrollable-message
     span(ng-if='::message.uuid!="system"')
       a.label.label-default.chat-message.hidden-label

--- a/views/options/social/group.jade
+++ b/views/options/social/group.jade
@@ -60,7 +60,7 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
             ng-change='set({"party.order": user.party.order})'
             )
           table.table.table-striped(bindonce='group')
-            tr(ng-repeat='member in group.members')
+            tr(ng-repeat='member in group.members track by member._id')
               td
                 // allow leaders to ban members
                 div(ng-show='group.leader == user.id && user.id!=member._id')

--- a/views/options/social/index.jade
+++ b/views/options/social/index.jade
@@ -39,7 +39,7 @@ script(type='text/ng-template', id='partials/options.social.guilds.public.html')
   .col-md-3
     input.form-control(type='text',ng-model='guildSearch', placeholder=env.t('search'))
   table.table.table-striped
-    tr(ng-repeat='group in groups.public | filter:guildSearch')
+    tr(ng-repeat='group in groups.public | filter:guildSearch track by group._id')
       td
         ul.pull-right.challenge-accordion-header-specs
           li='{{::group.memberCount}} ' + env.t('members')
@@ -65,7 +65,7 @@ script(type='text/ng-template', id='partials/options.social.guilds.html')
     li(ng-class="{ active: $state.includes('options.social.guilds.public') }")
       a(ui-sref='options.social.guilds.public')
         =env.t('publicGuilds')
-    li(ng-class="{ active: $stateParams.gid == group._id }", ng-repeat='group in groups.guilds')
+    li(ng-class="{ active: $stateParams.gid == group._id }", ng-repeat='group in groups.guilds track by group._id')
       a(ui-sref="options.social.guilds.detail({gid:group._id})")
         | {{group.name}}
     li(ng-class="{ active: $state.includes('options.social.guilds.create') }")

--- a/views/shared/tasks/task.jade
+++ b/views/shared/tasks/task.jade
@@ -1,4 +1,4 @@
-li(bindonce='list', bo-id='"task-"+task.id', ng-repeat='task in obj[list.type+"s"]', class='task {{Shared.taskClasses(task, user.filters, user.preferences.dayStart, user.lastCron, list.showCompleted, main)}}', ng-click='spell && castEnd(task, "task", $event)', ng-class='{"cast-target":spell}', popover-trigger='mouseenter', popover-placement='top', popover='{{task.notes}}')
+li(bindonce='list', bo-id='"task-"+task.id', ng-repeat='task in obj[list.type+"s"] track by task.id', class='task {{Shared.taskClasses(task, user.filters, user.preferences.dayStart, user.lastCron, list.showCompleted, main)}}', ng-click='spell && castEnd(task, "task", $event)', ng-class='{"cast-target":spell}', popover-trigger='mouseenter', popover-placement='top', popover='{{task.notes}}')
   // right-hand side control buttons
   .task-meta-controls
 


### PR DESCRIPTION
ng-Repeat without using track by , creates always many "angular" versions of an object AND the underlying html (every time new DOM will be created) , which causes the browser to do ALOT of work while refresh of a ngRepeat Array.

More Information on track by : 
- http://www.bennadel.com/blog/2556-using-track-by-with-ngrepeat-in-angularjs-1-2.htm
- http://www.codelord.net/2014/04/15/improving-ng-repeat-performance-with-track-by/

This could fix or speed up (I don't have that many guilds / challenges / chats in my local server^^) following issues:
- #3663 
- #3486 
- #1884
- #1451
- #1499

I've tested on my local server, with a good number of todos, without trackby I nearly had an "unresponsive script" error, but with trackby the "sync" was VERY fast.

Using track by could also speed up mobile (haven't looked there yet)
