### PR TITLE
Group Sorting

### DIFF
--- a/public/js/controllers/groupsCtrl.js
+++ b/public/js/controllers/groupsCtrl.js
@@ -305,6 +305,7 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '
       'pets': window.env.t('sortPets'),
       'habitrpg_date_joined' : window.env.t('sortHabitrpgJoined'),
       'party_date_joined': window.env.t('sortJoined'),
+      'habitrpg_last_logged_in': window.env.t('sortHabitrpgLastLoggedIn'),
       'name': window.env.t('sortName'),
       'backgrounds': window.env.t('sortBackgrounds'),
     };

--- a/public/js/controllers/groupsCtrl.js
+++ b/public/js/controllers/groupsCtrl.js
@@ -206,6 +206,11 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '
       'party_date_joined': window.env.t('sortJoined'),
     };
 
+    $scope.partyOrderAscendingChoices = {
+      'ascending': window.env.t('ascendingSort'),
+      'descending': window.env.t('descendingSort')
+    }
+
   }])
 
   .controller("GuildsCtrl", ['$scope', 'Groups', 'User', 'Challenges', '$rootScope', '$state', '$location', '$compile',

--- a/public/js/controllers/groupsCtrl.js
+++ b/public/js/controllers/groupsCtrl.js
@@ -201,6 +201,8 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '
       'level': window.env.t('sortLevel'),
       'random': window.env.t('sortRandom'),
       'pets': window.env.t('sortPets'),
+      'username': window.env.t('sortUsername'),
+      'habitrpg_date_joined' : window.env.t('sortHabitrpgJoined'),
       'party_date_joined': window.env.t('sortJoined'),
     };
 

--- a/public/js/controllers/headerCtrl.js
+++ b/public/js/controllers/headerCtrl.js
@@ -33,7 +33,10 @@ habitrpg.controller("HeaderCtrl", ['$scope', 'Groups', 'User',
                 return true;
           }
         }
-      ).reverse()
+      )
+      if (User.user.party.orderAscending == "descending") {
+      	$scope.partyMinusSelf = $scope.partyMinusSelf.reverse()
+      }
     });
   }
 ]);

--- a/public/js/controllers/headerCtrl.js
+++ b/public/js/controllers/headerCtrl.js
@@ -31,6 +31,9 @@ habitrpg.controller("HeaderCtrl", ['$scope', 'Groups', 'User',
               case 'habitrpg_date_joined':
                 return member.auth.timestamps.created;
                 break
+              case 'habitrpg_last_logged_in':
+                return member.auth.timestamps.loggedin;
+                break
               default:
                 // party date joined
                 return true;

--- a/public/js/controllers/headerCtrl.js
+++ b/public/js/controllers/headerCtrl.js
@@ -22,6 +22,12 @@ habitrpg.controller("HeaderCtrl", ['$scope', 'Groups', 'User',
               case 'pets':
                 return member.items.pets.length;
                 break;
+              case 'username':
+                return member.profile.name;
+                break;
+              case 'habitrpg_date_joined':
+                return member.auth.timestamps.created;
+                break
               default:
                 // party date joined
                 return true;

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -229,6 +229,7 @@ var UserSchema = new Schema({
   party: {
     // id // FIXME can we use a populated doc instead of fetching party separate from user?
     order: {type:String, 'default':'level'},
+    orderAscending: {type:String, 'default':'ascending'},
     quest: {
       key: String,
       progress: {

--- a/views/options/social/group.jade
+++ b/views/options/social/group.jade
@@ -59,6 +59,12 @@ a.pull-right.gem-wallet(popover-trigger='mouseenter', popover-title=env.t('guild
             ng-options='k as v for (k , v) in partyOrderChoices',
             ng-change='set({"party.order": user.party.order})'
             )
+          select#partyOrderAscending(
+            ng-model='user.party.orderAscending',
+            ng-controller='ChatCtrl',
+            ng-options='k as v for (k , v) in partyOrderAscendingChoices',
+            ng-change='set({"party.orderAscending": user.party.orderAscending})'
+            )
           table.table.table-striped(bindonce='group')
             tr(ng-repeat='member in group.members')
               td


### PR DESCRIPTION
Expanded upon @vIiRuS's pr: https://github.com/HabitRPG/habitrpg/pull/3842

Adds habit joined date and last time logged into habit options for sorting party in header, as well as the ability to sort ascending or descending.

In tandem with: https://github.com/HabitRPG/habitrpg-shared/pull/423
