### PR TITLE
(DO NOT MERGE) Orient screen to the top when clicking on hour glass in inventory

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -183,7 +183,10 @@ window.habitrpg = angular.module('habitrpg',
         })
         .state('options.inventory.timetravelers', {
           url: '/timetravelers',
-          templateUrl: "partials/options.inventory.timetravelers.html"
+          templateUrl: "partials/options.inventory.timetravelers.html",
+          controller: function(){
+            window.scrollTo(0, 0);
+          }
         })
 
         // Options > Settings


### PR DESCRIPTION
Closes #4326

When routing to timetravelers, makes window automatically switch to the top of the window.

![hour](https://cloud.githubusercontent.com/assets/2916945/5299145/829dc78c-7b89-11e4-828f-51f1de8ceb0d.png)

![scroll to](https://cloud.githubusercontent.com/assets/2916945/5299187/f19b8bba-7b89-11e4-9fa5-ae4da1da4baf.png)
