### PR TITLE
feat(news): move old news to /static/old-news

### DIFF
--- a/public/js/controllers/notificationCtrl.js
+++ b/public/js/controllers/notificationCtrl.js
@@ -170,6 +170,6 @@ habitrpg.controller('NotificationCtrl',
 
     // Show new-stuff modal on load
     if (User.user.flags.newStuff)
-      $rootScope.openModal('newStuff');
+      $rootScope.openModal('newStuff', {size:'lg'});
   }
 ]);

--- a/src/routes/pages.js
+++ b/src/routes/pages.js
@@ -20,7 +20,7 @@ router.get('/', i18n.getUserLanguage, middleware.locals, function(req, res) {
 
 // -------- Marketing --------
 
-var pages = ['front', 'privacy', 'terms', 'api', 'features', 'videos', 'contact', 'plans', 'new-stuff', 'community-guidelines'];
+var pages = ['front', 'privacy', 'terms', 'api', 'features', 'videos', 'contact', 'plans', 'new-stuff', 'community-guidelines', 'old-news'];
 
 _.each(pages, function(name){
   router.get('/static/' + name, i18n.getUserLanguage, middleware.locals, function(req, res) {

--- a/views/shared/header/menu.jade
+++ b/views/shared/header/menu.jade
@@ -254,4 +254,4 @@ nav.toolbar(ng-controller='AuthCtrl', ng-class='{active: isToolbarHidden}')
         span {{Shared.silver(user.stats.gp)}}
     ul.toolbar-bailey(ng-class='{inactive: !_expandedMenu}')
       li.toolbar-bailey-container(ng-if='user.flags.newStuff')
-        .npc_bailey.npc_bailey_head(popover=env.t('psst'), popover-trigger='mouseenter', popover-placement='right', ng-click='openModal("newStuff")')
+        .npc_bailey.npc_bailey_head(popover=env.t('psst'), popover-trigger='mouseenter', popover-placement='right', ng-click='openModal("newStuff",{size:"lg"})')

--- a/views/shared/modals/new-stuff.jade
+++ b/views/shared/modals/new-stuff.jade
@@ -1,7 +1,11 @@
 script(type='text/ng-template', id='modals/newStuff.html')
   .modal-header
-    h4=env.t('newStuff')
+    | #{env.t('newStuff')} by&nbsp;
+    a(target='_blank', href='https://twitter.com/Mihakuu') Bailey
   .modal-body.new-stuff-modal.modal-fixed-height
+    .npc_bailey
+    br
+    br
     include ../new-stuff
   .modal-footer
     button.btn.btn-default(ng-click='$close()')=env.t('cool') 

--- a/views/shared/new-stuff.jade
+++ b/views/shared/new-stuff.jade
@@ -1,1391 +1,1384 @@
-table
-  tr
-    td
-      .npc_bailey
-    td
-      .popover.static-popover.fade.right.in.wide-popover
-        .arrow
-        h3.popover-title
-          a(target='_blank', href='https://twitter.com/Mihakuu') Bailey
-        .popover-content
-          h5 SITE OUTAGE EXPLANATION, DECEMBER BACKGROUNDS, AND DECEMBER MYSTERY ITEM SET
-          table.table.table-striped
-            tr
-              td
-                h5 Site Outage Explanation
-                p Many of you may have noticed that you could not access HabitRPG for a large portion of December 1st. This wasn't a problem on our end - it was due to an outage by DNSimple, the service that provides us with our domain. We're very sorry about any frustration that this caused! If you lost any stats, you can restore them using Settings > Site > Fix Character Values. For future reference, if you ever have trouble accessing HabitRPG, be sure to follow our official Twitter, @HabitRPG, for updates! Thank you for all of your supportive messages <3
-            tr
-              td
-                h5 December Backgrounds
-                p There are three new avatar backgrounds in the <a href=https://habitrpg.com/#/options/profile/backgrounds>Background Shop</a>! Now your avatar can explore the South Pole, drift on an Iceberg, or admire the Winter Party Lights!
-                p.small.muted by McCoyly, RosieSully, and Holseties
-            tr
-              td
-                h5 December Mystery Item Set
-                p Hmmm! What could it be? All Habiticans who are subscribed during the month of December will receive the December Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
-                p.small.muted by Lemoness
-          p.small.muted 12/1/2014
-
-h5 11/26/2014 - Happy Thanksgiving!
+h5 SITE OUTAGE EXPLANATION, DECEMBER BACKGROUNDS, AND DECEMBER MYSTERY ITEM SET
 table.table.table-striped
   tr
     td
-      h5 Happy Thanksgiving!
-      p It's Thanksgiving in Habitica! On this day Habiticans celebrate by spending time with loved ones, giving thanks, and riding their glorious turkeys into the magnificent sunset. Some of the NPCs are celebrating the occasion!
+      h5 Site Outage Explanation
+      p Many of you may have noticed that you could not access HabitRPG for a large portion of December 1st. This wasn't a problem on our end - it was due to an outage by DNSimple, the service that provides us with our domain. We're very sorry about any frustration that this caused! If you lost any stats, you can restore them using Settings > Site > Fix Character Values. For future reference, if you ever have trouble accessing HabitRPG, be sure to follow our official Twitter, @HabitRPG, for updates! Thank you for all of your supportive messages <3
+  tr
+    td
+      h5 December Backgrounds
+      p There are three new avatar backgrounds in the <a href=https://habitrpg.com/#/options/profile/backgrounds>Background Shop</a>! Now your avatar can explore the South Pole, drift on an Iceberg, or admire the Winter Party Lights!
+      p.small.muted by McCoyly, RosieSully, and Holseties
+  tr
+    td
+      h5 December Mystery Item Set
+      p Hmmm! What could it be? All Habiticans who are subscribed during the month of December will receive the December Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
       p.small.muted by Lemoness
-  tr
-    td
-      h5 Turkey Pet and Mount!
-      p Those of you who weren't around last Thanksgiving have received an adorable Turkey Pet, and those of you who got a Turkey Pet last year have received a handsome Turkey Mount! Thank you for using HabitRPG - we really love you guys <3
-      p.small.muted by Lemoness
-
-h5 11/25/2014
-table.table.table-striped
-  tr
-    td
-      h5 November Item Set Revealed
-      p The November Subscriber Item has been revealed: the Feast and Fun Set! All November subscribers will receive the Pitchfork of Feasting and the Steel Helm of Sporting. You still have five days to subscribe and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
-      p.small.muted by Lemoness
-  tr
-    td
-      h5 Private Messaging Version 1.0
-      p We're excited to announce a new feature: Private Messaging! Now you can send someone a PM by clicking the envelope icon in the bottom-left of their profile window . You can check your messages under Social > Inbox! This is a very rudimentary feature so far, only containing the ability to send messages, block people, and opt out. To read about some of the planned features for the future and make suggestions, check out <a href='https://trello.com/c/hHpIzMc5/459-private-messaging-v-2' target='_blank'>this Trello card</a>!
-      p.small.muted by Lefnire
-
-h5 11/18/2014
-table.table.table-striped
-  tr
-    td
-      h5 New Pet Quest: The Night-Owl!
-      p Habiticans are in the dark when a giant Night-Owl blots out the Tavern light! Can you drive it away in time to finish your all-nighter? If so, you may find some cute pet owls in the morning...
-      p.small.muted by Twitching, Lemoness, and Arcosine
-
-h5 11/13/2014 - Share Avatar To Social Media, Email Invites, First Mini Quest, And Data Tab
-table.table.table-striped
-  tr
-    td
-      h5 Share Avatar To Social Media
-      p You can now automatically share your avatar and public profile to social media! Just hover over the picture and click the "Share" button in the right-hand corner. Show off your outfit, your achievements, and your profile picture! Note that your tasks, as always, remain 100% private.
-      p.small.muted by Lefnire
-  tr
-    td
-      h5 Invite Friends To Party Via Email
-      p Do you want to invite friends to join your party without inputting their User ID? Now you can send them an email directly from the party page - even if they don't have an account yet!
-      p.small.muted by Lefnire
-  tr
-    td
-      h5 Mini Quest: The Basi-List!
-      p Now when someone accepts your party invitation and joins your party, you will be given a Mini Quest: The Basi-List! Battle the Basi-List with your friends for an XP and GP reward.
-      p.small.muted by Arcosine and Redphoenix
-  tr
-    td
-      h5 Data Tab
-      p Now you can access the Data Display Tool and Export Data from the toolbar!
-      p.small.muted by ShilohT
-
-h5 11/12/2014
-table.table.table-striped
-  tr
-    td
-      h5 New Equipment Quest Line: The Golden Knight!
-      p The Golden Knight believes that she is the perfect Habitican, and that anyone who slips up in their quest for self-improvement is a lazy failure. Can you talk some sense into her - or will it come to blows? If you complete the entire quest line, you'll be rewarded with a legendary weapon...
-      p The first scroll in this quest line, "A Stern Talking-to," drops automatically at Level 40! If you're already over Level 40, you will automatically be awarded this quest - just check off a task and then check your inventory.
-
-h5 11/09/2014 - Facebook Login Fixed For Mobile And Community Guidelines To Chat
-table.table.table-striped
-  tr
-    td
-      h5 Facebook Login Fixed For Mobile!
-      p Great news! If you use Facebook to log in to the mobile app, we've released an update so you no longer have to type in your UUID/API manually, misspelling things on your tiny keyboard and bemoaning your fate. Thank goodness! The Android update is out now, and the iOS update has been submitted and should be out soon.
-  tr
-    td
-      h5 Community Guidelines To Chat
-      p Before you can use any of the public chat features, you now have to agree to our Community Guidelines. We know they're long, but they're important, so please do read them if you haven't already. Plus, we worked hard to make them entertaining, and they were illustrated by many of our excellent artisans!
-
-h5 11/06/2014
-table.table.table-striped
-  tr
-    td
-      h5 Bailey: Costume Challenge Badges Awarded!
-      p The HabitRPG Costume Challenge Badges have been awarded! Thanks for your patience while we went through all the entries individually. You can see some of the entries <a href='http://blog.habitrpg.com/tagged/cosplay' target='_blank'>on the HabitRPG blog</a> already, and more will be added every week.
-      p IMPORTANT: some of the links that people provided did not work. If you entered the Challenge but even after refreshing the page you still don't have your badge, email leslie@habitrpg.com with the link to your costume and your avatar. (The costume and avatar must have been posted prior to November 1st to count.)
-      p Thanks to all our amazing participants!
-
-h5 11/05/2014- November Backgrounds And Beeminder Integration
-table.table.table-striped
-  tr
-    td
-      h5 November Backgrounds
-      p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can enjoy a Harvest Feast, admire a Sunset Meadow, or gaze at the Starry Skies!
-      p.small.muted by Kiwibot, Holsety1, and Draayder
-  tr
-    td
-      h5 Beeminder Integration
-      p We've integrated with Beeminder! Now you can beemind your To-Dos automatically :) <a href='https://www.beeminder.com/habitrpg' target='_blank'>Check it out</a>!
-      p If you've never heard of Beeminder or want to learn more about what we've integrated so far, check out our <a href='http://blog.habitrpg.com/post/101773418876/beeminder-integration' target='_blank'>blog post about it</a>. Enjoy!
-      p.small.muted by Alys and Alice Monday
-
-h5 11/01/2014
-table.table.table-striped
-  tr
-    td
-      h5 November Mystery Item Set
-      .pull-right.inventory_present
-      p Cool! What could it be? All Habiticans who are subscribed during the month of November will receive the November Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
-
-h5 10/31/2014 - Monster Npcs, Last Day For Fall Festival Items, Last Day Of Community Costume Challenge, Last Day For Winged Goblin Item Set
-table.table.table-striped
-  tr
-    td
-      h5 Last Day For Fall Festival Items
-      p Tomorrow everything will be back to normal in Habitica, so if you still have any remaining Fall Festival Items that you want to buy, you'd better do it now! The Seasonal Edition items won't be back until next fall, and if the Limited Edition items return they will have increased prices or changed art, so strike while the iron is hot!
-  tr
-    td
-      h5 Last Day For Winged Goblin Item Set
-      p Reminder: this is the final day to subscribe and receive the Winged Goblin Item Set! If you want the Goblin Wings or the Goblin Gear, now's the time! Thanks so much for your support <3
-  tr
-    td
-      h5 Last Day Of Community Costume Challenge
-      p It's the last day to post your pictures of yourself dressed up as your HabitRPG avatar if you want to get the Costume Challenge Badge! You can join the Challenge <a href='https://habitrpg.com/#/options/groups/challenges/39f7e9b4-1fbf-4b01-baee-221fd9b9ef43' target='_blank'>here</a>.
-  tr
-    td
-      h5 Monster Npcs
-      p The NPCs have dressed up in their Halloween costumes! Be sure to stop by and check them all out.
-
-h5 10/27/2014 - Increased Gems For Contributors And Community Guidelines
-table.table.table-striped
-  tr
-    td
-      h5 Community Guidelines
-      p Our community has grown and evolved over this past year and a half, and we realized that none of the community expectations had been codified anywhere. This has now changed with the implementation of the <a href='/static/community-guidelines' target='_blank'>Community Guidelines</a>. The Guidelines have been written by the staff and mods and illustrated by many of our talented artisans. We know they're long, but they contain all the expectations for participating in the public social side of HabitRPG, so please do read them carefully! Soon you'll have to agree to them to participate in any of the Public Chat.
-      p.small.muted by <strong>Alys</strong>, Lemoness, lefnire, redphoenix, SabreCat, paglias, Bailey, Ryan, Breadstrings, Megan, Daniel the Bard, Draayder, Kiwibot, Leephon, Luciferian, Revcleo, Shaner, Starsystemic, UncommonCriminal
-  tr
-    td
-      h5 Increased Gems For Contributors
-      p When we first started rewarding contributors, we decided to give them 2 gems per contributor tier. Since then, however, we've introduced many more things to buy, so we've decided to increase this number. All contributors now receive 3 gems/tier for tiers 1-3, and then 4 gems/tier for tiers 4-7, bringing the total number of gems you can earn by contributing to the site to 25.
-      p If you've already contributed, you've been given the gems that you're owed according to the new system. (For example, if you are a tier 3 contributor, you received 6 gems in the past and would receive 9 gems under the new system, so you've been awarded 3 gems to account for the difference.)
-      p Enjoy!
-      p.small.muted by Alys
-
-h5 10/25/2014 - October Item Set Revealed And Community Costume Challenge Reminder
-table.table.table-striped
-  tr
-    td
-      h5 October Item Set Revealed
-      .promo_mystery_201410.pull-right
-      The October Subscriber Item has been revealed: the Winged Goblin Item Set! All October subscribers will receive the Goblin Gear and the Goblin Wings. You still have six days to subscribe and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
-      by Lemoness
-      h5 Community Costume Challenge Reminder
-      .achievement-costumeContest.pull-right
-      p Don't forget about the <a href='https://habitrpg.com/#/options/groups/challenges/39f7e9b4-1fbf-4b01-baee-221fd9b9ef43' target='_blank'>Community Costume Challenge</a>! We've had some really amazing entries so far, and we're looking forward to seeing more over the next six days! All participants will receive the 2014 Costume Challenge Badge.
-      p You can view some of the awesome costumes <a href='http://blog.habitrpg.com/tagged/cosplay' target='_blank'>here</a>!
-
-h5 10/23/2014
-table.table.table-striped
-  tr
-    td
-      h5 Level 60 Equipment Quest: Recidivate Quest Line!
-      p All over Habitica, Bad Habits thought long-dead are rising up again - it must be the work of Recidivate, the wicked Necromancer! Can you complete your Dailies and fight down your Bad Habits to lay her to rest once more? If so, you'll reap some fine spoils... including some legendary armor!
-      p This quest line contains the hardest Boss Battle that we've released to date, so the first quest scroll drops for free at Level 60. If you're already Level 60 or over, you can unlock it for free, too - just check off any task and it will drop for you :) Good luck! You'll need it.
-      p.small.muted by Lemoness, Tru_, aurakami, Inventrix, and Baconsaur
-
-h5 10/15/2014 - Spider Pet Quest, Mobile App Update, Hide Grey Dailies, And Sortable Checklists!
-table.table.tables-striped
-  tr
-    td
-      h5 New Pet Quest: The Icy Arachnid!
-      p Yikes, what's leaving these icy webs all over Habitica? It must be the Frost Spider from the newest Pet Quest: The Icy Arachnid! You can buy this quest in the <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>Market</a>. Don't worry, it will be around even after the Fall Festival ends :)
-      p.small.muted by Arcosine
-  tr
-    td
-      h5 Mobile App Update!
-      p The newest mobile app update is available on iOS and Android! Now when you're on your phone you can see Fall Festival items, get drop notifications, and view the pixel art of the bosses that you're battling!
-      p.small.muted By lefnire, negue, huarui, and paglias
-  tr
-    td
-      h5 Hide Grey Dailies
-      p You can now hide grey Dailies to de-clutter your list! There are tabs at the bottom of the Dailies column that you can toggle to see only which Dailies are still active.
-      p.small.muted by Gaelan, and Alys
-  tr
-    td
-      h5 Sortable Checklists
-      p Have you ever wanted to rearrange checklist order? Now you can! Simply drag and drop to sort your checklist points.
-      p.small.muted By gjoyner
-
-h5 10/7/2014 - Back-To-School Advice Challenge Winners And Jack-O-Lantern Pet!
-table.table.table-striped
-  tr
-    td
-      h5 Back-To-School Advice Challenge Winners
-      p We had a ton of participants in our Back-To-School Advice Challenge, and we've finally sorted through and chosen the winners! Congratulations to
-      p DJ Ringis, The Writer, San Condor, Tavi Wright, Stepharuka, Clyc, samaeldreams, LitNerdy, Tritlo, Shansie, Han Solo, FrauleinNinja, Nortya, itsallaboutfalling, TomFrankly, [TGL] Dogg, Amanda, InfH, Evan950, and Mizuokami! You've all received your gems :)
-      p Thanks so much for participating! If you had fun, don't forget that the Community Costume Challenge is happening all October :)
-  tr
-    td
-      h5 Jack-O-Lantern Pet
-      p Habiticans have been carving lots of pumpkins recently - and it looks like one has followed you home! Everyone has received a pet Jack-O-Lantern! You can find it in the Stables :)
-      p.small.muted by Lemoness
-
-h5 10/3/2014- Spooky Sparkles, New Backgrounds, And Memory Leaks Almost Fixed!
-table.table.table-striped
-  tr
-    td
-      h5 Spooky Sparkles
-      .pull-right
-        .inventory_special_spookDust
-        .achievement-spookDust
-        .spookman
-      p There's a new gold-purchasable item in the <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>Market</a>: Spooky Sparkles! Buy some and then cast it on your friends. I wonder what it will do?
-      br
-      p If you have Spooky Sparkles cast on you, you will receive the "Alarming Friends" badge! Don't worry, any mysterious effects will wear off the next day.... or you can cancel them early by buying an Opaque Potion!
-      br
-      p Spooky Sparkles will only be in the Rewards store until October 31st, so stock up!
-      p.small.muted by Lemoness, lefnire
-  tr
-    td
-      h5 New Backgrounds Revealed: Haunted House, Graveyard, And Pumpkin Patch
-      p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can sneak through a Haunted House, visit a creepy Graveyard, or carve jack-o-lanterns in a Pumpkin Patch!
-      p.small.muted by cecilyperez, Kiwibot, and Sooz
-  tr
-    td
-      h5 Memory Leaks Almost Fixed
-      p It took a ton of effort, but Tyler has fixed the largest memory leak that was crashing our servers! There are a few smaller ones that he’s still conquering one by one, but the fiercest monster has been slain. Ten thousand cheers for Tyler! You can read the technical description of how we’re fixing the leaks <a href='https://github.com/HabitRPG/habitrpg/issues/4079' target='_blank'>here</a>, and for any JavaScript developers out there: we'd love your help! We’ll let you all know when we’ve fixed the problem for once and for all.
-      p.small.muted by lefnire
-
-h5 10/1/2014 - Seasonal Edition Skins, Seasonal Edition Hair Colors, Community Costume Challenge, Release Pets, and October Mystery Item!
-table.table.table-striped
-  tr
-    td
-      h5 Seasonal Edition Hair
-      p The Seasonal Edition Haunted Hair Colors are now available for purchase in the avatar customizations page! Now you can dye your avatar's hair Pumpkin, Midnight, Candy Corn, Ghost White, Zombie, or Halloween.
-      p Seasonal Edition items recur unchanged every year, but they are only available to purchase during a short period of time. This is different from Limited Edition Items, which only recur if something is changed, such as the art or the price. Read more about the difference between Seasonal and Limited Edition items <a href='http://habitrpg.wikia.com/wiki/Item_Availability' target='_blank'>here</a>!
-      p.small.muted by Lemoness, mariahm, and crystal phoenix
-  tr
-    td
-      h5 Seasonal Edition Skins
-      p The Supernatural Skin Set is here! Now your avatar can become an Ogre, Skeleton, Pumpkin, Candy Corn, Reptile, or Dread Shade. You can buy them from now until October 31st!
-      p These skins may remind some of you of the Spooky Skin set that was available briefly last fall. This is because we've received many requests for these Limited Edition skins from more recent players who were unable to purchase those skins. As a compromise, we have decided to Retire the Spooky Skin Set and release some similar but unique skins as part of the Supernatural Skin Set. That way, anyone who wants their avatar to be a pumpkin can have their way, but the original owners of the skin sets still have the unique items that they were promised. You can read more about the new Item Availability categories <a href='http://habitrpg.wikia.com/wiki/Item_Availability' target='_blank'>here</a>.
-      p.small.muted by Lemoness
-  tr
-    td
-      h5 Community Costume Challenge
-      p The Community Costume Challenge has begun! Between now and October 31st, dress up as your avatar in real life and post a photo on social media to get the coveted Costume Challenge badge! Read the full rules on the Challenge page <a href='https://habitrpg.com/#/options/groups/challenges/39f7e9b4-1fbf-4b01-baee-221fd9b9ef43' target='_blank'>here</a>.
-      p.small.muted by Lemoness
-  tr
-    td
-      h5 Release Pets and Mounts
-      p If you find collecting pets highly motivating and want to start over from zero, you're in luck! You can now release all your pets and mounts so that you can collect them again - and stack your Beastmaster achievement!
-      p.small.muted By Ryan
-  tr
-    td
-      h5 October Mystery Item
-      p Spooky! What could it be? All Habiticans who are subscribed during the month of October will receive the October Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
-      p.small.muted by Lemoness
-
-h5 9/25/2014
-table.table.table-striped
-  tr
-    td
-      h5 Update: Diagnosing Server Problems
-      p Our servers have been under a massive strain recently, and so we've created a <a href='https://github.com/HabitRPG/habitrpg/issues/4079' target='_blank'>Github ticket</a> that you can follow for updates on the things we're doing to fix the problem. We've also written a <a href='http://blog.habitrpg.com/post/98367930371/update-diagnosing-server-problems' target='_blank'>blog post</a>. We'll keep you updated with new developments as we strive to solve this problem.
-      p If you've lost any of your stats during this time, you can restore them using Settings > Site > Fix Character Values. Thank you so much for your patience and encouragement as we work to fight this fearsome foe!
-      p.small.muted by lefnire, Lemoness
-  tr
-    td
-      h5 September Item Set Revealed
-      .promo_mystery_201409.pull-right
-      p In happier news, the September Subscriber Item has been revealed: the Autumn Strider Item Set. All people who are subscribed before the end of September will receive the Autumn Antlers and the Strider Vest. Thank you so much for your support - it means a lot to us, especially right now.
-      p.small.muted by Lemoness
-
-h5 9/22/2014 - Fall Festival! Limited-Edition Outfits, Candy Food Drops, And Npc Dress-Up
-p Autumn is upon us! The air is crisp, the leaves are red, and Habitica is feeling spooky. Come celebrate the Fall Festival with us... if you dare!
-table.table.table-striped
-  tr
-    td
-      h5 Limited Edition Class Outfits
-      p Habiticans everywhere are dressing up. From now until October 31st, limited edition outfits are available in the Rewards column. Depending on your class, you can be a Witchy Wizard, Monster of Science, Vampire Smiter, or Mummy Medic! You'd better get productive to earn enough gold before your time runs out...
-  tr
-    td
-      h5 Candy Food Drops!
-      p You've received some Candy in your inventory in honor of the Fall Festival! Plus, for the duration of the Event, Habiticans may randomly find candy drops when they complete their tasks. These candies function just like normal food drops - can you guess which flavor your pet will like best?
-  tr
-    td
-      h5 NPC Dress-Up
-      p Looks like the NPCs are really getting in to the spooky autumnal mood around the site. Who wouldn't?
-
-h5 9/17/2014 - Rooster Pets, Party Sorting, And Back-To-School Challenge
-table.table.table-striped
-  tr
-    td
-      h5 New Pet Quest: Rooster Rampage!
-      p There's a new pet quest in <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>the Market</a>! This monstrous rooster can't be quieted, and Habiticans are unable to sleep. Can you and your Party calm down this foul fowl? You'll be rewarded with Rooster eggs if you do!
-      p.small.muted by LordDarkly, Pandoro, EmeraldOx, extrajordanary, and playgroundgiraffe
-  tr
-    td
-      h5 Party Sorting!
-      p We've improved the preexisting party sort feature. Now you can sort your party members' avatars by level, backgrounds, and more! Simply go to Social > Party > Members and select from the drop-down menu.
-      p.small.muted by Alys and Viirus
-  tr
-    td
-      h5 Back-To-School Challenge!
-      p Don't forget that the 2nd Official HabitRPG Challenge is running right now - the <a href='https://habitrpg.com/#/options/groups/challenges/a367eb40-8514-46fd-805e-b9b7f89bad7f' target='_blank'>Back-To-School Advice Challenge</a>! Post your best tips for using HabitRPG during the Back-To-School season on social media for a chance at winning 60 gems. If you want to share it with the maximum number of people, you can use the #habitrpg and #backtoschool tags. You only have thirteen more days to enter. Good luck!
-
-h5 9/12/2014 - Official Back-To-School Challenge, Markdown In Checklists, And Help Tab
-table.table.table-striped
-  tr
-    td
-      h5 Official Back-To-School Challenge
-      p We've launched our 2nd Official HabitRPG Challenge: the Back-To-School Advice Challenge! Use social media to tell us how you use HabitRPG to improve study habits, share stories of scholarly success with the app, or just give us your advice on using HabitRPG to be the best you can be.
-      p The contest ends on September 30th, and the 20 winners will each get 60 Gems! For the full rules, <a href='https://habitrpg.com/#/options/groups/challenges/a367eb40-8514-46fd-805e-b9b7f89bad7f' target='_blank'>check out the challenge here</a>.
-      h5 Markdown In Checklists
-      p Previously, you've been able to use <a href='http://habitrpg.wikia.com/wiki/Markdown_Cheat_Sheet' target='_blank'>markdown</a> in your task names and in chat. Now you can also use it in checklists! Fill every aspect of your tasks with emoji, bolding, italics, or links. NOTE: If your checklists look strange, it's probably because they're accidentally using markdown now, so just edit them accordingly! Check out <a href='http://habitrpg.wikia.com/wiki/Markdown_Cheat_Sheet' target='_blank'>this Cheat Sheet</a> for an explanation of how to use markdown.
-      p.small.muted By @negue
-      h5 Help Tab
-      p There's a new tab on the top bar that contains some helpful links. If you're confused about something, want to request a feature, or wonder if your question was asked before, you can now use the Help Tab's drop down menu!
-      p.small.muted By @Alys
-
-h5 9/10/2014
-table.table.table-striped
-  tr
-    td
-      h5 Get Ready For The Community Costume Challenge!
-      p We've got an exciting event coming up this October - the first-ever Community Costume Challenge! In the spirit of the season, Habiticans who dress up in real-life versions of their avatar's armor (or in any HabitRPG costume) will receive a special badge. (No, just wearing a colored shirt doesn't count. Where's the fun in that?)
-      p The Community Costume Challenge will start on October 1st, but we're announcing it early so that people have time to get their costumes together.
-      p Instructions on how to participate in the CCC will be posted on October 1st. We can't wait to see your costumes!
-
-h5 9/3/2014
-table.table.table-striped
-  tr
-    td
-      h5 New Backgrounds Revealed: Thunderstorm, Autumn Forest, Harvest Fields
-      p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop!</a> Now your avatar can conduct lightning in a Thunderstorm, stroll through an Autumn Forest, or cultivate their Harvest Fields!
-      p.small.muted by krajzega and Uncommon Criminal
-
-h5 9/1/2014
-table.table.table-striped
-  tr
-    td
-      h5 September Mystery Item
-      p Hmm, intriguing... All Habiticans who are subscribed during the month of September will receive the September Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
-
-h5 8/31/2014
-table.table.table-striped
-  tr
-    td
-      h5 Last Day For Sun Sorcerer Item Set
-      p Reminder: this is the final day to subscribe and receive the Sun Sorcerer Item Set! If you want the Sun Crown or the Sun Robes, now's the time! Thanks so much for your support <3
-
-h5 8/26/2014 - August Mystery Item, Sortable Tags, Push To Top
-table.table.table-striped
-  tr
-    td
-      h5 August Item Set Revealed!
-      .promo_mystery_201408.pull-right
-      p The August Subscriber Item has been revealed: the Sun Sorcerer Item Set! All August subscribers will receive the Sun Crown and the Sun Robes. You still have five days to subscribe and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
-      p.small.muted by Lemoness
-  tr
-    td
-      h5 Sortable Tags
-      p You can now sort your tags. Drag left-to-right and drop them into place.
-      p.small.muted by Fandekasp, lefnire
-  tr
-    td
-      h5 Push to Top
-      p We've added a small button in your tasks' one-click actions: Push to Top. This will help easily you sort your day's priorities, which may change from day-to-day.
-      p.small.muted by negue
-
-h5 8/19/2014 - Parrot Quest, Audio, And Mobile App Update!
-table.table.table-striped
-  tr
-    td
-      h5 New Pet Quest: Help! Harpy!
-      p There's a new Pet Quest available in the <a href='https://habitrpg.com/#/options/inventory/drops'>Market</a>! @UncommonCriminal is being held hostage by a Parrot-like Harpy. If you can find a way to help, you'll definitely get your hands on some coveted Parrot Eggs....
-      p After you've purchased the scroll, battle the Boss by completing Habits and To-Dos. Be careful - every Daily that you skip will cause the Boss to attack your party!
-      p.small.muted by Uncommon Criminal and Token
-  tr
-    td
-      h5 Audio
-      p You can now enable sound effects for various website actions. Click the volume icon (<span class='glyphicon glyphicon-volume-off'></span>) and choose an "Audio Theme". For now, the only theme available is "Daniel The Bard" (@DanielTheBard designed this set); however, we'll release more themes over time (<a href='http://habitrpg.wikia.com/wiki/Guidance_for_Bards' target='_blank'>get involved here</a>). We'll also add more sound effects, and possibly music, to the current set.
-      p.small.muted by DanielTheBard, Fandekasp
-
-  tr
-    td
-      h5 New Mobile Update: Backgrounds and Guilds!
-      p We've updated the mobile app to include Backgrounds and Guilds! Now you can use the mobile app to join common interest groups, chat with like-minded people, and swap your avatar’s background. The iOS app is <a href='https://itunes.apple.com/us/app/habitrpg/id689569235?mt=8' target='_blank'>here</a>, and the Android app is <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg&hl=en' target='_blank'>here</a>. If you enjoy the direction that we’ve been taking the app, we would really appreciate it if you would leave us a review <3 Thank you!
-      p.small.muted by huarui, paglias
-
-h5 8/12/2014
-table.table.table-striped
-  tr
-    td
-      h5 New Equipment Quest: Attack Of The Mundane!
-      p There's a new Quest that will drop automatically for all users level 15 and up: the Dish Disaster, first quest in the Attack of the Mundane Questline! Scrub enchanted dirty dishes, battle the SnackLess Monster, and face off against the Evil Laundromancer. You might just be rewarded with a new piece of armor...
-      p As you complete each quest in this questline, you will be awarded with the quest scroll for the next part. There are three parts in total. Good luck!
-      small.muted by Arcosine, Kiwibot, Lemoness, Daniel the Bard, itokro
-
-h5 8/6/2014
-table.table.table-striped
-  tr
-    td
-      h5 New Backgrounds Revealed: Volcano, Dusty Canyon, Clouds
-      p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can heat up inside a Volcano, wander through a Dusty Canyon, or soar through the Clouds!
-
-h5 8/4/2014
-table.table.table-striped
-  tr
-    td
-      h5 New Mobile Update: Checklist Editing And Bug Fixes!
-      p In case you missed it, we’ve released a new mobile update! You can edit checklists from the mobile app now. We also fixed some bugs, including the image problems on iOS! The Android app is <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg&hl=en' target='_blank'>here</a> and the iOS app is <a href='https://itunes.apple.com/us/app/habitrpg/id689569235?mt=8' target='_blank'>here</a>.
-      p You may have noticed that we've been releasing lots of updates recently. This is greatly due to two awesome members of our team!
-      p The first is superstar contributor Matteo, aka <a href='https://github.com/paglias' target='_blank'>paglias</a>. In addition to the mobile app, he contributes tons of code to the site, runs translations, and fixes bugs without blinking. We are so thankful to have him on the team!
-      p We also have another new mobile app contributor who has rocketed to Level 7 in record time: <a href='https://github.com/huaruiwu' target='_blank'>huarui</a>! Huarui has been an absolute whirlwind with mobile app improvements.
-      p Give them both a giant round of applause!
-
-h5 8/2/2014
-table.table.table-striped
-  tr
-    td
-      h5 Dread Drag'on Defeated! Prizes: Mantis Shrimp Pet, Mantis Shrimp Mount, Food, and Badge
-      p We've done it!
-      p With a final last roar, the Dread Drag'on collapses and swims far, far away. Crowds of cheering Habiticans line the shores! We've helped Daniel rebuild his Tavern.
-      p But what's this?
-      p THE CITIZENS RETURN!
-      p Now that the Drag'on has fled, thousands of sparkling colors are ascending through the sea. It is a rainbow swarm of Mantis Shrimp... and among them, hundreds of merpeople!
-      p "We are the lost citizens of Dilatory!" explains their leader, Manta. "When Dilatory sank, the Mantis Shrimp that lived in these waters used a spell to transform us into merpeople so that we could survive. But in its rage, the Dread Drag'on trapped us all in the dark crevasse. We have been imprisoned there for hundreds of years - but now at last we are free to rebuild our city!"
-      p "As a thank you," says his friend @Ottl, "Please accept this Mantis Shrimp pet and Mantis Shrimp mount, this feast, and our eternal gratitude!"
-  tr
-    td
-      h5 August Mystery Item
-      p Ooh, mysterious! All Habiticans who are subscribed during the month of August will receive the August Mystery Item Set! It will be revealed on the 26th, so keep your eyes peeled. Thanks for supporting the site <3
-
-h5 7/31/2014
-table.table.table-striped
-  tr
-    td
-      h5 Last Day for July Subscriber Set
-      .promo_mystery_201407.pull-right
-      p Reminder: this is the final day to subscribe and receive the Undersea Explorer Item Set! If you want the Undersea Explorer Helm or the Undersea Explorer Suit, now's the time! Thank you so much for your support <3
-  tr
-    td
-      h5 Final Day for Limited Edition Summer Outfits
-      p Today is the last day of the Summer Splash Event, so it is the last day to buy the Limited Edition Outfits and the Rainbow Warrior Armor from the Rewards store. Get productive and spend that gold!
-
+p.small.muted 12/1/2014
 hr
-h5 7/25/2014
-table.table.table-striped
-  tr
-    td
-      h5 July Subscriber Item
-      .promo_mystery_201407.pull-right
-      p The July Subscriber Item has been revealed: the Undersea Explorer Item Set! All July subscribers will receive the Undersea Explorer Helm and the Undersea Explorer Suit. You still have six days to subscribe and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
+a(href='/static/old-news', target='_blank') Read older news
 
-hr
-h5 7/16/2014
-table.table.table-striped
-  tr
-    td
-      h5 Mobile App Update
-      p We’ve released another update to the mobile app! Now you can feed and select pets from the app. Carry your cute pets with you everywhere you go! The app is available for <a href='https://itunes.apple.com/us/app/habitrpg/id689569235?mt=8' target='_blank'>iOS here</a>, and <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg' target='_blank'>Android here</a>. We’re continuing to release updates on a regular basis, so if you like the direction that we’ve been taking the app, please do consider leaving us a review. Thank you!
-  tr
-    td
-      h5 Neglect Strike: Tavern Art Swap
-      p The Dread Drag'on's Rage Bar has filled, and it has unleashed its Neglect Strike, leading to a new look for the Tavern! As a reminder, the Drag'on's rage will NEVER hurt any users or interfere with their ability to be productive, so the chat and inn are still functional. Even so... poor Daniel!
-      p All users are automatically damaging the Drag'on with their tasks. There is nothing bad that can happen to you or your account by being in this fight!
-  tr
-    td
-      h5 Dread Drag'on Prize Change: Food Reward!
-      p We've received a lot of feedback due to the weekend's confusion, and it seems that awarding GP and XP for defeating the world boss significantly unbalanced the game for newer players. Based on your feedback, XP and GP will no longer be awarded. Instead, players will receive an assortment of food! The Mantis Shrimps will still be awarded.
-      p If you were looking forward to receiving the 900XP and 90 GP upon completion of the battle, feel free to award it to yourself using Settings > Site > Fix Character Values when the battle is done!
-      p Thank you for bearing with us through the confusion. We love you guys.
-hr
-h5 7/12/2014
-table.table.table-striped
-  tr
-    td
-      h5 Wow, What'S Going On?!
-      p You may have noticed some strange things happening - extra gold? Drag'on defeated? No quest damage?
-      br
-      p Turns out the Dread Drag'on of Dilatory was harder to handle than we expected, and wreaked havoc on us last night by unexpectedly completing due to a glitch, throwing off party quest damage, and granting all of its rewards early! *shakes fist at terrible beast*
-      br
-      p The Drag’on is now back in the battle (<a href='http://habitrpg.wikia.com/wiki/The_Dread_Drag'on_of_Dilatory' target='_blank'>read about how to fight it here</a>), and the Mantis Shrimp pet/mount were removed until it is defeated for good. We are so sorry about the confusion!
-      br
-      p If you don’t want the 900 XP and 90 Gold, you can delete it using Settings > Site >Fix Character Values. You can also keep it as an apology from the devs for all the confusion! Do whatever is most motivating for you :) It will be granted again when the Drag'on is truly vanquished.
-      br
-      p The Drag’on also caused some glitches with party boss damage, but they should be repaired now.
-      br
-      p For a detailed breakdown of what happened, follow the issue <a href='https://github.com/HabitRPG/habitrpg/issues/3712' target='_blank'>here</a>!
-      br
-      p Now let's fight this monster for real.
+mixin oldNews
+  h5 11/26/2014 - Happy Thanksgiving!
+  table.table.table-striped
+    tr
+      td
+        h5 Happy Thanksgiving!
+        p It's Thanksgiving in Habitica! On this day Habiticans celebrate by spending time with loved ones, giving thanks, and riding their glorious turkeys into the magnificent sunset. Some of the NPCs are celebrating the occasion!
+        p.small.muted by Lemoness
+    tr
+      td
+        h5 Turkey Pet and Mount!
+        p Those of you who weren't around last Thanksgiving have received an adorable Turkey Pet, and those of you who got a Turkey Pet last year have received a handsome Turkey Mount! Thank you for using HabitRPG - we really love you guys <3
+        p.small.muted by Lemoness
 
-hr
-table.table.table-striped
-  tr
-    td
-      h5 July 11th: GaymerX reminder
-      p Reminder: Vicky (aka redphoenix) is at GaymerX at the InterContinental in San Francisco this weekend! She will have lots of promo codes for the Unconventional Armor Set. Our champion moderator Ryan will be there, too, and would love to meet you guys! Vicky will be wearing a dinosaur hoodie and a red shirt, and Ryan has a partially-shaved head and is in a wheelchair.
-      br
-      p There will be an official HabitRPG meet-up on <strong>Saturday 3:15-4:30</strong> outside GX Panel Room A (Grand Ballroom AB (3F)). Come get your promo codes there! If you can't make it at that time, contact Vicky via email (vicky@habitrpg.com) or Twitter (@caffeinatedvee) to coordinate an alternative time and place to meet up at the convention!
-small.muted 7/11/2014
-hr
+  h5 11/25/2014
+  table.table.table-striped
+    tr
+      td
+        h5 November Item Set Revealed
+        p The November Subscriber Item has been revealed: the Feast and Fun Set! All November subscribers will receive the Pitchfork of Feasting and the Steel Helm of Sporting. You still have five days to subscribe and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
+        p.small.muted by Lemoness
+    tr
+      td
+        h5 Private Messaging Version 1.0
+        p We're excited to announce a new feature: Private Messaging! Now you can send someone a PM by clicking the envelope icon in the bottom-left of their profile window . You can check your messages under Social > Inbox! This is a very rudimentary feature so far, only containing the ability to send messages, block people, and opt out. To read about some of the planned features for the future and make suggestions, check out <a href='https://trello.com/c/hHpIzMc5/459-private-messaging-v-2' target='_blank'>this Trello card</a>!
+        p.small.muted by Lefnire
 
-h5 7/9/2014
-table.table.table-striped
-  tr
-    td
-      h5 Happy Derby Day!
-      p In celebration of Derby Day, all Habiticans have received a seahorse egg! On this day, the worst of Habitica's ancient bugs were defeated, and so every year we celebrate. Let's ride through Dilatory on this fun day.
-      h5 New Pet Quest: Seahorse!
-      p But oh, no - it looks like a wild Sea Stallion is disrupting the races! Quickly, battle the Sea Stallion to calm him down, and you might just get your hands on some additional seahorse eggs...
-      p.small.muted - by Kiwibot and Lemoness
-      h5 Updated Stats Bars
-      p Based on your feedback, we’ve updated the design of the new status bars with an 8-bit style and improved accessibility.
-      p.small.muted - by BenManley
+  h5 11/18/2014
+  table.table.table-striped
+    tr
+      td
+        h5 New Pet Quest: The Night-Owl!
+        p Habiticans are in the dark when a giant Night-Owl blots out the Tavern light! Can you drive it away in time to finish your all-nighter? If so, you may find some cute pet owls in the morning...
+        p.small.muted by Twitching, Lemoness, and Arcosine
 
-hr
-h5 7/3/2014
-table.table.table-striped
-  tr
-    td
-      h5 New backgrounds available: Coral Reef, Open Waters, Seafarer Ship
-      p Three new avatar backgrounds are available in the Background Shop! Now your avatar can swim in a <strong>coral reef</strong>, enjoy the <strong>open waters</strong>, or sail aboard a <strong>Seafarer Ship</strong>. Thanks so much for supporting the site!
-  tr
-    td
-      h5 Next Convention: GaymerX!
-      p HabitRPG's own Vicky Hsu will be at GaymerX, a game convention celebrating LGBTQ and gaming which is open to everyone, at the InterContinental in downtown San Francisco on July 11-13. (For more information, check out gaymerx.com!) Vicky will be giving away promo codes for the UnConventional Armor Set, so if you want to meet up with her (and snag some awesome capes), send a message to vicky@habitrpg.com or @caffeinatedvee on Twitter!
-  tr
-    td
-      h5 Rainbow Warrior Set!
-      p Even if you can't make it to the convention, you can still enjoy the two new armor pieces available for free in the Rewards Store: the Rainbow Warrior Helm and the Rainbow Warrior Armor! They were designed by our GaymerX friends and they look awesome. They'll be available until the end of the month, so enjoy!
+  h5 11/13/2014 - Share Avatar To Social Media, Email Invites, First Mini Quest, And Data Tab
+  table.table.table-striped
+    tr
+      td
+        h5 Share Avatar To Social Media
+        p You can now automatically share your avatar and public profile to social media! Just hover over the picture and click the "Share" button in the right-hand corner. Show off your outfit, your achievements, and your profile picture! Note that your tasks, as always, remain 100% private.
+        p.small.muted by Lefnire
+    tr
+      td
+        h5 Invite Friends To Party Via Email
+        p Do you want to invite friends to join your party without inputting their User ID? Now you can send them an email directly from the party page - even if they don't have an account yet!
+        p.small.muted by Lefnire
+    tr
+      td
+        h5 Mini Quest: The Basi-List!
+        p Now when someone accepts your party invitation and joins your party, you will be given a Mini Quest: The Basi-List! Battle the Basi-List with your friends for an XP and GP reward.
+        p.small.muted by Arcosine and Redphoenix
+    tr
+      td
+        h5 Data Tab
+        p Now you can access the Data Display Tool and Export Data from the toolbar!
+        p.small.muted by ShilohT
 
-hr
-h5 7/1/2014
-table.table.table-striped
-  tr
-    td
-      h5 WORLD BOSS: The Dread Drag'on of Dilatory!
-      p We should have heeded the warnings.
-      p Dark shining eyes. Ancient scales. Massive jaws, and flashing teeth. We've awoken something horrifying from the crevasse: **the Dread Drag'on of Dilatory!** Screaming Habiticans fled in all directions when it reared out of the sea, its terrifyingly long neck extending hundreds of feet out of the water as it shattered windows with its searing roar.
-      p "This must be what dragged Dilatory down!" yells Lemoness. "It wasn't the weight of the neglected tasks - the Dark Red Dailies just attracted its attention!"
-      p "It's surging with magical energy!" @Baconsaur cries. "To have lived this long, it must be able to heal itself! How can we defeat it?"
-      p Why, the same way we defeat all beasts - with productivity! Quickly, Habitica, band together and strike through your tasks, and all of us will battle this monster together. (There's no need to abandon previous quests -  we believe in your ability to double-strike!) It won't attack us individually, but the more Dailies we skip, the closer we get to triggering its Neglect Strike - and I don't like the way it's eyeing the Tavern....
-hr
-h5 6/30/2014
-table.table.table-striped
-  tr
-    td
-      h5 Last day for June Item Set!
-      p Reminder: this is the final day to subscribe and receive the Octomage Item Set! If you want the Octopus Robe or the Tentacle Helm, now's the time! Thanks so much for your support <3
-      h5 Dilatory Update
-      p PLEASE! Habiticans, stop  exploring the dark crevasse!!! Lemoness is really getting worried. There have been.... reports.
-      p Reports of something big.
-      p Reports of something terrifying.
-      p Reports of mysterious aftershocks, growing in intensity.
-      p Besides, exploring the dark and dangerous crevasse has become a source of procrastination. Let's get back to work, people!
+  h5 11/12/2014
+  table.table.table-striped
+    tr
+      td
+        h5 New Equipment Quest Line: The Golden Knight!
+        p The Golden Knight believes that she is the perfect Habitican, and that anyone who slips up in their quest for self-improvement is a lazy failure. Can you talk some sense into her - or will it come to blows? If you complete the entire quest line, you'll be rewarded with a legendary weapon...
+        p The first scroll in this quest line, "A Stern Talking-to," drops automatically at Level 40! If you're already over Level 40, you will automatically be awarded this quest - just check off a task and then check your inventory.
 
-hr
-h5 6/25/2014
-table.table.table-striped
-  tr
-    td
-      h5 June Subscriber Item
-      .pull-right.promo_mystery_201406.png
-      p The June Subscriber Item has been revealed: the Octomage Item Set!  All June subscribers will receive the Octopus Robe and the Crown of Tentacles. You still have six days to subscribe and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
-      h5 Mobile App Update
-      p There's a new mobile app update available! In addition to bug fixes, there are many improvements, including a new button-based menu, tap-and-hold to edit tasks, and the return of stats and in-app avatar customization! Working on the mobile app is our biggest To-Do this summer, so expect more in the coming months. If you feel that the app is improving, we'd love it if you would take the time to give us a review and let us know what you think!
-      h5 Dilatory Update
-      p It's great to see Habiticans having fun exploring the ruins! There's just one small thing Lemoness wants us to avoid. She's noticed a lot of Habiticans trying to explore the fallen palace of the other side of the dark crevasse. She really doesn't feel that the crevasse is safe, so please don't swim so close. Other than that, enjoy your explorations!
+  h5 11/09/2014 - Facebook Login Fixed For Mobile And Community Guidelines To Chat
+  table.table.table-striped
+    tr
+      td
+        h5 Facebook Login Fixed For Mobile!
+        p Great news! If you use Facebook to log in to the mobile app, we've released an update so you no longer have to type in your UUID/API manually, misspelling things on your tiny keyboard and bemoaning your fate. Thank goodness! The Android update is out now, and the iOS update has been submitted and should be out soon.
+    tr
+      td
+        h5 Community Guidelines To Chat
+        p Before you can use any of the public chat features, you now have to agree to our Community Guidelines. We know they're long, but they're important, so please do read them if you haven't already. Plus, we worked hard to make them entertaining, and they were illustrated by many of our excellent artisans!
 
-hr
-h5 6/21/2014
-table.table.table-striped
-  tr
-    td
-      h5 Summer Mystery Update
-      p Lady Lemoness has returned at last! She startled beach-goers by charging up out of the waves and onto the shore, shouting "I found it!!! I found it!!! Oh, I just KNEW that citing it as impossible would make it a narrative probability!"
-      p Wait - found what?
-      h5 Summer Splash Event: The Lost City Of Dilatory!
-      p Dilatory was a lovely island city of ancient Habitica. It was a prosperous place, but as the wealth of the city grew, the inHabitants grew lazy and procrastinated on their Dailies and To-Dos... until the combined weight of their dark red tasks triggered a massive earthquake that sunk the city. Legends say that all of the inHabitants were transformed into sea creatures.
-      p The location of this city was lost to time... until now!
-      h5 Limited Edition Outfits!
-      p What's the fun of an underwater city if you can't explore it? Luckily, from now until July 31st, special Limited Edition Outfits are available for gold in the Rewards store! Spellcasters can transform themselves into <strong>Emerald Mermages</strong> and <strong>Reef Seahealers</strong> to swim among the ruins, while fighters may prefer to dress as <strong>Roguish Pirates</strong> and <strong>Daring Swashbucklers</strong>, riding above the city on magnificent ships. Work hard, and you can join them!
-      h5 NPC Dress-up
-      p The NPCs got so excited about the discovery of Dilatory that they've moved over there for the summer! Daniel the Innkeeper has opened a beachside tavern, and Alex is also selling by the shore! Meanwhile, Justin the Guide is giving tours aboard boats, Ian is dispensing quest wisdom from the deep ocean, Matt has opened stables for aquatic pets, and I am swimming about keeping everyone informed!
-      h5 But what caused the Earthquake?
-      p Only one piece of the mystery remains unsolved - what caused the second earthquake that unearthed the ancient Dailies? After all, the earthquake that destroyed Dilatory was caused by a build up of undone Dailies and To-Dos, wasn't it?
-      p But *we've* all been doing our tasks...
+  h5 11/06/2014
+  table.table.table-striped
+    tr
+      td
+        h5 Bailey: Costume Challenge Badges Awarded!
+        p The HabitRPG Costume Challenge Badges have been awarded! Thanks for your patience while we went through all the entries individually. You can see some of the entries <a href='http://blog.habitrpg.com/tagged/cosplay' target='_blank'>on the HabitRPG blog</a> already, and more will be added every week.
+        p IMPORTANT: some of the links that people provided did not work. If you entered the Challenge but even after refreshing the page you still don't have your badge, email leslie@habitrpg.com with the link to your costume and your avatar. (The costume and avatar must have been posted prior to November 1st to count.)
+        p Thanks to all our amazing participants!
 
-hr
-h5 6/14/2014
-table.table.table-striped
-  tr
-    td
-      h5 New Feature: Backgrounds!
-      p We're debuting a brand-new feature - backgrounds for your avatar! Stroll through a Summer Forest, lounge upon a warm Beach, or dance in a Fairy Ring. You can buy the backgrounds in the new Background tab, under User. Have fun!
-      h5 Summer Mystery Update
-      p It's been a while since we've seen Lemoness around - she's been a bit scarce since she started trying to decipher those ancient Dailies. We just stopped by her hut to check on her and found her..... missing?
-      br
-      p It looked like she'd taken her armor-enchanting crochet hook, but little else. There was a single scrawled note on the table: "I think I've translated it!!!! If I'm right, this is going to be QUITE the summer. Verifying claims - be back soon!!!"
-      br
-      p The only other thing on the table was an ancient map... with the corner ripped off.
-small.muted 6/14/2014
+  h5 11/05/2014- November Backgrounds And Beeminder Integration
+  table.table.table-striped
+    tr
+      td
+        h5 November Backgrounds
+        p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can enjoy a Harvest Feast, admire a Sunset Meadow, or gaze at the Starry Skies!
+        p.small.muted by Kiwibot, Holsety1, and Draayder
+    tr
+      td
+        h5 Beeminder Integration
+        p We've integrated with Beeminder! Now you can beemind your To-Dos automatically :) <a href='https://www.beeminder.com/habitrpg' target='_blank'>Check it out</a>!
+        p If you've never heard of Beeminder or want to learn more about what we've integrated so far, check out our <a href='http://blog.habitrpg.com/post/101773418876/beeminder-integration' target='_blank'>blog post about it</a>. Enjoy!
+        p.small.muted by Alys and Alice Monday
 
-hr
-h5 6/10/2014
-table.table.table-striped
-  tr
-    td
-      h5 New Pet Quest: The Call Of Octothulu!
-      p There's a new pet in town! The dreaded Octothulu, sticky spawn of the stars, has emerged from a whirlpool in a dark cave by the sea. It's up to you and your party to banish the foul beast by being extra-productive! If you manage to defeat it, you might just find some octopus eggs...
-      h5 Earthquake Update
-      p Remember the strange earthquake we had recently? Well, this probably isn't related in any way, but Habiticans have recently noticed some mysterious black Dailies strewn along the beaches. Lemoness happily reports that they are scrawled upon with an ancient language, and that she is hard at work deciphering the script. More news as this develops!
-
-hr
-h5 6/5/2014
-table.table.table-striped
-  tr
-    td
-      h5 June Mystery Item
-      p Wow, what could it be? All Habiticans who are subscribed during the month of June will receive the June Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
-  tr
-    td
-      h5 What Was That?
-      p Yikes! A mysterious earthquake has rocked Habitica! Luckily, nobody was hurt and there was no real damage, but our scholars are baffled. "We're not even IN a seismic zone," Lady Lemoness was heard muttering as she paged through an enormous tome. "There hasn't been an earthquake since.... but no, that's impossible." Well, if Lemoness says so, it must be true! Seems like it was just a false alarm.
-
-hr
-h5 5/23/2014
-table.table.table-striped
-  tr
-    td
-      h5 May Mystery Outfit Revealed!
-      .pull-right.promo_mystery_201405.png
-      p The May Mystery Item Set has been revealed for all subscribers... <strong>Flame Wielder Item Set</strong>! All people who are subscribed this May will receive two items:
-      ul
-        li Flame of Mind (helm)
-        li Flame of Heart (armor)
-      p You still have eight more days to subscribe and get the item set. Thank you all for supporting us! We love you <3
-
-
-hr
-h5 5/14/2014
-table.table.table-striped
-  tr
-    td
-      h5 The Rat King
-      p Habitica's streets are filled with the skittering of little paws... looks like there's a new Pet Quest available in the Market! Can you and your party defeat the Rat King? If so, there will be some eggs to reward you...
-      small.muted By: Pandah and Token
-  tr
-    td
-      h5 Level Cap Lifted
-      p You can now level up beyond 100, the 100-cap has been lifted!
-      small.muted By: Ryan
-
-hr
-h5 5/5/2014
-table.table.table-striped
-  tr
-    td
-      h5 Mobile Update
-      p The new iOS update is live! <a href='https://itunes.apple.com/us/app/habitrpg/id689569235?mt=8' target='_blank'>You can download it here</a>. If you have Android, <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg' target='_blank'>the update is available here.</a>
-      br
-      p Note: to edit a task or view checklists, swipe left on the task. We're <a href='https://github.com/HabitRPG/habitrpg-mobile/issues/199' target='_blank'>working on click-to-view</a>, we'd love some developer help!
-      br
-      p If you think the new app is an improvement, please consider rating us - many of our old reviews were (justifiably!) pretty low, especially on Apple, but we feel that this update is the first in a line of major improvements. Thanks for sticking with us!
-  tr
-    td
-      h5 The HabitRPG Chrome Extension
-      p Great news - we've fixed our Chrome Extension! Many thanks to new contributor <a href='https://github.com/HabitRPG/habitrpg-chrome/pull/88' target='_blank'>@GoldBattle<a/>. Now you can set the times and dates you want to only browse productive sites. If you're procrastinating, it will automatically start docking your character's health; if you're hard at work, it will reward you with GP and XP! <a href='https://chrome.google.com/webstore/detail/habitrpg/pidkmpibnnnhneohdgjclfdjpijggmjj' target='_blank'>Read more about it here.</a>
-  tr
-    td
-      p Also, a quick change - May's mystery item will now be revealed on the 23rd, instead of the 25th. Rejoice, impatient Habiticans!
-
-hr
-h5 4/30/2014
-table.table.table-striped
-  tr
-    td
-      h5 May Mystery Item
-      p Ooh, how mysterious! All Habiticans who are subscribed during the month of May will receive the May Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
-hr
-h5 4/30/2014
-table.table.table-striped
-  tr
-    td
-      h5 Mobile Update
-      p Great news! We've just released a big upgrade to our mobile app. One of our biggest priorities right now is improving the HabitRPG mobile experience, so this is an important first step. We've upgraded the framework to Ionic, which means a cleaner look and smoother feel, and best of all, it is now easier for the developers to add new updates and features! <a href='http://blog.habitrpg.com/post/84100207996/habitrpg-mobile-on-ionic' target='_blank'>Read more about the upgrade here.</a>
-      p The Android App is <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg' target='_blank'>available here</a>! The iOS app was submitted to the App Store, but Apple always takes a while to process things, so it may be a few more days. Let's hope they're quick this time around! We'll let you know when it goes through.
-      p Have a productive day!
-  tr
-    td
-      h5 Spread the Word Challenge
-      p Also, at long last the staff has finished sorting through the 1.5K+ participants in the Spread The World Challenge, and we are pleased (and so, so relieved) to finally announce a winner!
-      p Congratulations to ALEX KRALIE, the winner of the Spread The Word Challenge! 47K+ notes is truly momentous.
-      p A warm congratulation is also due to the runner-ups: sarahtyler, HannahAR, Raiyna, thefandomsarecool, Chickenfox, Anrisa Ryn, frabajulous, galdrasdottir, Judith Meyer, jazzmoth, RavenclawKiba, daraxlaine, Phiso, Billieboo, Victor Fonic, nikoftime, Aedra, amBarthes, and thaichicken! You guys are great <3 Thanks for helping to get the word out about HabitRPG!
-  tr
-    td
-
-      h5 Spring Fling
-      p Reminder that today, 4/30, is the LAST DAY of the Spring Fling event! After today, you will no longer be able to purchase the Pastel Hair Set or the Limited-Edition class items. Additionally, the Egg Hunt scroll will no longer be available in the Market, although if you have started the quest, it will NOT disappear and you will be able to complete it at your leisure.
-      p It is also the last day to get the Twilight Butterfly Item Set before it disappears forever! If you want the Twilight Butterfly Wings or the Twilight Butterfly head accessory, this is your last chance to subscribe and get them.
-      p Happy Spring!
-
-hr
-h5 4/25/2014
-table.table.table-striped
-  tr
-    td
-      h5 April Mystery Outfit Revealed!
-      //-img.pull-right(src='/marketing/promos/April14SAMPLE2.png')
-      p The April Mystery Item Set has been revealed for all subscribers... <strong>Twilight Butterfly Armor Set</strong>! All people who are subscribed this April will receive two items:
-      ul
-        li Twilight Butterfly Antennae
-        li Twilight Butterfly Wings!
-      p You still have five more days to subscribe and get the item set. Thank you all for supporting us! We love you <3
-
-hr
-h5 4/6/2014
-table.table.table-striped
-  tr
-    td
-      h5 The Great Egg Hunt
-      p A new quest is available in the Market between now and April 30th. Anyone who signed up before April 7th has one in their inventory free!
-
-hr
-h5 4/3/2014
-table.table.table-striped
-  tr
-    td
-      h5 Limited Edition Pastel Hair Color Set
-      p A new set of hair colors has been released: the Pastel Set! Now your avatar can have flowing locks in Pastel Blue, Pastel Pink, Pastel Purple, Pastel Orange, Pastel Green, or Pastel Yellow! You will only be able to purchase these hair colors until April 30th, so don't miss out!
-
-hr
-h5 4/2/2014
-table.table.table-striped
-  tr
-    td
-      h5 April Mystery Item
-      p  What could it be? All people who are subscribed during the month of April will receive the April Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled.
-
-hr
-h5 April F... irst
-table.table.table-striped
-  tr
-    td
-      p Hiya, folks! I'm Mrs. Carrot the Carroty Carrot, and I am your new announcer here at HabitRPG! I'm pleased to say that we've released several important updates that we are convinced will drastically improve user experience. Be sure to click around to admire our completely warranted and not at all arbitrary changes! In short, we were worried that the fantasy role-playing-game theme was getting somewhat overplayed, so we've decided unanimously to take the app in a different, more nutritious direction.
-      br
-      p After all, talking vegetables NEVER get old.
-      small.muted By @lemoness and @baconsaur
-
-hr
-h5 03/31/2014
-table.table.table-striped
-  tr
-    td
-      p Reminder that today is the <strong>last day</strong> to get the Forest Walker Subscriber Set before it disappears forever! If you want the Forest Walker Armor or the Forest Walker Antler head accessory, this is your last chance to subscribe and get it.
-
-
-hr
-h5 03/25/2014
-table.table.table-striped
-  tr
-    td
-      h5 March Mystery Item Set
-      //-img.pull-right(src='/marketing/promos/201403_Forest_Walker.png')
-      p The March Mystery Item Set has been revealed for all subscribers... The Forest Walker Set! All people who are subscribed this March will receive two items: <strong>Forest Walker Armor</strong> and <strong>Forest Walker Antlers</strong>!
-      br
-      p The antlers are a head accessory, so they can be worn with any helmet.
-      br
-      p You still have five more days to subscribe and get the item set. Thank you all for supporting us! We love you <3
-  tr
-    td
-      h5 PayPal Subscriptions
-      p We've added PayPal as a payment method for subscriptions. We still recommend the <strong>Card</strong> method, as <a href='https://stripe.com/' target='_blank'>Stripe</a> (the processor we use) has a more stable API and better account management tools. However, we realize not everyone owns a credit/debit card, so there's PayPal for ya!
-
-hr
-h5 03/22/2014
-table.table.table-striped
-  tr
-    td
-      h5 Spring Fling Event
-      p Spring has come to Habitica, and flowers have sprouted everywhere: in the Stables, in the Marketplace... and even in your character customization pages!
-  tr
-    td
-      h5 Head Accessories
-      p That's right - we've introduced Head Accessories! Your avatar can now bedeck their helms with colorful flowers. And that's not the only place to get head accessories….
-  tr
-    td
-      h5 Limited Edition Class Outfits
-      p The Spring 2014 Limited Edition Class Outfits have been released!
-      p From now until April 30th, you will be able to use your gold to buy your current class' armor set from the Rewards store! You can be a Stealthy Kitty, a Mighty Bunny, a Magic Mouse, or a Loving Pup. If you switch classes (system unlocked at level 10), you will gain access to your new classes' armor set. Make sure to collect yours first, though!
-      p What are you waiting for? Go be productive and earn some gold!
-  tr
-    td
-      h5 New Un-Equip Mechanic
-      p Now to un-equip your gear, click the same item that you have currently equipped. We removed the "Base Equipment" tier for consistency with how un-equipping pets & mounts is handled, and to easily support adding new gear types.
-  tr
-    td
-      h5 Pet Quest: The Ghost Stag
-      p The meadows of Habitica are bursting with flowers, sunshine, and.... ominous mist? Looks like a ghost stag is keeping winter alive! Defeat him, and maybe you'll get an egg or three....
-  tr
-    td
-      h5 And More To Come...
-      p This is only the beginning of all the treats that we've got in store for you. Stay tuned - and happy Spring Fling!
-
-hr
-h5 03/18/2014
-table.table.table-striped
-  tr
-    td
-      h5 New Pet Quest Mechanics
-      p Great news - now it is easier to complete the Quest Pet sets! Pet Quest  Bosses will now drop 3 eggs instead of 2. Additionally, after you have defeated a Pet Quest Boss two times, those eggs will be gem-purchasable in the market like all other eggs, so that your party doesn't have to replay the same quest over and over :)
-  tr
-    td
-      h5 WonderCon
-      p HabitRPG will be attending WonderCon from April 18th-20th! Come say hi to Tyler, Leslie, and Vicky, and chat about productivity and games. Tickets are available <a href='http://www.comic-con.org/wca/2014/badge-sale' target='_blank'>here</a>.
-      p All the users who visit our booth will receive the <a href='http://goo.gl/2urFUt' target='_blank'>Unconventional Armor Accessory Set</a>! (It will also be available if we attend other cons in the future.)
-  tr
-    td
-      h5 LifeHacker Poll
-      p HabitRPG is in the running to be Lifehacker's #1 To-Do list manager! We've got some tough competition, so if you like our site, please help us out <a href='http://lifehacker.com/5924093/five-best-to-do-list-managers' target='_blank'>by voting for us here</a> <3
-
-hr
-h5 03/02/2014
-table.table.table-striped
-  tr
-    td
-      h5 March Mystery Item
-      p Happy March! The awesome people who subscribe to HabitRPG will now receive the limited-edition March mystery item! The mystery item set will contain a stats-free costume piece that will <strong>only</strong> be available to the people who are subscribers this March. The set will be revealed on the 25th to everyone, but all people who are subscribers during the month of March will receive it. Get excited - and thank you so much for helping to support HabitRPG! We love you.
-  tr
-    td
-      h5 Hedgehog Quest
-      p A new pet has been introduced, the Hedgehog. You can find some eggs by battling the Hedgebeast Boss, a quest scroll available in the market.
-
-hr
-h5 02/22/2014
-table.table.table-striped
-  tr
-    td
-      .pull-right.character-sprites(style='clear:both;width:90px;height:90px')
-        span.back_mystery_201402
-        span.slim_armor_mystery_201402
-        span.head_mystery_201402
-      p The February Mystery Item Set has been revealed for all subscribers... <strong>The Winged Messenger Set</strong>! All people who are subscribed this February will receive three items:
-      ul(style='margin-left:15px')
-        li Winged Helm
-        li Messenger Robes
-        li and... <strong>Golden Wings</strong>!
-      p The wings are a brand-new type of item, called a Back Accessory! These items appear behind your avatar, so you can wear the wings with any outfit. You still have five more days to subscribe and get the item set. Thank you all so, so much for supporting HabitRPG!
-
-
-hr
-h5 02/18/2014
-table.table.table-striped
-  tr
-    td
-      h5 Translations
-      p Translations are well underway! Many of you should already be seeing HabitRPG in your own languages. If not, head <a href='https://trello.com/c/SvTsLdRF/12-translations' target='_blank'>here</a> to see your language's progress or to help translate.
-      p
-        small.muted by @paglias, @Sinza-, @Luveluen, and more.
-  tr
-    td
-      h5 BountySource
-      p We’ve started using BountySource, a service which lets users post bounties on bug fixes and feature requests. Any features or bugs in HabitRPG you’ve been dying to see resolved? <a href='https://www.bountysource.com/teams/habitrpg/issues' target='_blank'>Post a bounty</a> to attract contributor attention. <a href='http://blog.habitrpg.com/post/76898655192/bountysource' target='_blank'>Read more here</a>.
-      p
-        small.muted by @Cole, @lefnire, @Ryan
-
-hr
-h5 02/13/2014
-table.table.table-striped
-  tr
-    td
-      h5 Happy Valentine's Day!
-      p Help motivate all of the lovely people in your life by sending them a caring valentine. Valentines can be purchased for 10 gold from the Item Store. For spreading love and joy throughout the community, both the giver AND the receiver get a coveted "adoring friends" badge. Hooray!
-      p
-        small.muted By Lemoness and zoebeagle
-
-
-hr
-h5 02/12/2014
-table.table.table-striped
-  tr
-    td
-      h5 Chat & Invite Notifications
-      p Chat & group-invitation notifications are back! Miss them? They currently work for all chat updates in parties & guilds. Any devs willing to jump into @tagging in Tavern, <a href='http://goo.gl/uhcjkg' target='_blank'>see here</a>.
-  tr
-    td
-      h5 Toolbar
-      p In order to make room for these notifs, we added a toolbar above the header. You can collapse the toolbar (far-right icon), but take care as Bailey notifs are inside the toolbar!
-hr
-h5 02/07/2014
-table.table.table-striped
-  tr
-    td
-      h5 February Mystery Item
-      p
+  h5 11/01/2014
+  table.table.table-striped
+    tr
+      td
+        h5 November Mystery Item Set
         .pull-right.inventory_present
-        | We're excited to announce a new feature a s a big thank-you to the awesome people who <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribe</a> to HabitRPG! Every month, all subscribers will now receive a limited-edition mystery item! The mystery item will be a stats-free costume piece (like the Absurd Party Robes) that will <strong>only</strong> be available to the people who are subscribers each month. The February 2014 item will be revealed on the 23rd to everyone, but all people who are subscribers during the month of February will receive it. <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>Subscribe now</a>, get excited, and thank you so much for helping to support HabitRPG! We love you.
-  tr
-    td
-      h5 Critical Hammer Of Bug-Crushing
-      p
-        .pull-right.weapon_special_critical
-        | Some of you may have noticed that we periodically have some bugs that are nastier than the norm - the dreaded critical bugs. These monstrous apparitions have been snapping at the heels of many a player. For updates on what we're currently working on to improve site stability, read <a href='https://github.com/HabitRPG/habitrpg/issues/milestones' target='_blank'>this link</a> - and then jump in to help!  Not only will programming assistance reward you with the usual contributor levels, but if you actually manage to fix a bug marked <a href='http://goo.gl/v4DnzB' target='_blank'>"critical,"</a> you will now receive the <em>Critical Hammer of Bug-Crushing</em> as your reward!
-  tr
-    td
+        p Cool! What could it be? All Habiticans who are subscribed during the month of November will receive the November Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
 
-      h5 Rainbow Hair Colors
-      p
-        .pull-right.customize-option.hair_bangs_1_rainbow
-        | Want to spruce up your avatar? Rainbow hair colors are now available! Dye your luscious locks purple, green, or even rainbow-striped, and passersby will look at you with envy.
-  tr
-    td
-      h5 Stability Update
-      p We've stabilized the site a lot (we're still working out kinks, but we're way better now). Follow the <a href='https://github.com/HabitRPG/habitrpg/issues/milestones' target='_blank'>progress here</a>, but here are some workarounds for now:
-      ul
-        li Click slower. <a href='https://github.com/HabitRPG/habitrpg/issues/2301#issuecomment-34398206' target='_blank'>VersionError</a> is caused by clicking things off too fast (we're working on a fix).
-        li If you see an error, refresh before proceeding﻿.
+  h5 10/31/2014 - Monster Npcs, Last Day For Fall Festival Items, Last Day Of Community Costume Challenge, Last Day For Winged Goblin Item Set
+  table.table.table-striped
+    tr
+      td
+        h5 Last Day For Fall Festival Items
+        p Tomorrow everything will be back to normal in Habitica, so if you still have any remaining Fall Festival Items that you want to buy, you'd better do it now! The Seasonal Edition items won't be back until next fall, and if the Limited Edition items return they will have increased prices or changed art, so strike while the iron is hot!
+    tr
+      td
+        h5 Last Day For Winged Goblin Item Set
+        p Reminder: this is the final day to subscribe and receive the Winged Goblin Item Set! If you want the Goblin Wings or the Goblin Gear, now's the time! Thanks so much for your support <3
+    tr
+      td
+        h5 Last Day Of Community Costume Challenge
+        p It's the last day to post your pictures of yourself dressed up as your HabitRPG avatar if you want to get the Costume Challenge Badge! You can join the Challenge <a href='https://habitrpg.com/#/options/groups/challenges/39f7e9b4-1fbf-4b01-baee-221fd9b9ef43' target='_blank'>here</a>.
+    tr
+      td
+        h5 Monster Npcs
+        p The NPCs have dressed up in their Halloween costumes! Be sure to stop by and check them all out.
 
-p
-  small.muted By Lemoness, mariahm, crystalphoenix, aiseant, zoebeagle, cole, lefnire
+  h5 10/27/2014 - Increased Gems For Contributors And Community Guidelines
+  table.table.table-striped
+    tr
+      td
+        h5 Community Guidelines
+        p Our community has grown and evolved over this past year and a half, and we realized that none of the community expectations had been codified anywhere. This has now changed with the implementation of the <a href='/static/community-guidelines' target='_blank'>Community Guidelines</a>. The Guidelines have been written by the staff and mods and illustrated by many of our talented artisans. We know they're long, but they contain all the expectations for participating in the public social side of HabitRPG, so please do read them carefully! Soon you'll have to agree to them to participate in any of the Public Chat.
+        p.small.muted by <strong>Alys</strong>, Lemoness, lefnire, redphoenix, SabreCat, paglias, Bailey, Ryan, Breadstrings, Megan, Daniel the Bard, Draayder, Kiwibot, Leephon, Luciferian, Revcleo, Shaner, Starsystemic, UncommonCriminal
+    tr
+      td
+        h5 Increased Gems For Contributors
+        p When we first started rewarding contributors, we decided to give them 2 gems per contributor tier. Since then, however, we've introduced many more things to buy, so we've decided to increase this number. All contributors now receive 3 gems/tier for tiers 1-3, and then 4 gems/tier for tiers 4-7, bringing the total number of gems you can earn by contributing to the site to 25.
+        p If you've already contributed, you've been given the gems that you're owed according to the new system. (For example, if you are a tier 3 contributor, you received 6 gems in the past and would receive 9 gems under the new system, so you've been awarded 3 gems to account for the difference.)
+        p Enjoy!
+        p.small.muted by Alys
 
-hr
-h5 02/01/2014
-table.table.table-striped
-  tr
-    td
-      h5 Vice
-      p You awaken after the Winter Wonderland festivities and birthday celebrations with a smile. It's been a snowy, cheerful couple months, and the NPCs have finally returned to their normal attire. But today something is very wrong. Shadowy whisps cover the ground of Habitica, the sky has darkened. At the tavern you hear @DanielTheBard struming dark tales on his lute, and @Baconsaur peering into a mug, grumbling about her mounts swallowed in the shadows. They speak of the same thing: <strong>Vice</strong>, a dark an terrible foe. This new boss arc is a 3-part quest that requires level 30 to begin. Bring your strongest party members, and don't miss your dailies - there's a powerful weapon at the end!
-      p
-        small.muted by @baconsaur & @DanielTheBard
+  h5 10/25/2014 - October Item Set Revealed And Community Costume Challenge Reminder
+  table.table.table-striped
+    tr
+      td
+        h5 October Item Set Revealed
+        .promo_mystery_201410.pull-right
+        The October Subscriber Item has been revealed: the Winged Goblin Item Set! All October subscribers will receive the Goblin Gear and the Goblin Wings. You still have six days to subscribe and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
+        by Lemoness
+        h5 Community Costume Challenge Reminder
+        .achievement-costumeContest.pull-right
+        p Don't forget about the <a href='https://habitrpg.com/#/options/groups/challenges/39f7e9b4-1fbf-4b01-baee-221fd9b9ef43' target='_blank'>Community Costume Challenge</a>! We've had some really amazing entries so far, and we're looking forward to seeing more over the next six days! All participants will receive the 2014 Costume Challenge Badge.
+        p You can view some of the awesome costumes <a href='http://blog.habitrpg.com/tagged/cosplay' target='_blank'>here</a>!
 
-hr
-h5 01/30/2014
-table.table.table-striped
-  tr
-    td
-      h5 Happy Birthday, HabitRPG!
-      p The fair land of Habitica is two years old on January 31st! The NPCs are celebrating in style, and it looks like some of the staff is, too! Won't you join in?
-  tr
-    td
-      h5 Absurd Party Robtes
-      p As part of the festivities, Absurd Party Robes are available free of charge in the Item Store! Swath yourself in those silly garbs and don your matching hats to celebrate this momentous day.
-  tr
-    td
-      h5 Delicious Cake
-      p What would a birthday be without birthday cake in a myriad of flavors? Of course, pets are very picky, but luckily Lemoness and her team of bakers have plenty of slices to go around. Mmm, delicious!
-  tr
-    td
-      h5 Last Day of Winter Wonderland Event
-      p Also, just a reminder - January 31st is the final day of the Winter Wonderland event, so it's your last day to get the Limited Edition Winter Hair Colors, the Winter Outfits, the snowballs, and the Trapper Santa and Find the Cub quest scrolls. Remember that mid-progress Trapper Santa and Find the Cub quests will not abort, nor will you lose your scrolls - they will simply be removed from Alexander's marketplace. We hope that you've had a wonderful winter!
-  tr
-    td
-      h5 Birthday Bash Badge
-      p Finally, to commemorate the fun, all party participants receive a birthday badge! Polish it frequently and wear it fondly.
+  h5 10/23/2014
+  table.table.table-striped
+    tr
+      td
+        h5 Level 60 Equipment Quest: Recidivate Quest Line!
+        p All over Habitica, Bad Habits thought long-dead are rising up again - it must be the work of Recidivate, the wicked Necromancer! Can you complete your Dailies and fight down your Bad Habits to lay her to rest once more? If so, you'll reap some fine spoils... including some legendary armor!
+        p This quest line contains the hardest Boss Battle that we've released to date, so the first quest scroll drops for free at Level 60. If you're already Level 60 or over, you can unlock it for free, too - just check off any task and it will drop for you :) Good luck! You'll need it.
+        p.small.muted by Lemoness, Tru_, aurakami, Inventrix, and Baconsaur
 
-p Thanks so much for being a part of the HabitRPG community. We love you guys, and we can't wait to have you at our sides in the upcoming year! Stay productive, Habiteers, and have an awesome day.
+  h5 10/15/2014 - Spider Pet Quest, Mobile App Update, Hide Grey Dailies, And Sortable Checklists!
+  table.table.tables-striped
+    tr
+      td
+        h5 New Pet Quest: The Icy Arachnid!
+        p Yikes, what's leaving these icy webs all over Habitica? It must be the Frost Spider from the newest Pet Quest: The Icy Arachnid! You can buy this quest in the <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>Market</a>. Don't worry, it will be around even after the Fall Festival ends :)
+        p.small.muted by Arcosine
+    tr
+      td
+        h5 Mobile App Update!
+        p The newest mobile app update is available on iOS and Android! Now when you're on your phone you can see Fall Festival items, get drop notifications, and view the pixel art of the bosses that you're battling!
+        p.small.muted By lefnire, negue, huarui, and paglias
+    tr
+      td
+        h5 Hide Grey Dailies
+        p You can now hide grey Dailies to de-clutter your list! There are tabs at the bottom of the Dailies column that you can toggle to see only which Dailies are still active.
+        p.small.muted by Gaelan, and Alys
+    tr
+      td
+        h5 Sortable Checklists
+        p Have you ever wanted to rearrange checklist order? Now you can! Simply drag and drop to sort your checklist points.
+        p.small.muted By gjoyner
 
-p.muted By @lemoness
+  h5 10/7/2014 - Back-To-School Advice Challenge Winners And Jack-O-Lantern Pet!
+  table.table.table-striped
+    tr
+      td
+        h5 Back-To-School Advice Challenge Winners
+        p We had a ton of participants in our Back-To-School Advice Challenge, and we've finally sorted through and chosen the winners! Congratulations to
+        p DJ Ringis, The Writer, San Condor, Tavi Wright, Stepharuka, Clyc, samaeldreams, LitNerdy, Tritlo, Shansie, Han Solo, FrauleinNinja, Nortya, itsallaboutfalling, TomFrankly, [TGL] Dogg, Amanda, InfH, Evan950, and Mizuokami! You've all received your gems :)
+        p Thanks so much for participating! If you had fun, don't forget that the Community Costume Challenge is happening all October :)
+    tr
+      td
+        h5 Jack-O-Lantern Pet
+        p Habiticans have been carving lots of pumpkins recently - and it looks like one has followed you home! Everyone has received a pet Jack-O-Lantern! You can find it in the Stables :)
+        p.small.muted by Lemoness
 
