### PR TITLE
hide Plain Egg mounts and remove them from totalMounts count - fixes https://github.com/HabitRPG/habitrpg/issues/3240

### DIFF
--- a/public/js/controllers/inventoryCtrl.js
+++ b/public/js/controllers/inventoryCtrl.js
@@ -8,7 +8,7 @@ habitrpg.controller("InventoryCtrl", ['$rootScope', '$scope', '$window', 'User',
     $scope.selectedEgg = null; // {index: 1, name: "Tiger", value: 5}
     $scope.selectedPotion = null; // {index: 5, name: "Red", value: 3}
     $scope.totalPets = _.size(Content.dropEggs) * _.size(Content.hatchingPotions);
-    $scope.totalMounts = _.size(Content.eggs) * _.size(Content.hatchingPotions);
+    $scope.totalMounts = _.size(_.reject(Content.eggs,function(egg){return egg.noMount})) * _.size(Content.hatchingPotions);
 
     // count egg, food, hatchingPotion stack totals
     var countStacks = function(items) { return _.reduce(items,function(m,v){return m+v;},0);}

--- a/views/options/inventory/stable.jade
+++ b/views/options/inventory/stable.jade
@@ -14,15 +14,17 @@ script(type='text/ng-template', id='partials/options.inventory.mounts.html')
       .col-md-12
         menu.pets(type='list')
           each egg in env.Content.eggs
-            li.customize-menu
-              menu
-                each potion in env.Content.hatchingPotions
-                  - mount = egg.key+"-"+potion.key
-                  div(popover-trigger='mouseenter', popover=env.t('mountName', {potion: potion.text(env.language.code), mount: egg.mountText(env.language.code)}), popover-placement='bottom')
-                    button(class="pet-button Mount_Head_#{mount}", ng-show='user.items.mounts["#{mount}"]', ng-class='{active: user.items.currentMount == "#{mount}"}', ng-click='chooseMount("#{egg.key}", "#{potion.key}")')
-                      //div(class='Mount_Head_{{mount}}')
-                    button(class="pet-button pet-not-owned", ng-hide='user.items.mounts["#{mount}"]')
-                      .PixelPaw
+            -if(!egg.noMount) {
+              li.customize-menu
+                menu
+                  each potion in env.Content.hatchingPotions
+                    - mount = egg.key+"-"+potion.key
+                    div(popover-trigger='mouseenter', popover=env.t('mountName', {potion: potion.text(env.language.code), mount: egg.mountText(env.language.code)}), popover-placement='bottom')
+                      button(class="pet-button Mount_Head_#{mount}", ng-show='user.items.mounts["#{mount}"]', ng-class='{active: user.items.currentMount == "#{mount}"}', ng-click='chooseMount("#{egg.key}", "#{potion.key}")')
+                        //div(class='Mount_Head_{{mount}}')
+                      button(class="pet-button pet-not-owned", ng-hide='user.items.mounts["#{mount}"]')
+                        .PixelPaw
+            -}
       .col-md-12
         h4=env.t('rareMounts')
         menu


### PR DESCRIPTION
Requires https://github.com/HabitRPG/habitrpg-shared/pull/308 which adds a "noMount" flag to the Plain Eggs.

Any egg with noMount:true is not counted in the total number of possible mounts and does not have a space reserved for it on the Mounts page.
