### PR TITLE
add support for pushTaskToBottom to help with To-Do sort order bug

### DIFF
--- a/public/js/controllers/tasksCtrl.js
+++ b/public/js/controllers/tasksCtrl.js
@@ -41,6 +41,14 @@ habitrpg.controller("TasksCtrl", ['$scope', '$rootScope', '$location', 'User','N
     $scope.clearDoneTodos = function() {};
 
     /**
+     * Pushes task to top or bottom of list
+     */
+    $scope.pushTask = function(task, index, location) {
+      var to = (location === 'bottom') ? -1 : 0;
+      User.user.ops.sortTask({params:{id:task.id},query:{from:index, to:to}})
+    };
+
+    /**
      * This is calculated post-change, so task.completed=true if they just checked it
      */
     $scope.changeCheck = function(task) {

--- a/views/shared/tasks/task.jade
+++ b/views/shared/tasks/task.jade
@@ -70,9 +70,10 @@ li(bindonce='list', bo-id='"task-"+task.id', ng-repeat='task in obj[list.type+"s
 
     // Daily & Todos
     span.task-checker.action-yesno(bo-if='task.type=="daily" || task.type=="todo"')
-      input.visuallyhidden.focusable(ng-if='$state.includes("tasks")', id='box-{{obj._id}}_{{task.id}}', type='checkbox', ng-model='task.completed', ng-change='changeCheck(task)')
+      input.visuallyhidden.focusable(ng-if='$state.includes("tasks")', id='box-{{obj._id}}_{{task.id}}', type='checkbox', ng-model='task.completed', ng-change='User.user.ops.sortTask({params:{id:task.id},query:{from:$index, to:-1}}); changeCheck(task)')
       input.visuallyhidden.focusable(ng-if='!$state.includes("tasks")', id='box-{{obj._id}}_{{task.id}}', type='checkbox')
       label(for='box-{{obj._id}}_{{task.id}}')
+
   // main content
   div.task-text(ng-dblclick='task._editing ? saveTask(task) : editTask(task)')
     markdown(ng-model='task.text',target='_blank')

--- a/views/shared/tasks/task.jade
+++ b/views/shared/tasks/task.jade
@@ -14,10 +14,11 @@ li(bindonce='list', bo-id='"task-"+task.id', ng-repeat='task in obj[list.type+"s
 
     // Icons only available if you own the tasks (aka, hidden from challenge stats)
     span(ng-if='!obj._locked')
-      a(ng-click='User.user.ops.sortTask({params:{id:task.id},query:{from:$index, to:0}})', tooltip=env.t('pushTaskToTop'))
+      a(ng-click='pushTask(task,$index,"top")', tooltip=env.t('pushTaskToTop'))
         span.glyphicon.glyphicon-open
-      a(ng-click='User.user.ops.sortTask({params:{id:task.id},query:{from:$index, to:-1}})', tooltip=env.t('pushTaskToBottom'))
+      a(ng-click='pushTask(task,$index,"bottom")', tooltip=env.t('pushTaskToBottom'))
         span.glyphicon.glyphicon-import
+        // glyphicon-import or glyphicon-save or glyphicon-sort-by-attributes
       a.badge(ng-if='task.checklist[0]', ng-class='{"badge-success":checklistCompletion(task.checklist) == task.checklist.length}', ng-click='collapseChecklist(task)', tooltip=env.t('expandCollapse'))
         {{checklistCompletion(task.checklist)}}/{{task.checklist.length}}
       span.glyphicon.glyphicon-tags(tooltip='{{Shared.appliedTags(user.tags, task.tags)}}', ng-hide='Shared.noTags(task.tags)')
@@ -72,7 +73,7 @@ li(bindonce='list', bo-id='"task-"+task.id', ng-repeat='task in obj[list.type+"s
 
     // Daily & Todos
     span.task-checker.action-yesno(bo-if='task.type=="daily" || task.type=="todo"')
-      input.visuallyhidden.focusable(ng-if='$state.includes("tasks")', id='box-{{obj._id}}_{{task.id}}', type='checkbox', ng-model='task.completed', ng-change='User.user.ops.sortTask({params:{id:task.id},query:{from:$index, to:-1}}); changeCheck(task)')
+      input.visuallyhidden.focusable(ng-if='$state.includes("tasks")', id='box-{{obj._id}}_{{task.id}}', type='checkbox', ng-model='task.completed', ng-change='pushTask(task,$index,"bottom"); changeCheck(task)')
       input.visuallyhidden.focusable(ng-if='!$state.includes("tasks")', id='box-{{obj._id}}_{{task.id}}', type='checkbox')
       label(for='box-{{obj._id}}_{{task.id}}')
 

--- a/views/shared/tasks/task.jade
+++ b/views/shared/tasks/task.jade
@@ -16,9 +16,9 @@ li(bindonce='list', bo-id='"task-"+task.id', ng-repeat='task in obj[list.type+"s
     span(ng-if='!obj._locked')
       a(ng-click='pushTask(task,$index,"top")', tooltip=env.t('pushTaskToTop'))
         span.glyphicon.glyphicon-open
-      a(ng-click='pushTask(task,$index,"bottom")', tooltip=env.t('pushTaskToBottom'))
-        span.glyphicon.glyphicon-import
-        // glyphicon-import or glyphicon-save or glyphicon-sort-by-attributes
+      // a(ng-click='pushTask(task,$index,"bottom")', tooltip=env.t('pushTaskToBottom'))
+      //   span.glyphicon.glyphicon-import
+      //   // glyphicon-import or glyphicon-save or glyphicon-sort-by-attributes
       a.badge(ng-if='task.checklist[0]', ng-class='{"badge-success":checklistCompletion(task.checklist) == task.checklist.length}', ng-click='collapseChecklist(task)', tooltip=env.t('expandCollapse'))
         {{checklistCompletion(task.checklist)}}/{{task.checklist.length}}
       span.glyphicon.glyphicon-tags(tooltip='{{Shared.appliedTags(user.tags, task.tags)}}', ng-hide='Shared.noTags(task.tags)')

--- a/views/shared/tasks/task.jade
+++ b/views/shared/tasks/task.jade
@@ -16,6 +16,8 @@ li(bindonce='list', bo-id='"task-"+task.id', ng-repeat='task in obj[list.type+"s
     span(ng-if='!obj._locked')
       a(ng-click='User.user.ops.sortTask({params:{id:task.id},query:{from:$index, to:0}})', tooltip=env.t('pushTaskToTop'))
         span.glyphicon.glyphicon-open
+      a(ng-click='User.user.ops.sortTask({params:{id:task.id},query:{from:$index, to:-1}})', tooltip=env.t('pushTaskToBottom'))
+        span.glyphicon.glyphicon-import
       a.badge(ng-if='task.checklist[0]', ng-class='{"badge-success":checklistCompletion(task.checklist) == task.checklist.length}', ng-click='collapseChecklist(task)', tooltip=env.t('expandCollapse'))
         {{checklistCompletion(task.checklist)}}/{{task.checklist.length}}
       span.glyphicon.glyphicon-tags(tooltip='{{Shared.appliedTags(user.tags, task.tags)}}', ng-hide='Shared.noTags(task.tags)')


### PR DESCRIPTION
Requires https://github.com/HabitRPG/habitrpg-shared/pull/304

Implements SabreCat's idea for a workaround for the To-Do sorting bug: https://github.com/HabitRPG/habitrpg/issues/2606#issuecomment-53584917
I.e., this PR causes a To-Do to be moved to the bottom of the list when the To-Do is marked as completed.

This PR also adds a "Push task to bottom" button, but it's commented out until we decide if we want it. I would like to use the button, but I'm not sure it's worth the extra icon clutter. Perhaps we can enable it in future when we've hidden some icons by default until the user hovers over the task.
