### PR TITLE
Added ng-sanitize

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,7 +1,7 @@
 "use strict";
 
 window.habitrpg = angular.module('habitrpg',
-    ['ui.bootstrap', 'ui.keypress', 'ui.router', 'chieffancypants.loadingBar', 'At', 'infinite-scroll', 'ui.select2', 'angular.filter', 'ngResource'])
+    ['ui.bootstrap', 'ui.keypress', 'ui.router', 'chieffancypants.loadingBar', 'At', 'infinite-scroll', 'ui.select2', 'angular.filter', 'ngResource', 'ngSanitize'])
 
   // @see https://github.com/angular-ui/ui-router/issues/110 and https://github.com/HabitRPG/habitrpg/issues/1705
   // temporary hack until they have a better solution


### PR DESCRIPTION
Was javascript console errors from the quest scroll modals (both owned and for purchase):

``` console

 Error: [$sce:unsafe] Attempting to use an unsafe value in a safe context.
http://errors.angularjs.org/1.3.9/$sce/unsafe
    at https://habitrpg.com/app-ef854652.js:4:21718
    at n (https://habitrpg.com/app-ef854652.js:7:18373)
    at m (https://habitrpg.com/app-ef854652.js:7:19869)
    at Object.d.(anonymous function) [as getTrustedHtml] (https://habitrpg.com/app-ef854652.js:7:20881)
    at Object.f [as fn] (https://habitrpg.com/app-ef854652.js:8:8520)
    at j.$digest (https://habitrpg.com/app-ef854652.js:7:13775)
    at j.$apply (https://habitrpg.com/app-ef854652.js:7:15329)
    at HTMLButtonElement.<anonymous> (https://habitrpg.com/app-ef854652.js:8:10466)
    at HTMLButtonElement.n.event.dispatch (https://habitrpg.com/app-ef854652.js:2:6444)
    at HTMLButtonElement.r.handle (https://habitrpg.com/app-ef854652.js:2:3219)

```

It was also preventing the text of the quest from populating. Determined it was because ngSanitize wasn't added in the module level.

I believe this will close #4521
