### PR TITLE
T-Rex pet quest and party boss Rage implementation

### DIFF
--- a/src/controllers/groups.js
+++ b/src/controllers/groups.js
@@ -662,6 +662,7 @@ questStart = function(req, res, next) {
   group.quest.active = true;
   if (quest.boss)
     group.quest.progress.hp = quest.boss.hp;
+    if (quest.boss.rage) group.quest.progress.rage = 0;
   else
     group.quest.progress.collect = collected;
   group.quest.members = questMembers;

--- a/src/models/group.js
+++ b/src/models/group.js
@@ -301,8 +301,17 @@ GroupSchema.statics.bossQuest = function(user, progress, cb) {
     var down = progress.down * quest.boss.str; // multiply by boss strength
 
     group.quest.progress.hp -= progress.up;
-    group.sendChat("`" + user.profile.name + " attacks " + quest.boss.name('en') + " for " + (progress.up.toFixed(1)) + " damage, " + quest.boss.name('en') + " attacks party for " + Math.abs(down).toFixed(1) + " damage.`");
+    group.sendChat("`" + user.profile.name + " attacks " + quest.boss.name('en') + " for " + (progress.up.toFixed(1)) + " damage, " + quest.boss.name('en') + " attacks party for " + Math.abs(down).toFixed(1) + " damage.`"); //TODO Create a party preferred language option so emits like this can be localized
 
+    // If boss has Rage, increment Rage as well
+    if (quest.boss.rage) {
+      group.quest.progress.rage += Math.abs(down);
+      if (group.quest.progress.rage >= quest.boss.rage.value) {
+        group.sendChat(quest.boss.rage.effect('en'));
+        group.quest.progress.rage = 0;
+        if (quest.boss.rage.healing) group.quest.progress.hp += (group.quest.progress.hp * quest.boss.rage.healing); //TODO To make Rage effects more expandable, let's turn these into functions in quest.boss.rage
+      }
+    }
     // Everyone takes damage
     var series = [
       function(cb2){

--- a/views/options/inventory/inventory.jade
+++ b/views/options/inventory/inventory.jade
@@ -183,6 +183,11 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
                     p
                       |  {{::Content.eggs.#{egg}.value}}&nbsp;
                       span.Pet_Currency_Gem1x.inline-gems
+                div(ng-show='(user.achievements.quests.trex + user.achievements.quests.trex_undead) > 1')
+                  button.customize-option(popover='{{::Content.eggs.TRex.notes()}}', popover-title!=env.t("egg", {eggType: "{{Content.eggs.TRex.text()}}"}), popover-trigger='mouseenter', popover-placement='top', ng-click='purchase("eggs", Content.eggs.TRex)', class='Pet_Egg_TRex')
+                  p
+                    | {{::Content.eggs.TRex.value}}&nbsp;
+                    span.Pet_Currency_Gem1x.inline-gems
 
             li.customize-menu
               menu.pets-menu(label=env.t('hatchingPotions'))

--- a/views/shared/new-stuff.jade
+++ b/views/shared/new-stuff.jade
@@ -1,4 +1,14 @@
-h5 STRESS HAS STRUCK!
+h5 TYRANNOSAUR PET QUEST, SPREAD THE WORD CHALLENGE, AND FIRST STRESS STRIKE!
+  tr
+    td
+      h5 Tyrannosaur Pet Quest
+      p In the <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>Market</a> there are now two new pet quests: King of the Dinosaurs and The Dinosaur Unearthed! They both give out the same rewards, including pet Tyrannosaur eggs. The difference is that "King of the Dinosaurs" is a normal pet quest, like all the others, whereas "The Dinosaur Unearthed" has less HP - but also a Rage bar (a la World Bosses) that allows it to heal if you skip too many of your Dailies. Both bosses still attack your party based on how many Dailies are incomplete. Users will be able to buy Tyrannosaur eggs after defeating either boss twice or both bosses once.
+      p Have fun!
+      p.small.muted by Baconsaur, Urse, Lemoness, and SabreCat
+  tr
+    td
+      h5 Spread the Word Challenge Reminder
+      p In case you missed it, we're running our second Spread the Word Challenge! The rules are simple: make a post some time between December 31st 2014 and January 31st 2015 on some form of blog or social media that tells people about HabitRPG. The top post will be awarded 100 GEMS, and the next nineteen top posts will be awarded 80 GEMS each. Learn more and join in <a href='https://habitrpg.com/#/options/groups/challenges/e1ad6d92-587d-4137-848e-4a1f643603ba' target='_blank'>here</a>!
   tr
     td
       h5 World Boss: First Stress Strike!


### PR DESCRIPTION
Includes news announcements for 1/15/2015, Market implementation for T-Rex dual quest, and the ability for "healing" type Rage meters to work in party-scale boss fights.

Requires https://github.com/HabitRPG/habitrpg-shared/pull/440 for quest content.
