### PR TITLE
See mp on stats page

### DIFF
--- a/views/shared/profiles/stats.jade
+++ b/views/shared/profiles/stats.jade
@@ -7,7 +7,7 @@ table.table.table-striped
   tr
     td
       strong=env.t('mana')
-      | : {{user.stats.mp | number:0}} / {{user._statsComputed.maxMP}}
+      | : {{profile.stats.mp | number:0}} / {{profile._statsComputed.maxMP}}
   tr
     td
       strong=env.t('gold')

--- a/views/shared/profiles/stats.jade
+++ b/views/shared/profiles/stats.jade
@@ -4,7 +4,7 @@ table.table.table-striped
     td
       strong=env.t('health')
       | : {{profile.stats.hp | number:0}} / 50
-  tr
+  tr(ng-if='profile.stats.lvl >= 10 && !profile.preferences.disableClasses')
     td
       strong=env.t('mana')
       | : {{profile.stats.mp | number:0}} / {{profile._statsComputed.maxMP}}

--- a/views/shared/profiles/stats.jade
+++ b/views/shared/profiles/stats.jade
@@ -6,6 +6,10 @@ table.table.table-striped
       | : {{profile.stats.hp | number:0}} / 50
   tr
     td
+      strong=env.t('mana')
+      | : {{Math.floor(user.stats.mp)}} / {{user._statsComputed.maxMP}}
+  tr
+    td
       strong=env.t('gold')
       | : {{profile.stats.gp | number:0}}
   tr

--- a/views/shared/profiles/stats.jade
+++ b/views/shared/profiles/stats.jade
@@ -7,7 +7,7 @@ table.table.table-striped
   tr
     td
       strong=env.t('mana')
-      | : {{Math.floor(user.stats.mp)}} / {{user._statsComputed.maxMP}}
+      | : {{user.stats.mp | number:0}} / {{user._statsComputed.maxMP}}
   tr
     td
       strong=env.t('gold')


### PR DESCRIPTION
I don't think it was left off intentionally, but was unsure.
## Stats Page

![screen shot 2015-01-09 at 9 46 42 am](https://cloud.githubusercontent.com/assets/2916945/5682319/aa796dc0-97e4-11e4-87cb-8b5fdaa73685.png)
## Member Modal

![screen shot 2015-01-09 at 9 46 56 am](https://cloud.githubusercontent.com/assets/2916945/5682320/aa797a2c-97e4-11e4-8cd3-ba4cbb823801.png)

Edit: I reversed the images when uploading
