### PR TITLE
Issue #3477 (again) - Fixed admin email address display text from admin@gmail.com 

### DIFF
--- a/views/static/contact.jade
+++ b/views/static/contact.jade
@@ -14,7 +14,7 @@ block content
         h1=env.t('contactUs')
       p
         | Report Account Problems: 
-        a(href='mailto:admin@habitrpg.com') admin&commat;gmail&period;com
+        a(href='mailto:admin@habitrpg.com') admin&commat;habitrpg&period;com
         br
         | Report a Bug: 
         a(target='_blank', href='https://github.com/HabitRPG/habitrpg/issues?q=is%3Aopen') Github


### PR DESCRIPTION
to admin@habitrpg.com.
