### PR TITLE
re-enable +1 "like" button, add spaces before delete button, add "quick reply" to chat

### DIFF
--- a/views/options/social/chat-message.jade
+++ b/views/options/social/chat-message.jade
@@ -12,16 +12,19 @@ mixin chatMessages(inbox)
         markdown(ng-model='::message.text')
         | -
         span.muted.time(from-now='::message.timestamp')
-        unless type='inbox'
+        unless inbox
           span
             a.label.label-default(ng-show='countExists(message.likes)', ng-class='{"label-success":message.likes[user._id]}', ng-click='likeChatMessage(group,message)') +{{countExists(message.likes)}}
             a.chat-plus-one.muted(ng-show='!countExists(message.likes)', ng-click='likeChatMessage(group, message)') +1
-          | &nbsp;
-        a(ng-click='#{inbox? "user.ops.deletePM({params:{id:message.$key}})" : "deleteChatMessage(group, message)"}', ng-if='#{inbox ? "true" : ":: user.contributor.admin || message.uuid == user.id"}')
-          span.glyphicon.glyphicon-trash(tooltip=env.t('delete'))
+          | &nbsp; &nbsp;
+          a(ng-click="quickReply(message.uuid)")
+            span.glyphicon.glyphicon-envelope(tooltip=env.t('sendPM'))
         if inbox
           a(ng-click="quickReply(message.uuid)")
             span.glyphicon.glyphicon-share-alt(tooltip=env.t('pm-reply'))
+        | &nbsp; &nbsp; &nbsp; &nbsp;
+        a(ng-click='#{inbox? "user.ops.deletePM({params:{id:message.$key}})" : "deleteChatMessage(group, message)"}', ng-if='#{inbox ? "true" : ":: user.contributor.admin || message.uuid == user.id"}')
+          span.glyphicon.glyphicon-trash(tooltip=env.t('delete'))
       span.float-label
         a.label.label-default.chat-message(ng-if=':: message.user', ng-class='::userLevelStyleFromLevel(message.contributor.level, message.backer.npc, style)', ng-click='clickMember(message.uuid, true)')
           span.glyphicon.glyphicon-arrow-right(ng-if='::message.sent')


### PR DESCRIPTION
ping @lefnire - is this ok?

This PR:
- puts the +1 button back into Tavern/guild/party chat
- adds a "quick reply" button to Tavern/guild/party chat that works like the reply button in the inbox
- moves the delete button (for chat and inbox) to the far right and adds spaces before it so it's harder to click it by accident

![screen shot 2014-11-25 at 2 46 25 pm](https://cloud.githubusercontent.com/assets/1495809/5178179/f99256a6-74b2-11e4-96ca-1146465f6437.png)
![screen shot 2014-11-25 at 2 46 48 pm](https://cloud.githubusercontent.com/assets/1495809/5178180/f994e11e-74b2-11e4-9e6e-b167c1690cd8.png)
