### PR TITLE
Add muted class when no food is in inventory

### DIFF
--- a/views/options/inventory/inventory.jade
+++ b/views/options/inventory/inventory.jade
@@ -108,7 +108,7 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
 
           li.customize-menu
             menu.pets-menu(label=env.t('food') + ' ({{foodCount}})')
-              p(ng-show='foodCount < 1')=env.t('noFood')
+              p.muted(ng-show='foodCount < 1')=env.t('noFood')
               div(ng-repeat='(food,points) in ownedItems(user.items.food)')
                 button.customize-option(popover='{{::Content.food[food].notes()}}', popover-title='{{::Content.food[food].text()}}', popover-trigger='mouseenter', popover-placement='right', ng-click='chooseFood(food)', class='Pet_Food_{{::food}}')
                   .badge.badge-info.stack-count {{points}}


### PR DESCRIPTION
Fix for issue #4405. Adds `muted` class if no food is in the users inventory.

**Before:**
![before](https://cloud.githubusercontent.com/assets/278775/5560214/093fb2a8-8d2f-11e4-8bf8-0a61091a0ca7.png)

**After:**
![after](https://cloud.githubusercontent.com/assets/278775/5560215/0cd36036-8d2f-11e4-83bf-75d475f75d7e.png)
