### PR TITLE
fixed bug where +habits would behave strangely when targeted by spells

### DIFF
--- a/views/shared/tasks/task.jade
+++ b/views/shared/tasks/task.jade
@@ -63,8 +63,8 @@ li(bindonce='list', id='task-{{::task.id}}', ng-repeat='task in obj[list.type+"s
     // Habits
     span(ng-if='::task.type=="habit"')
       // score() is overridden in challengesCtrl to do nothing
-      a.task-action-btn(ng-if='task.up', ng-click='score(task,"up")') +
-      a.task-action-btn(ng-if='task.down', ng-click='score(task,"down")') -
+      a.task-action-btn(ng-if='task.up', ng-click='$root.applyingAction || score(task,"up")') +
+      a.task-action-btn(ng-if='task.down', ng-click='$root.applyingAction || score(task,"down")') -
 
     // Rewards
     span(ng-show='task.type=="reward"')


### PR DESCRIPTION
Responding to https://github.com/HabitRPG/habitrpg/issues?q=is%3Aopen+is%3Aissue+label%3A%22priority+-+medium%22

To the best of my understanding, the bug was caused because in this edge case the spell and the habit are both calculated on the frontend, but only the habit is 'put' on the backend- resulting in the apparent loss of experience and the gain of mana when the front end refreshes. This fix disables the habit being 'put' when the spell (marked by the +tooltip) is active.

Question: Is using $root in the view a bad practice?

Other ways to solve this is to fix the ordering of spell and habit 'puts' or to mark the spell in progress in a different way like a scope variable.
