### PR TITLE
Fixes #4604 Stealth allows checklists to reset at cron, etc.

### DIFF
--- a/common/script/content.coffee
+++ b/common/script/content.coffee
@@ -611,8 +611,8 @@ api.spells =
       notes: t('spellRogueStealthNotes')
       cast: (user, target) ->
         user.stats.buffs.stealth ?= 0
-        ## scales to user's # of dailies; maxes out at 100% at 100 per ##
-        user.stats.buffs.stealth += Math.ceil(user.dailys.length * user._statsComputed.per / 100)
+        ## scales to user's # of dailies; Diminishing Returns, maxes out at 25%, halfway point at 100 PER##
+        user.stats.buffs.stealth += Math.ceil( diminishingReturns(user._statsComputed.per, user.dailys.length*0.25,100))
 
   healer:
     heal:

--- a/common/script/content.coffee
+++ b/common/script/content.coffee
@@ -611,8 +611,8 @@ api.spells =
       notes: t('spellRogueStealthNotes')
       cast: (user, target) ->
         user.stats.buffs.stealth ?= 0
-        ## scales to user's # of dailies; Diminishing Returns, maxes out at 65%, halfway point at 90 PER##
-        user.stats.buffs.stealth += Math.ceil( diminishingReturns(user._statsComputed.per, user.dailys.length*0.65,90))
+        ## scales to user's # of dailies; Diminishing Returns, maxes out at 64%, halfway point at 55 PER##
+        user.stats.buffs.stealth += Math.ceil( diminishingReturns(user._statsComputed.per, user.dailys.length*0.64,55))
 
   healer:
     heal:

--- a/common/script/content.coffee
+++ b/common/script/content.coffee
@@ -611,8 +611,8 @@ api.spells =
       notes: t('spellRogueStealthNotes')
       cast: (user, target) ->
         user.stats.buffs.stealth ?= 0
-        ## scales to user's # of dailies; Diminishing Returns, maxes out at 25%, halfway point at 100 PER##
-        user.stats.buffs.stealth += Math.ceil( diminishingReturns(user._statsComputed.per, user.dailys.length*0.25,100))
+        ## scales to user's # of dailies; Diminishing Returns, maxes out at 65%, halfway point at 90 PER##
+        user.stats.buffs.stealth += Math.ceil( diminishingReturns(user._statsComputed.per, user.dailys.length*0.65,90))
 
   healer:
     heal:

--- a/common/script/index.coffee
+++ b/common/script/index.coffee
@@ -1493,9 +1493,6 @@ api.wrap = (user, main=true) ->
 
         {id, type, completed, repeat} = task
 
-#        return if (type is 'daily') && !completed && user.stats.buffs.stealth && user.stats.buffs.stealth-- # User "evades" a certain number of uncompleted dailies
-
-
         # Deduct experience for missed Daily tasks, but not for Todos (just increase todo's value)
         EvadeTask = 0
         scheduleMisses = daysMissed


### PR DESCRIPTION
Stealth allows checklists to reset at cron. Stealth only affects active dailys. Inactive dailys do not reset their checklists at cron unless they are completed. As a companion to only affecting active dailys, reduced  strength of stealth.

I understand that this PR may not be used since there is a change to how cron runs to be less damaging. However, I worked this out so it can be applied to the "more difficult cron" setting if/when difficulty settings are implemented.

**Tests performed:**
Starts up no problem
Using +1 missed day button to test
Gray daily w/checklist: Stays checked when main unchecked, Checklist unchecks if main checked off
Active daily w/checklist: becomes unchecked whether main is checked or not.

Stealth Testing: 
_3 dailies, level 16 (only 1 should be evaded for stealth)_
First daily gray, neither 2nd nor 3rd checked, no stealth: 13 HP lost
First daily gray, neither 2nd nor 3rd checked, stealth: 6.5 HP lost
First daily gray, 2nd checked, 3rd unchecked, stealth: 0 HP lost
First daily gray, 2nd partial checklist checked, 3rd main checked, stealth: 0 HP lost, checklist becomes unchecked.
