### PR TITLE
block chat until user agrees to Community Guidelines

### DIFF
--- a/views/options/social/chat-box.jade
+++ b/views/options/social/chat-box.jade
@@ -1,18 +1,16 @@
-//div.chat-form.guidelines-not-accepted(ng-if='!user.flags.communityGuidelinesAccepted')
-//  p If you would like to post messages in the Tavern or any party or guild chat, please first read our
-//    |&nbsp;
-//    a(target='_blank', href='/static/community-guidelines')=env.t('communityGuidelines')
-//    |&nbsp;and then click the button below to indicate that you accept them.
-//  .chat-controls
-//    div
-//      button.btn.btn-warning(ng-click='acceptCommunityGuidelines()')=env.t('iAcceptCommunityGuidelines')
-//    .chat-buttons
-//      button(type="button", ng-click='sync(group)', tooltip=env.t('toolTipMsg'))
-//        span.glyphicon.glyphicon-refresh
+div.chat-form.guidelines-not-accepted(ng-if='!user.flags.communityGuidelinesAccepted')
+  p If you would like to post messages in the Tavern or any party or guild chat, please first read our
+    |&nbsp;
+    a(target='_blank', href='/static/community-guidelines')=env.t('communityGuidelines')
+    |&nbsp;and then click the button below to indicate that you accept them.
+  .chat-controls
+    div
+      button.btn.btn-warning(ng-click='acceptCommunityGuidelines()')=env.t('iAcceptCommunityGuidelines')
+    .chat-buttons
+      button(type="button", ng-click='sync(group)', tooltip=env.t('toolTipMsg'))
+        span.glyphicon.glyphicon-refresh
 
-//form.chat-form(ng-if='user.flags.communityGuidelinesAccepted' ng-submit='postChat(group,message.content)')
-//////////// When we want to block the ability to chat until the Community Guidelines have been accepted, delete the one line immediately below this comment and un-comment all lines above.
-form.chat-form(ng-submit='postChat(group,message.content)')
+form.chat-form(ng-if='user.flags.communityGuidelinesAccepted' ng-submit='postChat(group,message.content)')
   div(ng-controller='AutocompleteCtrl')
     textarea.form-control(rows=4, ui-keypress='{13:"postChat(group,message.content)"}', ng-model='message.content', updateinterval='250', flag='@', at-user, auto-complete)
     span.user-list(ng-show='!isAtListHidden')


### PR DESCRIPTION
## Do not merge until @lemoness says to.
#### I would REALLY like someone other than me to test this.

This PR enables a feature that prevents a user from being able to send a message in the Tavern, party, or guilds, until the user has clicked a button agreeing to abide by the Community Guidelines.

Before the user clicks the "agree" button, the chat interface looks like this:
![screen shot 2014-11-01 at 11 10 48 am](https://cloud.githubusercontent.com/assets/1495809/4870358/04981de0-6164-11e4-8529-7190cf1006b4.png)

After they have clicked the "agree" button, it looks the same as it does on the live website now.
