### PR TITLE
Add in extra user gem cap to sabrecat gems

### DIFF
--- a/public/css/inventory.styl
+++ b/public/css/inventory.styl
@@ -71,7 +71,7 @@ menu.pets div
     p
       text-align:center
       //width:6em
-      margin-top:-.5em
+      margin-top:-.3em
 .hatchingPotion-menu > div
     display:inline-block
     vertical-align:top

--- a/views/options/inventory/inventory.jade
+++ b/views/options/inventory/inventory.jade
@@ -201,6 +201,7 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
                 div(ng-if='user.purchased.plan.planId')
                   button.customize-option(ng-click='user.ops.purchase({params:{type:"gems",key:"gem"}})')
                     span.Pet_Currency_Gem.inline-gems
+                    .badge.badge-info.stack-count {{api.planGemLimits + user.purchased.plan.consecutive.gemCapExtra - user.purchased.plan.gemsBought}}
                   p
                     | 20
                     span.shop_gold

--- a/views/options/inventory/inventory.jade
+++ b/views/options/inventory/inventory.jade
@@ -201,7 +201,7 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
                 div(ng-if='user.purchased.plan.planId')
                   button.customize-option(ng-click='user.ops.purchase({params:{type:"gems",key:"gem"}})')
                     span.Pet_Currency_Gem.inline-gems
-                    .badge.badge-info.stack-count {{api.planGemLimits + user.purchased.plan.consecutive.gemCapExtra - user.purchased.plan.gemsBought}}
+                    .badge.badge-info.stack-count {{Shared.planGemLimits.convCap - User.user.purchased.plan.gemsBought}}
                   p
                     | 20
                     span.shop_gold

--- a/views/options/inventory/inventory.jade
+++ b/views/options/inventory/inventory.jade
@@ -201,7 +201,7 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
                 div(ng-if='user.purchased.plan.planId')
                   button.customize-option(ng-click='user.ops.purchase({params:{type:"gems",key:"gem"}})')
                     span.Pet_Currency_Gem.inline-gems
-                    .badge.badge-info.stack-count {{Shared.planGemLimits.convCap - User.user.purchased.plan.gemsBought}}
+                    .badge.badge-info.stack-count {{Shared.planGemLimits.convCap + user.purchased.plan.consecutive.gemCapExtra - User.user.purchased.plan.gemsBought}}
                   p
                     | 20
                     span.shop_gold


### PR DESCRIPTION
@SabreCat I figured out the negative gem count issue in #4328, it's because the boost to the gem count  for subscribing for more than 3 months wasn't taken into account. This should do it.

I was worried that a brand new account, one that hadn't subscribed, would throw an error, but it looks like the `ng-if='user.purchased.plan.planId''` took care of that.

![screen shot 2014-12-04 at 5 49 44 pm](https://cloud.githubusercontent.com/assets/2916945/5308568/f368bc20-7bdd-11e4-8672-e3dd4d863d91.png)
