### PR TITLE
Updated href with angular expression to ng-href

### DIFF
--- a/views/options/social/challenges.jade
+++ b/views/options/social/challenges.jade
@@ -46,7 +46,7 @@ script(type='text/ng-template', id='partials/options.social.challenges.detail.ht
 
   // Member List
   div(bindonce='challenge', ng-if='challenge.members.length > 0')
-    a.btn.btn-primary.btn-sm.pull-right(href='/api/v2/challenges/{{challenge._id}}/csv')
+    a.btn.btn-primary.btn-sm.pull-right(ng-href='/api/v2/challenges/{{challenge._id}}/csv')
       =env.t('exportChallengeCSV')
     h3=env.t('hows')
     menu


### PR DESCRIPTION
Per [this doc](https://docs.angularjs.org/api/ng/directive/ngHref), any href that contains an angular expression should be an ng-href.

I did `grep -ril ".href=.\+/{" views` and the only results were this file (options/social/challenges.jade) and shared/tasks/lists.jade, but lists applicable a tags were commented out, so I left them alone.
