### PR TITLE
migration script to force active users to be resting in the inn

### DIFF
--- a/migrations/20150224_force_resting_in_inn.js
+++ b/migrations/20150224_force_resting_in_inn.js
@@ -1,0 +1,58 @@
+var migrationName = '20150224_force_resting_in_inn';
+var authorName = 'Alys'; // in case script author needs to know when their ...
+var authorUuid = 'd904bd62-da08-416b-a816-ba797c9ee265'; //... own data is done
+
+/*
+ * force all active players to rest in the inn due to massive server fail
+ */
+
+var dbserver = 'localhost:27017' // CHANGE THIS FOR PRODUCTION DATABASE
+
+var mongo = require('mongoskin');
+var _ = require('lodash');
+
+var dbUsers = mongo.db(dbserver + '/habitrpg?auto_reconnect').collection('users');
+
+var query = {
+    'auth.timestamps.loggedin':{$gt:new Date('2015-02-22')}
+    };
+
+var fields = {
+	'preferences.sleep':1,
+    };
+
+console.warn('Updating users...');
+var progressCount = 1000;
+var count = 0;
+dbUsers.findEach(query, fields, {batchSize:250}, function(err, user) {
+    if (err) { return exiting(1, 'ERROR! ' + err); }
+    if (!user) {
+        console.warn('All appropriate users found and modified.');
+        return displayData();
+    }
+    count++;
+
+    var set = {'migration':migrationName, 'preferences.sleep':1 };
+    dbUsers.update({_id:user._id}, {$set:set});
+
+    if (count%progressCount == 0) console.warn(count + ' ' + user._id);
+    if (user._id == authorUuid) console.warn(authorName + ' processed');
+    if (user._id == '9'       ) console.warn('lefnire'  + ' processed');
+});
+
+
+function displayData() {
+    console.warn('\n' + count + ' users processed\n');
+    return exiting(0);
+}
+
+
+function exiting(code, msg) {
+    code = code || 0; // 0 = success
+    if (code && !msg) { msg = 'ERROR!'; }
+    if (msg) {
+        if (code) { console.error(msg); }
+        else      { console.log(  msg); }
+    }
+    process.exit(code);
+}


### PR DESCRIPTION
For use when we have massive server problems to stop users dying from not being able to complete their Dailies.

It sets `preferences.sleep` to true for any user whose `auth.timestamps.loggedin` date is greater than a certain date (e.g., one or two days before the outage) -- i.e., all / most active users.
