### PR TITLE
Differentiated quest scrolls and January 2015 subscriber item

### DIFF
--- a/migrations/mysteryitems.js
+++ b/migrations/mysteryitems.js
@@ -2,7 +2,7 @@ var _id = '';
 var update = {
   $push: {
     'purchased.plan.mysteryItems':{
-      $each:['head_mystery_201412','armor_mystery_201412']
+      $each:['head_mystery_201501','armor_mystery_201501']
     }
   }
 };

--- a/views/options/inventory/inventory.jade
+++ b/views/options/inventory/inventory.jade
@@ -39,7 +39,7 @@ script(type='text/ng-template', id='partials/options.inventory.seasonalshop.html
             span.Pet_Currency_Gem1x.inline-gems
       menu.pets-menu(label=env.t('quests'))
         div(ng-repeat='quest in ::getSeasonalShopQuests()')
-          button.customize-option(popover="{{::quest.previous && !user.achievements.quests[quest.previous] ? env.t('scrollsPre') : quest.notes() | htmlDecode}}", popover-title='{{::quest.text()}}', popover-trigger='mouseenter', popover-placement='right', ng-click='buyQuest(quest.key)', class='inventory_quest_scroll', ng-class='::{locked: quest.previous && !user.achievements.quests[quest.previous]}')
+          button.customize-option(popover="{{::quest.previous && !user.achievements.quests[quest.previous] ? env.t('scrollsPre') : quest.notes() | htmlDecode}}", popover-title='{{::quest.text()}}', popover-trigger='mouseenter', popover-placement='right', ng-click='buyQuest(quest.key)', ng-class='(quest.previous && !user.achievements.quests[quest.previous]) ? "inventory_quest_scroll_locked inventory_quest_scroll_{{::quest.key}}_locked locked" : "inventory_quest_scroll inventory_quest_scroll_{{::quest.key}}"')
           p
             | {{::quest.value}}&nbsp;
             span.Pet_Currency_Gem1x.inline-gems
@@ -114,7 +114,7 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
               p.muted(ng-show='questCount < 1')=env.t('noScrolls')
               p.muted!=env.t('scrollsText1') + ' <a href="/#/options/groups/party">' + env.t('scrollsText2') + '</a>'
               div(ng-repeat='(quest_key,points) in ownedItems(user.items.quests)', ng-init='quest = Content.quests[quest_key]')
-                button.customize-option(popover="{{:: quest.previous && !user.achievements.quests[quest.previous] ? env.t('scrollsPre') : quest.notes() | htmlDecode}}", popover-title='{{::quest.text()}}', popover-trigger='mouseenter', popover-placement='right', ng-click='showQuest(quest_key)', class='inventory_quest_scroll', ng-class='::{locked: quest.previous && !user.achievements.quests[quest.previous]}')
+                button.customize-option(popover="{{:: quest.previous && !user.achievements.quests[quest.previous] ? env.t('scrollsPre') : quest.notes() | htmlDecode}}", popover-title='{{::quest.text()}}', popover-trigger='mouseenter', popover-placement='right', ng-click='showQuest(quest_key)', ng-class='(quest.previous && !user.achievements.quests[quest.previous]) ? "inventory_quest_scroll_locked inventory_quest_scroll_{{::quest.key}}_locked locked" : "inventory_quest_scroll inventory_quest_scroll_{{::quest.key}}"')
                   .badge.badge-info.stack-count {{points}}
 
           li.customize-menu
@@ -209,7 +209,7 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
               menu.pets-menu(label=env.t('quests'))
                 p.muted!=env.t('scrollsText1') + ' <a href="/#/options/groups/party">' + env.t('scrollsText2') + '</a>'
                 div(ng-repeat='quest in Content.quests', ng-if='quest.canBuy')
-                  button.customize-option(popover="{{::quest.previous && !user.achievements.quests[quest.previous] ? env.t('scrollsPre') : quest.notes() | htmlDecode}}", popover-title='{{::quest.text()}}', popover-trigger='mouseenter', popover-placement='top', ng-click='buyQuest(quest.key)', class='inventory_quest_scroll', ng-class='::{locked: quest.previous && !user.achievements.quests[quest.previous]}')
+                  button.customize-option(popover="{{::quest.previous && !user.achievements.quests[quest.previous] ? env.t('scrollsPre') : quest.notes() | htmlDecode}}", popover-title='{{::quest.text()}}', popover-trigger='mouseenter', popover-placement='top', ng-click='buyQuest(quest.key)', ng-class='(quest.previous && !user.achievements.quests[quest.previous]) ? "inventory_quest_scroll_locked inventory_quest_scroll_{{::quest.key}}_locked locked" : "inventory_quest_scroll inventory_quest_scroll_{{::quest.key}}"')
                   p
                     |  {{::quest.value}}&nbsp;
                     span.Pet_Currency_Gem1x.inline-gems

--- a/views/shared/new-stuff.jade
+++ b/views/shared/new-stuff.jade
@@ -1,18 +1,39 @@
-h5
+h5 1/26/2015 - SUBSCRIBER OUTFIT REVEALED, NEW AUDIO THEME, QUEST SCROLL REDESIGN, AND SPREAD THE WORD CHALLENGE REMINDER
   hr
   tr
     td
-      h5 1/21/2015 - THIRD STRESS STRIKE!
-      .npc_justin_broken.pull-right
-      p The World Boss in the <a href='https://habitrpg.com/#/options/groups/tavern' target='_blank'>Tavern</a> has used a third Stress Strike!
-      p Justin the Guide is trying to distract the Stressbeast by running around its ankles, yelling productivity tips! The Abominable Stressbeast is stomping madly, but it seems like we're really wearing this beast down. I doubt it has enough energy for another strike. Don't give up... we're so close to finishing it off!
-      p Complete Dailies and To-Dos to damage the World Boss! A World Boss will never damage individual players or accounts in any way. Only active accounts who are not resting in the inn will have their incomplete Dailies tallied.
-      p.small.muted by Lemoness, Kiwibot, and SabreCat
+      h5 Subscriber Outfit Revealed
+      .promo_mystery_201501.pull-right
+      p The January Subscriber Item has been revealed: the Starry Knight Item Set! All January subscribers will receive the Starry Helm and the Starry Armor. You still have five days to <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribe</a> and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
+      p.small.muted by Lemoness
+  tr
+    td
+      h5 New Audio Theme
+      p A new audio theme is available: Watts' Theme! You can toggle between Watts' Theme and Daniel the Bard's Theme by selecting the megaphone in the upper right-hand corner. Watts' Theme was created by Harry Pepe. You can visit his <a href='https://www.linkedin.com/in/hpepe4' target='_blank'>LinkedIn page here</a>.
+      p.small.muted by Hpepe4 and Blade
+  tr
+    td
+      h5 Quest Scroll Redesign
+      p We've redesigned the quest scrolls so that they are visually unique! Quest type and difficulty is determined by the scroll lining (Easy Boss = Green, Medium Boss = Yellow, Hard Boss = Red, Collection Quest = Blue, Rage Bar Boss = Purple speckles), and an icon symbolizing the quest is located in the lower left.
+      p.small.muted by UncommonCriminal and Rattify
+  tr
+    td
+      h5 Spread the Word Challenge Ending Soon
+      p Reminder: January 31st is the last day to enter the <a href='https://habitrpg.com/#/options/groups/challenges/e1ad6d92-587d-4137-848e-4a1f643603ba' target='_blank'>Spread the Word Challenge</a>) for your chance at winning 100 gems! We will stop accepting new applications on February 1st, but it will be some time before the winners are announced because we have to go over all the entries ourselves. Good luck!
 
 hr
 a(href='/static/old-news', target='_blank') Read older news
 
 mixin oldNews
