### PR TITLE
add Cancel button for quests, allow party to cancel/abort if quest owner missing, add Debug tools for quest testing

### DIFF
--- a/public/js/controllers/footerCtrl.js
+++ b/public/js/controllers/footerCtrl.js
@@ -54,6 +54,11 @@
      * Debug functions. Note that the server route for gems is only available if process.env.DEBUG=true
      */
     if (_.contains(['development','test'],window.env.NODE_ENV)) {
+      $scope.setHealthLow = function(){
+        User.set({
+          'stats.hp': 1
+        });
+      }
       $scope.addMissedDay = function(){
         if (!confirm("Are you sure you want to reset the day?")) return;
         var dayBefore = moment(User.user.lastCron).subtract('days', 1).toDate();
@@ -65,11 +70,16 @@
           User.log({});
         })
       }
+      $scope.addGold = function(){
+        User.set({
+          'stats.gp': User.user.stats.gp + 500,
+        });
+      }
       $scope.addLevelsAndGold = function(){
         User.set({
           'stats.exp': User.user.stats.exp + 10000,
-          'stats.gp': User.user.stats.gp + 10000,
-          'stats.mp': User.user.stats.mp + 10000
+          'stats.gp':  User.user.stats.gp  + 10000,
+          'stats.mp':  User.user.stats.mp  + 10000
         });
       }
       $scope.addOneLevel = function(){
@@ -77,6 +87,10 @@
           'stats.exp': User.user.stats.exp + (Math.round(((Math.pow(User.user.stats.lvl, 2) * 0.25) + (10 * User.user.stats.lvl) + 139.75) / 10) * 10)
         });
       }
+      $scope.addBossQuestProgressUp = function(){
+        User.set({
+          'party.quest.progress.up': User.user.party.quest.progress.up + 1000
+        });
+      }
     }
-
   }])

--- a/public/js/controllers/groupsCtrl.js
+++ b/public/js/controllers/groupsCtrl.js
@@ -3,6 +3,24 @@
 habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '$http', 'API_URL', '$q', 'User', 'Members', '$state',
   function($scope, $rootScope, Shared, Groups, $http, API_URL, $q, User, Members, $state) {
 
+      $scope.isMemberOfPendingQuest = function(userid, group){
+		if (!group.quest || !group.quest.members) return false;
+		if (group.quest.active) return false; // quest is started, not pending
+		return userid in group.quest.members && group.quest.members[userid] != false;
+	  }
+
+      $scope.isMemberOfRunningQuest = function(userid, group){
+		if (!group.quest || !group.quest.members) return false;
+		if (!group.quest.active) return false; // quest is pending, not started
+		return group.quest.members[userid];
+	  }
+
+      $scope.isMemberOfGroup = function(userid, group){
+		if (!group.members) return false;
+		var memberIds = _.map(group.members, function(x){return x._id});
+        return ~(memberIds.indexOf(userid));
+      }
+
       $scope.isMember = function(user, group){
         return ~(group.members.indexOf(user._id));
       }
@@ -362,11 +380,17 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '
         User.set({'invitations.party':{}});
       }
 
+      $scope.questCancel = function(){
+        if (!confirm(window.env.t('sureCancel'))) return;
+        $rootScope.party.$questCancel();
+      }
+
       $scope.questAbort = function(){
         if (!confirm(window.env.t('sureAbort'))) return;
         if (!confirm(window.env.t('doubleSureAbort'))) return;
         $rootScope.party.$questAbort();
       }
+
     }
   ])
 

--- a/public/js/services/groupServices.js
+++ b/public/js/services/groupServices.js
@@ -19,6 +19,7 @@ angular.module('groupServices', ['ngResource']).
             removeMember: {method: "POST", url: API_URL + '/api/v2/groups/:gid/removeMember'},
             questAccept: {method: "POST", url: API_URL + '/api/v2/groups/:gid/questAccept'},
             questReject: {method: "POST", url: API_URL + '/api/v2/groups/:gid/questReject'},
+            questCancel: {method: "POST", url: API_URL + '/api/v2/groups/:gid/questCancel'},
             questAbort: {method: "POST", url: API_URL + '/api/v2/groups/:gid/questAbort'}
           });
 

--- a/src/routes/apiv2.coffee
+++ b/src/routes/apiv2.coffee
@@ -465,10 +465,18 @@ module.exports = (swagger, v2) ->
       middleware: [auth.auth, i18n.getUserLanguage, groups.attachGroup]
       action: groups.questReject
 
+    "/groups/{gid}/questCancel":
+      spec:
+        method: 'POST'
+        description: 'Cancel quest before it starts (in invitation stage)'
+        parameters: [path('gid','Group to cancel quest in','string')]
+      middleware: [auth.auth, i18n.getUserLanguage, groups.attachGroup]
+      action: groups.questCancel
+
     "/groups/{gid}/questAbort":
       spec:
         method: 'POST'
