### PR TITLE
Community Guidelines date; wrapping in staff/mod names in Tavern

### DIFF
--- a/views/options/social/tavern.jade
+++ b/views/options/social/tavern.jade
@@ -148,7 +148,7 @@
       .alert.alert-info.alert-sm
         != ' ' + env.t('tavernAlert1') + ' <a href="https://github.com/HabitRPG/habitrpg/issues/2760" target="_blank">' + env.t('tavernAlert2') + '</a>.<br />' + env.t('moderatorIntro1')
         span(ng-repeat='mod in env.mods')
-          | &nbsp;
+          |&nbsp; &nbsp;
           span(ng-if='mod.contributor.admin',popover=env.t('gamemaster'),popover-trigger='mouseenter',popover-placement='right')
             a.label.label-default(ng-class='userLevelStyle(mod)', ng-click='clickMember(mod._id, true)')
               {{mod.profile.name}}&nbsp;

--- a/views/static/community-guidelines.jade
+++ b/views/static/community-guidelines.jade
@@ -27,8 +27,8 @@ block content
         h1=env.t('communityGuidelines')
       p.pagemeta
         |Last updated&nbsp;
-        =env.t('September')
-        |&nbsp;14&comma; 2014
+        =env.t('October')
+        |&nbsp;27&comma; 2014
       h2=env.t('commGuideHeadingWelcome')
       div(class='clearfix')
         img(class='pull-left', src='/community-guidelines-images/intro.png', alt='')


### PR DESCRIPTION
adjust last-updated date in Community Guidelines; add quick-and-dirty fix to allow staff/moderator names to wrap in message above Tavern chat
