### PR TITLE
Stripe name error

### DIFF
--- a/public/js/services/paymentServices.js
+++ b/public/js/services/paymentServices.js
@@ -32,6 +32,7 @@ function($rootScope, User, $http, Content) {
       amount: amount,
       name: 'HabitRPG',
       description: sub ? window.env.t('subscribe') : window.env.t('checkout'),
+      image: "/apple-touch-icon-144-precomposed.png",
       panelLabel: sub ? window.env.t('subscribe') : window.env.t('checkout'),
       token: function(res) {
         var url = '/stripe/checkout?a=a'; // just so I can concat &x=x below

--- a/public/js/services/paymentServices.js
+++ b/public/js/services/paymentServices.js
@@ -30,8 +30,8 @@ function($rootScope, User, $http, Content) {
       key: window.env.STRIPE_PUB_KEY,
       address: false,
       amount: amount,
-      name: sub ? window.env.t('subscribe') : window.env.t('checkout'),
-      //description: sub ? window.env.t('buySubsText') : window.env.t('donationDesc'),
+      name: 'HabitRPG',
+      description: sub ? window.env.t('subscribe') : window.env.t('checkout'),
       panelLabel: sub ? window.env.t('subscribe') : window.env.t('checkout'),
       token: function(res) {
         var url = '/stripe/checkout?a=a'; // just so I can concat &x=x below


### PR DESCRIPTION
ping @lefnire 

Closes #4338 

One consequence of changing the name field is that the stripe modal will also display that name. Is that cool?

I uncommented the description field and populated it with the old name field so it would show whether this is a subscription or checkout.

I also added in the image field and pointed it to the 144 x 144 Apple touch icon.

![screen shot 2014-12-29 at 8 37 26 pm](https://cloud.githubusercontent.com/assets/2916945/5575233/86b748f0-8f9a-11e4-9852-72704d6a3c11.png)
