### PR TITLE
Changed margin .row under .container-fluid to match padding

### DIFF
--- a/public/css/shared.styl
+++ b/public/css/shared.styl
@@ -42,6 +42,9 @@ a.hint:hover
   .container-fluid
     padding-right: 5px
     padding-left: 5px
+    > .row
+      margin-left: -5px
+      margin-right: -5px
   .tasks-lists .row .col-md-3
     padding-right: 0
     padding-left: 0


### PR DESCRIPTION
The default padding for `.container-fluid` is `0 15px`, and the margin for `.row` is `0 -15px` to compensate. The padding for `.container-fluid` was overridden to be `0 5px`, so I changed the `.row` directly under it to have the margin `0 -5px`.

The reason it matters is that when the window width is smaller than the md screen size screen, you get 20px of overflow because of the mismatch.
