### PR TITLE
Quest image added in the completion screen

### DIFF
--- a/public/css/quests.styl
+++ b/public/css/quests.styl
@@ -1,3 +1,7 @@
 .quest_collected_true
   color: #ccc
   text-decoration:line-through
+
+quest-rewards
+	hr
+		clear:both

--- a/public/css/quests.styl
+++ b/public/css/quests.styl
@@ -4,4 +4,4 @@
 
 quest-rewards
   hr
-	clear:both
+    clear:both

--- a/public/css/quests.styl
+++ b/public/css/quests.styl
@@ -3,5 +3,5 @@
   text-decoration:line-through
 
 quest-rewards
-	hr
-		clear:both
+  hr
+	clear:both

--- a/views/shared/modals/quest-rewards.jade
+++ b/views/shared/modals/quest-rewards.jade
@@ -1,5 +1,5 @@
 script(id='partials/options.social.party.quest-rewards.html', type='text/ng-template')
-  hr(style='clear:both')
+  hr
   h5 {{header}}
   table.table.table-striped
     tr(ng-repeat='drop in quest.drop.items')

--- a/views/shared/modals/quest-rewards.jade
+++ b/views/shared/modals/quest-rewards.jade
@@ -1,5 +1,5 @@
 script(id='partials/options.social.party.quest-rewards.html', type='text/ng-template')
-  hr
+  hr(style='clear:both')
   h5 {{header}}
   table.table.table-striped
     tr(ng-repeat='drop in quest.drop.items')

--- a/views/shared/modals/quests.jade
+++ b/views/shared/modals/quests.jade
@@ -5,7 +5,8 @@ script(type='text/ng-template', id='modals/questCompleted.html')
     h4 "{{::Content.quests[user.party.quest.completed].text()}}"
       =env.t('completed')
   .modal-body
-    p(ng-bind-html='::Content.quests[user.party.quest.completed].completion()')
+    .pull-right(class='quest_{{user.party.quest.completed}}')
+    p(ng-bind-html='::Content.quests[user.party.quest.completed].completion()' style='min-height: 80px')
     quest-rewards(key='{{user.party.quest.completed}}', header=env.t('youReceived'))
   .modal-footer
     button.btn.btn-primary(ng-click='set({"party.quest.completed":""}); $close()')=env.t('ok')

--- a/views/shared/modals/quests.jade
+++ b/views/shared/modals/quests.jade
@@ -6,7 +6,7 @@ script(type='text/ng-template', id='modals/questCompleted.html')
       =env.t('completed')
   .modal-body
     .pull-right(class='quest_{{user.party.quest.completed}}')
-    p(ng-bind-html='::Content.quests[user.party.quest.completed].completion()' style='min-height: 80px')
+    p(ng-bind-html='::Content.quests[user.party.quest.completed].completion()')
     quest-rewards(key='{{user.party.quest.completed}}', header=env.t('youReceived'))
   .modal-footer
     button.btn.btn-primary(ng-click='set({"party.quest.completed":""}); $close()')=env.t('ok')


### PR DESCRIPTION
referencing https://github.com/HabitRPG/habitrpg/issues/4333, I've added in the image (it wasn't there previously) and made it so that the reward text had to clear the image before starting. This works well because the final text can still float left of the image, but doesn't break it if there is no text. As far as the other issue that was referenced, not all quests have completion text, which is why sometimes no text appears. 
![screenshot 2014-12-11 21 56 22](https://cloud.githubusercontent.com/assets/5234453/5416320/41506626-81e3-11e4-8fc4-6a77c2c63420.png)
