### PR TITLE
change link in gala page to gala wiki

### DIFF
--- a/views/options/inventory/inventory.jade
+++ b/views/options/inventory/inventory.jade
@@ -29,7 +29,7 @@ script(type='text/ng-template', id='partials/options.inventory.seasonalshop.html
           .arrow
           h3.popover-title!=env.t('seasonalShopClosedTitle', {linkStart:"<a href='http://blog.habitrpg.com/who' target='_blank'>", linkEnd: "</a>"})
           .popover-content
-            p!=env.t('seasonalShopClosedText', {linkStart: "<a href='https://habitrpg.wikia.com/wiki/Community#World_Events' target='_blank'>", linkEnd: "</a>"})
+            p!=env.t('seasonalShopClosedText', {linkStart: "<a href='http://habitrpg.wikia.com/wiki/Grand_Galas' target='_blank'>", linkEnd: "</a>"})
 
 script(type='text/ng-template', id='partials/options.inventory.timetravelers.html')
   .container-fluid


### PR DESCRIPTION
I've changed the link from this issue: https://github.com/HabitRPG/habitrpg/issues/4389 to link to the wiki about the gala instead of just the community page.