-hr
-h5 01/28/2014
-table.table.table-striped
-  tr
-    td
-      h5 Group Plans
-      p We've begun adding <a href='/static/plans' targte='_blank'>plans for groups</a> (parents, teachers, health & wellness administrators, etc). These plans will provide group leaders with more control, privacy, security, and support. Currently only the Organization Plan (top tier) is available (due to tech limitations believe it or not), and we'll be releasing the Family & Group plans later. <a href='/static/plans' targte='_blank'>Click the "Contact Us" buttons</a> if you're interested, and we'll keep you updated!
-  tr
-    td
-      h5 Individual Plan
-      p We've introduced a $5/mo basic subscription plan. It comes with a number of perks, which <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>you can see here</a>. We'll likely add more benefits over time, follow <a href='https://trello.com/c/euDUHPpn/371-basic-plan-subscription' target='_blank'>the conversation here</a>.
-  tr
-    td
-      h5 Perfect Day Achievement
-      p Now when you complete all your dailies, you stack this badge, plus and additional perk: you get a +(level/2) buff to all stats!
-  tr
-    td
-      h5 <a href='/#/options/groups/challenges/95533e05-1ff9-4e46-970b-d77219f199e9' target='_blank'>Spread The Word Challenge</a> Update
-      p We have 1k+ submissions, holy cow! Great job everyone! Now, we need to go through these manually, so it will take a few days to a couple weeks to process. The challenge will stay open until we're done choosing our winners, but be sure to edit the To-Do with your submission URL before 1/31, as that's the cut-off date for processing. We'll send a Tweet out when the winner has been selected, so follow <a href='https://twitter.com/habitrpg' target='_blank'>@habitrpg</a> and stay tuned.
+  h5 10/3/2014- Spooky Sparkles, New Backgrounds, And Memory Leaks Almost Fixed!
+  table.table.table-striped
+    tr
+      td
+        h5 Spooky Sparkles
+        .pull-right
+          .inventory_special_spookDust
+          .achievement-spookDust
+          .spookman
+        p There's a new gold-purchasable item in the <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>Market</a>: Spooky Sparkles! Buy some and then cast it on your friends. I wonder what it will do?
+        br
+        p If you have Spooky Sparkles cast on you, you will receive the "Alarming Friends" badge! Don't worry, any mysterious effects will wear off the next day.... or you can cancel them early by buying an Opaque Potion!
+        br
+        p Spooky Sparkles will only be in the Rewards store until October 31st, so stock up!
+        p.small.muted by Lemoness, lefnire
+    tr
+      td
+        h5 New Backgrounds Revealed: Haunted House, Graveyard, And Pumpkin Patch
+        p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can sneak through a Haunted House, visit a creepy Graveyard, or carve jack-o-lanterns in a Pumpkin Patch!
+        p.small.muted by cecilyperez, Kiwibot, and Sooz
+    tr
+      td
+        h5 Memory Leaks Almost Fixed
+        p It took a ton of effort, but Tyler has fixed the largest memory leak that was crashing our servers! There are a few smaller ones that he’s still conquering one by one, but the fiercest monster has been slain. Ten thousand cheers for Tyler! You can read the technical description of how we’re fixing the leaks <a href='https://github.com/HabitRPG/habitrpg/issues/4079' target='_blank'>here</a>, and for any JavaScript developers out there: we'd love your help! We’ll let you all know when we’ve fixed the problem for once and for all.
+        p.small.muted by lefnire
 
