### PR TITLE
move Dailies default setting to bottom to keep together the three settings about task edit mode

### DIFF
--- a/views/options/settings.jade
+++ b/views/options/settings.jade
@@ -50,16 +50,16 @@ script(type='text/ng-template', id='partials/options.settings.settings.html')
                 span.hint(popover-trigger='mouseenter', popover-placement='right', popover=env.t('newTaskEditPop'))=env.t('newTaskEdit')
             .checkbox
               label
-                input(type='checkbox', ng-model='user.preferences.dailyDueDefaultView', ng-change='set({"preferences.dailyDueDefaultView": user.preferences.dailyDueDefaultView?true: false})')
-                span.hint(popover-trigger='mouseenter', popover-placement='right', popover=env.t('dailyDueDefaultViewPop'))=env.t('dailyDueDefaultView')
-            .checkbox
-              label
                 input(type='checkbox', ng-model='user.preferences.tagsCollapsed', ng-change='set({"preferences.tagsCollapsed": user.preferences.tagsCollapsed?true: false})')
                 span.hint(popover-trigger='mouseenter', popover-placement='right', popover=env.t('startCollapsedPop'))=env.t('startCollapsed')
             .checkbox
               label
                 input(type='checkbox', ng-model='user.preferences.advancedCollapsed', ng-change='set({"preferences.advancedCollapsed": user.preferences.advancedCollapsed?true: false})')
                 span.hint(popover-trigger='mouseenter', popover-placement='right', popover=env.t('startAdvCollapsedPop'))=env.t('startAdvCollapsed')
+            .checkbox
+              label
+                input(type='checkbox', ng-model='user.preferences.dailyDueDefaultView', ng-change='set({"preferences.dailyDueDefaultView": user.preferences.dailyDueDefaultView?true: false})')
+                span.hint(popover-trigger='mouseenter', popover-placement='right', popover=env.t('dailyDueDefaultViewPop'))=env.t('dailyDueDefaultView')
             button.btn.btn-default(ng-click='showTour()', popover-placement='right', popover-trigger='mouseenter', popover=env.t('restartTour'))= env.t('showTour')
             button.btn.btn-default(ng-click='showBailey()', popover-trigger='mouseenter', popover-placement='right', popover=env.t('showBaileyPop'))= env.t('showBailey')
             button.btn.btn-default(ng-click='openRestoreModal()', popover-trigger='mouseenter', popover-placement='right', popover=env.t('fixValPop'))= env.t('fixVal')


### PR DESCRIPTION
This PR moves the setting arrowed in the screenshot below from the fourth position in the list to the bottom, so that the three settings above it are still grouped together (since they are all related to the task edit mode).

![screen shot 2014-10-20 at 5 53 11 am](https://cloud.githubusercontent.com/assets/1495809/4694746/16a93cce-57d4-11e4-884e-7ad4ed0f5436.png)

Ref: https://github.com/HabitRPG/habitrpg/pull/4157
