### PR TITLE
create 'Data' menu item

### DIFF
--- a/views/shared/header/menu.jade
+++ b/views/shared/header/menu.jade
@@ -45,6 +45,11 @@ nav.toolbar(ng-controller='AuthCtrl', ng-class='{active: isToolbarHidden}')
                 a(ui-sref='options.inventory.equipment')=env.t('equipment')
             ul.toolbar-submenu
               li
+                a(target="_blank" href='http://data.habitrpg.com')=env.t('dataTool')
+              li
+                a(ui-sref='options.settings.export')=env.t('exportData')
+            ul.toolbar-submenu
+              li
                 a(target="_blank" href='http://habitrpg.wikia.com/wiki/FAQ')=env.t('FAQ')
               li
                 a(target="_blank" href='https://github.com/HabitRPG/habitrpg/issues/2760')=env.t('reportBug')
@@ -112,6 +117,17 @@ nav.toolbar(ng-controller='AuthCtrl', ng-class='{active: isToolbarHidden}')
               a(ui-sref='options.inventory.mounts')=env.t('mounts')
             li
               a(ui-sref='options.inventory.equipment')=env.t('equipment')
+      li.toolbar-button-dropdown
+        a(target="_blank" href='http://data.habitrpg.com')
+          span=env.t('data')
+        a(ng-click='expandMenu("data")', ng-class='{active: _expandedMenu == "data"}')
+          span  &#9776;
+        div(ng-if='_expandedMenu == "data"')
+          ul.toolbar-submenu(ng-click='expandMenu(null)')
+            li
+              a(target="_blank" href='http://data.habitrpg.com')=env.t('dataTool')
+            li
+              a(ui-sref='options.settings.export')=env.t('exportData')
       li.toolbar-button-dropdown
         a(target="_blank" href='http://habitrpg.wikia.com/wiki/')
           span=env.t('help')


### PR DESCRIPTION
As requested by Lemoness via Alys in Aspiring Coders:

> On the website, we want a new menu item called "Data" in between "Inventory" and "Help". It should have two entries under it: "Data Display Tool" and "Export Data". The top-level "Data" item and the "Data Display Tool" entry should both point to http://data.habitrpg.com and that page must open in a new window/tab. The "Export Data" entry should point to https://habitrpg.com/#/options/settings/export and open in the tab that the user is already on.

New /en/ definitions in https://github.com/HabitRPG/habitrpg-shared/pull/357
