### PR TITLE
Notification for Unallocated Attribute Points (fixes #4109)

### DIFF
--- a/public/js/controllers/authCtrl.js
+++ b/public/js/controllers/authCtrl.js
@@ -94,5 +94,30 @@ angular.module('authCtrl', [])
       $scope.expandMenu = function(menu) {
         $scope._expandedMenu = ($scope._expandedMenu == menu) ? null : menu;
       };
+
+      function selectNotificationValue(mysteryValue, invitationValue, messageValue, noneValue) {
+        var user = $scope.user;
+        if (user.purchased.plan.mysteryItems.length) {
+          return mysteryValue;
+        } else if ((user.invitations.party && user.invitations.party.id) || user.invitations.guilds.length > 0) {
+          return invitationValue;
+        } else if (!(_.isEmpty(user.newMessages))) {
+          return messageValue;
+        } else {
+          return noneValue;
+        }
+      };
+
+      $scope.iconClasses = function() {
+        return selectNotificationValue(
+            "glyphicon-gift",
+            "glyphicon-user",
+            "glyphicon-comment",
+            "glyphicon-comment inactive");
+      };
+
+      $scope.hasNoNotifications = function() {
+        return selectNotificationValue(false, false, false, true);
+      }
     }
 ]);

--- a/public/js/controllers/authCtrl.js
+++ b/public/js/controllers/authCtrl.js
@@ -97,9 +97,9 @@ angular.module('authCtrl', [])
 
       function selectNotificationValue(mysteryValue, invitationValue, unallocatedValue, messageValue, noneValue) {
         var user = $scope.user;
-        if (user.purchased.plan.mysteryItems.length) {
+        if (user.purchased && user.purchased.plan && user.purchased.plan.mysteryItems && user.purchased.plan.mysteryItems.length) {
           return mysteryValue;
-        } else if ((user.invitations.party && user.invitations.party.id) || user.invitations.guilds.length > 0) {
+        } else if ((user.invitations.party && user.invitations.party.id) || (user.invitations.guilds && user.invitations.guilds.length > 0)) {
           return invitationValue;
         } else if (user.flags.classSelected && !(user.preferences && user.preferences.disableClasses) && user.stats.points) {
           return unallocatedValue;

--- a/public/js/controllers/authCtrl.js
+++ b/public/js/controllers/authCtrl.js
@@ -95,12 +95,14 @@ angular.module('authCtrl', [])
         $scope._expandedMenu = ($scope._expandedMenu == menu) ? null : menu;
       };
 
-      function selectNotificationValue(mysteryValue, invitationValue, messageValue, noneValue) {
+      function selectNotificationValue(mysteryValue, invitationValue, unallocatedValue, messageValue, noneValue) {
         var user = $scope.user;
         if (user.purchased.plan.mysteryItems.length) {
           return mysteryValue;
         } else if ((user.invitations.party && user.invitations.party.id) || user.invitations.guilds.length > 0) {
           return invitationValue;
+        } else if (user.flags.classSelected && !(user.preferences && user.preferences.disableClasses) && user.stats.points) {
+          return unallocatedValue;
         } else if (!(_.isEmpty(user.newMessages))) {
           return messageValue;
         } else {
@@ -112,12 +114,13 @@ angular.module('authCtrl', [])
         return selectNotificationValue(
             "glyphicon-gift",
             "glyphicon-user",
+            "glyphicon-plus-sign",
             "glyphicon-comment",
             "glyphicon-comment inactive");
       };
 
       $scope.hasNoNotifications = function() {
-        return selectNotificationValue(false, false, false, true);
+        return selectNotificationValue(false, false, false, false, true);
       }
     }
 ]);

--- a/views/shared/header/menu.jade
+++ b/views/shared/header/menu.jade
@@ -155,6 +155,10 @@ nav.toolbar(ng-controller='AuthCtrl', ng-class='{active: isToolbarHidden}')
                 a(ui-sref='options.social.guilds', ng-click='expandMenu(null)')
                   span.glyphicon.glyphicon-user
                   span=env.t('invitedTo', {name: '{{guild.name}}'})
+              li(ng-if='user.flags.classSelected && !user.preferences.disableClasses && user.stats.points')
+                a(ui-sref='options.profile.stats', ng-click='expandMenu(null)')
+                  span.glyphicon.glyphicon-plus-sign
+                  span=env.t('haveUnallocated', {points: '{{user.stats.points}}'})
               li(ng-repeat='(k,v) in user.newMessages', ng-if='v.value')
                 a(ng-click='k==party._id ? $state.go("options.social.party") : $state.go("options.social.guilds.detail",{gid:k}); expandMenu(null)')
                   span.glyphicon.glyphicon-comment

--- a/views/shared/header/menu.jade
+++ b/views/shared/header/menu.jade
@@ -137,14 +137,12 @@ nav.toolbar(ng-controller='AuthCtrl', ng-class='{active: isToolbarHidden}')
     ul.toolbar-options  
       li.toolbar-notifs
         a(ng-click='expandMenu("notifs")')
-          span.glyphicon.glyphicon-comment(ng-if='!user.invitations.party.id && !user.purchased.plan.mysteryItems.length && user.invitations.guilds.length === 0', ng-class='{inactive: _.isEmpty(user.newMessages)}')
-          span.glyphicon.glyphicon-user(ng-if='!user.purchased.plan.mysteryItems.length && (user.invitations.party.id || user.invitations.guilds.length > 0)')
-          span.glyphicon.glyphicon-gift(ng-if='user.purchased.plan.mysteryItems.length')
+          span.glyphicon(ng-class='iconClasses()')
         div(ng-if='_expandedMenu=="notifs"')
           h4=env.t('notifications')
           div
             ul.toolbar-notifs-notifs
-              li.toolbar-notifs-no-messages(ng-if='!user.invitations.party.id && !user.purchased.plan.mysteryItems.length && user.invitations.guilds.length === 0 && _.isEmpty(user.newMessages)')=env.t('noNotifications')
+              li.toolbar-notifs-no-messages(ng-if='hasNoNotifications()')=env.t('noNotifications')
               li(ng-if='user.purchased.plan.mysteryItems.length')
                 a(ng-click='$state.go("options.inventory.drops"); expandMenu(null)')
                   span.glyphicon.glyphicon-gift


### PR DESCRIPTION
Adds a notification when a player has unallocated attribute points. In addition to checking for unallocated attribute points, it checks the same condition used to determine whether to display the section on attribute points in the Stats & Achievements page.

To facilitate this, some of the logic conditions in the original notification code were refactored out into several controller methods in authCtrl.js. (I basically learned Angular yesterday, so I don't know if this arrangement makes sense, but it seems to work.)
![unallocated-1](https://cloud.githubusercontent.com/assets/3482833/4515512/3a2dc940-4bc1-11e4-9369-36e493417810.png)
![unallocated-2](https://cloud.githubusercontent.com/assets/3482833/4515513/3a2ebada-4bc1-11e4-9e96-b0c11bd4d5a3.png)
