### PR TITLE
Add available Gems counter to Market

### DIFF
--- a/public/css/inventory.styl
+++ b/public/css/inventory.styl
@@ -71,7 +71,7 @@ menu.pets div
     p
       text-align:center
       //width:6em
-      margin-top:-.5em
+      margin-top:-.3em
 .hatchingPotion-menu > div
     display:inline-block
     vertical-align:top

--- a/views/options/inventory/inventory.jade
+++ b/views/options/inventory/inventory.jade
@@ -194,8 +194,7 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
                     | 8
                     span.Pet_Currency_Gem1x.inline-gems
                 div(ng-show='petCount >= 90')
-                  button.customize-option(popover=env.t('petKeyPop'), popover-title=env.t('petKeyName'), popover-trigger='mouseenter', popover-placement='top', ng-click='openModal("pet-key")')
-                    span.pet_key
+                  button.customize-option(popover=env.t('petKeyPop'), popover-title=env.t('petKeyName'), popover-trigger='mouseenter', popover-placement='top', ng-click='openModal("pet-key")', class='pet_key')
                   p
                     | 4
                     span.Pet_Currency_Gem1x.inline-gems

--- a/views/options/inventory/inventory.jade
+++ b/views/options/inventory/inventory.jade
@@ -201,6 +201,7 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
                 div(ng-if='user.purchased.plan.planId')
                   button.customize-option(ng-click='user.ops.purchase({params:{type:"gems",key:"gem"}})')
                     span.Pet_Currency_Gem.inline-gems
+                    .badge.badge-info.stack-count {{api.planGemLimits + user.purchased.plan.consecutive.gemCapExtra - user.purchased.plan.gemsBought}}
                   p
                     | 20
                     span.shop_gold

--- a/views/options/inventory/inventory.jade
+++ b/views/options/inventory/inventory.jade
@@ -201,7 +201,7 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
                 div(ng-if='user.purchased.plan.planId')
                   button.customize-option(ng-click='user.ops.purchase({params:{type:"gems",key:"gem"}})')
                     span.Pet_Currency_Gem.inline-gems
-                    .badge.badge-info.stack-count {{api.planGemLimits + user.purchased.plan.consecutive.gemCapExtra - user.purchased.plan.gemsBought}}
+                    .badge.badge-info.stack-count {{Shared.planGemLimits.convCap - User.user.purchased.plan.gemsBought}}
                   p
                     | 20
                     span.shop_gold

--- a/views/options/inventory/inventory.jade
+++ b/views/options/inventory/inventory.jade
@@ -201,7 +201,7 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
                 div(ng-if='user.purchased.plan.planId')
                   button.customize-option(ng-click='user.ops.purchase({params:{type:"gems",key:"gem"}})')
                     span.Pet_Currency_Gem.inline-gems
-                    .badge.badge-info.stack-count {{Shared.planGemLimits.convCap - User.user.purchased.plan.gemsBought}}
+                    .badge.badge-info.stack-count {{Shared.planGemLimits.convCap + user.purchased.plan.consecutive.gemCapExtra - User.user.purchased.plan.gemsBought}}
                   p
                     | 20
                     span.shop_gold

--- a/views/options/inventory/inventory.jade
+++ b/views/options/inventory/inventory.jade
@@ -199,9 +199,9 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
                     | 4
                     span.Pet_Currency_Gem1x.inline-gems
                 div(ng-if='user.purchased.plan.planId')
-                  button.customize-option(ng-click='user.ops.purchase({params:{type:"gems",key:"gem"}})')
+                  button.customize-option(popover=env.t('subGemPop'), popover-title=env.t('subGemName'), popover-trigger='mouseenter', popover-placement='top',ng-click='user.ops.purchase({params:{type:"gems",key:"gem"}})')
                     span.Pet_Currency_Gem.inline-gems
-                    .badge.badge-info.stack-count {{Shared.planGemLimits.convCap + user.purchased.plan.consecutive.gemCapExtra - User.user.purchased.plan.gemsBought}}
+                    .badge.badge-success.stack-count {{Shared.planGemLimits.convCap + User.user.purchased.plan.consecutive.gemCapExtra - User.user.purchased.plan.gemsBought}}
                   p
                     | 20
                     span.shop_gold

--- a/views/options/inventory/inventory.jade
+++ b/views/options/inventory/inventory.jade
@@ -194,7 +194,8 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
                     | 8
                     span.Pet_Currency_Gem1x.inline-gems
                 div(ng-show='petCount >= 90')
-                  button.customize-option(popover=env.t('petKeyPop'), popover-title=env.t('petKeyName'), popover-trigger='mouseenter', popover-placement='top', ng-click='openModal("pet-key")', class='pet_key')
+                  button.customize-option(popover=env.t('petKeyPop'), popover-title=env.t('petKeyName'), popover-trigger='mouseenter', popover-placement='top', ng-click='openModal("pet-key")')
+                    span.pet_key
                   p
                     | 4
                     span.Pet_Currency_Gem1x.inline-gems


### PR DESCRIPTION
Creates an Angular binding that shows how many Gems the user has remaining for purchase in the current month, based on their subscription setup. Uses the same "stack badge" style as found on inventory items.

Note the change to the overall inventory style to allow stack badges to coexist with prices without running into one another. It spreads out the whole of the Market just perceptibly, so I welcome suggestions for a better way to accomplish the matter!
