### PR TITLE
remove fix for case where quest owner has abandoned the party - fixes https://github.com/HabitRPG/habitrpg/issues/4074

### DIFF
--- a/views/options/social/boss.jade
+++ b/views/options/social/boss.jade
@@ -17,18 +17,22 @@ mixin boss(tavern, mobile)
         span(ng-if=':: group.quest.leader && isMemberOfGroup(group.quest.leader,group) && isMemberOfPendingQuest(group.quest.leader,group)')
           |*&nbsp;
           =env.t('questOwner')
-        span(ng-if=':: group.quest.leader && isMemberOfGroup(group.quest.leader,group) && ! isMemberOfPendingQuest(group.quest.leader,group)')
-          =env.t('questOwnerNotInPendingQuest')
-        span(ng-if=':: ! group.quest.leader || ! isMemberOfGroup(group.quest.leader,group)')
-          =env.t('questOwnerNotInPendingQuestParty')
+        // This is commented-out until we have time to work out why it fails intermittently on the website and always on the mobile app (https://github.com/HabitRPG/habitrpg/issues/4074):
+        // span(ng-if=':: group.quest.leader && isMemberOfGroup(group.quest.leader,group) && ! isMemberOfPendingQuest(group.quest.leader,group)')
+          // =env.t('questOwnerNotInPendingQuest')
+        // span(ng-if=':: ! group.quest.leader || ! isMemberOfGroup(group.quest.leader,group)')
+          // =env.t('questOwnerNotInPendingQuestParty')
         hr
         .npc_ian.pull-left
         p=env.t('questStart')
 
         // only the quest owner sees the begin button:
         button.btn.btn-sm.btn-warning(ng-if=':: group.quest.leader  && group.quest.leader==user._id && isMemberOfGroup(group.quest.leader,group) && isMemberOfPendingQuest(group.quest.leader,group)', ng-click='party.$questAccept({"force":true})')=env.t('begin')
-        // only the quest owner sees the cancel button UNLESS the quest owner is no longer in the quest/party and then everyone sees it:
-        button.btn.btn-sm.btn-danger(ng-if=':: (group.quest.leader  && group.quest.leader==user._id && isMemberOfGroup(group.quest.leader,group) && isMemberOfPendingQuest(group.quest.leader,group)) || (! group.quest.leader || ! isMemberOfGroup(group.quest.leader,group) || ! isMemberOfPendingQuest(group.quest.leader,group))', ng-click='questCancel()')=env.t('cancel')
+        // // only the quest owner sees the cancel button UNLESS the quest owner is no longer in the quest/party and then everyone sees it:
+        // This is commented-out until we have time to work out why it fails intermittently on the website and always on the mobile app (https://github.com/HabitRPG/habitrpg/issues/4074):
+        // button.btn.btn-sm.btn-danger(ng-if=':: (group.quest.leader  && group.quest.leader==user._id && isMemberOfGroup(group.quest.leader,group) && isMemberOfPendingQuest(group.quest.leader,group)) || (! group.quest.leader || ! isMemberOfGroup(group.quest.leader,group) || ! isMemberOfPendingQuest(group.quest.leader,group))', ng-click='questCancel()')=env.t('cancel')
+        // only the quest owner sees the cancel button:
+        button.btn.btn-sm.btn-danger(ng-if=':: (group.quest.leader  && group.quest.leader==user._id && isMemberOfGroup(group.quest.leader,group) && isMemberOfPendingQuest(group.quest.leader,group))', ng-click='questCancel()')=env.t('cancel')
 
       div(ng-if='group.quest.active==true')
         div(ng-if='::Content.quests[group.quest.key].boss',ng-init='boss=Content.quests[group.quest.key].boss;progress=group.quest.progress')
@@ -76,10 +80,11 @@ mixin boss(tavern, mobile)
           span(ng-if=':: group.quest.leader && isMemberOfGroup(group.quest.leader,group) && isMemberOfRunningQuest(group.quest.leader,group)')
             |*&nbsp;
             =env.t('questOwner')
-          span(ng-if=':: group.quest.leader && isMemberOfGroup(group.quest.leader,group) && ! isMemberOfRunningQuest(group.quest.leader,group)')
-            =env.t('questOwnerNotInRunningQuest')
-          span(ng-if=':: ! group.quest.leader || ! isMemberOfGroup(group.quest.leader,group)')
-            =env.t('questOwnerNotInRunningQuestParty')
+          // This is commented-out until we have time to work out why it fails intermittently on the website and always on the mobile app (https://github.com/HabitRPG/habitrpg/issues/4074):
+          // span(ng-if=':: group.quest.leader && isMemberOfGroup(group.quest.leader,group) && ! isMemberOfRunningQuest(group.quest.leader,group)')
+            // =env.t('questOwnerNotInRunningQuest')
+          // span(ng-if=':: ! group.quest.leader || ! isMemberOfGroup(group.quest.leader,group)')
+            // =env.t('questOwnerNotInRunningQuestParty')
 
         quest-rewards(key='{{::group.quest.key}}')
 
@@ -99,5 +104,8 @@ mixin boss(tavern, mobile)
           p=env.t('bossColl2')
 
         unless tavern
-          // only the quest owner sees the abort button UNLESS the quest owner is no longer in the quest/party and then everyone sees it:
-          button.btn.btn-sm.btn-warning(ng-if=':: (group.quest.leader  && group.quest.leader==user._id && isMemberOfGroup(group.quest.leader,group) && isMemberOfRunningQuest(group.quest.leader,group)) || ! group.quest.leader || ! isMemberOfGroup(group.quest.leader,group) || ! isMemberOfRunningQuest(group.quest.leader,group)', ng-click='questAbort()')=env.t('abort')
+          // // only the quest owner sees the abort button UNLESS the quest owner is no longer in the quest/party and then everyone sees it:
+          // This is commented-out until we have time to work out why it fails intermittently on the website and always on the mobile app (https://github.com/HabitRPG/habitrpg/issues/4074):
+          // button.btn.btn-sm.btn-warning(ng-if=':: (group.quest.leader  && group.quest.leader==user._id && isMemberOfGroup(group.quest.leader,group) && isMemberOfRunningQuest(group.quest.leader,group)) || ! group.quest.leader || ! isMemberOfGroup(group.quest.leader,group) || ! isMemberOfRunningQuest(group.quest.leader,group)', ng-click='questAbort()')=env.t('abort')
+          // only the quest owner sees the abort button:
+          button.btn.btn-sm.btn-warning(ng-if=':: (group.quest.leader  && group.quest.leader==user._id && isMemberOfGroup(group.quest.leader,group) && isMemberOfRunningQuest(group.quest.leader,group))', ng-click='questAbort()')=env.t('abort')


### PR DESCRIPTION
comment-out code that handles the cases where the quest owner has left the quest or left the party, at least until we can work out why it fails sometimes on the website and usually/always on mobile
