### PR TITLE
Add null check on subscription blocks

### DIFF
--- a/views/options/settings.jade
+++ b/views/options/settings.jade
@@ -250,12 +250,13 @@ script(id='partials/options.settings.subscription.html',type='text/ng-template')
               li Mystic Hourglasses: {{user.purchased.plan.consecutive.trinkets}}
         div(ng-if='!user.purchased.plan.customerId || (user.purchased.plan.customerId && user.purchased.plan.dateTerminated)')
           .form-group
-            each block in env.Content.subscriptionBlocks
-              .radio
-                label
-                  input(type="radio", name="subRadio", value="#{block.months}", ng-model='_subscription.months')
-                  //-| #{block.months} Month(s) Recurring: $#{block.price} #{env.t('monthUSD')}
-                  | Recurring $#{block.price} each #{block.months} Month(s)
+            if env.Content.subscriptionBlocks
+              each block in env.Content.subscriptionBlocks
+                .radio
+                  label
+                    input(type="radio", name="subRadio", value="#{block.months}", ng-model='_subscription.months')
+                    //-| #{block.months} Month(s) Recurring: $#{block.price} #{env.t('monthUSD')}
+                    | Recurring $#{block.price} each #{block.months} Month(s)
 
           h3(ng-if='(user.purchased.plan.customerId && user.purchased.plan.dateTerminated)') Resubscribe
           a.btn.btn-primary(ng-click='Payments.showStripe({subscription:_subscription.months})', ng-disabled='!_subscription.months') Card

--- a/views/shared/modals/members.jade
+++ b/views/shared/modals/members.jade
@@ -75,11 +75,12 @@ script(type='text/ng-template', id='modals/send-gift.html')
       .panel-heading Subscription
       .panel-body
         .form-group
-          each block in env.Content.subscriptionBlocks
-            .radio
-              label
-                input(type="radio", name="subRadio", value="#{block.months}", ng-model='gift.subscription.months')
-                | #{block.months} Month(s): $#{block.price}
+          if env.Content.subscriptionBlocks
+            each block in env.Content.subscriptionBlocks
+              .radio
+                label
+                  input(type="radio", name="subRadio", value="#{block.months}", ng-model='gift.subscription.months')
+                  | #{block.months} Month(s): $#{block.price}
 
     textarea.form-control(rows='3', ng-model='gift.message', placeholder='Personal message (optional)')
 


### PR DESCRIPTION
`env.Content.subscriptionBlocks` is nullable and needs to be checked, otherwise we will get this exception:

``` nodejs
error: TypeError: /home/thont/Desktop/habitrpg/views/shared/modals/members.jade:78
    76|       .panel-body
    77|         .form-group
  > 78|           each block in env.Content.subscriptionBlocks
    79|             .radio
    80|               label
    81|                 input(type="radio", name="subRadio", value="#{block.months}", ng-model='gift.subscription.months')

Cannot read property 'length' of undefined
```
