### PR TITLE
allow Daily to stay visible while being edited

### DIFF
--- a/public/js/controllers/tasksCtrl.js
+++ b/public/js/controllers/tasksCtrl.js
@@ -193,6 +193,8 @@ habitrpg.controller("TasksCtrl", ['$scope', '$rootScope', '$location', 'User','N
      */
 
     $scope.shouldShow = function(task, list, prefs){
+      if (task._editing) // never hide a task while being edited
+        return true;
       if (task.type == 'habit' || task.type == 'todo' || task.type == 'reward')
         return true;
       var shouldDo = task.type == 'daily' ? habitrpgShared.shouldDo(new Date, task.repeat, prefs) : true;


### PR DESCRIPTION
https://github.com/HabitRPG/habitrpg/pull/3574 / https://github.com/HabitRPG/habitrpg/pull/4129 added tabs to Dailies (All/Due/Grey). This change allows a Daily to remain visible while it is open for editing, even if the edits have cause it to belong in a different tab than it was in when you started editing it.
