### PR TITLE
Front page's Forgot Password will report an invalid email address instead of simply errorring. Does NOT include updated locals/en/front.json

### DIFF
--- a/public/js/controllers/authCtrl.js
+++ b/public/js/controllers/authCtrl.js
@@ -82,13 +82,17 @@ angular.module('authCtrl', [])
       };
 
       $scope.passwordReset = function(email){
-        $http.post(ApiUrlService.get() + '/api/v2/user/reset-password', {email:email})
-          .success(function(){
-            alert(window.env.t('newPassSent'));
-          })
-          .error(function(data){
-            alert(data.err);
-          });
+        if(email == null || email.length == 0) {
+          alert(window.env.t('invalidEmail'));
+        } else {
+          $http.post(ApiUrlService.get() + '/api/v2/user/reset-password', {email:email})
+            .success(function(){
+              alert(window.env.t('newPassSent'));
+            })
+            .error(function(data){
+                alert(data.err);
+            });
+          }
       };
 
       $scope.expandMenu = function(menu) {

--- a/views/static/login-modal.jade
+++ b/views/static/login-modal.jade
@@ -39,12 +39,12 @@ script(id='modals/login.html', type='text/ng-template')
                 a(data-toggle="collapse" data-parent="#forgot-password" href="#forgot-password-panel")=env.t('forgotPass')
           
             .panel-body.collapse#forgot-password-panel
-              form(ng-submit='passwordReset(passwordResetEmail)')
+              form(name='passwordResetForm', ng-submit='passwordReset(passwordResetEmail)', novalidate)
                 //.alert.alert-success {.success.passwordReset}
                 //.control-group.{#if..errors.passwordReset}error{/}
                 h3=env.t('emailNewPass')
                 .form-group
-                  input.form-control(type='text', name='email', placeholder=env.t('email') , ng-model='passwordResetEmail')
+                  input.form-control(type='email', name='email', placeholder=env.t('email') , ng-model='passwordResetEmail')
                   //span.help-inline {.errors.passwordReset}
                 .form-group
                   input.btn.btn-default(type='submit', value=env.t('submit'))


### PR DESCRIPTION
**Issue:** https://github.com/HabitRPG/habitrpg/issues/3815
**Referenced Pull Request:** https://github.com/HabitRPG/habitrpg-shared/pull/338
The issue with Forgot Password had to do with entering nothing at all in the field and submitting. There was also no validation on the email input.
**Technical Details:** Since the passed variable into authCtrl.resetPassword was null from nothing being in the field, the "Cannot call method `replace` of undefined" error would appear. To make things more appropriate, Angular email validation was implemented. I did give the form a name to try other things, but it probably isn't needed anymore, but doesn't affect anything by being in there. In the authCtrl.resetPassword function, it first checks to see if the email passed in is not null and has a length == 0. If either are true, a message general stating "please input a valid email address" appears via alert(). The language file was updated to show this message. To find this commit, please refer to the reference pull request.
