### PR TITLE
Added transparent class to gem purchasing if zero gems are available for purchase

### DIFF
--- a/views/options/inventory/inventory.jade
+++ b/views/options/inventory/inventory.jade
@@ -222,7 +222,7 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
                   p
                     | 4
                     span.Pet_Currency_Gem1x.inline-gems
-                div(ng-if='user.purchased.plan.customerId')
+                div(ng-if='user.purchased.plan.customerId', ng-class='::{transparent:(Shared.planGemLimits.convCap + User.user.purchased.plan.consecutive.gemCapExtra - User.user.purchased.plan.gemsBought) < 1}')
                   button.customize-option(popover=env.t('subGemPop'), popover-title=env.t('subGemName'), popover-trigger='mouseenter', popover-placement='top',ng-click='user.ops.purchase({params:{type:"gems",key:"gem"}})')
                     span.Pet_Currency_Gem.inline-gems
                     .badge.badge-success.stack-count {{Shared.planGemLimits.convCap + User.user.purchased.plan.consecutive.gemCapExtra - User.user.purchased.plan.gemsBought}}


### PR DESCRIPTION
This will keep it in line with the seasonal shop that displays items that have already been purchased.

Added the [one-time binding](https://docs.angularjs.org/guide/expression#one-time-binding) since the only time the class would need to be enabled in the page on the fly is when going from having one gem available to purchase to zero. That seems infrequent enough to merit allowing it to appear after a refresh.

If enough people open issues about it, we can change it to update on the fly.

![screen shot 2014-12-29 at 11 19 23 am](https://cloud.githubusercontent.com/assets/2916945/5570771/8eea0ea2-8f4c-11e4-9ead-9c1e2594ab0b.png)
