### PR TITLE
Fixes #4719. Guild select for challenges pre-populates with first group

### DIFF
--- a/website/public/js/controllers/challengesCtrl.js
+++ b/website/public/js/controllers/challengesCtrl.js
@@ -33,7 +33,7 @@ habitrpg.controller("ChallengesCtrl", ['$rootScope','$scope', 'Shared', 'User', 
         todos: [],
         rewards: [],
         leader: User.user._id,
-        group: null,
+        group: $scope.groups[0]._id,
         timestamp: +(new Date),
         members: [],
         official: false


### PR DESCRIPTION
Mobile Safari doesn't play nice with angular generated select boxes that start with a null value.

Setting the default to the first group in the groups list instead of null should fix the problem. An alternative would be to make the default the Tavern (id = "habitrpg").
