### PR TITLE
Stressbeast healing on rage

### DIFF
--- a/src/models/group.js
+++ b/src/models/group.js
@@ -280,6 +280,7 @@ GroupSchema.statics.tavernBoss = function(user,progress) {
             tavern.quest.extra.worldDmg.recent = scene;
             tavern.markModified('quest.extra.worldDmg');
             tavern.quest.progress.rage = 0;
+            tavern.quest.progress.hp += (quest.boss.rage.healing * quest.boss.hp);
           }
         }
         tavern.save(cb);


### PR DESCRIPTION
When a Rage Strike fires, and the world boss has not exhausted its NPC attack options, it now heals a fraction of its Health based on a `healing` attribute in its boss definition.

Requires https://github.com/HabitRPG/habitrpg-shared/pull/436