-hr
-h5 01/25/2014
-table
-  tr
-    td
-      h5 Gryphon Quest
-      p A new pet has been introduced, the Gryphon. You can find some eggs by battling the Fiery Gryphon Boss, a quest scroll available in the market.
-      p
-        small.muted Note: we'll be fixing the beast-master achievement to work from the original 90 in coming days. Fear not current beast-masters, you'll get sorted soon!
-      p
-        small.muted By @baconsaur, @danielthebard
+  h5 10/1/2014 - Seasonal Edition Skins, Seasonal Edition Hair Colors, Community Costume Challenge, Release Pets, and October Mystery Item!
+  table.table.table-striped
+    tr
+      td
+        h5 Seasonal Edition Hair
+        p The Seasonal Edition Haunted Hair Colors are now available for purchase in the avatar customizations page! Now you can dye your avatar's hair Pumpkin, Midnight, Candy Corn, Ghost White, Zombie, or Halloween.
+        p Seasonal Edition items recur unchanged every year, but they are only available to purchase during a short period of time. This is different from Limited Edition Items, which only recur if something is changed, such as the art or the price. Read more about the difference between Seasonal and Limited Edition items <a href='http://habitrpg.wikia.com/wiki/Item_Availability' target='_blank'>here</a>!
+        p.small.muted by Lemoness, mariahm, and crystal phoenix
+    tr
+      td
+        h5 Seasonal Edition Skins
+        p The Supernatural Skin Set is here! Now your avatar can become an Ogre, Skeleton, Pumpkin, Candy Corn, Reptile, or Dread Shade. You can buy them from now until October 31st!
+        p These skins may remind some of you of the Spooky Skin set that was available briefly last fall. This is because we've received many requests for these Limited Edition skins from more recent players who were unable to purchase those skins. As a compromise, we have decided to Retire the Spooky Skin Set and release some similar but unique skins as part of the Supernatural Skin Set. That way, anyone who wants their avatar to be a pumpkin can have their way, but the original owners of the skin sets still have the unique items that they were promised. You can read more about the new Item Availability categories <a href='http://habitrpg.wikia.com/wiki/Item_Availability' target='_blank'>here</a>.
+        p.small.muted by Lemoness
+    tr
+      td
+        h5 Community Costume Challenge
+        p The Community Costume Challenge has begun! Between now and October 31st, dress up as your avatar in real life and post a photo on social media to get the coveted Costume Challenge badge! Read the full rules on the Challenge page <a href='https://habitrpg.com/#/options/groups/challenges/39f7e9b4-1fbf-4b01-baee-221fd9b9ef43' target='_blank'>here</a>.
+        p.small.muted by Lemoness
+    tr
+      td
+        h5 Release Pets and Mounts
+        p If you find collecting pets highly motivating and want to start over from zero, you're in luck! You can now release all your pets and mounts so that you can collect them again - and stack your Beastmaster achievement!
+        p.small.muted By Ryan
+    tr
+      td
+        h5 October Mystery Item
+        p Spooky! What could it be? All Habiticans who are subscribed during the month of October will receive the October Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
+        p.small.muted by Lemoness
+
+  h5 9/25/2014
+  table.table.table-striped
+    tr
+      td
+        h5 Update: Diagnosing Server Problems
+        p Our servers have been under a massive strain recently, and so we've created a <a href='https://github.com/HabitRPG/habitrpg/issues/4079' target='_blank'>Github ticket</a> that you can follow for updates on the things we're doing to fix the problem. We've also written a <a href='http://blog.habitrpg.com/post/98367930371/update-diagnosing-server-problems' target='_blank'>blog post</a>. We'll keep you updated with new developments as we strive to solve this problem.
+        p If you've lost any of your stats during this time, you can restore them using Settings > Site > Fix Character Values. Thank you so much for your patience and encouragement as we work to fight this fearsome foe!
+        p.small.muted by lefnire, Lemoness
+    tr
+      td
+        h5 September Item Set Revealed
+        .promo_mystery_201409.pull-right
+        p In happier news, the September Subscriber Item has been revealed: the Autumn Strider Item Set. All people who are subscribed before the end of September will receive the Autumn Antlers and the Strider Vest. Thank you so much for your support - it means a lot to us, especially right now.
+        p.small.muted by Lemoness
+
+  h5 9/22/2014 - Fall Festival! Limited-Edition Outfits, Candy Food Drops, And Npc Dress-Up
+  p Autumn is upon us! The air is crisp, the leaves are red, and Habitica is feeling spooky. Come celebrate the Fall Festival with us... if you dare!
+  table.table.table-striped
+    tr
+      td
+        h5 Limited Edition Class Outfits
+        p Habiticans everywhere are dressing up. From now until October 31st, limited edition outfits are available in the Rewards column. Depending on your class, you can be a Witchy Wizard, Monster of Science, Vampire Smiter, or Mummy Medic! You'd better get productive to earn enough gold before your time runs out...
+    tr
+      td
+        h5 Candy Food Drops!
+        p You've received some Candy in your inventory in honor of the Fall Festival! Plus, for the duration of the Event, Habiticans may randomly find candy drops when they complete their tasks. These candies function just like normal food drops - can you guess which flavor your pet will like best?
+    tr
+      td
+        h5 NPC Dress-Up
+        p Looks like the NPCs are really getting in to the spooky autumnal mood around the site. Who wouldn't?
+
+  h5 9/17/2014 - Rooster Pets, Party Sorting, And Back-To-School Challenge
+  table.table.table-striped
+    tr
+      td
+        h5 New Pet Quest: Rooster Rampage!
+        p There's a new pet quest in <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>the Market</a>! This monstrous rooster can't be quieted, and Habiticans are unable to sleep. Can you and your Party calm down this foul fowl? You'll be rewarded with Rooster eggs if you do!
+        p.small.muted by LordDarkly, Pandoro, EmeraldOx, extrajordanary, and playgroundgiraffe
+    tr
+      td
+        h5 Party Sorting!
+        p We've improved the preexisting party sort feature. Now you can sort your party members' avatars by level, backgrounds, and more! Simply go to Social > Party > Members and select from the drop-down menu.
+        p.small.muted by Alys and Viirus
+    tr
+      td
+        h5 Back-To-School Challenge!
+        p Don't forget that the 2nd Official HabitRPG Challenge is running right now - the <a href='https://habitrpg.com/#/options/groups/challenges/a367eb40-8514-46fd-805e-b9b7f89bad7f' target='_blank'>Back-To-School Advice Challenge</a>! Post your best tips for using HabitRPG during the Back-To-School season on social media for a chance at winning 60 gems. If you want to share it with the maximum number of people, you can use the #habitrpg and #backtoschool tags. You only have thirteen more days to enter. Good luck!
+
+  h5 9/12/2014 - Official Back-To-School Challenge, Markdown In Checklists, And Help Tab
+  table.table.table-striped
+    tr
+      td
+        h5 Official Back-To-School Challenge
+        p We've launched our 2nd Official HabitRPG Challenge: the Back-To-School Advice Challenge! Use social media to tell us how you use HabitRPG to improve study habits, share stories of scholarly success with the app, or just give us your advice on using HabitRPG to be the best you can be.
+        p The contest ends on September 30th, and the 20 winners will each get 60 Gems! For the full rules, <a href='https://habitrpg.com/#/options/groups/challenges/a367eb40-8514-46fd-805e-b9b7f89bad7f' target='_blank'>check out the challenge here</a>.
+        h5 Markdown In Checklists
+        p Previously, you've been able to use <a href='http://habitrpg.wikia.com/wiki/Markdown_Cheat_Sheet' target='_blank'>markdown</a> in your task names and in chat. Now you can also use it in checklists! Fill every aspect of your tasks with emoji, bolding, italics, or links. NOTE: If your checklists look strange, it's probably because they're accidentally using markdown now, so just edit them accordingly! Check out <a href='http://habitrpg.wikia.com/wiki/Markdown_Cheat_Sheet' target='_blank'>this Cheat Sheet</a> for an explanation of how to use markdown.
+        p.small.muted By @negue
+        h5 Help Tab
+        p There's a new tab on the top bar that contains some helpful links. If you're confused about something, want to request a feature, or wonder if your question was asked before, you can now use the Help Tab's drop down menu!
+        p.small.muted By @Alys
+
+  h5 9/10/2014
+  table.table.table-striped
+    tr
+      td
+        h5 Get Ready For The Community Costume Challenge!
+        p We've got an exciting event coming up this October - the first-ever Community Costume Challenge! In the spirit of the season, Habiticans who dress up in real-life versions of their avatar's armor (or in any HabitRPG costume) will receive a special badge. (No, just wearing a colored shirt doesn't count. Where's the fun in that?)
+        p The Community Costume Challenge will start on October 1st, but we're announcing it early so that people have time to get their costumes together.
+        p Instructions on how to participate in the CCC will be posted on October 1st. We can't wait to see your costumes!
+
+  h5 9/3/2014
+  table.table.table-striped
+    tr
+      td
+        h5 New Backgrounds Revealed: Thunderstorm, Autumn Forest, Harvest Fields
+        p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop!</a> Now your avatar can conduct lightning in a Thunderstorm, stroll through an Autumn Forest, or cultivate their Harvest Fields!
+        p.small.muted by krajzega and Uncommon Criminal
+
+  h5 9/1/2014
+  table.table.table-striped
+    tr
+      td
+        h5 September Mystery Item
+        p Hmm, intriguing... All Habiticans who are subscribed during the month of September will receive the September Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
+
+  h5 8/31/2014
+  table.table.table-striped
+    tr
+      td
+        h5 Last Day For Sun Sorcerer Item Set
+        p Reminder: this is the final day to subscribe and receive the Sun Sorcerer Item Set! If you want the Sun Crown or the Sun Robes, now's the time! Thanks so much for your support <3
+
+  h5 8/26/2014 - August Mystery Item, Sortable Tags, Push To Top
+  table.table.table-striped
+    tr
+      td
+        h5 August Item Set Revealed!
+        .promo_mystery_201408.pull-right
+        p The August Subscriber Item has been revealed: the Sun Sorcerer Item Set! All August subscribers will receive the Sun Crown and the Sun Robes. You still have five days to subscribe and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
+        p.small.muted by Lemoness
+    tr
+      td
+        h5 Sortable Tags
+        p You can now sort your tags. Drag left-to-right and drop them into place.
+        p.small.muted by Fandekasp, lefnire
+    tr
+      td
+        h5 Push to Top
+        p We've added a small button in your tasks' one-click actions: Push to Top. This will help easily you sort your day's priorities, which may change from day-to-day.
+        p.small.muted by negue
+
+  h5 8/19/2014 - Parrot Quest, Audio, And Mobile App Update!
+  table.table.table-striped
+    tr
+      td
+        h5 New Pet Quest: Help! Harpy!
+        p There's a new Pet Quest available in the <a href='https://habitrpg.com/#/options/inventory/drops'>Market</a>! @UncommonCriminal is being held hostage by a Parrot-like Harpy. If you can find a way to help, you'll definitely get your hands on some coveted Parrot Eggs....
+        p After you've purchased the scroll, battle the Boss by completing Habits and To-Dos. Be careful - every Daily that you skip will cause the Boss to attack your party!
+        p.small.muted by Uncommon Criminal and Token
+    tr
+      td
+        h5 Audio
+        p You can now enable sound effects for various website actions. Click the volume icon (<span class='glyphicon glyphicon-volume-off'></span>) and choose an "Audio Theme". For now, the only theme available is "Daniel The Bard" (@DanielTheBard designed this set); however, we'll release more themes over time (<a href='http://habitrpg.wikia.com/wiki/Guidance_for_Bards' target='_blank'>get involved here</a>). We'll also add more sound effects, and possibly music, to the current set.
+        p.small.muted by DanielTheBard, Fandekasp
+
+    tr
+      td
+        h5 New Mobile Update: Backgrounds and Guilds!
+        p We've updated the mobile app to include Backgrounds and Guilds! Now you can use the mobile app to join common interest groups, chat with like-minded people, and swap your avatar’s background. The iOS app is <a href='https://itunes.apple.com/us/app/habitrpg/id689569235?mt=8' target='_blank'>here</a>, and the Android app is <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg&hl=en' target='_blank'>here</a>. If you enjoy the direction that we’ve been taking the app, we would really appreciate it if you would leave us a review <3 Thank you!
+        p.small.muted by huarui, paglias
+
+  h5 8/12/2014
+  table.table.table-striped
+    tr
+      td
+        h5 New Equipment Quest: Attack Of The Mundane!
+        p There's a new Quest that will drop automatically for all users level 15 and up: the Dish Disaster, first quest in the Attack of the Mundane Questline! Scrub enchanted dirty dishes, battle the SnackLess Monster, and face off against the Evil Laundromancer. You might just be rewarded with a new piece of armor...
+        p As you complete each quest in this questline, you will be awarded with the quest scroll for the next part. There are three parts in total. Good luck!
+        small.muted by Arcosine, Kiwibot, Lemoness, Daniel the Bard, itokro
+
+  h5 8/6/2014
+  table.table.table-striped
+    tr
+      td
+        h5 New Backgrounds Revealed: Volcano, Dusty Canyon, Clouds
+        p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can heat up inside a Volcano, wander through a Dusty Canyon, or soar through the Clouds!
+
+  h5 8/4/2014
+  table.table.table-striped
+    tr
+      td
+        h5 New Mobile Update: Checklist Editing And Bug Fixes!
+        p In case you missed it, we’ve released a new mobile update! You can edit checklists from the mobile app now. We also fixed some bugs, including the image problems on iOS! The Android app is <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg&hl=en' target='_blank'>here</a> and the iOS app is <a href='https://itunes.apple.com/us/app/habitrpg/id689569235?mt=8' target='_blank'>here</a>.
+        p You may have noticed that we've been releasing lots of updates recently. This is greatly due to two awesome members of our team!
+        p The first is superstar contributor Matteo, aka <a href='https://github.com/paglias' target='_blank'>paglias</a>. In addition to the mobile app, he contributes tons of code to the site, runs translations, and fixes bugs without blinking. We are so thankful to have him on the team!
+        p We also have another new mobile app contributor who has rocketed to Level 7 in record time: <a href='https://github.com/huaruiwu' target='_blank'>huarui</a>! Huarui has been an absolute whirlwind with mobile app improvements.
+        p Give them both a giant round of applause!
+
+  h5 8/2/2014
+  table.table.table-striped
+    tr
+      td
+        h5 Dread Drag'on Defeated! Prizes: Mantis Shrimp Pet, Mantis Shrimp Mount, Food, and Badge
+        p We've done it!
+        p With a final last roar, the Dread Drag'on collapses and swims far, far away. Crowds of cheering Habiticans line the shores! We've helped Daniel rebuild his Tavern.
+        p But what's this?
+        p THE CITIZENS RETURN!
+        p Now that the Drag'on has fled, thousands of sparkling colors are ascending through the sea. It is a rainbow swarm of Mantis Shrimp... and among them, hundreds of merpeople!
+        p "We are the lost citizens of Dilatory!" explains their leader, Manta. "When Dilatory sank, the Mantis Shrimp that lived in these waters used a spell to transform us into merpeople so that we could survive. But in its rage, the Dread Drag'on trapped us all in the dark crevasse. We have been imprisoned there for hundreds of years - but now at last we are free to rebuild our city!"
+        p "As a thank you," says his friend @Ottl, "Please accept this Mantis Shrimp pet and Mantis Shrimp mount, this feast, and our eternal gratitude!"
+    tr
+      td
+        h5 August Mystery Item
+        p Ooh, mysterious! All Habiticans who are subscribed during the month of August will receive the August Mystery Item Set! It will be revealed on the 26th, so keep your eyes peeled. Thanks for supporting the site <3
+
+  h5 7/31/2014
+  table.table.table-striped
+    tr
+      td
+        h5 Last Day for July Subscriber Set
+        .promo_mystery_201407.pull-right
+        p Reminder: this is the final day to subscribe and receive the Undersea Explorer Item Set! If you want the Undersea Explorer Helm or the Undersea Explorer Suit, now's the time! Thank you so much for your support <3
+    tr
+      td
+        h5 Final Day for Limited Edition Summer Outfits
+        p Today is the last day of the Summer Splash Event, so it is the last day to buy the Limited Edition Outfits and the Rainbow Warrior Armor from the Rewards store. Get productive and spend that gold!
+
+  hr
+  h5 7/25/2014
+  table.table.table-striped
+    tr
+      td
+        h5 July Subscriber Item
+        .promo_mystery_201407.pull-right
+        p The July Subscriber Item has been revealed: the Undersea Explorer Item Set! All July subscribers will receive the Undersea Explorer Helm and the Undersea Explorer Suit. You still have six days to subscribe and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
+
+  hr
+  h5 7/16/2014
+  table.table.table-striped
+    tr
+      td
+        h5 Mobile App Update
+        p We’ve released another update to the mobile app! Now you can feed and select pets from the app. Carry your cute pets with you everywhere you go! The app is available for <a href='https://itunes.apple.com/us/app/habitrpg/id689569235?mt=8' target='_blank'>iOS here</a>, and <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg' target='_blank'>Android here</a>. We’re continuing to release updates on a regular basis, so if you like the direction that we’ve been taking the app, please do consider leaving us a review. Thank you!
+    tr
+      td
+        h5 Neglect Strike: Tavern Art Swap
+        p The Dread Drag'on's Rage Bar has filled, and it has unleashed its Neglect Strike, leading to a new look for the Tavern! As a reminder, the Drag'on's rage will NEVER hurt any users or interfere with their ability to be productive, so the chat and inn are still functional. Even so... poor Daniel!
+        p All users are automatically damaging the Drag'on with their tasks. There is nothing bad that can happen to you or your account by being in this fight!
+    tr
+      td
+        h5 Dread Drag'on Prize Change: Food Reward!
+        p We've received a lot of feedback due to the weekend's confusion, and it seems that awarding GP and XP for defeating the world boss significantly unbalanced the game for newer players. Based on your feedback, XP and GP will no longer be awarded. Instead, players will receive an assortment of food! The Mantis Shrimps will still be awarded.
+        p If you were looking forward to receiving the 900XP and 90 GP upon completion of the battle, feel free to award it to yourself using Settings > Site > Fix Character Values when the battle is done!
+        p Thank you for bearing with us through the confusion. We love you guys.
+  hr
+  h5 7/12/2014
+  table.table.table-striped
+    tr
+      td
+        h5 Wow, What'S Going On?!
+        p You may have noticed some strange things happening - extra gold? Drag'on defeated? No quest damage?
+        br
+        p Turns out the Dread Drag'on of Dilatory was harder to handle than we expected, and wreaked havoc on us last night by unexpectedly completing due to a glitch, throwing off party quest damage, and granting all of its rewards early! *shakes fist at terrible beast*
+        br
+        p The Drag’on is now back in the battle (<a href='http://habitrpg.wikia.com/wiki/The_Dread_Drag'on_of_Dilatory' target='_blank'>read about how to fight it here</a>), and the Mantis Shrimp pet/mount were removed until it is defeated for good. We are so sorry about the confusion!
+        br
+        p If you don’t want the 900 XP and 90 Gold, you can delete it using Settings > Site >Fix Character Values. You can also keep it as an apology from the devs for all the confusion! Do whatever is most motivating for you :) It will be granted again when the Drag'on is truly vanquished.
+        br
+        p The Drag’on also caused some glitches with party boss damage, but they should be repaired now.
+        br
+        p For a detailed breakdown of what happened, follow the issue <a href='https://github.com/HabitRPG/habitrpg/issues/3712' target='_blank'>here</a>!
+        br
+        p Now let's fight this monster for real.
+
+  hr
+  table.table.table-striped
+    tr
+      td
+        h5 July 11th: GaymerX reminder
+        p Reminder: Vicky (aka redphoenix) is at GaymerX at the InterContinental in San Francisco this weekend! She will have lots of promo codes for the Unconventional Armor Set. Our champion moderator Ryan will be there, too, and would love to meet you guys! Vicky will be wearing a dinosaur hoodie and a red shirt, and Ryan has a partially-shaved head and is in a wheelchair.
+        br
+        p There will be an official HabitRPG meet-up on <strong>Saturday 3:15-4:30</strong> outside GX Panel Room A (Grand Ballroom AB (3F)). Come get your promo codes there! If you can't make it at that time, contact Vicky via email (vicky@habitrpg.com) or Twitter (@caffeinatedvee) to coordinate an alternative time and place to meet up at the convention!
+  small.muted 7/11/2014
+  hr
+
+  h5 7/9/2014
+  table.table.table-striped
+    tr
+      td
+        h5 Happy Derby Day!
+        p In celebration of Derby Day, all Habiticans have received a seahorse egg! On this day, the worst of Habitica's ancient bugs were defeated, and so every year we celebrate. Let's ride through Dilatory on this fun day.
+        h5 New Pet Quest: Seahorse!
+        p But oh, no - it looks like a wild Sea Stallion is disrupting the races! Quickly, battle the Sea Stallion to calm him down, and you might just get your hands on some additional seahorse eggs...
+        p.small.muted - by Kiwibot and Lemoness
+        h5 Updated Stats Bars
+        p Based on your feedback, we’ve updated the design of the new status bars with an 8-bit style and improved accessibility.
+        p.small.muted - by BenManley
+
+  hr
+  h5 7/3/2014
+  table.table.table-striped
+    tr
+      td
+        h5 New backgrounds available: Coral Reef, Open Waters, Seafarer Ship
+        p Three new avatar backgrounds are available in the Background Shop! Now your avatar can swim in a <strong>coral reef</strong>, enjoy the <strong>open waters</strong>, or sail aboard a <strong>Seafarer Ship</strong>. Thanks so much for supporting the site!
+    tr
+      td
+        h5 Next Convention: GaymerX!
+        p HabitRPG's own Vicky Hsu will be at GaymerX, a game convention celebrating LGBTQ and gaming which is open to everyone, at the InterContinental in downtown San Francisco on July 11-13. (For more information, check out gaymerx.com!) Vicky will be giving away promo codes for the UnConventional Armor Set, so if you want to meet up with her (and snag some awesome capes), send a message to vicky@habitrpg.com or @caffeinatedvee on Twitter!
+    tr
+      td
+        h5 Rainbow Warrior Set!
+        p Even if you can't make it to the convention, you can still enjoy the two new armor pieces available for free in the Rewards Store: the Rainbow Warrior Helm and the Rainbow Warrior Armor! They were designed by our GaymerX friends and they look awesome. They'll be available until the end of the month, so enjoy!
+
+  hr
+  h5 7/1/2014
+  table.table.table-striped
+    tr
+      td
+        h5 WORLD BOSS: The Dread Drag'on of Dilatory!
+        p We should have heeded the warnings.
+        p Dark shining eyes. Ancient scales. Massive jaws, and flashing teeth. We've awoken something horrifying from the crevasse: **the Dread Drag'on of Dilatory!** Screaming Habiticans fled in all directions when it reared out of the sea, its terrifyingly long neck extending hundreds of feet out of the water as it shattered windows with its searing roar.
+        p "This must be what dragged Dilatory down!" yells Lemoness. "It wasn't the weight of the neglected tasks - the Dark Red Dailies just attracted its attention!"
+        p "It's surging with magical energy!" @Baconsaur cries. "To have lived this long, it must be able to heal itself! How can we defeat it?"
+        p Why, the same way we defeat all beasts - with productivity! Quickly, Habitica, band together and strike through your tasks, and all of us will battle this monster together. (There's no need to abandon previous quests -  we believe in your ability to double-strike!) It won't attack us individually, but the more Dailies we skip, the closer we get to triggering its Neglect Strike - and I don't like the way it's eyeing the Tavern....
+  hr
+  h5 6/30/2014
+  table.table.table-striped
+    tr
+      td
+        h5 Last day for June Item Set!
+        p Reminder: this is the final day to subscribe and receive the Octomage Item Set! If you want the Octopus Robe or the Tentacle Helm, now's the time! Thanks so much for your support <3
+        h5 Dilatory Update
+        p PLEASE! Habiticans, stop  exploring the dark crevasse!!! Lemoness is really getting worried. There have been.... reports.
+        p Reports of something big.
+        p Reports of something terrifying.
+        p Reports of mysterious aftershocks, growing in intensity.
+        p Besides, exploring the dark and dangerous crevasse has become a source of procrastination. Let's get back to work, people!
+
+  hr
+  h5 6/25/2014
+  table.table.table-striped
+    tr
+      td
+        h5 June Subscriber Item
+        .pull-right.promo_mystery_201406.png
+        p The June Subscriber Item has been revealed: the Octomage Item Set!  All June subscribers will receive the Octopus Robe and the Crown of Tentacles. You still have six days to subscribe and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
+        h5 Mobile App Update
+        p There's a new mobile app update available! In addition to bug fixes, there are many improvements, including a new button-based menu, tap-and-hold to edit tasks, and the return of stats and in-app avatar customization! Working on the mobile app is our biggest To-Do this summer, so expect more in the coming months. If you feel that the app is improving, we'd love it if you would take the time to give us a review and let us know what you think!
+        h5 Dilatory Update
+        p It's great to see Habiticans having fun exploring the ruins! There's just one small thing Lemoness wants us to avoid. She's noticed a lot of Habiticans trying to explore the fallen palace of the other side of the dark crevasse. She really doesn't feel that the crevasse is safe, so please don't swim so close. Other than that, enjoy your explorations!
+
+  hr
+  h5 6/21/2014
+  table.table.table-striped
+    tr
+      td
+        h5 Summer Mystery Update
+        p Lady Lemoness has returned at last! She startled beach-goers by charging up out of the waves and onto the shore, shouting "I found it!!! I found it!!! Oh, I just KNEW that citing it as impossible would make it a narrative probability!"
+        p Wait - found what?
+        h5 Summer Splash Event: The Lost City Of Dilatory!
+        p Dilatory was a lovely island city of ancient Habitica. It was a prosperous place, but as the wealth of the city grew, the inHabitants grew lazy and procrastinated on their Dailies and To-Dos... until the combined weight of their dark red tasks triggered a massive earthquake that sunk the city. Legends say that all of the inHabitants were transformed into sea creatures.
+        p The location of this city was lost to time... until now!
+        h5 Limited Edition Outfits!
+        p What's the fun of an underwater city if you can't explore it? Luckily, from now until July 31st, special Limited Edition Outfits are available for gold in the Rewards store! Spellcasters can transform themselves into <strong>Emerald Mermages</strong> and <strong>Reef Seahealers</strong> to swim among the ruins, while fighters may prefer to dress as <strong>Roguish Pirates</strong> and <strong>Daring Swashbucklers</strong>, riding above the city on magnificent ships. Work hard, and you can join them!
+        h5 NPC Dress-up
+        p The NPCs got so excited about the discovery of Dilatory that they've moved over there for the summer! Daniel the Innkeeper has opened a beachside tavern, and Alex is also selling by the shore! Meanwhile, Justin the Guide is giving tours aboard boats, Ian is dispensing quest wisdom from the deep ocean, Matt has opened stables for aquatic pets, and I am swimming about keeping everyone informed!
+        h5 But what caused the Earthquake?
+        p Only one piece of the mystery remains unsolved - what caused the second earthquake that unearthed the ancient Dailies? After all, the earthquake that destroyed Dilatory was caused by a build up of undone Dailies and To-Dos, wasn't it?
+        p But *we've* all been doing our tasks...
+
+  hr
+  h5 6/14/2014
+  table.table.table-striped
+    tr
+      td
+        h5 New Feature: Backgrounds!
+        p We're debuting a brand-new feature - backgrounds for your avatar! Stroll through a Summer Forest, lounge upon a warm Beach, or dance in a Fairy Ring. You can buy the backgrounds in the new Background tab, under User. Have fun!
+        h5 Summer Mystery Update
+        p It's been a while since we've seen Lemoness around - she's been a bit scarce since she started trying to decipher those ancient Dailies. We just stopped by her hut to check on her and found her..... missing?
+        br
+        p It looked like she'd taken her armor-enchanting crochet hook, but little else. There was a single scrawled note on the table: "I think I've translated it!!!! If I'm right, this is going to be QUITE the summer. Verifying claims - be back soon!!!"
+        br
+        p The only other thing on the table was an ancient map... with the corner ripped off.
+  small.muted 6/14/2014
+
+  hr
+  h5 6/10/2014
+  table.table.table-striped
+    tr
+      td
+        h5 New Pet Quest: The Call Of Octothulu!
+        p There's a new pet in town! The dreaded Octothulu, sticky spawn of the stars, has emerged from a whirlpool in a dark cave by the sea. It's up to you and your party to banish the foul beast by being extra-productive! If you manage to defeat it, you might just find some octopus eggs...
+        h5 Earthquake Update
+        p Remember the strange earthquake we had recently? Well, this probably isn't related in any way, but Habiticans have recently noticed some mysterious black Dailies strewn along the beaches. Lemoness happily reports that they are scrawled upon with an ancient language, and that she is hard at work deciphering the script. More news as this develops!
+
+  hr
+  h5 6/5/2014
+  table.table.table-striped
+    tr
+      td
+        h5 June Mystery Item
+        p Wow, what could it be? All Habiticans who are subscribed during the month of June will receive the June Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
+    tr
+      td
+        h5 What Was That?
+        p Yikes! A mysterious earthquake has rocked Habitica! Luckily, nobody was hurt and there was no real damage, but our scholars are baffled. "We're not even IN a seismic zone," Lady Lemoness was heard muttering as she paged through an enormous tome. "There hasn't been an earthquake since.... but no, that's impossible." Well, if Lemoness says so, it must be true! Seems like it was just a false alarm.
+
+  hr
+  h5 5/23/2014
+  table.table.table-striped
+    tr
+      td
+        h5 May Mystery Outfit Revealed!
+        .pull-right.promo_mystery_201405.png
+        p The May Mystery Item Set has been revealed for all subscribers... <strong>Flame Wielder Item Set</strong>! All people who are subscribed this May will receive two items:
+        ul
+          li Flame of Mind (helm)
+          li Flame of Heart (armor)
+        p You still have eight more days to subscribe and get the item set. Thank you all for supporting us! We love you <3
 
 
-hr
-h5 01/16/2014
-table.table.table-striped
-  tr
-    td
-      h5 "Spread The Word" Challenge Updates
-      p If you're not yet participating, check out the <a target='_blank' href='/#/options/groups/challenges/95533e05-1ff9-4e46-970b-d77219f199e9'>Spread The Word Challenge</a>, which has a large prize and many winners. We've made some updates: upped the prize to 80 Gems for the top 20 posts, 100 Gems for the winner. Note: some people are listing their submission as a Tumblr reblog of someone else's post, often with added commentary. Though reblogs are greatly appreciated, we can only count original submissions. Read more <a target='_blank' href='/#/options/groups/challenges/95533e05-1ff9-4e46-970b-d77219f199e9'>challenge guidelines here</a>.
-  tr
-    td
-      h5 Quest Deadlines
-      p To clear some confusion, you have until Jan 31, 2014 to <strong>purchase</strong> your quest scrolls, after 1/31 Alexander no longer sells them. You can still begin / finish your quests any time after. Thanks to @Cole, you're now allowed to purchase the Cub quest even if you haven't finished Trapper. Stock up!
+  hr
+  h5 5/14/2014
+  table.table.table-striped
+    tr
+      td
+        h5 The Rat King
+        p Habitica's streets are filled with the skittering of little paws... looks like there's a new Pet Quest available in the Market! Can you and your party defeat the Rat King? If so, there will be some eggs to reward you...
+        small.muted By: Pandah and Token
+    tr
+      td
+        h5 Level Cap Lifted
+        p You can now level up beyond 100, the 100-cap has been lifted!
+        small.muted By: Ryan
 
-hr
-h5 01/06/2014
-h4 <a tooltip='Winter Wonderland Event' href='http://habitrpg.wikia.com/wiki/Winter_Wonderland' target='_blank'>WWE</a> Part 4: Winter Classes
-table.table.table-striped
-  tr
-    td
-      h5 Limited-Edition Winter Class Outfits
-      p Happy winter! Instead of a boring pair of earmuffs, why not use the gold that you earned with all your hard work to buy a Limited Edition class outfit?
-      p From now until January 31st, you will be able to use your gold to buy your current class' armor set from the Rewards store! You can be a Yeti Tamer, a Ski-Sassin, a Candy Cane Mage, or a Snowflake Healer. If you switch classes (system unlocked at level 10), you will gain access to your new classes' armor set. Make sure to collect yours first, though!
-      p What are you waiting for? Go be productive and earn some gold!
-      small.muted by @lemoness
-  tr
-    td
-      h5 Chat +1
-      p You can now +1 chat messages in Tavern, Guilds, & Parties
-  tr
-    td
-      h5 Halls
-      p We've added the "Hall of Heroes" and "Hall of Patrons" <a href='https://habitrpg.com/#/options/groups/hall/heroes' target='_blank'>here</a>, which list our project contributors and Kickstarter backers. Want be amongst those immortalized in the Hall of Heroes? <a href='http://habitrpg.wikia.com/wiki/Contributor_Rewards' target='_blank'>Lend us your sword!</a>
+  hr
+  h5 5/5/2014
+  table.table.table-striped
+    tr
+      td
+        h5 Mobile Update
+        p The new iOS update is live! <a href='https://itunes.apple.com/us/app/habitrpg/id689569235?mt=8' target='_blank'>You can download it here</a>. If you have Android, <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg' target='_blank'>the update is available here.</a>
+        br
+        p Note: to edit a task or view checklists, swipe left on the task. We're <a href='https://github.com/HabitRPG/habitrpg-mobile/issues/199' target='_blank'>working on click-to-view</a>, we'd love some developer help!
+        br
+        p If you think the new app is an improvement, please consider rating us - many of our old reviews were (justifiably!) pretty low, especially on Apple, but we feel that this update is the first in a line of major improvements. Thanks for sticking with us!
+    tr
+      td
+        h5 The HabitRPG Chrome Extension
+        p Great news - we've fixed our Chrome Extension! Many thanks to new contributor <a href='https://github.com/HabitRPG/habitrpg-chrome/pull/88' target='_blank'>@GoldBattle<a/>. Now you can set the times and dates you want to only browse productive sites. If you're procrastinating, it will automatically start docking your character's health; if you're hard at work, it will reward you with GP and XP! <a href='https://chrome.google.com/webstore/detail/habitrpg/pidkmpibnnnhneohdgjclfdjpijggmjj' target='_blank'>Read more about it here.</a>
+    tr
+      td
+        p Also, a quick change - May's mystery item will now be revealed on the 23rd, instead of the 25th. Rejoice, impatient Habiticans!
 
-hr
-h5 12/31/2013
-h4 Winter Wonderland Event Part 3: Party!
-table.table.table-striped
-  tr
-    td
-      h5 Happy New Year!
-      p Happy New Year! Join the NPCs and Staff in showing off your new Absurd party hat.... and have a great night!
-      small.muted by @lemoness
-  tr
-    td
-      h5 Rebirth
-      p Nothing says New Year like a fresh start. Now when you reach level 50, Ultimate Gear, or BeastMaster, you can begin anew with the most prestigious of achievements: Rebirth. <a href='https://trello.com/c/SLiq4enr/333-rebirth-new-game' target='_blank'>Read more here</a>. But take heed! Scouts have reported <a href='https://github.com/HabitRPG/habitrpg/issues/945#issuecomment-31355229' target='_blank'>monster sightings</a>, harbinged by Trapper Santa. You may need all the strength you can muster come late January, Rebirth is for the hard-core.
-      small.muted by @SabreCat
-  tr
-    td
-      h5 Checklists
-      p <a href='https://trello.com/c/PJ1iJ413/65-checklists' target='_blank'>Checklists</a> are here! You can break your Dailies and To-Dos down into bite-size chunks. Their game mechanic takes some learning, so <a href='http://habitrpg.wikia.com/wiki/Checklist' target='_blank'>read more here</a>.
-      small.muted by @lefnire
-  tr
-    td
-      h5 Task Icons & Markdown
-      p Task titles now support Markdown and Emoji, so you can create something <a href='http://gyazo.com/f2021674925a79a1dec22101ef74a63c' target='_blank'>like this</a>. Read more <a href='https://trello.com/c/FCVdjdUd/102-task-reward-icons' target='_blank'>here</a>.
-      small.muted by @lefnire
+  hr
+  h5 4/30/2014
+  table.table.table-striped
+    tr
+      td
+        h5 May Mystery Item
+        p Ooh, how mysterious! All Habiticans who are subscribed during the month of May will receive the May Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
+  hr
+  h5 4/30/2014
+  table.table.table-striped
+    tr
+      td
+        h5 Mobile Update
+        p Great news! We've just released a big upgrade to our mobile app. One of our biggest priorities right now is improving the HabitRPG mobile experience, so this is an important first step. We've upgraded the framework to Ionic, which means a cleaner look and smoother feel, and best of all, it is now easier for the developers to add new updates and features! <a href='http://blog.habitrpg.com/post/84100207996/habitrpg-mobile-on-ionic' target='_blank'>Read more about the upgrade here.</a>
+        p The Android App is <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg' target='_blank'>available here</a>! The iOS app was submitted to the App Store, but Apple always takes a while to process things, so it may be a few more days. Let's hope they're quick this time around! We'll let you know when it goes through.
+        p Have a productive day!
+    tr
+      td
+        h5 Spread the Word Challenge
+        p Also, at long last the staff has finished sorting through the 1.5K+ participants in the Spread The World Challenge, and we are pleased (and so, so relieved) to finally announce a winner!
+        p Congratulations to ALEX KRALIE, the winner of the Spread The Word Challenge! 47K+ notes is truly momentous.
+        p A warm congratulation is also due to the runner-ups: sarahtyler, HannahAR, Raiyna, thefandomsarecool, Chickenfox, Anrisa Ryn, frabajulous, galdrasdottir, Judith Meyer, jazzmoth, RavenclawKiba, daraxlaine, Phiso, Billieboo, Victor Fonic, nikoftime, Aedra, amBarthes, and thaichicken! You guys are great <3 Thanks for helping to get the word out about HabitRPG!
+    tr
+      td
 
-hr
-h5 12/25/2013
-h4 Winter Wonderland Event Part 2: Rescue the Bears
-table.table.table-striped
-  tr
-    td
-      h5 Quests & Bosses!
-      p A beast is roaring in the distant mountains, mysterious tracks have appeared in the snow. A new feature has been unlocked, <a href='https://trello.com/c/VPPjVRlF/212-quests-bosses' target='_blank'>Quests & Bosses</a>. As a holiday present, HabitRPG gives you your first quest: "Trapper Santa". Check your inventory, you have until Jan 31 to complete it!
+        h5 Spring Fling
+        p Reminder that today, 4/30, is the LAST DAY of the Spring Fling event! After today, you will no longer be able to purchase the Pastel Hair Set or the Limited-Edition class items. Additionally, the Egg Hunt scroll will no longer be available in the Market, although if you have started the quest, it will NOT disappear and you will be able to complete it at your leisure.
+        p It is also the last day to get the Twilight Butterfly Item Set before it disappears forever! If you want the Twilight Butterfly Wings or the Twilight Butterfly head accessory, this is your last chance to subscribe and get them.
+        p Happy Spring!
 
-p By @lefnire, @pandoro, @Shaners
+  hr
+  h5 4/25/2014
+  table.table.table-striped
+    tr
+      td
+        h5 April Mystery Outfit Revealed!
+        //-img.pull-right(src='/marketing/promos/April14SAMPLE2.png')
+        p The April Mystery Item Set has been revealed for all subscribers... <strong>Twilight Butterfly Armor Set</strong>! All people who are subscribed this April will receive two items:
+        ul
+          li Twilight Butterfly Antennae
+          li Twilight Butterfly Wings!
+        p You still have five more days to subscribe and get the item set. Thank you all for supporting us! We love you <3
 
-hr
+  hr
+  h5 4/6/2014
+  table.table.table-striped
+    tr
+      td
+        h5 The Great Egg Hunt
+        p A new quest is available in the Market between now and April 30th. Anyone who signed up before April 7th has one in their inventory free!
+
+  hr
+  h5 4/3/2014
+  table.table.table-striped
+    tr
+      td
+        h5 Limited Edition Pastel Hair Color Set
+        p A new set of hair colors has been released: the Pastel Set! Now your avatar can have flowing locks in Pastel Blue, Pastel Pink, Pastel Purple, Pastel Orange, Pastel Green, or Pastel Yellow! You will only be able to purchase these hair colors until April 30th, so don't miss out!
+
+  hr
+  h5 4/2/2014
+  table.table.table-striped
+    tr
+      td
+        h5 April Mystery Item
+        p  What could it be? All people who are subscribed during the month of April will receive the April Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled.
+
+  hr
+  h5 April F... irst
+  table.table.table-striped
+    tr
+      td
+        p Hiya, folks! I'm Mrs. Carrot the Carroty Carrot, and I am your new announcer here at HabitRPG! I'm pleased to say that we've released several important updates that we are convinced will drastically improve user experience. Be sure to click around to admire our completely warranted and not at all arbitrary changes! In short, we were worried that the fantasy role-playing-game theme was getting somewhat overplayed, so we've decided unanimously to take the app in a different, more nutritious direction.
+        br
+        p After all, talking vegetables NEVER get old.
+        small.muted By @lemoness and @baconsaur
+
+  hr
+  h5 03/31/2014
+  table.table.table-striped
+    tr
+      td
+        p Reminder that today is the <strong>last day</strong> to get the Forest Walker Subscriber Set before it disappears forever! If you want the Forest Walker Armor or the Forest Walker Antler head accessory, this is your last chance to subscribe and get it.
 
 
-h5 12/20/2013
-h4 Winter Wonderland Event Part 1: The Great Snowball Fight
-p It's time for HabitRPG's biggest event yet - Winter Wonderland! The fun starts today, on the first day of winter, and ends on January 31st - HabitRPG's birthday.
-p Get prepared to build new habits, earn fun drops, hold your party members accountable for their tasks, and decorate your avatar. Various features will be rolling out over the course of the event, so expect many updates! For starters...
-table.table.table-striped
-  tr
-    td
-      h5 NPC Decorations
-      p Looks like everyone is really getting into the winter spirit! Check out the new NPC sprites. (And I heard a rumor that the final NPC might show up, just in time for the new year...)
-  tr
-    td
-      .customize-option.hair_bangs_1_winternight.pull-right
-      h5 Limited-Edition Holiday Hair-Colors
-      p Now your avatar can dye their hair Candy Cane, Frost, Winter Sky, or Holly! You'll only be able to purchase these hair colors until January 31st, when they will be retired.
-  tr
-    td
-      .shop_snowball.pull-right
-      h5 The Great HabitRPG Snowball Fight
-      p Yes, you can now buy snowballs and hurl them at all your friends... to, uh, help them improve their habits. How? Weeeeellll, let's just say that after getting walloped, they might find themselves needing some extra gold to escape their predicament...
-        //-span.shop_head_special_candycane.item-img.shop-sprite
-  tr
-    td
-      h5 More to Come
-      p A beast is roaring in the distant mountains, mysterious tracks have appeared in the snow, and Lemoness is furiously crocheting something sparkly.
-      p It's going to be a wild winter.
+  hr
+  h5 03/25/2014
+  table.table.table-striped
+    tr
+      td
+        h5 March Mystery Item Set
+        //-img.pull-right(src='/marketing/promos/201403_Forest_Walker.png')
+        p The March Mystery Item Set has been revealed for all subscribers... The Forest Walker Set! All people who are subscribed this March will receive two items: <strong>Forest Walker Armor</strong> and <strong>Forest Walker Antlers</strong>!
+        br
+        p The antlers are a head accessory, so they can be worn with any helmet.
+        br
+        p You still have five more days to subscribe and get the item set. Thank you all for supporting us! We love you <3
+    tr
+      td
+        h5 PayPal Subscriptions
+        p We've added PayPal as a payment method for subscriptions. We still recommend the <strong>Card</strong> method, as <a href='https://stripe.com/' target='_blank'>Stripe</a> (the processor we use) has a more stable API and better account management tools. However, we realize not everyone owns a credit/debit card, so there's PayPal for ya!
 
-p By @lemoness
+  hr
+  h5 03/22/2014
+  table.table.table-striped
+    tr
+      td
+        h5 Spring Fling Event
+        p Spring has come to Habitica, and flowers have sprouted everywhere: in the Stables, in the Marketplace... and even in your character customization pages!
+    tr
+      td
+        h5 Head Accessories
+        p That's right - we've introduced Head Accessories! Your avatar can now bedeck their helms with colorful flowers. And that's not the only place to get head accessories….
+    tr
+      td
+        h5 Limited Edition Class Outfits
+        p The Spring 2014 Limited Edition Class Outfits have been released!
+        p From now until April 30th, you will be able to use your gold to buy your current class' armor set from the Rewards store! You can be a Stealthy Kitty, a Mighty Bunny, a Magic Mouse, or a Loving Pup. If you switch classes (system unlocked at level 10), you will gain access to your new classes' armor set. Make sure to collect yours first, though!
+        p What are you waiting for? Go be productive and earn some gold!
+    tr
+      td
+        h5 New Un-Equip Mechanic
+        p Now to un-equip your gear, click the same item that you have currently equipped. We removed the "Base Equipment" tier for consistency with how un-equipping pets & mounts is handled, and to easily support adding new gear types.
+    tr
+      td
+        h5 Pet Quest: The Ghost Stag
+        p The meadows of Habitica are bursting with flowers, sunshine, and.... ominous mist? Looks like a ghost stag is keeping winter alive! Defeat him, and maybe you'll get an egg or three....
+    tr
+      td
+        h5 And More To Come...
+        p This is only the beginning of all the treats that we've got in store for you. Stay tuned - and happy Spring Fling!
 
-hr
+  hr
+  h5 03/18/2014
+  table.table.table-striped
+    tr
+      td
+        h5 New Pet Quest Mechanics
+        p Great news - now it is easier to complete the Quest Pet sets! Pet Quest  Bosses will now drop 3 eggs instead of 2. Additionally, after you have defeated a Pet Quest Boss two times, those eggs will be gem-purchasable in the market like all other eggs, so that your party doesn't have to replay the same quest over and over :)
+    tr
+      td
+        h5 WonderCon
+        p HabitRPG will be attending WonderCon from April 18th-20th! Come say hi to Tyler, Leslie, and Vicky, and chat about productivity and games. Tickets are available <a href='http://www.comic-con.org/wca/2014/badge-sale' target='_blank'>here</a>.
+        p All the users who visit our booth will receive the <a href='http://goo.gl/2urFUt' target='_blank'>Unconventional Armor Accessory Set</a>! (It will also be available if we attend other cons in the future.)
+    tr
+      td
+        h5 LifeHacker Poll
+        p HabitRPG is in the running to be Lifehacker's #1 To-Do list manager! We've got some tough competition, so if you like our site, please help us out <a href='http://lifehacker.com/5924093/five-best-to-do-list-managers' target='_blank'>by voting for us here</a> <3
 
-h5 12/16/2013
-p Good gracious, where do I start...
-br
-table.table.table-striped
-  tr
-    td
-      h4 Classes
-      p You can now be a Warrior, Rogue, Wizard, or Healer. <a href='http://habitrpg.wikia.com/wiki/Class_System' target='_blank'>See details here.</a>
-  tr
-    td
-      h4 Armory & Costumes
-      p Once you select your new class, you're now equipped with your new class's apprentice gear. Fear not, your old gear is still available in your inventory! You can switch gear at any time, and wear a different costume than your equipment. See <a href='https://trello.com/c/83M5RqQB/299-armory' target='_blank'>Armory</a> & <a href='https://trello.com/c/iY6A7nlX/336-costumes-armory-v2' target='_blank'>Costumes</a>
-  tr
-    td
-      h4 New Customizations
-      p We now have a much wider selection of hair, shirt, facial-hair, body-size, etc. customizations. See <a href='https://trello.com/c/YKXmHNjY/306-customization-redo' target='_blank'>Customizations v2</a>
-  tr
-    td
-      h4 300 Tier Gear
-      p All you $300 backers who have been waiting patiently, your gear is now in! Currently, only available to $300+ backers, but we'll add them as drops to the Boss system once that's released. See <a href='https://trello.com/c/sb6f9w5r/217-custom-items-300-tier' target='_blank'>300-tier</a>
-  tr
-    td
-      h4 API v2
-      p The API has been completely overhauled, and v2 comes with many more routes for a *full featured* API. v1 is no longer supported, take heed ye 3rd-party-ists! For the time being, basic routes are supported (such as up/down -scoring). v2 will be documented soon, and I'll ping you when. see <a href='https://trello.com/c/L4pYimQM/343-api-v2' target='_blank'>APIv2</a>
-hr
-p By @lemoness @sabrecat @danielthebard @fuzzytrees @crystalphoenix @rosemonkeyct @fandekasp, and many more. (Who am I missing? We'll put up a CONTRIBUTORS.md soon)
+  hr
+  h5 03/02/2014
+  table.table.table-striped
+    tr
+      td
+        h5 March Mystery Item
+        p Happy March! The awesome people who subscribe to HabitRPG will now receive the limited-edition March mystery item! The mystery item set will contain a stats-free costume piece that will <strong>only</strong> be available to the people who are subscribers this March. The set will be revealed on the 25th to everyone, but all people who are subscribers during the month of March will receive it. Get excited - and thank you so much for helping to support HabitRPG! We love you.
+    tr
+      td
+        h5 Hedgehog Quest
+        p A new pet has been introduced, the Hedgehog. You can find some eggs by battling the Hedgebeast Boss, a quest scroll available in the market.
 
-h5 12/7/20132
-table.table.table-striped
-  tr
-    td
-      h4 Mounts!
-      p You can now feed your pets and they'll grow into trusty steeds. Obtain food as new random drops, or you can hasten the process buy buying a saddle from Alexander.
-      // We may want to use their twitter handles, or something they prefer instead
-      hr
-      p.
-       By <a target='_blank' href='https://github.com/lemoness'>@lemoness</a> <a target='_blank' href='https://github.com/Shaners'>@Shaners</a> <a target='_blank' href='https://github.com/baconsaur'>@baconsaur</a> <a target='_blank' href='https://github.com/RandallStanhope'>@RandallStanhope</a> <a target='_blank' href='https://github.com/ashjolliffe'>@ashjolliffe</a> <a target='_blank' href='https://github.com/fuzzytrees'>@fuzzytrees</a>
+  hr
+  h5 02/22/2014
+  table.table.table-striped
+    tr
+      td
+        .pull-right.character-sprites(style='clear:both;width:90px;height:90px')
+          span.back_mystery_201402
+          span.slim_armor_mystery_201402
+          span.head_mystery_201402
+        p The February Mystery Item Set has been revealed for all subscribers... <strong>The Winged Messenger Set</strong>! All people who are subscribed this February will receive three items:
+        ul(style='margin-left:15px')
+          li Winged Helm
+          li Messenger Robes
+          li and... <strong>Golden Wings</strong>!
+        p The wings are a brand-new type of item, called a Back Accessory! These items appear behind your avatar, so you can wear the wings with any outfit. You still have five more days to subscribe and get the item set. Thank you all so, so much for supporting HabitRPG!
 
-h5 11/27/2013
-table.table.table-striped
-  tr
-    td
-      h4 Turkey Event (by @lemoness)
-      p Say hi to our NPCs, dressed to impressed for Turkey day! Also - check your stable, you'll find a fun new pet.
-  tr
-    td
-      h4 Chat Enhancements (by @Nick Gordon)
-      p.
-        Chat can now use markdown, Emoji, and @-tagging. Some pointers on using markdown & Emoji at <a href="http://habitrpg.wikia.com/wiki/Markdown_Cheat_Sheet" target="_blank">here</a>. To use @-tagging, simply type '@' in chat.
-  tr
-    td
-      h4 Party Sorting (by @Fandekasp)
-      p.
-        You can now adjust the way you view your party members in the top bar. They can be sorted by level, number of pets, the date they joined the party, or just randomly. Also, level colors now reflect your contributor status.
-  tr
-    td
-      h4 Wiki Updates (by @bobbyroberts99)
-      p.
-       The <a href='http://habitrpg.wikia.com/wiki/HabitRPG_Wiki' target='_blank'>HabitRPG wiki</a> is being speedily updated. If you’re confused about anything, go check it out - it’s a treasure trove.
 
-h5 11/08/2013
-table.table.table-striped
-  tr
-    td.
-      Contrib Gear. You can now unlock new a top-tier gear set and pet by contributing (code, art, docs, etc) to HabitRPG. <a href='http://habitrpg.wikia.com/wiki/Contributor_Rewards' target='_blank'>Read more</a>
+  hr
+  h5 02/18/2014
+  table.table.table-striped
+    tr
+      td
+        h5 Translations
+        p Translations are well underway! Many of you should already be seeing HabitRPG in your own languages. If not, head <a href='https://trello.com/c/SvTsLdRF/12-translations' target='_blank'>here</a> to see your language's progress or to help translate.
+        p
+          small.muted by @paglias, @Sinza-, @Luveluen, and more.
+    tr
+      td
+        h5 BountySource
+        p We’ve started using BountySource, a service which lets users post bounties on bug fixes and feature requests. Any features or bugs in HabitRPG you’ve been dying to see resolved? <a href='https://www.bountysource.com/teams/habitrpg/issues' target='_blank'>Post a bounty</a> to attract contributor attention. <a href='http://blog.habitrpg.com/post/76898655192/bountysource' target='_blank'>Read more here</a>.
+        p
+          small.muted by @Cole, @lefnire, @Ryan
 
-h5 11/01/2013
-table.table.table-striped
-  tr
-    td.
-      Challenges! Compete with your party, guilds, or the tavern on certain tasks. Win gem prizes. <a href='http://blog.habitrpg.com/post/65721506787/challenges-ui-router' target='_blank'>Read more.</a>
-  tr
-    td Backend overhaul, including bookmark-able paths throughout the application. Will pave the way towards improved performance.
+  hr
+  h5 02/13/2014
+  table.table.table-striped
+    tr
+      td
+        h5 Happy Valentine's Day!
+        p Help motivate all of the lovely people in your life by sending them a caring valentine. Valentines can be purchased for 10 gold from the Item Store. For spreading love and joy throughout the community, both the giver AND the receiver get a coveted "adoring friends" badge. Hooray!
+        p
+          small.muted By Lemoness and zoebeagle
 
-h5 10/22/2013
-table.table.table-striped
-  tr
-    td TRICK OR TREAT! It's Habit Halloween! Some of the NPCs have decorated for the occasion. Can you spot us?
-  tr
-    td Two gem-purchasable skin tones are now available! The Rainbow Skin Set is here to stay, but in honor of Halloween, we also have the LIMITED EDITION SPOOKY SKIN SET. You will only be able to purchase the Spooky Skin Set until November 10th, so if you want a monstrous avatar, now's the time to act!
-  tr
-    td Do note, skins won't work on mobile until the app is updated. We'll update Android ASAP, iPhone usually takes ~1wk to approve.
 
-h5 10/19/2013
-table.table.table-striped
-  tr
-    td New custom skin colors are now available! Go check them out in the Profile section. Also, the new mobile update, 0.0.10, is now available to download! It includes the new skin tones and the ability to hide or show your helm, among other things.
-  tr
-    td You can now sell un-wanted drops to Alex the Merchant. Trade those troves of eggs for gold!
+  hr
+  h5 02/12/2014
+  table.table.table-striped
+    tr
+      td
+        h5 Chat & Invite Notifications
+        p Chat & group-invitation notifications are back! Miss them? They currently work for all chat updates in parties & guilds. Any devs willing to jump into @tagging in Tavern, <a href='http://goo.gl/uhcjkg' target='_blank'>see here</a>.
+    tr
+      td
+        h5 Toolbar
+        p In order to make room for these notifs, we added a toolbar above the header. You can collapse the toolbar (far-right icon), but take care as Bailey notifs are inside the toolbar!
+  hr
+  h5 02/07/2014
+  table.table.table-striped
+    tr
+      td
+        h5 February Mystery Item
+        p
+          .pull-right.inventory_present
+          | We're excited to announce a new feature a s a big thank-you to the awesome people who <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribe</a> to HabitRPG! Every month, all subscribers will now receive a limited-edition mystery item! The mystery item will be a stats-free costume piece (like the Absurd Party Robes) that will <strong>only</strong> be available to the people who are subscribers each month. The February 2014 item will be revealed on the 23rd to everyone, but all people who are subscribers during the month of February will receive it. <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>Subscribe now</a>, get excited, and thank you so much for helping to support HabitRPG! We love you.
+    tr
+      td
+        h5 Critical Hammer Of Bug-Crushing
+        p
+          .pull-right.weapon_special_critical
+          | Some of you may have noticed that we periodically have some bugs that are nastier than the norm - the dreaded critical bugs. These monstrous apparitions have been snapping at the heels of many a player. For updates on what we're currently working on to improve site stability, read <a href='https://github.com/HabitRPG/habitrpg/issues/milestones' target='_blank'>this link</a> - and then jump in to help!  Not only will programming assistance reward you with the usual contributor levels, but if you actually manage to fix a bug marked <a href='http://goo.gl/v4DnzB' target='_blank'>"critical,"</a> you will now receive the <em>Critical Hammer of Bug-Crushing</em> as your reward!
+    tr
+      td
 
-h5 09/01/2013
-table.table.table-striped
-  tr
-    td.
-      We <a target='_blank' href="http://habitrpg.tumblr.com/post/59104876969/website-issues-what-were-doing">re-wrote the website from the ground up</a>
-      And in case you missed it, <a target='_blank' href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg'>Android</a> & <a target='_blank' href='https://itunes.apple.com/us/app/habitrpg/id689569235?mt=8'>iOS</a> Apps are out!
-      Both apps and the website are open source, and we desparately need your help porting the rest of the features, and polishing off the bugs. <a target='_blank' href='http://habitrpg.wikia.com/wiki/Contributing_to_HabitRPG'>Read this guide</a> to getting started.
-      We're working on a system of Contributor Gear to reward the awesome people who help out, so stay tuned!
+        h5 Rainbow Hair Colors
+        p
+          .pull-right.customize-option.hair_bangs_1_rainbow
+          | Want to spruce up your avatar? Rainbow hair colors are now available! Dye your luscious locks purple, green, or even rainbow-striped, and passersby will look at you with envy.
+    tr
+      td
+        h5 Stability Update
+        p We've stabilized the site a lot (we're still working out kinks, but we're way better now). Follow the <a href='https://github.com/HabitRPG/habitrpg/issues/milestones' target='_blank'>progress here</a>, but here are some workarounds for now:
+        ul
+          li Click slower. <a href='https://github.com/HabitRPG/habitrpg/issues/2301#issuecomment-34398206' target='_blank'>VersionError</a> is caused by clicking things off too fast (we're working on a fix).
+          li If you see an error, refresh before proceeding﻿.
 
-h5 The Rewrite! (Mid August)
-table.table.table-striped
-  tr
-    td.
-      Hello my Habiteers! I have some amazing news to share with you, it's huge!
-       Has Habit ever crashed for you? (Joke). Well we <u><a target='_blank' href="http://habitrpg.tumblr.com/post/59104876969/website-issues-what-were-doing">re-wrote the website</a></u> from the ground up
-       to conquor those critical bugs once and for all (more from Tyler in a bit). If you haven't seen me for a while (due to a bug in the old site), be sure to catch up with me on the right side of the screen for any missed news. Importantly:
-       <a target='_blank' href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg'>Android</a> & <a target='_blank' href='https://itunes.apple.com/us/app/habitrpg/id689569235?mt=8'>iOS</a> Apps are out!</u>
-  tr
-    td.
-      They're open source, so help us make them awesome. As for the rewrite: not all features are yet ported, but don't worry - you're still getting drops and streak-bonuses in the background, even if you can't see them yet.
-       We'll be working hard to bring in all the missing features. And if you're not already, be sure to follow our updates on <a href="http://habitrpg.tumblr.com/" target="_blank">Tumblr</a> (there are some fun member highlights recently). One more thing: if you are a Veteran of the old site, I have granted you a Veteran Wolf! Check your inventory :)
-  tr
-    td.
-      JavaScript developers! To me! We must finish vanquishing the old site, as not all features have been ported.
-       We rewrote Habit on <a target='_blank' href='http://angularjs.org/'>AngularJS</a> + <a target='_blank' href='http://expressjs.com/'>Express</a>.
-       We desparately need your help porting <a href='http://goo.gl/jYWTwl' target='_blank'>the rest of the features</a>, and polishing off the bugs. <a target='_blank' href='http://habitrpg.wikia.com/wiki/Contributing_to_HabitRPG'>Read this guide</a> to getting started.
-       Thanks everyone for all your support and patience!
+  p
+    small.muted By Lemoness, mariahm, crystalphoenix, aiseant, zoebeagle, cole, lefnire
 
-h5 8/20/2013
-table.table.table-striped
-  tr
-    td.
-      Timezone + custom day start issues fixed, your dailies should now reset properly and in your own timezone. (This was vexing <strong>Android</strong> users particularly). If you're still experiencing issues, <a target='_blank' href='https://github.com/HabitRPG/habitrpg-mobile/issues/73#issuecomment-22960877'>chime in here</a>.
-  tr
-    td.
-      API developers, the above means that <strong>cron</strong> is automatically run for your users! Weee, they no longer have to log into the website to reset their dailies!
+  hr
+  h5 02/01/2014
+  table.table.table-striped
+    tr
+      td
+        h5 Vice
+        p You awaken after the Winter Wonderland festivities and birthday celebrations with a smile. It's been a snowy, cheerful couple months, and the NPCs have finally returned to their normal attire. But today something is very wrong. Shadowy whisps cover the ground of Habitica, the sky has darkened. At the tavern you hear @DanielTheBard struming dark tales on his lute, and @Baconsaur peering into a mug, grumbling about her mounts swallowed in the shadows. They speak of the same thing: <strong>Vice</strong>, a dark an terrible foe. This new boss arc is a 3-part quest that requires level 30 to begin. Bring your strongest party members, and don't miss your dailies - there's a powerful weapon at the end!
+        p
+          small.muted by @baconsaur & @DanielTheBard
 
-h5 8/18/2013
-table.table.table-striped
-  tr
-    td.
-      The Mobile Apps are out! <a target='_blank' href="https://itunes.apple.com/us/app/habitrpg/id689569235">iOS app</a> and <a target='_blank' href="https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg">Android</a>. There's a bug with Android 2.3, <a target='_blank' href='https://github.com/HabitRPG/habitrpg-mobile/issues/85'>follow the progress here</a>.  For more details, see our <a target=_blank href="http://habitrpg.tumblr.com/post/58449057415/android-mobile-app-released-iphone-app-coming-soon">Tumblr post</a>
-  tr
-    td
-      | Hey guys! Long time no see :) We want to make sure you guys have a better idea of what's going on behind the scenes, so we're going to be releasing
-      b weekly status reports
-      | of what we're currently working on! This weekend, we are working hard to fix the "Not Enough GP" bug, a cruel and greedy monster that has wrapped itself around the rewards box and is refusing to let anyone purchase anything. Rest assured that our heroic Tyler will slay this beast soon! Then it wiil be full steam ahead on the new site upgrade process.
-      a(target='_blank', href='http://habitrpg.tumblr.com/post/57627483715/news-about-upgrade-and-app') Read more about how that will work in this post here
+  hr
+  h5 01/30/2014
+  table.table.table-striped
+    tr
+      td
+        h5 Happy Birthday, HabitRPG!
+        p The fair land of Habitica is two years old on January 31st! The NPCs are celebrating in style, and it looks like some of the staff is, too! Won't you join in?
+    tr
+      td
+        h5 Absurd Party Robtes
+        p As part of the festivities, Absurd Party Robes are available free of charge in the Item Store! Swath yourself in those silly garbs and don your matching hats to celebrate this momentous day.
+    tr
+      td
+        h5 Delicious Cake
+        p What would a birthday be without birthday cake in a myriad of flavors? Of course, pets are very picky, but luckily Lemoness and her team of bakers have plenty of slices to go around. Mmm, delicious!
+    tr
+      td
+        h5 Last Day of Winter Wonderland Event
+        p Also, just a reminder - January 31st is the final day of the Winter Wonderland event, so it's your last day to get the Limited Edition Winter Hair Colors, the Winter Outfits, the snowballs, and the Trapper Santa and Find the Cub quest scrolls. Remember that mid-progress Trapper Santa and Find the Cub quests will not abort, nor will you lose your scrolls - they will simply be removed from Alexander's marketplace. We hope that you've had a wonderful winter!
+    tr
+      td
+        h5 Birthday Bash Badge
+        p Finally, to commemorate the fun, all party participants receive a birthday badge! Polish it frequently and wear it fondly.
 
-h5 6/03/2013
-table.table.table-striped
-  tr
-    td
-      a(target='_blank', href='https://trello.com/card/groups-guilds/50e5d3684fe3a7266b0036d6/84') Guilds!
-      | You can now belong to multiple groups, not just your party. There are public and private guilds, think "Subreddits" v "multiple friend groups".
+  p Thanks so much for being a part of the HabitRPG community. We love you guys, and we can't wait to have you at our sides in the upcoming year! Stay productive, Habiteers, and have an awesome day.
 
-h5 5/27/2013
-table.table.table-striped
-  tr
-    td
-      | Get the "Helped Habit Grow" badge by
-      a(href='http://community.habitrpg.com/node/290', target='_blank') filling out this survey.
-  tr
-    td
-      a(href='http://habitrpg.tumblr.com/post/51476277225/upcoming-features-bugs-update-user-survey', target='_blank') New blog post
-      | about upcoming Guilds & Challenges features, & huge bug-fixes on the horizon.
+  p.muted By @lemoness
 
-h5 5/25/2013
-table.table.table-striped
-  tr
-    td
-      | Code logic migrated to
-      a(target='_blank', href='https://github.com/habitrpg/habitrpg-shared') habitrpg-shared
-      | . See
-      a(target='_blank', href='https://github.com/lefnire/habitrpg/issues/1039') details here
-      | , but two takeaways: (1) keep an eye out and
-      a(href='http://community.habitrpg.com/content/submitting-bugs', target='_blank') report a problem
-      | if you experience any issues, (2) this is going to allow for much less buggy code (read previous link for reasoning).
+  hr
+  h5 01/28/2014
+  table.table.table-striped
+    tr
+      td
+        h5 Group Plans
+        p We've begun adding <a href='/static/plans' targte='_blank'>plans for groups</a> (parents, teachers, health & wellness administrators, etc). These plans will provide group leaders with more control, privacy, security, and support. Currently only the Organization Plan (top tier) is available (due to tech limitations believe it or not), and we'll be releasing the Family & Group plans later. <a href='/static/plans' targte='_blank'>Click the "Contact Us" buttons</a> if you're interested, and we'll keep you updated!
+    tr
+      td
+        h5 Individual Plan
+        p We've introduced a $5/mo basic subscription plan. It comes with a number of perks, which <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>you can see here</a>. We'll likely add more benefits over time, follow <a href='https://trello.com/c/euDUHPpn/371-basic-plan-subscription' target='_blank'>the conversation here</a>.
+    tr
+      td
+        h5 Perfect Day Achievement
+        p Now when you complete all your dailies, you stack this badge, plus and additional perk: you get a +(level/2) buff to all stats!
+    tr
+      td
+        h5 <a href='/#/options/groups/challenges/95533e05-1ff9-4e46-970b-d77219f199e9' target='_blank'>Spread The Word Challenge</a> Update
+        p We have 1k+ submissions, holy cow! Great job everyone! Now, we need to go through these manually, so it will take a few days to a couple weeks to process. The challenge will stay open until we're done choosing our winners, but be sure to edit the To-Do with your submission URL before 1/31, as that's the cut-off date for processing. We'll send a Tweet out when the winner has been selected, so follow <a href='https://twitter.com/habitrpg' target='_blank'>@habitrpg</a> and stay tuned.
 
-h5 5/12/2013
-table.table.table-striped
-  tr
-    td Renamed "Tokens" to "Gems". Tokens caused confusion.
-h5 5/10/2013
-table.table.table-striped
-  tr
-    td
-      | Less harsh death: Used to be you lose everything, now you lose GP & one random gear piece, 1 level. We're working on a
-      a(_target='blank', href='https://trello.com/card/death-mechanic/50e5d3684fe3a7266b0036d6/204') really cool death mechanic here.
-      | , but this is a stop-gap so people don't lose heart presently.
-  tr
-    td Chat messages: can delete your own message, fix the duplicate messages issue.
+  hr
+  h5 01/25/2014
+  table
+    tr
+      td
+        h5 Gryphon Quest
+        p A new pet has been introduced, the Gryphon. You can find some eggs by battling the Fiery Gryphon Boss, a quest scroll available in the market.
+        p
+          small.muted Note: we'll be fixing the beast-master achievement to work from the original 90 in coming days. Fear not current beast-masters, you'll get sorted soon!
+        p
+          small.muted By @baconsaur, @danielthebard
 
-h5 5/9/2013
-table.table.table-striped
-  tr
-    td
-      a(_target='blank', href='https://trello.com/card/backer-gear/50e5d3684fe3a7266b0036d6/213') Backer Gear
-      | : There's a new top-tier gear set for Kickstarter Backers. $45+ gets new Shield, Helm, Armor. $70+ that plus Weapon. $80+ that plus Pet. Keep leveling my friends, get that gear! Discuss gear-unlocking mechanic
-      a(href='https://trello.com/card/backer-items-availability-mechanic/50e5d3684fe3a7266b0036d6/188', target='_blank') here
-      | , and if you're top-gear but not seeing backer stuff, message me from your KS profile.
 
-h5 5/7/2013
-table.table.table-striped
-  tr
-    td
-      a(_target='blank', href='https://trello.com/card/tags-categories/50e5d3684fe3a7266b0036d6/43') Tags
-      | . You can now categorize your tasks, eg "Work", "Home", "Morning", "Taxes", etc.
+  hr
+  h5 01/16/2014
+  table.table.table-striped
+    tr
+      td
+        h5 "Spread The Word" Challenge Updates
+        p If you're not yet participating, check out the <a target='_blank' href='/#/options/groups/challenges/95533e05-1ff9-4e46-970b-d77219f199e9'>Spread The Word Challenge</a>, which has a large prize and many winners. We've made some updates: upped the prize to 80 Gems for the top 20 posts, 100 Gems for the winner. Note: some people are listing their submission as a Tumblr reblog of someone else's post, often with added commentary. Though reblogs are greatly appreciated, we can only count original submissions. Read more <a target='_blank' href='/#/options/groups/challenges/95533e05-1ff9-4e46-970b-d77219f199e9'>challenge guidelines here</a>.
+    tr
+      td
+        h5 Quest Deadlines
+        p To clear some confusion, you have until Jan 31, 2014 to <strong>purchase</strong> your quest scrolls, after 1/31 Alexander no longer sells them. You can still begin / finish your quests any time after. Thanks to @Cole, you're now allowed to purchase the Cub quest even if you haven't finished Trapper. Stock up!
 
-h5 5/4/2013
-table.table.table-striped
-  tr
-    td
-      a(_target='blank', href='https://trello.com/card/streaks-consecutive-bonus/50e5d3684fe3a7266b0036d6/182') Streaks
-      | . You get a GP & drop-% increase the longer you hold daily streaks (they stack). You also get a stacking badge for each 21-day streak.
+  hr
+  h5 01/06/2014
+  h4 <a tooltip='Winter Wonderland Event' href='http://habitrpg.wikia.com/wiki/Winter_Wonderland' target='_blank'>WWE</a> Part 4: Winter Classes
+  table.table.table-striped
+    tr
+      td
+        h5 Limited-Edition Winter Class Outfits
+        p Happy winter! Instead of a boring pair of earmuffs, why not use the gold that you earned with all your hard work to buy a Limited Edition class outfit?
+        p From now until January 31st, you will be able to use your gold to buy your current class' armor set from the Rewards store! You can be a Yeti Tamer, a Ski-Sassin, a Candy Cane Mage, or a Snowflake Healer. If you switch classes (system unlocked at level 10), you will gain access to your new classes' armor set. Make sure to collect yours first, though!
+        p What are you waiting for? Go be productive and earn some gold!
+        small.muted by @lemoness
+    tr
+      td
+        h5 Chat +1
+        p You can now +1 chat messages in Tavern, Guilds, & Parties
+    tr
+      td
+        h5 Halls
+        p We've added the "Hall of Heroes" and "Hall of Patrons" <a href='https://habitrpg.com/#/options/groups/hall/heroes' target='_blank'>here</a>, which list our project contributors and Kickstarter backers. Want be amongst those immortalized in the Hall of Heroes? <a href='http://habitrpg.wikia.com/wiki/Contributor_Rewards' target='_blank'>Lend us your sword!</a>
 
-h5 5/3/2013
-table.table.table-striped
-  tr
-    td
-      | Two new achievements: Beast Master & Ultimate Gear. Got ideas for more achievements?
-      a(target='_blank', href='https://trello.com/card/awards-badges/50e5d3684fe3a7266b0036d6/19') chime in here
+  hr
+  h5 12/31/2013
+  h4 Winter Wonderland Event Part 3: Party!
+  table.table.table-striped
+    tr
+      td
+        h5 Happy New Year!
+        p Happy New Year! Join the NPCs and Staff in showing off your new Absurd party hat.... and have a great night!
+        small.muted by @lemoness
+    tr
+      td
+        h5 Rebirth
+        p Nothing says New Year like a fresh start. Now when you reach level 50, Ultimate Gear, or BeastMaster, you can begin anew with the most prestigious of achievements: Rebirth. <a href='https://trello.com/c/SLiq4enr/333-rebirth-new-game' target='_blank'>Read more here</a>. But take heed! Scouts have reported <a href='https://github.com/HabitRPG/habitrpg/issues/945#issuecomment-31355229' target='_blank'>monster sightings</a>, harbinged by Trapper Santa. You may need all the strength you can muster come late January, Rebirth is for the hard-core.
+        small.muted by @SabreCat
+    tr
+      td
+        h5 Checklists
+        p <a href='https://trello.com/c/PJ1iJ413/65-checklists' target='_blank'>Checklists</a> are here! You can break your Dailies and To-Dos down into bite-size chunks. Their game mechanic takes some learning, so <a href='http://habitrpg.wikia.com/wiki/Checklist' target='_blank'>read more here</a>.
+        small.muted by @lefnire
+    tr
+      td
+        h5 Task Icons & Markdown
+        p Task titles now support Markdown and Emoji, so you can create something <a href='http://gyazo.com/f2021674925a79a1dec22101ef74a63c' target='_blank'>like this</a>. Read more <a href='https://trello.com/c/FCVdjdUd/102-task-reward-icons' target='_blank'>here</a>.
+        small.muted by @lefnire
 
-h5 5/2/2013
-table.table.table-striped
-  tr
-    td
-      a(target='_blank', href='https://trello.com/card/party-chat/50e5d3684fe3a7266b0036d6/267') Party Chat!
-      | also, Tavern Chat (LFG)
-  tr
-    td
-      a(target='_blank', href='https://trello.com/card/rest-in-tavern/50e5d3684fe3a7266b0036d6/14') Rest in Tavern
-      | (basic implementation, more to come)
-  tr
-    td.
-      NPCs! <a target='_blank' href='https://twitter.com/Mihakuu'>Bailey</a> the Town Crier, <a target='_blank' href='http://www.kickstarter.com/profile/523661924'>Alexander</a> the <a target='_blank' href='https://trello.com/card/marketplace/50e5d3684fe3a7266b0036d6/167'>Merchant</a>, <a target='_blank' href='http://www.kickstarter.com/profile/2014640723'>Daniel</a> the <a target='_blank' href='http://goo.gl/FkSib'>Tavern Keep</a>.
-  tr
-    td
-      a(href='https://github.com/lefnire/habitrpg/issues/828') New "Game Options" layout
-      | (click your avatar to see)
+  hr
+  h5 12/25/2013
+  h4 Winter Wonderland Event Part 2: Rescue the Bears
+  table.table.table-striped
+    tr
+      td
+        h5 Quests & Bosses!
+        p A beast is roaring in the distant mountains, mysterious tracks have appeared in the snow. A new feature has been unlocked, <a href='https://trello.com/c/VPPjVRlF/212-quests-bosses' target='_blank'>Quests & Bosses</a>. As a holiday present, HabitRPG gives you your first quest: "Trapper Santa". Check your inventory, you have until Jan 31 to complete it!
 
-h5 3/27/2013
-table.table.table-striped
-  tr
-    td
-      | Drop system + pets overhaul (
-      a(href='http://www.kickstarter.com/projects/lefnire/habitrpg-mobile/posts/439433') Blog Post
-      | |
-      a(href='https://trello.com/card/pets/50e5d3684fe3a7266b0036d6/166') Trello Card
-      | )
+  p By @lefnire, @pandoro, @Shaners
 
-h5 3/21/2013
-table.table.table-striped
-  tr
-    td
-      a(href='https://github.com/lefnire/habitrpg/issues/585') More design tweaks to header & avatars
+  hr
 
-h5 3/20/2013
-table.table.table-striped
-  tr
-    td
-      a(href='https://github.com/lefnire/habitrpg/issues/585') New Design
-  tr
-    td
-      a(href='https://trello.com/card/toggle-helm-visible/50e5d3684fe3a7266b0036d6/153') Toggle helm visible
-  tr
-    td
-      a(href='https://trello.com/card/toggle-header/50e5d3684fe3a7266b0036d6/241') Toggle Header
-  tr
-    td
-      a(href='https://trello.com/card/deletable-accounts/50e5d3684fe3a7266b0036d6/69') Deletable Accounts
-  tr
-    td
-      a(href='https://trello.com/card/undo-button/50e5d3684fe3a7266b0036d6/20') Undo Button
 
-h5 3/3/2013
-table.table.table-striped
-  tr
-    td
-      a(href='https://trello.com/card/custom-day-start/50e5d3684fe3a7266b0036d6/15') Add custom day start
+  h5 12/20/2013
+  h4 Winter Wonderland Event Part 1: The Great Snowball Fight
+  p It's time for HabitRPG's biggest event yet - Winter Wonderland! The fun starts today, on the first day of winter, and ends on January 31st - HabitRPG's birthday.
+  p Get prepared to build new habits, earn fun drops, hold your party members accountable for their tasks, and decorate your avatar. Various features will be rolling out over the course of the event, so expect many updates! For starters...
+  table.table.table-striped
+    tr
+      td
+        h5 NPC Decorations
+        p Looks like everyone is really getting into the winter spirit! Check out the new NPC sprites. (And I heard a rumor that the final NPC might show up, just in time for the new year...)
+    tr
+      td
+        .customize-option.hair_bangs_1_winternight.pull-right
+        h5 Limited-Edition Holiday Hair-Colors
+        p Now your avatar can dye their hair Candy Cane, Frost, Winter Sky, or Holly! You'll only be able to purchase these hair colors until January 31st, when they will be retired.
+    tr
+      td
+        .shop_snowball.pull-right
+        h5 The Great HabitRPG Snowball Fight
+        p Yes, you can now buy snowballs and hurl them at all your friends... to, uh, help them improve their habits. How? Weeeeellll, let's just say that after getting walloped, they might find themselves needing some extra gold to escape their predicament...
+          //-span.shop_head_special_candycane.item-img.shop-sprite
+    tr
+      td
+        h5 More to Come
+        p A beast is roaring in the distant mountains, mysterious tracks have appeared in the snow, and Lemoness is furiously crocheting something sparkly.
+        p It's going to be a wild winter.
+
+  p By @lemoness
+
+  hr
+
+  h5 12/16/2013
+  p Good gracious, where do I start...
+  br
+  table.table.table-striped
+    tr
+      td
+        h4 Classes
+        p You can now be a Warrior, Rogue, Wizard, or Healer. <a href='http://habitrpg.wikia.com/wiki/Class_System' target='_blank'>See details here.</a>
+    tr
+      td
+        h4 Armory & Costumes
+        p Once you select your new class, you're now equipped with your new class's apprentice gear. Fear not, your old gear is still available in your inventory! You can switch gear at any time, and wear a different costume than your equipment. See <a href='https://trello.com/c/83M5RqQB/299-armory' target='_blank'>Armory</a> & <a href='https://trello.com/c/iY6A7nlX/336-costumes-armory-v2' target='_blank'>Costumes</a>
+    tr
+      td
+        h4 New Customizations
+        p We now have a much wider selection of hair, shirt, facial-hair, body-size, etc. customizations. See <a href='https://trello.com/c/YKXmHNjY/306-customization-redo' target='_blank'>Customizations v2</a>
+    tr
+      td
+        h4 300 Tier Gear
+        p All you $300 backers who have been waiting patiently, your gear is now in! Currently, only available to $300+ backers, but we'll add them as drops to the Boss system once that's released. See <a href='https://trello.com/c/sb6f9w5r/217-custom-items-300-tier' target='_blank'>300-tier</a>
+    tr
+      td
+        h4 API v2
+        p The API has been completely overhauled, and v2 comes with many more routes for a *full featured* API. v1 is no longer supported, take heed ye 3rd-party-ists! For the time being, basic routes are supported (such as up/down -scoring). v2 will be documented soon, and I'll ping you when. see <a href='https://trello.com/c/L4pYimQM/343-api-v2' target='_blank'>APIv2</a>
+  hr
+  p By @lemoness @sabrecat @danielthebard @fuzzytrees @crystalphoenix @rosemonkeyct @fandekasp, and many more. (Who am I missing? We'll put up a CONTRIBUTORS.md soon)
+
+  h5 12/7/20132
+  table.table.table-striped
+    tr
+      td
+        h4 Mounts!
+        p You can now feed your pets and they'll grow into trusty steeds. Obtain food as new random drops, or you can hasten the process buy buying a saddle from Alexander.
+        // We may want to use their twitter handles, or something they prefer instead
+        hr
+        p.
+         By <a target='_blank' href='https://github.com/lemoness'>@lemoness</a> <a target='_blank' href='https://github.com/Shaners'>@Shaners</a> <a target='_blank' href='https://github.com/baconsaur'>@baconsaur</a> <a target='_blank' href='https://github.com/RandallStanhope'>@RandallStanhope</a> <a target='_blank' href='https://github.com/ashjolliffe'>@ashjolliffe</a> <a target='_blank' href='https://github.com/fuzzytrees'>@fuzzytrees</a>
+
+  h5 11/27/2013
+  table.table.table-striped
+    tr
+      td
+        h4 Turkey Event (by @lemoness)
+        p Say hi to our NPCs, dressed to impressed for Turkey day! Also - check your stable, you'll find a fun new pet.
+    tr
+      td
+        h4 Chat Enhancements (by @Nick Gordon)
+        p.
+          Chat can now use markdown, Emoji, and @-tagging. Some pointers on using markdown & Emoji at <a href="http://habitrpg.wikia.com/wiki/Markdown_Cheat_Sheet" target="_blank">here</a>. To use @-tagging, simply type '@' in chat.
+    tr
+      td
+        h4 Party Sorting (by @Fandekasp)
+        p.
+          You can now adjust the way you view your party members in the top bar. They can be sorted by level, number of pets, the date they joined the party, or just randomly. Also, level colors now reflect your contributor status.
+    tr
+      td
+        h4 Wiki Updates (by @bobbyroberts99)
+        p.
+         The <a href='http://habitrpg.wikia.com/wiki/HabitRPG_Wiki' target='_blank'>HabitRPG wiki</a> is being speedily updated. If you’re confused about anything, go check it out - it’s a treasure trove.
+
+  h5 11/08/2013
+  table.table.table-striped
+    tr
+      td.
+        Contrib Gear. You can now unlock new a top-tier gear set and pet by contributing (code, art, docs, etc) to HabitRPG. <a href='http://habitrpg.wikia.com/wiki/Contributor_Rewards' target='_blank'>Read more</a>
+
+  h5 11/01/2013
+  table.table.table-striped
+    tr
+      td.
+        Challenges! Compete with your party, guilds, or the tavern on certain tasks. Win gem prizes. <a href='http://blog.habitrpg.com/post/65721506787/challenges-ui-router' target='_blank'>Read more.</a>
+    tr
+      td Backend overhaul, including bookmark-able paths throughout the application. Will pave the way towards improved performance.
+
+  h5 10/22/2013
+  table.table.table-striped
+    tr
+      td TRICK OR TREAT! It's Habit Halloween! Some of the NPCs have decorated for the occasion. Can you spot us?
+    tr
+      td Two gem-purchasable skin tones are now available! The Rainbow Skin Set is here to stay, but in honor of Halloween, we also have the LIMITED EDITION SPOOKY SKIN SET. You will only be able to purchase the Spooky Skin Set until November 10th, so if you want a monstrous avatar, now's the time to act!
+    tr
+      td Do note, skins won't work on mobile until the app is updated. We'll update Android ASAP, iPhone usually takes ~1wk to approve.
+
+  h5 10/19/2013
+  table.table.table-striped
+    tr
+      td New custom skin colors are now available! Go check them out in the Profile section. Also, the new mobile update, 0.0.10, is now available to download! It includes the new skin tones and the ability to hide or show your helm, among other things.
+    tr
+      td You can now sell un-wanted drops to Alex the Merchant. Trade those troves of eggs for gold!
+
+  h5 09/01/2013
+  table.table.table-striped
+    tr
+      td.
+        We <a target='_blank' href="http://habitrpg.tumblr.com/post/59104876969/website-issues-what-were-doing">re-wrote the website from the ground up</a>
+        And in case you missed it, <a target='_blank' href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg'>Android</a> & <a target='_blank' href='https://itunes.apple.com/us/app/habitrpg/id689569235?mt=8'>iOS</a> Apps are out!
+        Both apps and the website are open source, and we desparately need your help porting the rest of the features, and polishing off the bugs. <a target='_blank' href='http://habitrpg.wikia.com/wiki/Contributing_to_HabitRPG'>Read this guide</a> to getting started.
+        We're working on a system of Contributor Gear to reward the awesome people who help out, so stay tuned!
+
+  h5 The Rewrite! (Mid August)
+  table.table.table-striped
+    tr
+      td.
+        Hello my Habiteers! I have some amazing news to share with you, it's huge!
+         Has Habit ever crashed for you? (Joke). Well we <u><a target='_blank' href="http://habitrpg.tumblr.com/post/59104876969/website-issues-what-were-doing">re-wrote the website</a></u> from the ground up
+         to conquor those critical bugs once and for all (more from Tyler in a bit). If you haven't seen me for a while (due to a bug in the old site), be sure to catch up with me on the right side of the screen for any missed news. Importantly:
+         <a target='_blank' href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg'>Android</a> & <a target='_blank' href='https://itunes.apple.com/us/app/habitrpg/id689569235?mt=8'>iOS</a> Apps are out!</u>
+    tr
+      td.
+        They're open source, so help us make them awesome. As for the rewrite: not all features are yet ported, but don't worry - you're still getting drops and streak-bonuses in the background, even if you can't see them yet.
+         We'll be working hard to bring in all the missing features. And if you're not already, be sure to follow our updates on <a href="http://habitrpg.tumblr.com/" target="_blank">Tumblr</a> (there are some fun member highlights recently). One more thing: if you are a Veteran of the old site, I have granted you a Veteran Wolf! Check your inventory :)
+    tr
+      td.
+        JavaScript developers! To me! We must finish vanquishing the old site, as not all features have been ported.
+         We rewrote Habit on <a target='_blank' href='http://angularjs.org/'>AngularJS</a> + <a target='_blank' href='http://expressjs.com/'>Express</a>.
+         We desparately need your help porting <a href='http://goo.gl/jYWTwl' target='_blank'>the rest of the features</a>, and polishing off the bugs. <a target='_blank' href='http://habitrpg.wikia.com/wiki/Contributing_to_HabitRPG'>Read this guide</a> to getting started.
+         Thanks everyone for all your support and patience!
+
+  h5 8/20/2013
+  table.table.table-striped
+    tr
+      td.
+        Timezone + custom day start issues fixed, your dailies should now reset properly and in your own timezone. (This was vexing <strong>Android</strong> users particularly). If you're still experiencing issues, <a target='_blank' href='https://github.com/HabitRPG/habitrpg-mobile/issues/73#issuecomment-22960877'>chime in here</a>.
+    tr
+      td.
+        API developers, the above means that <strong>cron</strong> is automatically run for your users! Weee, they no longer have to log into the website to reset their dailies!
+
+  h5 8/18/2013
+  table.table.table-striped
+    tr
+      td.
+        The Mobile Apps are out! <a target='_blank' href="https://itunes.apple.com/us/app/habitrpg/id689569235">iOS app</a> and <a target='_blank' href="https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg">Android</a>. There's a bug with Android 2.3, <a target='_blank' href='https://github.com/HabitRPG/habitrpg-mobile/issues/85'>follow the progress here</a>.  For more details, see our <a target=_blank href="http://habitrpg.tumblr.com/post/58449057415/android-mobile-app-released-iphone-app-coming-soon">Tumblr post</a>
+    tr
+      td
+        | Hey guys! Long time no see :) We want to make sure you guys have a better idea of what's going on behind the scenes, so we're going to be releasing
+        b weekly status reports
+        | of what we're currently working on! This weekend, we are working hard to fix the "Not Enough GP" bug, a cruel and greedy monster that has wrapped itself around the rewards box and is refusing to let anyone purchase anything. Rest assured that our heroic Tyler will slay this beast soon! Then it wiil be full steam ahead on the new site upgrade process.
+        a(target='_blank', href='http://habitrpg.tumblr.com/post/57627483715/news-about-upgrade-and-app') Read more about how that will work in this post here
+
+  h5 6/03/2013
+  table.table.table-striped
+    tr
+      td
+        a(target='_blank', href='https://trello.com/card/groups-guilds/50e5d3684fe3a7266b0036d6/84') Guilds!
+        | You can now belong to multiple groups, not just your party. There are public and private guilds, think "Subreddits" v "multiple friend groups".
+
+  h5 5/27/2013
+  table.table.table-striped
+    tr
+      td
+        | Get the "Helped Habit Grow" badge by
+        a(href='http://community.habitrpg.com/node/290', target='_blank') filling out this survey.
+    tr
+      td
+        a(href='http://habitrpg.tumblr.com/post/51476277225/upcoming-features-bugs-update-user-survey', target='_blank') New blog post
+        | about upcoming Guilds & Challenges features, & huge bug-fixes on the horizon.
+
+  h5 5/25/2013
+  table.table.table-striped
+    tr
+      td
+        | Code logic migrated to
+        a(target='_blank', href='https://github.com/habitrpg/habitrpg-shared') habitrpg-shared
+        | . See
+        a(target='_blank', href='https://github.com/lefnire/habitrpg/issues/1039') details here
+        | , but two takeaways: (1) keep an eye out and
+        a(href='http://community.habitrpg.com/content/submitting-bugs', target='_blank') report a problem
+        | if you experience any issues, (2) this is going to allow for much less buggy code (read previous link for reasoning).
+
+  h5 5/12/2013
+  table.table.table-striped
+    tr
+      td Renamed "Tokens" to "Gems". Tokens caused confusion.
+  h5 5/10/2013
+  table.table.table-striped
+    tr
+      td
+        | Less harsh death: Used to be you lose everything, now you lose GP & one random gear piece, 1 level. We're working on a
+        a(_target='blank', href='https://trello.com/card/death-mechanic/50e5d3684fe3a7266b0036d6/204') really cool death mechanic here.
+        | , but this is a stop-gap so people don't lose heart presently.
+    tr
+      td Chat messages: can delete your own message, fix the duplicate messages issue.
+
+  h5 5/9/2013
+  table.table.table-striped
+    tr
+      td
+        a(_target='blank', href='https://trello.com/card/backer-gear/50e5d3684fe3a7266b0036d6/213') Backer Gear
+        | : There's a new top-tier gear set for Kickstarter Backers. $45+ gets new Shield, Helm, Armor. $70+ that plus Weapon. $80+ that plus Pet. Keep leveling my friends, get that gear! Discuss gear-unlocking mechanic
+        a(href='https://trello.com/card/backer-items-availability-mechanic/50e5d3684fe3a7266b0036d6/188', target='_blank') here
+        | , and if you're top-gear but not seeing backer stuff, message me from your KS profile.
+
+  h5 5/7/2013
+  table.table.table-striped
+    tr
+      td
+        a(_target='blank', href='https://trello.com/card/tags-categories/50e5d3684fe3a7266b0036d6/43') Tags
+        | . You can now categorize your tasks, eg "Work", "Home", "Morning", "Taxes", etc.
+
+  h5 5/4/2013
+  table.table.table-striped
+    tr
+      td
+        a(_target='blank', href='https://trello.com/card/streaks-consecutive-bonus/50e5d3684fe3a7266b0036d6/182') Streaks
+        | . You get a GP & drop-% increase the longer you hold daily streaks (they stack). You also get a stacking badge for each 21-day streak.
+
+  h5 5/3/2013
+  table.table.table-striped
+    tr
+      td
+        | Two new achievements: Beast Master & Ultimate Gear. Got ideas for more achievements?
+        a(target='_blank', href='https://trello.com/card/awards-badges/50e5d3684fe3a7266b0036d6/19') chime in here
+
+  h5 5/2/2013
+  table.table.table-striped
+    tr
+      td
+        a(target='_blank', href='https://trello.com/card/party-chat/50e5d3684fe3a7266b0036d6/267') Party Chat!
+        | also, Tavern Chat (LFG)
+    tr
+      td
+        a(target='_blank', href='https://trello.com/card/rest-in-tavern/50e5d3684fe3a7266b0036d6/14') Rest in Tavern
+        | (basic implementation, more to come)
+    tr
+      td.
+        NPCs! <a target='_blank' href='https://twitter.com/Mihakuu'>Bailey</a> the Town Crier, <a target='_blank' href='http://www.kickstarter.com/profile/523661924'>Alexander</a> the <a target='_blank' href='https://trello.com/card/marketplace/50e5d3684fe3a7266b0036d6/167'>Merchant</a>, <a target='_blank' href='http://www.kickstarter.com/profile/2014640723'>Daniel</a> the <a target='_blank' href='http://goo.gl/FkSib'>Tavern Keep</a>.
+    tr
+      td
+        a(href='https://github.com/lefnire/habitrpg/issues/828') New "Game Options" layout
+        | (click your avatar to see)
+
+  h5 3/27/2013
+  table.table.table-striped
+    tr
+      td
+        | Drop system + pets overhaul (
+        a(href='http://www.kickstarter.com/projects/lefnire/habitrpg-mobile/posts/439433') Blog Post
+        | |
+        a(href='https://trello.com/card/pets/50e5d3684fe3a7266b0036d6/166') Trello Card
+        | )
+
+  h5 3/21/2013
+  table.table.table-striped
+    tr
+      td
+        a(href='https://github.com/lefnire/habitrpg/issues/585') More design tweaks to header & avatars
+
+  h5 3/20/2013
+  table.table.table-striped
+    tr
+      td
+        a(href='https://github.com/lefnire/habitrpg/issues/585') New Design
+    tr
+      td
+        a(href='https://trello.com/card/toggle-helm-visible/50e5d3684fe3a7266b0036d6/153') Toggle helm visible
+    tr
+      td
+        a(href='https://trello.com/card/toggle-header/50e5d3684fe3a7266b0036d6/241') Toggle Header
+    tr
+      td
+        a(href='https://trello.com/card/deletable-accounts/50e5d3684fe3a7266b0036d6/69') Deletable Accounts
+    tr
+      td
+        a(href='https://trello.com/card/undo-button/50e5d3684fe3a7266b0036d6/20') Undo Button
+
+  h5 3/3/2013
+  table.table.table-striped
+    tr
+      td
+        a(href='https://trello.com/card/custom-day-start/50e5d3684fe3a7266b0036d6/15') Add custom day start

--- a/views/static/old-news.jade
+++ b/views/static/old-news.jade
@@ -1,0 +1,12 @@
+extends ./layout
+
+block vars
+  - var layoutEnv = env
+  - var menuItem = 'oldNews'
+
+block title
+  title Old News
+
+block content
+  include ../shared/new-stuff
+  +oldNews()


### PR DESCRIPTION
Moves any content in "new stuff" that isn't part of the current announcement to a separate static page. Also uses the full width of the newStuff modal, better use of space for content. It's not as pretty, but more effective. Looks like this now:

![top](http://i.gyazo.com/4acd9293e9223158a0a51998ce335fc0.png)
![bottom](http://i.gyazo.com/be61075d70f4b76aedf12a21901da257.png)

If y'all (@sabrecat @benmanley @lemoness etc) are down with this, i'll merge then leave it to one of our keener design-eyes to prettify as necessary
