### PR TITLE
Tags (filters) saves when pressing Enter instead of deleting

### DIFF
--- a/public/js/controllers/filtersCtrl.js
+++ b/public/js/controllers/filtersCtrl.js
@@ -20,7 +20,7 @@ habitrpg.controller("FiltersCtrl", ['$scope', '$rootScope', 'User', 'Shared',
         tagsSnap = _.object(_.pluck(tagsSnap,'id'), tagsSnap);
         $scope._editing = true;
       }
-    }
+    };
 
     $scope.toggleFilter = function(tag) {
       user.filters[tag.id] = !user.filters[tag.id];
@@ -32,5 +32,11 @@ habitrpg.controller("FiltersCtrl", ['$scope', '$rootScope', 'User', 'Shared',
     $scope.createTag = function(name) {
       User.user.ops.addTag({body:{name:name, id:Shared.uuid()}});
       $scope._newTag = '';
+    };
+    
+    $scope.checkKeyForSaving = function($event) {
+      if($event.keyCode === 13) {
+        $scope.saveOrEdit();
+      }
     };
 }]);

--- a/views/main/filters.jade
+++ b/views/main/filters.jade
@@ -26,8 +26,8 @@
         ul(ng-if='_editing')
           li.filters-edit(ng-class='{active: user.filters[tag.id]}', ng-repeat='tag in user.tags', bindonce='user.tags')
             form.hrpg-input-group
-              input(type='text', ng-model='tag.name')
-              button(ng-click='user.ops.deleteTag({params:{id:tag.id}})')
+              input(type='text', ng-model='tag.name', ng-keyup='checkKeyForSaving($event)')
+              button(type='button', ng-click='user.ops.deleteTag({params:{id:tag.id}})')
                 span.glyphicon.glyphicon-trash
         ul(ng-if='!_editing', hrpg-sort-tags)
           li.filters-tags(ng-class='{active: user.filters[tag.id], challenge: tag.challenge}', ng-repeat='tag in user.tags', bindonce='user.tags')


### PR DESCRIPTION
This is for https://github.com/HabitRPG/habitrpg/issues/3983. The issue was that when editing a tag, when you pressed Enter, it would delete the tag you were editing. It was a legitimate annoyance. Now hitting enter instead saves the changes instead of deleting.
Technical details: when using < button >, if you don't set a type it will default to type="submit". When the < button > is a submit, and especially if it's a single input outside of the button, Enter is assumed to be a submission AND is considered a mouse click. Changing the button's type to type="button" however stops the Enter key from submitting. From there, just setup a ng-keyup function to check for the Enter key, and if so, save.