-        description: 'Abort quest'
+        description: 'Abort quest after it has started (all progress will be lost)'
         parameters: [path('gid','Group to abort quest in','string')]
       middleware: [auth.auth, i18n.getUserLanguage, groups.attachGroup]
       action: groups.questAbort

--- a/views/options/social/boss.jade
+++ b/views/options/social/boss.jade
@@ -11,7 +11,6 @@ mixin boss(tavern, mobile)
             td
               span(ng-if=':: group.quest.leader && group.quest.leader==member._id && isMemberOfGroup(group.quest.leader,group) && isMemberOfPendingQuest(group.quest.leader,group)')
                 |*&nbsp;
-                // XXX does this trigger badly when ex-leader reenters group?
               {{::member.profile.name}}
             td {{group.quest.members[member._id] === true ? env.t('accepted') : group.quest.members[member._id] === false ? env.t('rejected') : env.t('pending')}}
 

--- a/views/options/social/boss.jade
+++ b/views/options/social/boss.jade
@@ -9,16 +9,23 @@ mixin boss(tavern, mobile)
         table.table.table-striped
           tr(ng-repeat='member in group.members')
             td
-              span(ng-if=':: group.quest.leader==member._id')
+              span(ng-if=':: group.quest.leader && group.quest.leader==member._id')
                 |*&nbsp;
               {{::member.profile.name}}
             td {{group.quest.members[member._id] === true ? env.t('accepted') : group.quest.members[member._id] === false ? env.t('rejected') : env.t('pending')}}
+        //span(ng-if=':: group.quest.leader && group.members.indexOf(group.quest.leader) > -1')
         |*&nbsp;
         =env.t('questOwner')
+        br
+        span(ng-if=':: !group.quest.leader') no quest leader
+        br
+        span(ng-if=':: group.members.indexOf(group.quest.leader) == -1') not in group
+        // span(ng-if=':: !group.quest.leader || group.members.indexOf(group.quest.leader) == -1')=env.t('questOwnerMIA')
         hr
         .npc_ian.pull-left
         p=env.t('questStart')
-        button.btn.btn-sm.btn-warning(ng-if=':: !group.quest.leader || group.quest.leader==user._id', ng-click='party.$questAccept({"force":true})')=env.t('begin')
+        button.btn.btn-sm.btn-warning(ng-if=':: !group.quest.leader || group.members.indexOf(group.quest.leader) == -1 || group.quest.leader==user._id', ng-click='party.$questAccept({"force":true})')=env.t('begin')
+        //button.btn.btn-sm.btn-warning(ng-if=':: !group.quest.leader || group.members.indexOf(group.quest.leader) == -1 || group.quest.leader==user._id', ng-click='party.$questCancel()')=env.t('cancel')
         //-TODO Cancel button
         //-TODO Both force-start & cancel should only be available to quest-initiator
 
@@ -65,8 +72,10 @@ mixin boss(tavern, mobile)
                 span(ng-if=':: group.quest.leader==v._id')
                   |*&nbsp;
                 {{::v.profile.name}}
-          |*&nbsp;
-          =env.t('questOwner')
+          // span(ng-if=':: group.quest.leader && group.members.indexOf(group.quest.leader) > -1')
+            // |*&nbsp;
+            // =env.t('questOwner')
+          // span(ng-if=':: !group.quest.leader || group.members.indexOf(group.quest.leader) == -1')=env.t('questOwnerMIA')
         quest-rewards(key='{{::group.quest.key}}')
 
         div(ng-if='::Content.quests[group.quest.key].boss')
@@ -86,4 +95,4 @@ mixin boss(tavern, mobile)
 
 
         unless tavern
-          button.btn.btn-xs.btn-danger(ng-if='::!group.quest.leader || group.quest.leader==user._id', ng-click='questAbort()')=env.t('abort')
+          button.btn.btn-xs.btn-danger(ng-if='::!group.quest.leader || group.members.indexOf(group.quest.leader) == -1 || group.quest.leader==user._id', ng-click='questAbort()')=env.t('abort')

--- a/views/options/social/boss.jade
+++ b/views/options/social/boss.jade
@@ -9,25 +9,27 @@ mixin boss(tavern, mobile)
         table.table.table-striped
           tr(ng-repeat='member in group.members')
             td
-              span(ng-if=':: group.quest.leader && group.quest.leader==member._id')
+              span(ng-if=':: group.quest.leader && group.quest.leader==member._id && isMemberOfGroup(group.quest.leader,group) && isMemberOfPendingQuest(group.quest.leader,group)')
                 |*&nbsp;
