### PR TITLE
Prevent multiple buy gems popups (issue #4401)

### DIFF
--- a/views/shared/gems.jade
+++ b/views/shared/gems.jade
@@ -1,5 +1,6 @@
 a.pull-right.gem-wallet(ng-click='openModal("buyGems",{track:"Gems > Wallet"})', popover-trigger='mouseenter', popover-title=env.t('gems'), popover=env.t('gemsWhatFor'), popover-placement='bottom')
-  span.task-action-btn.tile.flush.bright.add-gems-btn ＋
+  if !isGemsModal
+    span.task-action-btn.tile.flush.bright.add-gems-btn ＋
   span.task-action-btn.tile.flush.neutral
     .Pet_Currency_Gem2x.Gems
     | {{user.balance * 4 | number:0}} 

--- a/views/shared/gems.jade
+++ b/views/shared/gems.jade
@@ -1,4 +1,4 @@
-a.pull-right.gem-wallet(ng-click='openModal("buyGems",{track:"Gems > Wallet"})', popover-trigger='mouseenter', popover-title=env.t('gems'), popover=env.t('gemsWhatFor'), popover-placement='bottom')
+a.pull-right.gem-wallet(ng-click=( isGemsModal ? '' : 'openModal("buyGems",{track:"Gems > Wallet"})'), popover-trigger='mouseenter', popover-title=env.t('gems'), popover=env.t('gemsWhatFor'), popover-placement='bottom')
   if !isGemsModal
     span.task-action-btn.tile.flush.bright.add-gems-btn ＋
   span.task-action-btn.tile.flush.neutral

--- a/views/shared/modals/buy-gems.jade
+++ b/views/shared/modals/buy-gems.jade
@@ -1,7 +1,9 @@
 script(id='modals/buyGems.html', type='text/ng-template')
   .modal-body
     .buy-gems
+    - var isGemsModal = true
       include ../gems
+    - isGemsModal = false
       .well
         h3=env.t('buyGems')
         table.table


### PR DESCRIPTION
Simple fix for issue #4401

The widget itself:
- /views/shared/gems.jade is the "Buy Gems" Pop Up

This is sourced from 4 places:
- ./views/shared/modals/buy-gems.jade:4:      include ../gems
- ./views/shared/modals/drops.jade:21:    include ../gems
- ./views/shared/modals/rebirth.jade:18:    include ../gems
- ./views/shared/modals/reroll.jade:6:    include ../gems

The popup is ./views/shared/modals/buy-gems.jade.
The other three locations, I see no reason why they shouldn't cause a Buy Gems popup.
Therefore, only making a change in buy-gems.jade and gems.jade.

Don't think variable scope here is an issue, but I'm not too familiar with the Jade language, so I've set it to false after it's used just to be safe.

---

If you want this to look the same as before, it needs some CSS to override the following:

```
.tile.flush:first-child {
  border-right: 0;
}
```

Before the fix:
![Without fix](https://i.imgur.com/CCMzc9k.png)
After the fix:
![With fix](https://i.imgur.com/LD9shTj.png)

Also, the element is still an <a>, therefore the cursor will still be a pointer.
