### PR TITLE
Solution for: Differentiate Locked and Unlocked Backgrounds (#4261)

### DIFF
--- a/public/css/customizer.styl
+++ b/public/css/customizer.styl
@@ -66,3 +66,14 @@ menu
 .well.limited-edition
   padding: 5px
   margin: 25px 0 0
+
+.background-unlocked
+  border 4px solid white
+  width: 144px !important
+  height: 152px !important
+
+.background-locked
+  border 4px solid gray
+  width: 144px !important
+  height: 152px !important
+

--- a/public/css/customizer.styl
+++ b/public/css/customizer.styl
@@ -68,12 +68,21 @@ menu
   margin: 25px 0 0
 
 .background-unlocked
-  border 4px solid white
-  width: 144px !important
-  height: 152px !important
+  border 15px solid white
+  width: 170px !important
+  height: 177px !important
 
 .background-locked
-  border 4px solid gray
-  width: 144px !important
-  height: 152px !important
+  border 15px solid gray
+  width: 170px !important
+  height: 177px !important
 
+.background-locked
+    position: relative
+
+.background-locked i
+    position: absolute;
+    right: -13px;
+    bottom: -13px;
+    color: white;
+    top: auto;

--- a/views/options/profile.jade
+++ b/views/options/profile.jade
@@ -250,8 +250,7 @@ mixin backgrounds(mobile)
               //-button.btn.btn-xs(ng-hide="ownsSet('background',Content.backgrounds['#{k}'])",ng-click="unlock(setKeys('background',Content.backgrounds['#{k}']))")!= env.t('unlockSet',{cost:15}) + ' <span class="Pet_Currency_Gem1x inline-gems"/>'
               button.btn.btn-xs(ng-hide="ownsSet('background',#{JSON.stringify(bgs)})",ng-click="unlock(setKeys('background',#{JSON.stringify(bgs)}))")!= env.t('unlockSet',{cost:15}) + ' <span class="Pet_Currency_Gem1x inline-gems"/>'
             each bg,k in bgs
-              button.customize-option(type='button',class='background_#{k}',ng-click='unlock("background.#{k}")',popover-title=bg.text(),popover=bg.notes(),popover-trigger='mouseenter').background-unlocked(ng-if='user.purchased.background.#{k}')
-              button.customize-option(type='button',class='background_#{k}',ng-click='unlock("background.#{k}")',popover-title=bg.text(),popover=bg.notes(),popover-trigger='mouseenter').background-locked(ng-if='!user.purchased.background.#{k}')
+              button.customize-option(type='button',class='background_#{k}',ng-class="user.purchased.background.#{k} ? 'background-unlocked' : 'background-locked'", ng-click='unlock("background.#{k}")',popover-title=bg.text(),popover=bg.notes(),popover-trigger='mouseenter')
       - }
 
 script(type='text/ng-template', id='partials/options.profile.backgrounds.html')

--- a/views/options/profile.jade
+++ b/views/options/profile.jade
@@ -188,8 +188,8 @@ mixin profileStats
               td= env.t('allocatePer') + ' {{user.stats.per}}'
               td
                 a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("per")', popover-trigger='mouseenter', popover-placement='right', popover=env.t('allocatePerPop')) +
-            
-           
+
+
       div(ng-class='user.flags.classSelected && !user.preferences.disableClasses ? "col-md-4" : "col-md-6"')
         button.btn.btn-default(ng-if='user.preferences.disableClasses', ng-click='user.ops.changeClass({})', popover-trigger='mouseenter', popover-placement='right', popover=env.t('enableClassPop'))= env.t('enableClass')
         hr(ng-if='user.preferences.disableClasses')
@@ -250,7 +250,8 @@ mixin backgrounds(mobile)
               //-button.btn.btn-xs(ng-hide="ownsSet('background',Content.backgrounds['#{k}'])",ng-click="unlock(setKeys('background',Content.backgrounds['#{k}']))")!= env.t('unlockSet',{cost:15}) + ' <span class="Pet_Currency_Gem1x inline-gems"/>'
               button.btn.btn-xs(ng-hide="ownsSet('background',#{JSON.stringify(bgs)})",ng-click="unlock(setKeys('background',#{JSON.stringify(bgs)}))")!= env.t('unlockSet',{cost:15}) + ' <span class="Pet_Currency_Gem1x inline-gems"/>'
             each bg,k in bgs
-              button.customize-option(type='button',class='background_#{k}',ng-click='unlock("background.#{k}")',popover-title=bg.text(),popover=bg.notes(),popover-trigger='mouseenter')
+              button.customize-option(type='button',class='background_#{k}',ng-click='unlock("background.#{k}")',popover-title=bg.text(),popover=bg.notes(),popover-trigger='mouseenter').background-unlocked(ng-if='user.purchased.background.#{k}')
+              button.customize-option(type='button',class='background_#{k}',ng-click='unlock("background.#{k}")',popover-title=bg.text(),popover=bg.notes(),popover-trigger='mouseenter').background-locked(ng-if='!user.purchased.background.#{k}')
       - }
 
 script(type='text/ng-template', id='partials/options.profile.backgrounds.html')

--- a/views/options/profile.jade
+++ b/views/options/profile.jade
@@ -250,7 +250,8 @@ mixin backgrounds(mobile)
               //-button.btn.btn-xs(ng-hide="ownsSet('background',Content.backgrounds['#{k}'])",ng-click="unlock(setKeys('background',Content.backgrounds['#{k}']))")!= env.t('unlockSet',{cost:15}) + ' <span class="Pet_Currency_Gem1x inline-gems"/>'
               button.btn.btn-xs(ng-hide="ownsSet('background',#{JSON.stringify(bgs)})",ng-click="unlock(setKeys('background',#{JSON.stringify(bgs)}))")!= env.t('unlockSet',{cost:15}) + ' <span class="Pet_Currency_Gem1x inline-gems"/>'
             each bg,k in bgs
-              button.customize-option(type='button',class='background_#{k}',ng-class="user.purchased.background.#{k} ? 'background-unlocked' : 'background-locked'", ng-click='unlock("background.#{k}")',popover-title=bg.text(),popover=bg.notes(),popover-trigger='mouseenter')
+              button.customize-option(type='button', class='background_#{k}', ng-class="user.purchased.background.#{k} ? 'background-unlocked' : 'background-locked'", ng-click='unlock("background.#{k}")', popover-title=bg.text(), popover=bg.notes(),popover-trigger='mouseenter')
+                i.glyphicon.glyphicon-lock(ng-if="!user.purchased.background.#{k}")
       - }
 
 script(type='text/ng-template', id='partials/options.profile.backgrounds.html')


### PR DESCRIPTION
1. Added two new background-specific styles to `customizer.styl` (4px gray border and 4px white border) and utilized them in `profile.jade` by checking for ownership of the asset and displaying a border (or not, as appropriate). 
2. Editor automatically cleaned up some trailing spaces on a few lines of `profile.jade`
