### PR TITLE
Make .meter-text nowrap to prevent truncation

### DIFF
--- a/public/css/header.styl
+++ b/public/css/header.styl
@@ -158,6 +158,7 @@
     top: 0
     z-index: 4
     line-height: 1.618
+    white-space: nowrap
     &.value
       right: 0.382em
       


### PR DESCRIPTION
- Add white-space: nowrap to .meter-text to prevent the meter text from
  being cut off when the meter is very short and its content is long
  (mainly an issue with the experience bar, which can easily have a bar
  graph symbol plus one four-digit number over another e.g. 1,234 /
  5,678)

Before:
![nowrap-before](https://cloud.githubusercontent.com/assets/3482833/4490407/e21f2cea-4a2a-11e4-8344-f5048a1da47e.png)
After:
![nowrap-after](https://cloud.githubusercontent.com/assets/3482833/4490408/e3e46a5e-4a2a-11e4-9a3b-6890f30ff9ac.png)
Note that these are screenshots of my actual HabitRPG account, the second with CSS modified with Firefox Web Developer; since the problem only appears if one has a very large number of party members, I didn't know how to test it on my local instance without manually making ten test accounts, inviting each to a party, and then manually accepting the invitation from each, which I thought would rather be too much effort for a trivial one-line patch.

Interestingly, the bar actually becomes long enough that the problem goes away if the window is resized to be narrow enough, so this might not be the "right" solution. Still, I don't think there's any harm in preventing the meter text from wrapping anyway.
