### PR TITLE
change Fetch Recent Messages from tooltip to button text

### DIFF
--- a/views/options/social/chat-box.jade
+++ b/views/options/social/chat-box.jade
@@ -24,5 +24,4 @@ form.chat-form(ng-submit='postChat(group,message.content)')
       include ../../shared/formatting-help
     .chat-buttons
       input(type='submit', value=env.t('sendChat'), ng-class='{disabled: _sending == true}')
-      button(type="button", ng-click='sync(group)', tooltip=env.t('toolTipMsg'))
-        span.glyphicon.glyphicon-refresh
+      button(type="button", ng-click='sync(group)')=env.t('toolTipMsg')


### PR DESCRIPTION
This changes the "Fetch Recent Messages" button (in Tavern, party, and guild chat) so that instead of a sync icon with a tooltip, it just says "Fetch Recent Messages" on the button.

Users often don't realise they need to click the button to see new messages or boss damage. This might help. If nothing else, it will make it easier for us to explain which button we want them to click. :)

@lemoness Is this okay?

![screen shot 2014-11-01 at 11 39 46 am](https://cloud.githubusercontent.com/assets/1495809/4870438/e68fa386-6168-11e4-8cd5-624ffdfeacaf.png)
