### PR TITLE
Invite friends

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "paypal-ipn": "~1.0.1",
     "paypal-recurring": "git://github.com/jaybryant/paypal-recurring#656b496f43440893c984700191666a5c5c535dca",
     "pretty-data": "git://github.com/vkiryukhin/pretty-data#master",
+    "qs": "^2.3.2",
     "request": "~2.44.0",
     "s3-upload-stream": "^1.0.6",
     "stripe": "*",

--- a/public/js/controllers/groupsCtrl.js
+++ b/public/js/controllers/groupsCtrl.js
@@ -1,7 +1,7 @@
 "use strict";
 
-habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '$http', '$q', 'User', 'Members', '$state',
-  function($scope, $rootScope, Shared, Groups, $http, $q, User, Members, $state) {
+habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '$http', '$q', 'User', 'Members', '$state', 'Notification',
+  function($scope, $rootScope, Shared, Groups, $http, $q, User, Members, $state, Notification) {
     $scope.isMemberOfPendingQuest = function(userid, group) {
       if (!group.quest || !group.quest.members) return false;
       if (group.quest.active) return false; // quest is started, not pending
@@ -63,7 +63,7 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '
         }
       }
 
-    // ------ Invites ------
+      // ------ Invites ------
 
       $scope.invite = function(group){
         Groups.Group.invite({gid: group._id, uuid: group.invitee}, undefined, function(){
@@ -72,6 +72,15 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '
           group.invitee = '';
         });
       }
+
+      $scope.emails = [{name:"",email:""},{name:"",email:""}];
+      $scope.inviteEmails = function(emails){
+        $http.post('/api/v2/user/social/invite-friends', emails).success(function(){
+          Notification.text("Invitations sent!");
+          $scope.emails = [{name:'',email:''},{name:'',email:''}];
+        });
+      }
+
     }
   ])
 

--- a/public/js/controllers/groupsCtrl.js
+++ b/public/js/controllers/groupsCtrl.js
@@ -74,6 +74,9 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '
       }
 
       $scope.emails = [{name:"",email:""},{name:"",email:""}];
