### PR TITLE
Cmd/Ctrl + enter for chat

### DIFF
--- a/views/options/social/chat-box.jade
+++ b/views/options/social/chat-box.jade
@@ -12,7 +12,7 @@ div.chat-form.guidelines-not-accepted(ng-if='!user.flags.communityGuidelinesAcce
 
 form.chat-form(ng-if='user.flags.communityGuidelinesAccepted' ng-submit='postChat(group,message.content)')
   div(ng-controller='AutocompleteCtrl')
-    textarea.form-control(rows=4, ui-keypress='{13:"postChat(group,message.content)"}', ng-model='message.content', updateinterval='250', flag='@', at-user, auto-complete)
+    textarea.form-control(rows=4, ui-keydown='{"meta-enter":"postChat(group,message.content)"}', ui-keypress='{13:"postChat(group,message.content)"}', ng-model='message.content', updateinterval='250', flag='@', at-user, auto-complete)
     span.user-list(ng-show='!isAtListHidden')
       ul.list-at-user
         li(ng-repeat='user in response | filter:query.text | limitTo: 5', ng-click='autoComplete(user)')

--- a/views/shared/modals/members.jade
+++ b/views/shared/modals/members.jade
@@ -46,7 +46,7 @@ script(type='text/ng-template', id='modals/private-message.html')
   .modal-header
     h4=env.t('pmHeading', {name: "{{profile.profile.name}}"})
   .modal-body
-    textarea.form-control(type='text',rows='5',ng-model='_message')
+    textarea.form-control(type='text',rows='5',ui-keydown='{"meta-enter":"sendPrivateMessage(profile._id, _message)"}',ng-model='_message')
   .modal-footer
     button.btn.btn-primary(ng-click='sendPrivateMessage(profile._id, _message)')=env.t("send")
     button.btn.btn-default(ng-click='$close()')=env.t('cancel')


### PR DESCRIPTION
As discussed in #4460 

This DOES NOT remove the ability to send messages just by pressing enter. 

The idea is to give users a week or two to get used to being able to send message with cmd/ctrl + enter and warn them (through Bailey) that just pressing enter is being phased out. This won't prevent all frantic messages in the tavern about the enter key being broken, but it should give people plenty of advance notice.

It also adds the ability to send pm's with cmd/ctrl + enter.
