### PR TITLE
added space in Jade to the arrow and opt out text in the inbox

### DIFF
--- a/views/options/social/chat-message.jade
+++ b/views/options/social/chat-message.jade
@@ -6,6 +6,7 @@ mixin chatMessages(inbox)
         span(ng-if='::message.user')
           a.label.label-default.chat-message.hidden-label
             span.glyphicon.glyphicon-arrow-right(ng-if='::message.sent')
+            | &nbsp; &nbsp;
             span {{::message.user}}&nbsp;
             span(ng-class='userAdminGlyphiconStyleFromLevel(message.contributor.level)')
             // this invisible username label is here to push the message text far enough right that the visible label can be floated to this point without covering up any of the text
@@ -28,5 +29,6 @@ mixin chatMessages(inbox)
       span.float-label
         a.label.label-default.chat-message(ng-if=':: message.user', ng-class='::userLevelStyleFromLevel(message.contributor.level, message.backer.npc, style)', ng-click='clickMember(message.uuid, true)')
           span.glyphicon.glyphicon-arrow-right(ng-if='::message.sent')
+          | &nbsp;
           span(tooltip='{{::contribText(message.contributor, message.backer)}}') {{::message.user}}&nbsp;
           span(ng-class='::userAdminGlyphiconStyleFromLevel(message.contributor.level)')

--- a/views/options/social/index.jade
+++ b/views/options/social/index.jade
@@ -16,6 +16,7 @@ script(type='text/ng-template', id='partials/options.social.inbox.html')
           .checkbox
             label
               input(type='checkbox', ng-model='user.inbox.optOut', ng-change='set({"inbox.optOut": user.inbox.optOut?true: false})')
+              | &nbsp;
               span.hint(popover-trigger='mouseenter', popover-placement='right', popover=env.t('optOutPopover'))=env.t('optOut')
 
 script(type='text/ng-template', id='partials/options.social.tavern.html')


### PR DESCRIPTION
This resolves https://github.com/HabitRPG/habitrpg/issues/4311 and is also referenced from this pull: https://github.com/HabitRPG/habitrpg/pull/4359.

I changed the jade files to allow spaces for both the arrow and the opt out message without the need for a css change.

![screenshot 2014-12-10 12 57 13](https://cloud.githubusercontent.com/assets/5234453/5384255/d395424a-806c-11e4-9719-8b5ce0ee5329.png)
