### PR TITLE
fixing guild reject error (issue #2886)-correcting syntax

### DIFF
--- a/public/js/controllers/groupsCtrl.js
+++ b/public/js/controllers/groupsCtrl.js
@@ -305,7 +305,7 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '
         var i = _.findIndex(User.user.invitations.guilds, {id:guild.id});
         if (~i){
           User.user.invitations.guilds.splice(i, 1);
-          User.set('invitations.guilds', User.user.invitations.guilds);
+          User.set({'invitations.guilds':User.user.invitations.guilds});
         }
       }
     }


### PR DESCRIPTION
Changed syntax in database call to actually update the database when a guild invitation is rejected, fixes issue 2886
