### PR TITLE
Adjusted margin for markdown list in task-text. 

### DIFF
--- a/public/css/tasks.styl
+++ b/public/css/tasks.styl
@@ -107,6 +107,9 @@ for $stage in $stages
   line-height: 1.4
   word-wrap: break-word
 
+  markdown > ul > li // Otherwise, + gets turned into a bullet and gets maksed by buttons
+    margin-left:20px
+
   span.emoji
     width:1.5em
     height:1.5em


### PR DESCRIPTION
Closes #2721

When putting a `+` at the beginning of the task name, it gets translated to markdown, as expected, but since that turns into an `<li>` with default styling, the margin is all wonky.
## Before

![screen shot 2014-12-05 at 5 16 50 pm](https://cloud.githubusercontent.com/assets/2916945/5324649/f7846d84-7ca2-11e4-89d1-aabd5b1911d3.png)

![screen shot 2014-12-05 at 5 17 03 pm](https://cloud.githubusercontent.com/assets/2916945/5324651/fd81097c-7ca2-11e4-8c71-acfc07d09427.png)
## After

![screen shot 2014-12-05 at 5 18 33 pm](https://cloud.githubusercontent.com/assets/2916945/5324654/031abb4e-7ca3-11e4-939a-0f7bb82a6d9a.png)

![screen shot 2014-12-05 at 5 18 51 pm](https://cloud.githubusercontent.com/assets/2916945/5324655/0566e12a-7ca3-11e4-8060-16adc4207c68.png)
