### PR TITLE
add warning text for Beeminder users about deleting To-Dos

### DIFF
--- a/views/shared/tasks/lists.jade
+++ b/views/shared/tasks/lists.jade
@@ -58,6 +58,7 @@ script(id='templates/habitrpg-tasks.html', type="text/ng-template")
                   .alert
                     =env.t('lotOfToDos')
                   button.task-action-btn.tile.spacious.bright(ng-click='user.ops.clearCompleted({})',popover=env.t('deleteToDosExplanation'),popover-trigger='mouseenter')=env.t('clearCompleted')
+                  p!=env.t('beeminderDeleteWarning')
               // remaining/completed tabs
               ul.nav.nav-tabs
                 li(ng-class='{active: !list.showCompleted}')


### PR DESCRIPTION
Requires https://github.com/HabitRPG/habitrpg-shared/pull/354

Adds a sentence under the To-Dos' "Delete Completed" button to remind Beeminder users about important information (see orange arrow in screenshot). The link points to http://habitrpg.wikia.com/wiki/Beeminder#Deleting_Completed_To-Dos_Without_Confusing_Beeminder

![screen shot 2014-11-06 at 12 06 07 pm](https://cloud.githubusercontent.com/assets/1495809/4930066/cae4c938-655d-11e4-8858-ee995e1d611d.png)

This is just a quick-and-dirty fix to make important information visible quickly.

What I'd like to do is replace everything surrounded by the green box with one link saying "**Export or Delete my To-Dos**". That link would appear at the top and bottom of the completed To-Dos column. When you click the link, you see the information inside the green box, and more. Since it wouldn't be visible all the time, we could be more verbose. E.g., we could add a link to the [DDT](https://oldgods.net/habitrpg/habitrpg_user_data_display.html) ("To-Dos Completed" section). We could probably even put the actual export links right there, and a link to the [wiki page](http://habitrpg.wikia.com/wiki/Data_Export) that describes the export format.

If there's no complaints, I'll start on this after this PR is merged.