+      //$scope.inviteLink = function(obj){
+      //  return window.env.BASE_URL + '?partyInvite=' + encodeURIComponent(JSON.stringify(obj));
+      //}
       $scope.inviteEmails = function(emails){
         $http.post('/api/v2/user/social/invite-friends', emails).success(function(){
           Notification.text("Invitations sent!");

--- a/src/controllers/groups.js
+++ b/src/controllers/groups.js
@@ -300,7 +300,8 @@ api.join = function(req, res, next) {
     group = res.locals.group;
 
   if (group.type == 'party' && group._id == (user.invitations && user.invitations.party && user.invitations.party.id)) {
-    user.invitations.party = undefined;
+    User.update({_id:user.invitations.party.inviter}, {$inc:{'items.quests.basilist':1}}).exec(); // Reward inviter
+    user.invitations.party = undefined; // Clear invite
     user.save();
     // invite new user to pending quest
     if (group.quest.key && !group.quest.active) {
@@ -439,10 +440,10 @@ api.invite = function(req, res, next) {
 
     function sendInvite (){
       if(group.type === 'guild'){
-        invite.invitations.guilds.push({id: group._id, name: group.name});
+        invite.invitations.guilds.push({id: group._id, name: group.name, inviter:res.locals.user._id});
       }else{
         //req.body.type in 'guild', 'party'
-        invite.invitations.party = {id: group._id, name: group.name}
+        invite.invitations.party = {id: group._id, name: group.name, inviter:res.locals.user._id};
       }
 
       group.invites.push(invite._id);

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -404,7 +404,11 @@ api.inviteFriends = function(req, res, next) {
     var link = nconf.get('BASE_URL') + '?' + qs.stringify({partyInvite:{id:party._id, inviter:res.locals.user._id, name:party.name}});
     _.each(req.body, function(invite){
       if (invite.email) {
-        var variables = {link:link, inviter:res.locals.user.profile.name, invitee:invite.name};
+        var variables = [
+          {name: 'LINK', content: link},
+          {name: 'INVITER', content: res.locals.user.profile.name},
+          {name: 'INVITEE', content: invite.name}
+        ];
         // TODO implement "users can only be invited once"
         utils.txnEmail(invite, 'invite-friend', variables);
       }

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -414,10 +414,13 @@ api.inviteFriends = function(req, res, next) {
 }
 api.sessionPartyInvite = function(req,res,next){
   if (req.session.partyInvite) {
-    res.locals.user.invitations.party = req.session.partyInvite;
-    Group.update({_id:req.session.partyInvite.id},{$addToSet:{invites:res.locals.user._id}});
-    delete req.session.partyInvite;
-    return res.locals.user.save(next);
+    var inv = res.locals.user.invitations;
+    if (!(inv.party && inv.party.id)) {
+      inv.party = req.session.partyInvite;
+      Group.update({_id:req.session.partyInvite.id},{$addToSet:{invites:res.locals.user._id}});
+      delete req.session.partyInvite;
+      return res.locals.user.save(next);
+    }
   }
   next();
 }

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -12,6 +12,7 @@ var shared = require('habitrpg-shared');
 var request = require('request');
 var os = require('os');
 var moment = require('moment');
+var qs = require('qs');
 
 module.exports.apiThrottle = function(app) {
   if (nconf.get('NODE_ENV') !== 'production') return;
@@ -196,7 +197,12 @@ module.exports.locals = function(req, res, next) {
 
     tavern: tavern, // for world boss
     worldDmg: (tavern && tavern.quest && tavern.quest.extra && tavern.quest.extra.worldDmg) || {}
-  }
+  };
+
+  // Put query-string party invitations into session to be handled later
+  var partyInvite = qs.parse(req.query.partyInvite);
+  if (partyInvite && partyInvite.id)
+    req.session.partyInvite = partyInvite;
 
   next();
 }

--- a/src/routes/apiv2.coffee
+++ b/src/routes/apiv2.coffee
@@ -320,7 +320,7 @@ module.exports = (swagger, v2) ->
         parameters:[
           body '','The array of batch-operations to perform','object'
         ]
-      middleware: [middleware.forceRefresh, auth.auth, i18n.getUserLanguage, cron]
+      middleware: [middleware.forceRefresh, auth.auth, i18n.getUserLanguage, cron, user.sessionPartyInvite]
       action: user.batchUpdate
 
     # Tags
@@ -363,6 +363,15 @@ module.exports = (swagger, v2) ->
           path 'id','Id of tag to delete','string'
         ]
       action: user.deleteTag
+
+    "/user/social/invite-friends":
+      spec:
+        method: 'POST'
+        description: 'Invite friends via email'
+        parameters: [
+          body 'invites','Array of [{name:"Friend\'s Name", email:"friends@email.com"}] to invite to play in your party','object'
+        ]
+      action: user.inviteFriends
 
     # ---------------------------------
     # Groups

--- a/views/options/settings.jade
+++ b/views/options/settings.jade
@@ -63,6 +63,7 @@ script(type='text/ng-template', id='partials/options.settings.settings.html')
             button.btn.btn-default(ng-click='showTour()', popover-placement='right', popover-trigger='mouseenter', popover=env.t('restartTour'))= env.t('showTour')
             button.btn.btn-default(ng-click='showBailey()', popover-trigger='mouseenter', popover-placement='right', popover=env.t('showBaileyPop'))= env.t('showBailey')
             button.btn.btn-default(ng-click='openRestoreModal()', popover-trigger='mouseenter', popover-placement='right', popover=env.t('fixValPop'))= env.t('fixVal')
+            button.btn.btn-default(ng-click="openModal('invite-friends', {controller:'GroupsCtrl'})") Invite Friends
             button.btn.btn-default(ng-if='user.preferences.disableClasses==true', ng-click='user.ops.changeClass({})', popover-trigger='mouseenter', popover-placement='right', popover=env.t('enableClassPop'))= env.t('enableClass')
             button.btn.btn-default(ng-if='!user.preferences.disableClasses && user.flags.classSelected', ng-click='showClassesTour()', popover-trigger='mouseenter', popover-placement='right', popover=env.t('classTourPop'))= env.t('showClass')
 

--- a/views/options/social/group.jade
+++ b/views/options/social/group.jade
@@ -48,9 +48,11 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
       // ------ Members -------
       .panel.panel-default
         .panel-heading
-          h3.panel-title=env.t('members')
+          h3.panel-title
+            =env.t('members')
+            button.pull-right.btn.btn-primary(ng-click="openModal('invite-friends', {controller:'GroupsCtrl'})", ng-if='::group.type=="party"') Invite Friends
         .panel-body.modal-fixed-height
-          div(ng-if='group.type=="party"')
+          div(ng-if='::group.type=="party"')
             =env.t('partyList')
             br
             select#partyOrder(
@@ -86,7 +88,7 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
                 a.media-body
                   span(ng-click='clickMember(invite._id, true)')
                     | {{invite.profile.name}}
-        .panel-footer
+        .panel-footer(ng-if='::group.type!="party"')
           form.form-inline(ng-submit='invite(group)')
             //.alert.alert-danger(ng-show='_groupError') {{_groupError}}
             .form-group

--- a/views/shared/modals/index.jade
+++ b/views/shared/modals/index.jade
@@ -10,3 +10,4 @@ include ./classes
 include ./quests
 include ./rebirth
 include ./limited
+include ./invite-friends

--- a/views/shared/modals/invite-friends.jade
+++ b/views/shared/modals/invite-friends.jade
@@ -1,0 +1,39 @@
+script(type='text/ng-template', id='modals/invite-friends.html')
+  .modal-header
+    h4 Invite Friends
+  .modal-body
+    p.alert.alert-info Invite friends to your party who <strong>already play</strong> HabitRPG. Have them send you their <a href='http://habitrpg.wikia.com/wiki/API_Options' target='_blank'>User ID</a> and enter it here.
+
+    form.form-inline(ng-submit='invite(party)')
+      //-.alert.alert-danger(ng-show='_groupError') {{_groupError}}
+      .form-group
+        input.form-control(type='text', placeholder=env.t('userId'), ng-model='party.invitee')
+        |&nbsp;
+        button.btn.btn-primary(type='submit') Invite Existing User
+
+    hr
+
+    p.alert.alert-info Invite friends to your party who <strong>don't yet play</strong> HabitRPG. This will send them an invite email, and automatically invite them to your party.
+
+    table.table.table-striped
+      thead
+        tr
+          th Name
+          th Email
+      tbody
+        tr(ng-repeat='email in emails')
+          td
+            input.form-control(type='text', ng-model='email.name')
+          td
+            input.form-control(type='email', ng-model='email.email')
+        tr
+          td(colspan=2)
+            button.btn.btn-xs.pull-right(ng-click='emails = emails.concat([{name:"",email:""}])')
+              i.glyphicon.glyphicon-plus
+        tr
+          td(colspan=2)
+            button.btn.btn-primary.pull-right(ng-click='inviteEmails(emails)') Invite New User(s)
+
+  .modal-footer
+    button.btn.btn-default(ng-click='$close()') Close
+

--- a/views/shared/modals/invite-friends.jade
+++ b/views/shared/modals/invite-friends.jade
@@ -2,7 +2,7 @@ script(type='text/ng-template', id='modals/invite-friends.html')
   .modal-header
     h4 Invite Friends
   .modal-body
-    p.alert.alert-info Invite friends to your party who <strong>already play</strong> HabitRPG. Have them send you their <a href='http://habitrpg.wikia.com/wiki/API_Options' target='_blank'>User ID</a> and enter it here.
+    p.alert.alert-info Invite friends by <a href='http://habitrpg.wikia.com/wiki/API_Options' target='_blank'>User ID</a> here.
 
     form.form-inline(ng-submit='invite(party)')
       //-.alert.alert-danger(ng-show='_groupError') {{_groupError}}
@@ -13,7 +13,7 @@ script(type='text/ng-template', id='modals/invite-friends.html')
 
     hr
 
-    p.alert.alert-info Invite friends to your party who <strong>don't yet play</strong> HabitRPG. This will send them an invite email, and automatically invite them to your party.
+    p.alert.alert-info Invite friends by email. If they join via your email, they'll automatically be invited to your party.
 
     table.table.table-striped
       thead
@@ -33,6 +33,11 @@ script(type='text/ng-template', id='modals/invite-friends.html')
         tr
           td(colspan=2)
             button.btn.btn-primary.pull-right(ng-click='inviteEmails(emails)') Invite New User(s)
+
+    //-
+      hr
+      p.alert.alert-info Or share this link (copy/paste):
+      input.form-control(type='text', ng-value='inviteLink({id: party._id, inviter: user._id, name: party.name})')
 
   .modal-footer
     button.btn.btn-default(ng-click='$close()') Close


### PR DESCRIPTION
This adds the ability to invite friends via email. We've decided it really only makes sense in the context of a party, so now when clicking the "invite users" button in your party you'll get a modal that looks like:

![img](http://i.gyazo.com/12a058704aff1506ac26126013e4a9e9.png)
- If new user: they'll click the link, which sets the `partyInvite` session object for later consumption after they've joined the site. Upon registering, that session object will be consumed and they'll be invited automatically to the inviter's party.
- If existing user, the same setup happens - but upon logging in (or simply visiting, if they're already logged in).
- When (if) invitee joins the party, inviter is rewarded 1 `Basi-List` quest scroll. 