+                // XXX does this trigger badly when ex-leader reenters group?
               {{::member.profile.name}}
             td {{group.quest.members[member._id] === true ? env.t('accepted') : group.quest.members[member._id] === false ? env.t('rejected') : env.t('pending')}}
-        //span(ng-if=':: group.quest.leader && group.members.indexOf(group.quest.leader) > -1')
-        |*&nbsp;
-        =env.t('questOwner')
-        br
-        span(ng-if=':: !group.quest.leader') no quest leader
-        br
-        span(ng-if=':: group.members.indexOf(group.quest.leader) == -1') not in group
-        // span(ng-if=':: !group.quest.leader || group.members.indexOf(group.quest.leader) == -1')=env.t('questOwnerMIA')
+
+        span(ng-if=':: group.quest.leader && isMemberOfGroup(group.quest.leader,group) && isMemberOfPendingQuest(group.quest.leader,group)')
+          |*&nbsp;
+          =env.t('questOwner')
+        span(ng-if=':: group.quest.leader && isMemberOfGroup(group.quest.leader,group) && ! isMemberOfPendingQuest(group.quest.leader,group)')
+          =env.t('questOwnerNotInPendingQuest')
+        span(ng-if=':: ! group.quest.leader || ! isMemberOfGroup(group.quest.leader,group)')
+          =env.t('questOwnerNotInPendingQuestParty')
         hr
         .npc_ian.pull-left
         p=env.t('questStart')
-        button.btn.btn-sm.btn-warning(ng-if=':: !group.quest.leader || group.members.indexOf(group.quest.leader) == -1 || group.quest.leader==user._id', ng-click='party.$questAccept({"force":true})')=env.t('begin')
-        //button.btn.btn-sm.btn-warning(ng-if=':: !group.quest.leader || group.members.indexOf(group.quest.leader) == -1 || group.quest.leader==user._id', ng-click='party.$questCancel()')=env.t('cancel')
-        //-TODO Cancel button
-        //-TODO Both force-start & cancel should only be available to quest-initiator
+
+        // only the quest owner sees the begin button:
+        button.btn.btn-sm.btn-warning(ng-if=':: group.quest.leader  && group.quest.leader==user._id && isMemberOfGroup(group.quest.leader,group) && isMemberOfPendingQuest(group.quest.leader,group)', ng-click='party.$questAccept({"force":true})')=env.t('begin')
+        // only the quest owner sees the cancel button UNLESS the quest owner is no longer in the quest/party and then everyone sees it:
+        button.btn.btn-sm.btn-danger(ng-if=':: (group.quest.leader  && group.quest.leader==user._id && isMemberOfGroup(group.quest.leader,group) && isMemberOfPendingQuest(group.quest.leader,group)) || (! group.quest.leader || ! isMemberOfGroup(group.quest.leader,group) || ! isMemberOfPendingQuest(group.quest.leader,group))', ng-click='questCancel()')=env.t('cancel')
 
       div(ng-if='group.quest.active==true')
         div(ng-if='::Content.quests[group.quest.key].boss',ng-init='boss=Content.quests[group.quest.key].boss;progress=group.quest.progress')
@@ -69,13 +71,17 @@ mixin boss(tavern, mobile)
           table.table.table-striped
             tr(ng-repeat='(k,v) in group.members', ng-show='group.quest.members[v._id]')
               td
-                span(ng-if=':: group.quest.leader==v._id')
+                span(ng-if=':: group.quest.leader && group.quest.leader==v._id && isMemberOfGroup(group.quest.leader,group) && isMemberOfRunningQuest(group.quest.leader,group)')
                   |*&nbsp;
                 {{::v.profile.name}}
-          // span(ng-if=':: group.quest.leader && group.members.indexOf(group.quest.leader) > -1')
-            // |*&nbsp;
-            // =env.t('questOwner')
-          // span(ng-if=':: !group.quest.leader || group.members.indexOf(group.quest.leader) == -1')=env.t('questOwnerMIA')
+          span(ng-if=':: group.quest.leader && isMemberOfGroup(group.quest.leader,group) && isMemberOfRunningQuest(group.quest.leader,group)')
+            |*&nbsp;
+            =env.t('questOwner')
+          span(ng-if=':: group.quest.leader && isMemberOfGroup(group.quest.leader,group) && ! isMemberOfRunningQuest(group.quest.leader,group)')
+            =env.t('questOwnerNotInRunningQuest')
+          span(ng-if=':: ! group.quest.leader || ! isMemberOfGroup(group.quest.leader,group)')
+            =env.t('questOwnerNotInRunningQuestParty')
+
         quest-rewards(key='{{::group.quest.key}}')
 
         div(ng-if='::Content.quests[group.quest.key].boss')
