### PR TITLE
extra Help menu entries for only staff/moderators (community management links)

### DIFF
--- a/views/shared/header/menu.jade
+++ b/views/shared/header/menu.jade
@@ -131,6 +131,14 @@ nav.toolbar(ng-controller='AuthCtrl', ng-class='{active: isToolbarHidden}')
               a(target="_blank" href='http://habitrpg.wikia.com/wiki/Contributing_to_HabitRPG')=env.t('contributeToHRPG')
             li
               a(target="_blank" href='http://habitrpg.wikia.com/wiki/')=env.t('overview')
+            li(ng-if='user.contributor.admin')
+              a(target="_blank" href='https://plus.google.com/communities/107256308489730347629') [admin] G+ HabitRPG Contrib Guild
+            li(ng-if='user.contributor.admin')
+              a(target="_blank" href='https://docs.google.com/document/d/1isA0ZbaG30-PzLDnDPGU62A0HkZgBchkZYZBd6y8K4k/edit#') [admin] Super Secret Mod Cabal Documentation
+            li(ng-if='user.contributor.admin')
+              a(target="_blank" href='https://docs.google.com/spreadsheets/d/1SpipRYb-YAGHJMI8U53zLIBFUwvHwJQRZf0XV__4Gf0/edit') [admin] Socialite Level Tracker
+            li(ng-if='user.contributor.admin')
+              a(target="_blank" href='https://docs.google.com/spreadsheets/d/1hDomwTWAyV1AbfvqYLv3rH83m8zsXeKScjbV08PJJog/edit') [admin] Community Issues
     ul.toolbar-subscribe(ng-if='!user.purchased.plan.customerId')
       li.toolbar-subscribe-button
         button(ui-sref='options.settings.subscription',popover-trigger='mouseenter',popover-placement='bottom',popover-title=env.t('subscriptions'),popover=env.t('subDescription'),popover-append-to-body='true')=env.t('subscribe')


### PR DESCRIPTION
Adds links to the bottom of the Help menu for various documents used by staff and moderators. This links are visible to only players who have the "admin" flag set. Requested by Breadstrings in https://plus.google.com/114447825469587375506/posts/eFSCmDTsLxr

![screen shot 2014-10-03 at 8 24 57 am](https://cloud.githubusercontent.com/assets/1495809/4499464/111c99da-4a83-11e4-92ab-99386d0e6d26.png)

@lemoness : Is this okay?
