### PR TITLE
Fix #4259 HP/EXP meter bars always 100% on IE11

### DIFF
--- a/views/options/inventory/stable.jade
+++ b/views/options/inventory/stable.jade
@@ -8,7 +8,7 @@ mixin petList(source)
             div(popover-trigger='mouseenter', popover=env.t('petName', {potion: potion.text(env.language.code), egg: egg.text(env.language.code)}), popover-placement='bottom')
               button(class="pet-button Pet-#{pet}", ng-if='user.items.pets["#{pet}"]>0', ng-class='{active: user.items.currentPet == "#{pet}", selectableInventory: selectedFood && !user.items.mounts["#{pet}"]}', ng-click='choosePet("#{egg.key}", "#{potion.key}")')
                 .progress(ng-show='!user.items.mounts["#{pet}"] && "#{egg.key}"!="Egg"')
-                  .progress-bar.progress-bar-success(style='width:{{user.items.pets["#{pet}"]/.5}}%')
+                  .progress-bar.progress-bar-success(ng-style='{width: (user.items.pets["#{pet}"]/.5) + "%"}')
               button(class="pet-button pet-not-owned", ng-if='!user.items.pets["#{pet}"]')
                 .PixelPaw
               button(class="pet-evolved pet-button Pet-#{pet}", ng-if='user.items.pets["#{pet}"]<0')

--- a/views/options/social/boss.jade
+++ b/views/options/social/boss.jade
@@ -39,7 +39,7 @@ mixin boss(tavern, mobile)
           div(class="quest_{{::group.quest.key}}")
           //-
             .progress
-            .bar(style='width: {{Shared.percent(group.quest.hp, Content.quests[group.quest.key].hp)}}%;')
+            .bar(ng-style='{width: Shared.percent(group.quest.hp, Content.quests[group.quest.key].hp) + "%"};')
             span.meter-text
               span.glyphicon.glyphicon-heart
               | {{group.quest.hp | number:0}} / {{Content.quests[group.quest.key].hp}}
@@ -47,13 +47,13 @@ mixin boss(tavern, mobile)
             .meter-label(tooltip=env.t('bossHP'))
               span.glyphicon.glyphicon-heart
             .meter.health
-              .bar(style='width: {{Shared.percent(progress.hp, boss.hp)}}%;')
+              .bar(ng-style='{width: Shared.percent(progress.hp, boss.hp) + "%"};')
               span.meter-text.value
                 | {{Math.ceil(progress.hp) | goldRoundThousandsToK}} / {{boss.hp | goldRoundThousandsToK}}
             .meter-label(tooltip='Rage', ng-if='boss.rage')
               span.glyphicon.glyphicon-fire
             .meter.mana(ng-if='boss.rage',popover="{{::boss.rage.description()}}",popover-title="{{::boss.rage.title()}}",popover-trigger='mouseenter',popover-placement='right')
-              .bar(style='width: {{Shared.percent(progress.rage, boss.rage.value)}}%;')
+              .bar(ng-style='{width: Shared.percent(progress.rage, boss.rage.value) + "%"};')
               span.meter-text.value
                 | {{Math.ceil(progress.rage)  | goldRoundThousandsToK}} / {{boss.rage.value | goldRoundThousandsToK}}
         div(ng-if='::Content.quests[group.quest.key].collect')

--- a/views/shared/header/header.jade
+++ b/views/shared/header/header.jade
@@ -10,13 +10,13 @@
       .meter-label(tooltip=env.t('health'))
         span.glyphicon.glyphicon-heart
       .meter.health
-        .bar(style='width: {{Shared.percent(user.stats.hp, 50)}}%;')
+		.bar(ng-style='{width: Shared.percent(user.stats.hp, 50) + "%" }')
         span.meter-text.value
           | {{Math.ceil(user.stats.hp)}} / 50
       .meter-label(tooltip=env.t('experience'))
         span.glyphicon.glyphicon-star
       .meter.experience
-        .bar(style='width: {{Shared.percent(user.stats.exp,Shared.tnl(user.stats.lvl))}}%;')
+		.bar(ng-style='{width: Shared.percent(user.stats.exp,Shared.tnl(user.stats.lvl)) + "%" };')
         span.meter-text.value
           span(ng-show='user.history.exp', tooltip=env.t('progress'))
             a(ng-click='toggleChart("exp")').glyphicon.glyphicon-signal 
@@ -25,7 +25,7 @@
       .meter-label(tooltip='Mana', ng-if='user.flags.classSelected && !user.preferences.disableClasses')
         span.glyphicon.glyphicon-fire
       .meter.mana(ng-if='user.flags.classSelected && !user.preferences.disableClasses')
-        .bar(style='width: {{user.stats.mp / user._statsComputed.maxMP * 100}}%;')
+        .bar(ng-style='{width: (user.stats.mp / user._statsComputed.maxMP * 100) + "%" };')
         span.meter-text.value
           span
           | {{Math.floor(user.stats.mp)}} / {{user._statsComputed.maxMP}}


### PR DESCRIPTION
Fixes bars width on IE11 allover the place (Jade-Templates).
