### PR TITLE
improve and clarify party avatar sort options for header - fixes https://github.com/HabitRPG/habitrpg/issues/2239

### DIFF
--- a/public/js/controllers/groupsCtrl.js
+++ b/public/js/controllers/groupsCtrl.js
@@ -202,6 +202,8 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '
       'random': window.env.t('sortRandom'),
       'pets': window.env.t('sortPets'),
       'party_date_joined': window.env.t('sortJoined'),
+      'name': window.env.t('sortName'),
+      'backgrounds': window.env.t('sortBackgrounds'),
     };
 
   }])

--- a/public/js/controllers/headerCtrl.js
+++ b/public/js/controllers/headerCtrl.js
@@ -22,6 +22,12 @@ habitrpg.controller("HeaderCtrl", ['$scope', 'Groups', 'User',
               case 'pets':
                 return member.items.pets.length;
                 break;
+              case 'name':
+                return member.profile.name;
+                break;
+              case 'backgrounds':
+                return member.preferences.background;
+                break;
               default:
                 // party date joined
                 return true;

--- a/views/options/social/group.jade
+++ b/views/options/social/group.jade
@@ -50,15 +50,15 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
         .panel-heading
           h3.panel-title=env.t('members')
         .panel-body.modal-fixed-height
-          span
+          div(ng-if='group.type=="party"')
             =env.t('partyList')
-            |&nbsp;
-          select#partyOrder(
-            ng-model='user.party.order',
-            ng-controller='ChatCtrl',
-            ng-options='k as v for (k , v) in partyOrderChoices',
-            ng-change='set({"party.order": user.party.order})'
-            )
+            br
+            select#partyOrder(
+              ng-model='user.party.order',
+              ng-controller='ChatCtrl',
+              ng-options='k as v for (k , v) in partyOrderChoices',
+              ng-change='set({"party.order": user.party.order})'
+              )
           table.table.table-striped(bindonce='group')
             tr(ng-repeat='member in group.members')
               td


### PR DESCRIPTION
Requires https://github.com/HabitRPG/habitrpg-shared/pull/309
- add sort by avatar name (sort order is Z -> A due to how the original code is written [there are good reasons]; can be fixed later if needed)
- add sort by background (avatars with no backgrounds appear at end)
- clarify wording for sort option to indicate that it's only for the avatars in the header, not for the list of party member names
- remove sort feature from guilds pages because it has nothing to do with guilds
