### PR TITLE
Fix for truncated dates on task due date. Closes #4482

### DIFF
--- a/views/shared/tasks/task.jade
+++ b/views/shared/tasks/task.jade
@@ -4,7 +4,7 @@ li(bindonce='list', id='task-{{::task.id}}', ng-repeat='task in obj[list.type+"s
 
     // Due Date
     span(ng-if='task.type=="todo" && task.date')
-      span(ng-class='{"label label-danger":(moment(task.date).isBefore(_today, "days") && !task.completed)}') {{task.date | date:user.preferences.dateFormat.substr(0,5)}}
+      span(ng-class='{"label label-danger":(moment(task.date).isBefore(_today, "days") && !task.completed)}') {{task.date | date:(user.preferences.dateFormat.indexOf('yyyy') == 0 ? user.preferences.dateFormat.substr(5) : user.preferences.dateFormat.substr(0,5))}}
       
     // Streak
     | &nbsp;


### PR DESCRIPTION
The logic is kind of long and messy.

If `user.preferences.dateFormat` begins with `yyyy`, cut off the first five characters (the y's plus a /). Otherwise, behave as normal and `substr(0,5)`. If the format `yyyy/dd/mm` gets introduced later on for some reason, it'll still work.
