### PR TITLE
Popovers now disappear when clicking Save & Close

### DIFF
--- a/public/js/controllers/tasksCtrl.js
+++ b/public/js/controllers/tasksCtrl.js
@@ -64,11 +64,13 @@ habitrpg.controller("TasksCtrl", ['$scope', '$rootScope', '$location', 'User','N
       User.user.ops.deleteTask({params:{id:list[$index].id}})
     };
 
-    $scope.saveTask = function(task, stayOpen) {
+    $scope.saveTask = function(task, stayOpen, isSaveAndClose) {
       if (task.checklist)
         task.checklist = _.filter(task.checklist,function(i){return !!i.text});
       User.user.ops.updateTask({params:{id:task.id},body:task});
       if (!stayOpen) task._editing = false;
+      if (isSaveAndClose)
+        $("#task-" + task.id).parent().children('.popover').removeClass('in');
     };
 
     /**

--- a/views/shared/tasks/task.jade
+++ b/views/shared/tasks/task.jade
@@ -143,7 +143,7 @@ li(bindonce='list', bo-id='"task-"+task.id', ng-repeat='task in obj[list.type+"s
                 input.inline-edit(type='text',ng-model='item.text',ui-keydown="{'8 46':'removeChecklistItem(task,$event,$index)'}",ui-keyup="{'13':'addChecklistItem(task,$event,$index)','38 40':'navigateChecklist(task,$index,$event)'}")
 
 
-      form(ng-submit='saveTask(task)')
+      form(ng-submit='saveTask(task,false,true)')
         // text & notes
         fieldset.option-group
           label.option-title=env.t('text')


### PR DESCRIPTION
https://github.com/HabitRPG/habitrpg/issues/3977: When clicking the Save & Close button for tasks that have a comment, the popover would stay visible instead of fading out. This is incorrect behavior since the popover shouldn't display as the mouse is no longer with that task. Furthermore, the popover would fade out after double clicking the task, or clicking the checkmark. This commit fixes these behaviors by "closing" the popover when Save & Close is clicked, and keeping the popover when double clicking the task or clicking the checkmark.
**Technical details**: I modified saveTask to allow an extra argument - isSaveAndClose. If true, it will then find the current element based on the task ID, get its parent (as the popover is a part of the parent, NOT a part of the form), finds the child node with the popover class, and then removes it's "in" class. This finding method ensures that we only grab the popover for this task, just in case later on we allow multiple popovers to occur elsewhere. By removing "in", it allows the popover to fade out like usual instead of popping out of existence. With this change, the form was modified to pass the appropriate bool value of true for isSaveAndClose. Since the only submit is Save & Close, it should be safe to assume that making it pass true to isSaveAndClose shouldn't affect anything else.
