### PR TITLE
Putting the boot icon on the same line as the member name in group members

### DIFF
--- a/views/options/social/group.jade
+++ b/views/options/social/group.jade
@@ -61,12 +61,12 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
               )
           table.table.table-striped(bindonce='group')
             tr(ng-repeat='member in group.members track by member._id')
-              td
+              td.media
                 // allow leaders to ban members
-                div(ng-show='group.leader == user.id && user.id!=member._id')
-                  a(ng-click='removeMember(group, member, true)')
+                div.pull-left(ng-show='group.leader == user.id && user.id!=member._id')
+                  a.media-object(ng-click='removeMember(group, member, true)')
                     span.glyphicon.glyphicon-ban-circle(tooltip=env.t('banTip'))
-                a
+                a.media-body
                   span(ng-class='{"badge badge-info": group.leader==member._id}', ng-click='clickMember(member._id, true)')
                     | {{member.profile.name}}
             tr(ng-if='group.memberCount > group.members.length')


### PR DESCRIPTION
This was bugging me, since before this change the members of a group take up a ton of vertical space. I'm using the [bootstrap media component](http://getbootstrap.com/components/#media) so no additional CSS needed to be written. This works well for both admins and non-admins, and I tested it using the provided HabitRPG Vagrant box. 

Here's a before/after comparison:

![image](https://cloud.githubusercontent.com/assets/629982/4547500/a7059b18-4e4d-11e4-850a-a3d58178cc33.png)

![image](https://cloud.githubusercontent.com/assets/629982/4547482/8a501c50-4e4d-11e4-8b4a-a9c027f38d0c.png)
