### PR TITLE
Difficulty setting: Hide Health Potion

### DIFF
--- a/src/models/user.js
+++ b/src/models/user.js
@@ -291,17 +291,6 @@ var UserSchema = new Schema({
     showInProfile: {type: Boolean, 'default': false},
     locked: {type: Boolean, 'default': false}
   },
-  difficulty: {
-    potionHealing: {type: Boolean, 'default': true},
-    levelupHealing: {type: String, enum: ['percentage','constitution'], 'default': 'percentage'},
-    healingPercent: {type: Number, 'default': 100},
-    taskDamage: {type: Number, 'default': 1},
-    deathPenalty: {type: String, enum: ['mild','normal','harsh','hardcore'], 'default': 'normal'},
-    levelBoost: {type: Number, 'default': 0.5},
-    experienceRate: {type: Number, 'default': 1},
-    showInProfile: {type: Boolean, 'default': false},
-    locked: {type: Boolean, 'default': false}
-  },
   profile: {
     blurb: String,
     imageUrl: String,

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -280,7 +280,7 @@ var UserSchema = new Schema({
     background: String,
     webhooks: {type: Schema.Types.Mixed, 'default': {}},
     difficulty: {
-      potionHealing: {type: Boolean, 'default': true},
+      hidePotionHealing: {type: Boolean, 'default': false},
       levelupHealing: {type: String, enum: ['percentage','constitution'], 'default': 'percentage'},
       healingPercent: {type: Number, 'default': 100},
       taskDamage: {type: Number, 'default': 1},

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -278,18 +278,18 @@ var UserSchema = new Schema({
     advancedCollapsed: {type: Boolean, 'default': false},
     toolbarCollapsed: {type:Boolean, 'default':false},
     background: String,
-    webhooks: {type: Schema.Types.Mixed, 'default': {}}
-  },
-  difficulty: {
-    potionHealing: {type: Boolean, 'default': true},
-    levelupHealing: {type: String, enum: ['percentage','constitution'], 'default': 'percentage'},
-    healingPercent: {type: Number, 'default': 100},
-    taskDamage: {type: Number, 'default': 1},
-    deathPenalty: {type: String, enum: ['mild','normal','harsh','hardcore'], 'default': 'normal'},
-    levelBoost: {type: Number, 'default': 0.5},
-    experienceRate: {type: Number, 'default': 1},
-    showInProfile: {type: Boolean, 'default': false},
-    locked: {type: Boolean, 'default': false}
+    webhooks: {type: Schema.Types.Mixed, 'default': {}},
+    difficulty: {
+      potionHealing: {type: Boolean, 'default': true},
+      levelupHealing: {type: String, enum: ['percentage','constitution'], 'default': 'percentage'},
+      healingPercent: {type: Number, 'default': 100},
+      taskDamage: {type: Number, 'default': 1},
+      deathPenalty: {type: String, enum: ['mild','normal','harsh','hardcore'], 'default': 'normal'},
+      levelBoost: {type: Number, 'default': 0.5},
+      experienceRate: {type: Number, 'default': 1},
+      showInProfile: {type: Boolean, 'default': false},
+      locked: {type: Boolean, 'default': false}
+    }
   },
   profile: {
     blurb: String,

--- a/views/options/settings.jade
+++ b/views/options/settings.jade
@@ -151,6 +151,10 @@ script(id='partials/options.settings.difficulty.html', type="text/ng-template")
             // =env.t('settings') // ... can be grouped into subsections.
           .panel-body
 
+            .checkbox
+              label
+                input(type='checkbox', ng-model='user.preferences.difficulty.hidePotionHealing', ng-change='set({"preferences.difficulty.hidePotionHealing": user.preferences.difficulty.hidePotionHealing?true: false})')
+                span.hint(popover-trigger='mouseenter', popover-placement='right', popover=env.t('hidePotionHealingPop'))=env.t('hidePotionHealing')
 
 script(type='text/ng-template', id='partials/options.settings.api.html')
   .container-fluid

--- a/views/shared/tasks/lists.jade
+++ b/views/shared/tasks/lists.jade
@@ -80,7 +80,7 @@ script(id='templates/habitrpg-tasks.html', type="text/ng-template")
             include ./task
 
           // Static Rewards
-          ul.items.rewards(ng-if='main && list.type=="reward" && user.flags.itemsEnabled')
+          ul.items.rewards(ng-if='main && list.type=="reward" && user.flags.itemsEnabled && itemStore.length')
             li.task.reward-item(ng-repeat='item in itemStore',popover-trigger='mouseenter', popover-placement='top', popover='{{item.notes()}}')
               // right-hand side control buttons
               .task-meta-controls


### PR DESCRIPTION
Requires https://github.com/HabitRPG/habitrpg-shared/pull/399
- Adds support for a difficulty setting that prevents health potions appearing in the Rewards column. Potions could still be bought through the API but I don't think that's worth changing since it would be easier to untick this setting than use the API.
- Moves the `difficulty` object in src/models/user.js into `preferences.difficulty` because that allows us to take advantage of all the existing code for reading and saving preferences. Disagreements are welcome, especially if they are accompanied by the extra code required to keep `difficulty` separate. ;)    I do think it makes sense to think of these settings as preferences.
- Changes the `difficulty.potionHealing` setting to `difficulty.hidePotionHealing` because that allows for simpler code.

Note that this is going into the 'difficulty' feature branch, so merging it won't make it live. I'll merge it myself in a couple of days if no objections.

![screen shot 2014-12-21 at 7 19 02 am](https://cloud.githubusercontent.com/assets/1495809/5516348/f8f4bffa-88e3-11e4-95bc-d6f75d1d3497.png)
![screen shot 2014-12-21 at 7 18 58 am](https://cloud.githubusercontent.com/assets/1495809/5516347/f782b0e6-88e3-11e4-9f68-673631c05085.png)