+  h5 1/21/2015
+    tr
+      td
+        h5 THIRD STRESS STRIKE!
+        .npc_justin_broken.pull-right
+        p The World Boss in the <a href='https://habitrpg.com/#/options/groups/tavern' target='_blank'>Tavern</a> has used a third Stress Strike!
+        p Justin the Guide is trying to distract the Stressbeast by running around its ankles, yelling productivity tips! The Abominable Stressbeast is stomping madly, but it seems like we're really wearing this beast down. I doubt it has enough energy for another strike. Don't give up... we're so close to finishing it off!
+        p Complete Dailies and To-Dos to damage the World Boss! A World Boss will never damage individual players or accounts in any way. Only active accounts who are not resting in the inn will have their incomplete Dailies tallied.
+        p.small.muted by Lemoness, Kiwibot, and SabreCat
   h5 1/20/2015
     tr
       td

--- a/views/shared/new-stuff.jade
+++ b/views/shared/new-stuff.jade
@@ -19,7 +19,7 @@ h5 1/26/2015 - SUBSCRIBER OUTFIT REVEALED, NEW AUDIO THEME, QUEST SCROLL REDESIG
   tr
     td
       h5 Spread the Word Challenge Ending Soon
-      p Reminder: January 31st is the last day to enter the <a href='https://habitrpg.com/#/options/groups/challenges/e1ad6d92-587d-4137-848e-4a1f643603ba' target='_blank'>Spread the Word Challenge</a>) for your chance at winning 100 gems! We will stop accepting new applications on February 1st, but it will be some time before the winners are announced because we have to go over all the entries ourselves. Good luck!
+      p Reminder: January 31st is the last day to enter the <a href='https://habitrpg.com/#/options/groups/challenges/e1ad6d92-587d-4137-848e-4a1f643603ba' target='_blank'>Spread the Word Challenge</a> for your chance at winning 100 gems! We will stop accepting new applications on February 1st, but it will be some time before the winners are announced because we have to go over all the entries ourselves. Good luck!
 
 hr
 a(href='/static/old-news', target='_blank') Read older news


### PR DESCRIPTION
Implements logic to show specific scroll images per quest, falling back to the present scroll image if none is present. Also implements a "locked scroll" picture for unavailable quests in addition to the current background dimming.

Also includes migration support for this month's subscriber item set, and the Bailey announcement for all of the above.
