### PR TITLE
app.js // fix for links (when opening in new page)

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -20,16 +20,16 @@ window.habitrpg = angular.module('habitrpg',
 
       $urlRouterProvider
         // Setup default selected tabs
-        .when('/options', '/options/profile/avatar')
-        .when('/options/profile', '/options/profile/avatar')
-        .when('/options/groups', '/options/groups/tavern')
-        .when('/options/groups/guilds', '/options/groups/guilds/public')
-        .when('/options/groups/hall', '/options/groups/hall/heroes')
-        .when('/options/inventory', '/options/inventory/drops')
-        .when('/options/settings', '/options/settings/settings')
+        .when('/options', '/#/options/profile/avatar')
+        .when('/options/profile', '/#/options/profile/avatar')
+        .when('/options/groups', '/#/options/groups/tavern')
+        .when('/options/groups/guilds', '/#/options/groups/guilds/public')
+        .when('/options/groups/hall', '/#/options/groups/hall/heroes')
+        .when('/options/inventory', '/#/options/inventory/drops')
+        .when('/options/settings', '/#/options/settings/settings')
 
         // redirect states that don't match
-        .otherwise("/tasks");
+        .otherwise("/#/tasks");
 
       $stateProvider
 


### PR DESCRIPTION
Not sure if these changes will fix the issue with links in the main menu - still a bit clueless around the Github world. Essentially, the links currently need the '/#' at the beginning in order to work. Using the actual Github software has just caused confusion and crashes, so I am working via the website. If this is not the fix, then somebody who knows better should be able to fix it quick enough.
