### PR TITLE
Closes #4490. Day start saves on blur instead of change

### DIFF
--- a/views/options/settings.jade
+++ b/views/options/settings.jade
@@ -75,7 +75,7 @@ script(type='text/ng-template', id='partials/options.settings.settings.html')
               h5.hint(popover=env.t('clockInfo'), popover-trigger='mouseenter')=env.t('customDayStart')
               .form-group
                 .input-group
-                  input.form-control(type='number', min='0', max='23', ng-model='user.preferences.dayStart', ng-change='saveDayStart()')
+                  input.form-control(type='number', min='0', max='23', ng-model='user.preferences.dayStart', ng-blur='saveDayStart()')
                   span.input-group-addon= ':00 (' + env.t('24HrClock') + ')'
               small
                   =env.t('subWarning1')


### PR DESCRIPTION
Works when clicking out of the input, whether clicking on the page, another link, or in the address bar of the browser.

The only situations I can think of where this wouldn't work is if the user changed it, and then left their focus in the input box indefinitely or changed it and closed the window without moving focus from the input box. Navigating to the links, or clicking on the browser's url bar results in the value being saved.
