### PR TITLE
new tabs for Habits and Rewards columns on task page

### DIFF
--- a/public/js/controllers/tasksCtrl.js
+++ b/public/js/controllers/tasksCtrl.js
@@ -200,16 +200,22 @@ habitrpg.controller("TasksCtrl", ['$scope', '$rootScope', '$location', 'User','N
     $scope.shouldShow = function(task, list, prefs){
       if (task._editing) // never hide a task while being edited
         return true;
-      if (task.type == 'habit' || task.type == 'todo' || task.type == 'reward')
+      if (task.type == 'todo')  // TODO: convert To-Dos to use this new system and probably add a "Dated" column (i.e., "Incomplete" (includes dated), "Dated" (has due date and is not complete), "Complete")
         return true;
       var shouldDo = task.type == 'daily' ? habitrpgShared.shouldDo(new Date, task.repeat, prefs) : true;
       switch (list.view) {
-      case "remaining":
-        return !task.completed && shouldDo;
-      case "complete":
-        return task.completed || !shouldDo;
-      case "all":
-        return true;
+        case "yellowred":  // Habits
+          return task.value < 1;
+        case "greenblue":  // Habits
+          return task.value >= 1;
+        case "remaining":  // Dailies and To-Dos
+          return !task.completed && shouldDo;
+        case "complete":   // Dailies and To-Dos
+          return task.completed || !shouldDo;
+        case "ingamerewards":   // All skills/rewards except the user's own
+          return false; // Because "rewards" list includes only the user's own
+        case "all":
+          return true;
       }
     }
   }]);

--- a/public/js/directives/directives.js
+++ b/public/js/directives/directives.js
@@ -71,7 +71,8 @@ habitrpg
           {
             header: window.env.t('habits'),
             type: 'habit',
-            placeHolder: window.env.t('newHabit')
+            placeHolder: window.env.t('newHabit'),
+            view: "all"
           }, {
             header: window.env.t('dailies'),
             type: 'daily',
@@ -85,7 +86,8 @@ habitrpg
           }, {
             header: window.env.t('rewards'),
             type: 'reward',
-            placeHolder: window.env.t('newReward')
+            placeHolder: window.env.t('newReward'),
+            view: "all"
           }
         ];
 

--- a/views/shared/tasks/lists.jade
+++ b/views/shared/tasks/lists.jade
@@ -30,6 +30,15 @@ script(id='templates/habitrpg-tasks.html', type="text/ng-template")
           hr
 
           mixin taskColumnTabs(position)
+            // Habits Tabs
+            div(bo-if='main && list.type=="habit"', class='tabbable tabs-below')
+              ul.nav.nav-tabs
+                li(ng-class='{active: list.view == "all"}')
+                  a(ng-click='list.view = "all"')=env.t('all')
+                li(ng-class='{active: list.view == "yellowred"}')
+                  a(ng-click='list.view = "yellowred"')=env.t('yellowred')
+                li(ng-class='{active: list.view == "greenblue"}')
+                  a(ng-click='list.view = "greenblue"')=env.t('greenblue')
             // Daily Tabs
             div(bo-if='main && list.type=="daily"', class='tabbable tabs-below')
               // remaining/completed tabs
@@ -55,6 +64,13 @@ script(id='templates/habitrpg-tasks.html', type="text/ng-template")
                   a(ng-click='list.showCompleted = false')=env.t('remaining')
                 li(ng-class='{active: list.showCompleted}')
                   a(ng-click='list.showCompleted= true')=env.t('complete')
+            // Rewards Tabs
+            div(bo-if='main && list.type=="reward"', class='tabbable tabs-below')
+              ul.nav.nav-tabs
+                li(ng-class='{active: list.view == "all"}')
+                  a(ng-click='list.view = "all"')=env.t('all')
+                li(ng-class='{active: list.view == "ingamerewards"}')
+                  a(ng-click='list.view = "ingamerewards"')=env.t('ingamerewards')
 
           +taskColumnTabs('top')
 


### PR DESCRIPTION
Goes with https://github.com/HabitRPG/habitrpg-shared/pull/347

This PR adds tabs to the Habits column and the Rewards column:
![screen shot 2014-10-19 at 6 10 46 pm](https://cloud.githubusercontent.com/assets/1495809/4692526/e8f49b68-5768-11e4-91c0-06ae0ddcead0.png)

The "All" tabs show all Habits and all Rewards/Equipment/Skills (i.e., exactly the same as you see currently in your tasks page).

The Habits "Reddish" and "Bluish" tabs split up the Habits based on colour (yellow, orange, red in the "Reddish" tab; green and blue in the "Bluish" tab). I know I would find this useful; not sure about anyone else. Better tab label suggestions are welcome. They must be short otherwise the tabs wrap unpleasantly.
![screen shot 2014-10-19 at 6 24 42 pm](https://cloud.githubusercontent.com/assets/1495809/4692531/71926f4a-5769-11e4-8187-08339132b0d3.png)

The Rewards "Equipment & Skills" tab hides all of the user's custom rewards (useful when you have many rewards but want quick access to the skills).
![screen shot 2014-10-19 at 6 11 34 pm](https://cloud.githubusercontent.com/assets/1495809/4692532/915afe1e-5769-11e4-85e2-2cc4c206089f.png)
