### PR TITLE
Webhooks

### DIFF
--- a/public/js/controllers/settingsCtrl.js
+++ b/public/js/controllers/settingsCtrl.js
@@ -162,5 +162,19 @@ habitrpg.controller('SettingsCtrl',
       User.user.ops.release2({});
       $rootScope.$state.go('tasks');
     }
+
+    //FIXME push this all to habitrpg-shared so we have API routes for this
+    $scope.addWebhook = function(webhook) {
+      User.set({'preferences.webhooks':User.user.preferences.webhooks.concat({url:webhook, enabled:true})});
+      $scope._newWebhook = '';
+    }
+    $scope.saveWebhook = function(webhook){
+      delete webhook._editing;
+      User.set({'preferences.webhooks':User.user.preferences.webhooks});
+    }
+    $scope.deleteWebhook = function($index){
+      User.user.preferences.webhooks.splice($index, 1);
+      User.set({'preferences.webhooks':User.user.preferences.webhooks});
+    }
   }
 ]);

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -14,6 +14,7 @@ var moment = require('moment');
 var logging = require('./../logging');
 var acceptablePUTPaths;
 var api = module.exports;
+var request = require('request');
 
 // api.purchase // Shared.ops
 
@@ -105,6 +106,15 @@ api.score = function(req, res, next) {
       delta: delta,
       _tmp: user._tmp
     }, saved.toJSON().stats));
+
+    // Webhooks
+    _.each(user.preferences.webhooks, function(h){
+      request.post({
+        url: h.url,
+        //form: {task: task, delta: delta, user: _.pick(user, ['stats', '_tmp'])} // this is causing "Maximum Call Stack Exceeded"
+        body: {direction:direction, task: task, delta: delta, user: _.pick(user, ['_id', 'stats', '_tmp'])}, json:true
+      });
+    });
 
     if (
       (!task.challenge || !task.challenge.id || task.challenge.broken) // If it's a challenge task, sync the score. Do it in the background, we've already sent down a response and the user doesn't care what happens back there

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -274,7 +274,8 @@ var UserSchema = new Schema({
     tagsCollapsed: {type: Boolean, 'default': false},
     advancedCollapsed: {type: Boolean, 'default': false},
     toolbarCollapsed: {type:Boolean, 'default':false},
-    background: String
+    background: String,
+    webhooks: {type:Array, 'default': []}
   },
   profile: {
     blurb: String,

--- a/views/options/settings.jade
+++ b/views/options/settings.jade
@@ -150,6 +150,34 @@ script(type='text/ng-template', id='partials/options.settings.api.html')
         h6=env.t('qrCode')
         img(src='https://chart.googleapis.com/chart?cht=qr&chs=200x200&chl=%7B%22address%22%3A%22https%3A%2F%2Fhabitrpg.com%22%2C%22user%22%3A%22{{user.id}}%22%2C%22key%22%3A%22{{user.apiToken}}%22%7D&choe=UTF-8&chld=L', alt='qrcode')
 
+        hr
+
+        h2 Webhooks
+        table.table.table-striped
+          thead(ng-if='user.preferences.webhooks[0]')
+            tr
+              th Enabled
+              th Webhook URL
+              th
+          tbody
+            tr(ng-repeat='webhook in user.preferences.webhooks')
+              td
+                input(type='checkbox', ng-model='webhook.enabled', ng-change='saveWebhook(webhook)')
+              td
+                input.form-control(type='url', ng-model='webhook.url', ng-change='webhook._editing=true', ui-keyup="{13:'saveWebhook(webhook)'}")
+              td
+                span.pull-left(ng-show='webhook._editing') *
+                a.checklist-icons(ng-click='deleteWebhook($index)')
+                  span.glyphicon.glyphicon-trash(tooltip=env.t('delete'))
+            tr
+              td(colspan=2)
+                form.form-horizontal(ng-submit='addWebhook(_newWebhook)')
+                  .form-group.col-sm-10
+                    input.form-control(type='url', ng-model='_newWebhook', placeholder='Webhook URL')
+                  .col-sm-2
+                    button.btn.btn-sm.btn-primary(type='submit') Add
+
+
 script(id='partials/options.settings.export.html', type="text/ng-template")
   .container-fluid
     .row


### PR DESCRIPTION
## Don't merge!

Add webhooks to `user.preferences` (API settings) so we can POST to external services (eg, Beeminder). Initial proof-of-concept, will need lots of attention before it's ready - just wanted to see if we all like the general setup (@Alys, @dreeves, etc).

One big question, do we only care about sending push notifs for task-scoring operations? That's the most obvious place, and if it's the _only_ place then that makes life much simpler. If we want it for other things, we'll have to introduce some middleware at the end of requests and possibly just send along the request object. However, there are often cases where the result of the operation is important too (eg, here the `delta` variable is important) - so that might not work, and we'd instead have to tie into each pertinent route individually. 'Course, we could just start with task-scoring and work from there
