### PR TITLE
put Daily and To-Do tabs at top and bottom - fixes https://github.com/HabitRPG/habitrpg/issues/3827

### DIFF
--- a/views/shared/tasks/lists.jade
+++ b/views/shared/tasks/lists.jade
@@ -29,6 +29,35 @@ script(id='templates/habitrpg-tasks.html', type="text/ng-template")
             input.addtask-btn(type='submit', value='＋', ng-disabled='new{{list.type}}form.$invalid')
           hr
 
+          mixin taskColumnTabs(position)
+            // Daily Tabs
+            div(bo-if='main && list.type=="daily"', class='tabbable tabs-below')
+              // remaining/completed tabs
+              ul.nav.nav-tabs
+                li(ng-class='{active: list.view == "all"}')
+                  a(ng-click='list.view = "all"')=env.t('all')
+                li(ng-class='{active: list.view == "remaining"}')
+                  a(ng-click='list.view = "remaining"')=env.t('due')
+                li(ng-class='{active: list.view == "complete"}')
+                  a(ng-click='list.view = "complete"')=env.t('grey')
+            // Todo Tabs
+            div(bo-if='main && list.type=="todo"', bo-class='{"tabbable tabs-below": list.type=="todo"}')
+              // div(ng-show='list.view == "complete" || list.view == "all"')
+              // li.task.reward-item(ng-if='#{canceler ? "user.stats.buffs."+canceler : "user.items.special."+k+">0"}',popover-trigger='mouseenter', popover-placement='top', popover='{{Content.spells.special.#{k}.notes()}}')
+              if position=="bottom"
+                div(ng-show='list.showCompleted')
+                  .alert
+                    =env.t('lotOfToDos')
+                  button.task-action-btn.tile.spacious.bright(ng-click='user.ops.clearCompleted({})',popover=env.t('deleteToDosExplanation'),popover-trigger='mouseenter')=env.t('clearCompleted')
+              // remaining/completed tabs
+              ul.nav.nav-tabs
+                li(ng-class='{active: !list.showCompleted}')
+                  a(ng-click='list.showCompleted = false')=env.t('remaining')
+                li(ng-class='{active: list.showCompleted}')
+                  a(ng-click='list.showCompleted= true')=env.t('complete')
+
+          +taskColumnTabs('top')
+
           // Actual List
           ul(class='{{list.type}}s main-list', ng-show='obj[list.type + "s"].length > 0', hrpg-sort-tasks)
             include ./task
@@ -101,27 +130,4 @@ script(id='templates/habitrpg-tasks.html', type="text/ng-template")
             // Habit3
             ins.adsbygoogle(ng-init='initAds()', style='display: inline-block; width: 234px; height: 60px;', data-ad-client='ca-pub-3242350243827794', data-ad-slot='9529624576')
 
-          // Daily Tabs
-          div(bo-if='main && list.type=="daily"', class='tabbable tabs-below')
-            // remaining/completed tabs
-            ul.nav.nav-tabs
-              li(ng-class='{active: list.view == "all"}')
-                a(ng-click='list.view = "all"')=env.t('all')
-              li(ng-class='{active: list.view == "remaining"}')
-                a(ng-click='list.view = "remaining"')=env.t('due')
-              li(ng-class='{active: list.view == "complete"}')
-                a(ng-click='list.view = "complete"')=env.t('grey')
-
-          // Todo Tabs
-          div(bo-if='main && list.type=="todo"', bo-class='{"tabbable tabs-below": list.type=="todo"}')
-            // div(ng-show='list.view == "complete" || list.view == "all"')
-            div(ng-show='list.showCompleted')
-              .alert
-                =env.t('lotOfToDos')
-              button.task-action-btn.tile.spacious.bright(ng-click='user.ops.clearCompleted({})',popover=env.t('deleteToDosExplanation'),popover-trigger='mouseenter')=env.t('clearCompleted')
-            // remaining/completed tabs
-            ul.nav.nav-tabs
-              li(ng-class='{active: !list.showCompleted}')
-                a(ng-click='list.showCompleted = false')=env.t('remaining')
-              li(ng-class='{active: list.showCompleted}')
-                a(ng-click='list.showCompleted= true')=env.t('complete')
+          +taskColumnTabs('bottom')


### PR DESCRIPTION
Moves the code for the To-Do tabs and Dailies tabs to a mixin and puts them at the top and bottom of each column.

The mixin takes a "position" parameter (with "top" and "bottom" values) to allow customisation of the appearance (currently only used on the To-Dos completed tab to show the delete button at the bottom only).

![screen shot 2014-10-10 at 9 11 30 am](https://cloud.githubusercontent.com/assets/1495809/4585788/778fa616-500b-11e4-9ba4-6ab9d65f7a5c.png)
![screen shot 2014-10-10 at 9 11 43 am](https://cloud.githubusercontent.com/assets/1495809/4585787/7783463c-500b-11e4-8760-c890909ad756.png)
