### PR TITLE
Make Time Travel translatable

### DIFF
--- a/views/options/inventory/index.jade
+++ b/views/options/inventory/index.jade
@@ -17,7 +17,7 @@ script(type='text/ng-template', id='partials/options.inventory.html')
         =env.t('equipment')
     li.equipment-tab(ng-class="{ active: $state.includes('options.inventory.timetravelers') }")
       a(ui-sref='options.inventory.timetravelers')
-        | Time Travelers
+        =env.t('timeTravelers')
 
   .tab-content
     .tab-pane.active


### PR DESCRIPTION
Changes the "Time Travelers" hardcoded button text to a translatable string resource.

Requires https://github.com/HabitRPG/habitrpg-shared/pull/393 to display correctly (in `en` locale at least).
