### PR TITLE
Fixed classes so padding would be correct on party tab

### DIFF
--- a/views/options/social/create-group.jade
+++ b/views/options/social/create-group.jade
@@ -1,25 +1,23 @@
-.container-fluid
-  .row
-    form.col-md-12.form-horizontal(ng-submit='create(newGroup)')
-      .form-group
-        label.control-label(for='new-group-name')=env.t('newGroupName', {groupType: "{{text}}"})
-        input.form-control#new-group-name.input-medium.option-content(required, type='text', placeholder=env.t('newGroupName', {groupType: "{{text}}"}), ng-model='newGroup.name')
-      .form-group
-        label(for='new-group-description')=env.t('description')
-        textarea.form-control#new-group-description.option-content(cols='3', placeholder=env.t('description'), ng-model='newGroup.description')
-      .form-group(ng-show='type=="guild"')
-        .radio
-          label
-            input(type='radio', name='new-group-privacy', value='public', ng-model='newGroup.privacy')
-            =env.t('public')
-        .radio
-          label
-            input(type='radio', name='new-group-privacy', value='private', ng-model='newGroup.privacy')
-            =env.t('inviteOnly')
-        br
-        input.btn.btn-default(type='submit', ng-disabled='!newGroup.privacy && !newGroup.name', value=env.t('create'))
-        span.gem-cost= '4 ' + env.t('gems')
-        p
-          small=env.t('gemCost')
-      .form-group(ng-show='type=="party"')
-        input.btn.btn-default.form-control(type='submit', value=env.t('create'))
+form.col-md-12.form-horizontal(ng-submit='create(newGroup)')
+  .form-group
+    label.control-label(for='new-group-name')=env.t('newGroupName', {groupType: "{{text}}"})
+    input.form-control#new-group-name.input-medium.option-content(required, type='text', placeholder=env.t('newGroupName', {groupType: "{{text}}"}), ng-model='newGroup.name')
+  .form-group
+    label(for='new-group-description')=env.t('description')
+    textarea.form-control#new-group-description.option-content(cols='3', placeholder=env.t('description'), ng-model='newGroup.description')
+  .form-group(ng-show='type=="guild"')
+    .radio
+      label
+        input(type='radio', name='new-group-privacy', value='public', ng-model='newGroup.privacy')
+        =env.t('public')
+    .radio
+      label
+        input(type='radio', name='new-group-privacy', value='private', ng-model='newGroup.privacy')
+        =env.t('inviteOnly')
+    br
+    input.btn.btn-default(type='submit', ng-disabled='!newGroup.privacy && !newGroup.name', value=env.t('create'))
+    span.gem-cost= '4 ' + env.t('gems')
+    p
+      small=env.t('gemCost')
+  .form-group(ng-show='type=="party"')
+    input.btn.btn-default.form-control(type='submit', value=env.t('create'))

--- a/views/options/social/index.jade
+++ b/views/options/social/index.jade
@@ -12,11 +12,11 @@ script(type='text/ng-template', id='partials/options.social.party.html')
   div(ng-if='group._id')
     include ./group
   div(ng-if='!group._id')
-    div(ng-show='user.invitations.party.id')
+    div(ng-show='user.invitations.party.id').container-fluid
       h2=env.t('invitedTo', {name: '{{user.invitations.party.name}}'})
       a.btn.btn-success(data-type='party', ng-click='join(user.invitations.party)')=env.t('accept')
       a.btn.btn-danger(ng-click='reject()')=env.t('reject')
-    div(ng-hide='user.invitations.party.id')
+    div(ng-hide='user.invitations.party.id').container-fluid
       h2=env.t('createAParty')
       p
         =env.t('noPartyText')


### PR DESCRIPTION
The bootstrap classes (`.container-fluid`) for the party tab, when not in a party yet, were put in the wrong spots and it was causing padding issues. By shuffling around where the container-fluid class lives, the issue is fixed.

The only change to `create-group.jade` file was removing the `.container-fluid` and `.row` classes and removing the extra tabs.

![padding-issue](https://cloud.githubusercontent.com/assets/2916945/4682795/d9d935ec-5620-11e4-9f0c-728e149d7f89.jpg)

**Note:** since  `.container-fluid` has padding, and the h2 tags have a `margin-top: 20px` style, it may preferable to set an inline style on the `.container-fluid` or `h2` elements so that they aren't pushed down as far as they are now. Do you have a preference?