@@ -93,6 +99,6 @@ mixin boss(tavern, mobile)
           br
           p=env.t('bossColl2')
 
-
         unless tavern
-          button.btn.btn-xs.btn-danger(ng-if='::!group.quest.leader || group.members.indexOf(group.quest.leader) == -1 || group.quest.leader==user._id', ng-click='questAbort()')=env.t('abort')
+          // only the quest owner sees the abort button UNLESS the quest owner is no longer in the quest/party and then everyone sees it:
+          button.btn.btn-sm.btn-warning(ng-if=':: (group.quest.leader  && group.quest.leader==user._id && isMemberOfGroup(group.quest.leader,group) && isMemberOfRunningQuest(group.quest.leader,group)) || ! group.quest.leader || ! isMemberOfGroup(group.quest.leader,group) || ! isMemberOfRunningQuest(group.quest.leader,group)', ng-click='questAbort()')=env.t('abort')

--- a/views/shared/footer.jade
+++ b/views/shared/footer.jade
@@ -74,10 +74,13 @@ footer.footer(ng-controller='FooterCtrl')
         else if (env.NODE_ENV==='development' || env.NODE_ENV==='test') && !env.isStaticPage
           h4 Debug
           .btn-group-vertical
+            a.btn.btn-default(ng-click='setHealthLow()') Health = 1
             a.btn.btn-default(ng-click='addMissedDay()') +1 Missed Day
             a.btn.btn-default(ng-click='addTenGems()') +10 Gems
-            a.btn.btn-default(ng-click='addLevelsAndGold()') +Exp +GP
+            a.btn.btn-default(ng-click='addGold()') +GP
+            a.btn.btn-default(ng-click='addLevelsAndGold()') +Exp +GP +MP
             a.btn.btn-default(ng-click='addOneLevel()') +1 Level
+            a.btn.btn-default(ng-click='addBossQuestProgressUp()') +1000 Boss Quest Progress Up
 
   div(ng-init='deferredScripts()')
 


### PR DESCRIPTION
Requires https://github.com/HabitRPG/habitrpg-shared/pull/302

There's a few parts to this but all related:
- When a party member is removed from a party, also remove them from the group.quest.members list.
- Add Cancel button for quests in invite stage, and API cancel function. I.e., the quest owner can either Begin or Cancel a quest. If the quest owner has been removed from the party, then any party member can cancel (quest owner keeps the scroll).
- If the quest owner has left the quest or left the party and another owner has not been assigned, the text under the participant list explains this.
- If the quest owner has left the quest or left the party and another owner has not been assigned, any party member can now abort the quest (or cancel it if it hasn't started yet). See below for why. Quest owner regains the scroll.
- New Debug tools in footer to make it easier to test quest behaviour (that's the only reason for changes to `public/js/controllers/footerCtrl.js` and `views/shared/footer.jade`).
- Minor text improvements and removing an outdated comment.

Reasons for allowing any party member to abort quest when quest owner is gone:

With the current site code, it's possible for parties to get into a state where they can't start a new quest or are stuck in a quest that's too hard/slow for them, because the quest owner is no longer in the party or is in the party but is not in the quest [1]. The worst case is that no one now in the party is participating in the quest, so the quest will never finish.

If the quest owner left voluntarily, then a new quest owner would have been assigned and the quest would continue as normal, but that does not happen (and should not happen?) when the quest owner is removed from the party by the party leader. When the quest owner is no longer part of the quest, this PR lets any party member cancel the quest before it has begun, or abort it while it is running.

I realise that allowing any member to abort a running quest is open to abuse, but I think it's a better situation than having a party stuck in a quest that they have no control over (especially if none of them are participating in the quest). The current workaround for that situation is for everyone to leave the party and form a new one, which is annoying to do and which is not an obvious solution - parties need to be told to do that by support staff.

I think the chances of abuse are relatively low, and would only occur in parties that had already got themselves into a bad situation.

A party cannot use this to steal a scroll from a quest owner, because when the quest is aborted, the scroll returns to the owner even if the owner is not in the party. From this point of view, I think allowing any party member to abort a quest when the quest owner has been forcibly removed is LESS open to abuse than assigning a new quest owner when the original owner has been booted. That latter case would let the new quest owner steal the scroll.

It would be possible to allow a quest to be aborted by only the party leader after the quest owner has left, but that wouldn't help in cases where the party leader is no longer using HabitRPG. Allowing any party member to abort gives all stuck parties the opportunity to remove unwanted quests.

[1] A quest owner can be in a party but not part of the quest if the leader boots them out while the quest is running but then someone else invites them back in.
