### PR TITLE
prevent "Warning: missing space before text for line [nn] of jade file ..."

### DIFF
--- a/views/options/social/boss.jade
+++ b/views/options/social/boss.jade
@@ -11,7 +11,7 @@ mixin boss(tavern, mobile)
             td
               span(ng-if=':: group.quest.leader && group.quest.leader==member._id && isMemberOfGroup(group.quest.leader,group) && isMemberOfPendingQuest(group.quest.leader,group)')
                 |*&nbsp;
-              {{::member.profile.name}}
+              |{{::member.profile.name}}
             td {{group.quest.members[member._id] === true ? env.t('accepted') : group.quest.members[member._id] === false ? env.t('rejected') : env.t('pending')}}
 
         span(ng-if=':: group.quest.leader && isMemberOfGroup(group.quest.leader,group) && isMemberOfPendingQuest(group.quest.leader,group)')
@@ -72,7 +72,7 @@ mixin boss(tavern, mobile)
               td
                 span(ng-if=':: group.quest.leader && group.quest.leader==v._id && isMemberOfGroup(group.quest.leader,group) && isMemberOfRunningQuest(group.quest.leader,group)')
                   |*&nbsp;
-                {{::v.profile.name}}
+                |{{::v.profile.name}}
           span(ng-if=':: group.quest.leader && isMemberOfGroup(group.quest.leader,group) && isMemberOfRunningQuest(group.quest.leader,group)')
             |*&nbsp;
             =env.t('questOwner')

--- a/views/options/social/challenge-box.jade
+++ b/views/options/social/challenge-box.jade
@@ -2,7 +2,7 @@
 .panel.panel-default
   .panel-heading
     h3.panel-title=env.t('challenges')
-      &nbsp;
+      |&nbsp;
       a.pull-right(target='_blank', href='https://trello.com/card/challenges-individual-party-guild-public/50e5d3684fe3a7266b0036d6/58')
         small=env.t('moreInfo')
   .panel-body.modal-fixed-height(bindonce='group.challenges')

--- a/views/options/social/challenges.jade
+++ b/views/options/social/challenges.jade
@@ -105,7 +105,7 @@ script(type='text/ng-template', id='partials/options.social.challenges.html')
 
               .form-group
                 input.form-control(type='text', minlength="3", maxlength="16", ng-model='newChallenge.shortName', placeholder=env.t('challengeTag'), required)
-                &nbsp;
+                |&nbsp;
                 a.hint.vertical-20(target='_blank', href='http://habitrpg.wikia.com/wiki/Tags', popover=env.t('challengeTagPop'), popover-trigger='mouseenter', popover-placement='right')
                   =env.t('moreInfo')
 
@@ -119,7 +119,7 @@ script(type='text/ng-template', id='partials/options.social.challenges.html')
               .form-group
                 input.form-control(type='number', min="{{newChallenge.group=='habitrpg' ? 1 : 0}}", max="{{maxPrize}}", ng-model='newChallenge.prize', placeholder=env.t('prize'))
                 span.input-suffix.Pet_Currency_Gem1x.inline-gems
-                &nbsp;
+                |&nbsp;
                 span.hint.vertical-20(popover=env.t('prizePop'), popover-trigger='mouseenter', popover-placement='right')
                   =env.t('moreInfo')
                 span(ng-show='newChallenge.group=="habitrpg"')

--- a/views/options/social/group.jade
+++ b/views/options/social/group.jade
@@ -91,7 +91,7 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
             //.alert.alert-danger(ng-show='_groupError') {{_groupError}}
             .form-group
               input.form-control(type='text', placeholder=env.t('userId'), ng-model='group.invitee')
-              &nbsp;
+              |&nbsp;
               input.btn.btn-default(type='submit', value=env.t('invite'))
 
 

--- a/views/shared/tasks/task.jade
+++ b/views/shared/tasks/task.jade
@@ -20,7 +20,7 @@ li(bindonce='list', bo-id='"task-"+task.id', ng-repeat='task in obj[list.type+"s
       //   span.glyphicon.glyphicon-import
       //   // glyphicon-import or glyphicon-save or glyphicon-sort-by-attributes
       a.badge(ng-if='task.checklist[0]', ng-class='{"badge-success":checklistCompletion(task.checklist) == task.checklist.length}', ng-click='collapseChecklist(task)', tooltip=env.t('expandCollapse'))
-        {{checklistCompletion(task.checklist)}}/{{task.checklist.length}}
+        |{{checklistCompletion(task.checklist)}}/{{task.checklist.length}}
       span.glyphicon.glyphicon-tags(tooltip='{{Shared.appliedTags(user.tags, task.tags)}}', ng-hide='Shared.noTags(task.tags)')
       // edit
       a(ng-hide='task._editing', ng-click='editTask(task)', tooltip=env.t('edit'))


### PR DESCRIPTION
When reloading pages in my local install, I was noticing the warnings below. This change makes them go away.

```
Warning: missing space before text for line 23 of jade file "/vagrant/views/shared/tasks/task.jade"
Warning: missing space before text for line 100 of jade file "/vagrant/views/options/social/challenges.jade"
Warning: missing space before text for line 114 of jade file "/vagrant/views/options/social/challenges.jade"
Warning: missing space before text for line 14 of jade file "/vagrant/views/options/social/boss.jade"
Warning: missing space before text for line 70 of jade file "/vagrant/views/options/social/boss.jade"
Warning: missing space before text for line 5 of jade file "/vagrant/views/options/social/challenge-box.jade"
Warning: missing space before text for line 5 of jade file "/vagrant/views/options/social/challenge-box.jade"
Warning: missing space before text for line 94 of jade file "/vagrant/views/options/social/group.jade"
Warning: missing space before text for line 5 of jade file "/vagrant/views/options/social/challenge-box.jade"
Warning: missing space before text for line 94 of jade file "/vagrant/views/options/social/group.jade"
```

NB: Some of the line numbers don't match reality because the warning mechanism seems to not count comments and blank lines.
