### PR TITLE
Weekly and monthly "dailies" feature

### DIFF
--- a/common/locales/en/tasks.json
+++ b/common/locales/en/tasks.json
@@ -78,5 +78,13 @@
     "streakCoins": "Streak Bonus!",
     "pushTaskToTop": "Push task to top",
     "pushTaskToBottom": "Push task to bottom",
-    "emptyTask": "Enter the task's title first."
+    "emptyTask": "Enter the task's title first.",
+    "daily": "Daily",
+    "weekly": "Weekly",
+    "weeklyIcon": "W",
+    "monthly": "Monthly",
+    "monthlyIcon": "M",
+    "dailySubType": "Daily Type",
+    "dailySubTypeHelpTitle": "What are different daily types?",
+    "dailySubTypeHelpContent": "Daily type governs by what time the daily should be completed. 'Daily' is the old fashioned 'once a day' type of daily. A 'Weekly' needs to be completed once a week. And you guessed it, a 'Monthly' needs to be completed once a month!"
 }

--- a/migrations/20150228_set_dailies_subtype.js
+++ b/migrations/20150228_set_dailies_subtype.js
@@ -1,0 +1,9 @@
+// Make sure daily tasks have a subtype, default is daily
+
+db.users.find({}, {dailys: 1}).forEach(function (user) {
+  user.dailys.forEach(function (task) {
+    task.subtype = 'daily';
+  });
+
+  db.users.update({_id: user._id }, {$set: {dailys: user.dailys}});
+});

--- a/website/public/css/tasks.styl
+++ b/website/public/css/tasks.styl
@@ -12,7 +12,7 @@ for $stage in $stages
     .color-{$stage[0]}:not(.completed)
       background-color: $stage[1]
       border: 1px solid shade($stage[1],10%)
-      .priority-multiplier, .task-attributes, .repeat-days
+      .priority-multiplier, .task-attributes, .repeat-days, .daily-types
         li
           hrpg-button-color-mixin($stage[1])
           button
@@ -63,7 +63,7 @@ for $stage in $stages
   color: darken($completed,30%)
   background-color: $completed
   border: 1px solid shade($completed,10%)
-  .priority-multiplier, .task-attributes, .repeat-days
+  .priority-multiplier, .task-attributes, .repeat-days, .daily-types
     li
       hrpg-button-color-mixin($completed)
       button
@@ -488,7 +488,7 @@ form
 
   form
     padding-bottom: 1em
-  .priority-multiplier, .task-attributes, .repeat-days
+  .priority-multiplier, .task-attributes, .repeat-days, .daily-types
     text-align: center
     li
       @extend $hrpg-button

--- a/website/src/models/task.js
+++ b/website/src/models/task.js
@@ -51,6 +51,7 @@ var checklist = [{
 var DailySchema = new Schema(
   _.defaults({
     type: {type:String, 'default': 'daily'},
+    subtype: {type: String, 'default': 'daily'},
     history: Array,
     completed: {type: Boolean, 'default': false},
     repeat: {

--- a/website/views/shared/tasks/task.jade
+++ b/website/views/shared/tasks/task.jade
@@ -5,7 +5,13 @@ li(bindonce='list', id='task-{{::task.id}}', ng-repeat='task in obj[list.type+"s
     // Due Date
     span(ng-if='task.type=="todo" && task.date')
       span(ng-class='{"label label-danger":(moment(task.date).isBefore(_today, "days") && !task.completed)}') {{task.date | date:(user.preferences.dateFormat.indexOf('yyyy') == 0 ? user.preferences.dateFormat.substr(5) : user.preferences.dateFormat.substr(0,5))}}
-      
+
+    // Daily type
+    span(ng-if='task.type=="daily" && task.subtype != "daily"')
+      | &nbsp;
+      span(ng-if='task.subtype=="weekly"') {{ env.t('weeklyIcon') }}&nbsp;
+      span(ng-if='task.subtype=="monthly"') {{ env.t('monthlyIcon') }}&nbsp;
+
     // Streak
     | &nbsp;
     span(ng-show='task.streak') {{task.streak}}&nbsp;
@@ -206,15 +212,29 @@ li(bindonce='list', id='task-{{::task.id}}', ng-repeat='task in obj[list.type+"s
         span(ng-if='::task.type!="reward"')
           p.option-title.mega(ng-click='task._advanced = !task._advanced', tooltip=env.t('expandCollapse'))=env.t('advancedOptions')
           fieldset.option-group.advanced-option(ng-class="{visuallyhidden: task._advanced}")
-            legend.option-title
-              a.hint.priority-multiplier-help(href='https://trello.com/card/priority-multiplier/50e5d3684fe3a7266b0036d6/17', target='_blank', popover-title=env.t('difficultyHelpTitle'), popover-trigger='mouseenter', popover=env.t('difficultyHelpContent'))=env.t('difficulty')
-            ul.priority-multiplier
-              li
-                button(type='button', ng-class='{active: task.priority==1 || !task.priority}', ng-click='task.challenge.id || (task.priority=1)')=env.t('easy')
-              li
-                button(type='button', ng-class='{active: task.priority==1.5}', ng-click='task.challenge.id || (task.priority=1.5)')=env.t('medium')
-              li
-                button(type='button', ng-class='{active: task.priority==2}', ng-click='task.challenge.id || (task.priority=2)')=env.t('hard')
+
+            // Daily types
+            div(ng-if='task.type=="daily"')
+              legend.option-title(popover-title=env.t('dailySubTypeHelpTitle'), popover-trigger='mouseenter', popover=env.t('dailySubTypeHelpContent'))=env.t('dailySubType')
+              ul.daily-types
+                li
+                  button(type='button', ng-class='{active: task.subtype=="daily" || !task.subtype}', ng-click='task.subtype="daily"')=env.t('daily')
+                li
+                  button(type='button', ng-class='{active: task.subtype=="weekly"}', ng-click='task.subtype="weekly"')=env.t('weekly')
+                li
+                  button(type='button', ng-class='{active: task.subtype=="monthly"}', ng-click='task.subtype="monthly"')=env.t('monthly')
+
+            // Difficulty
+            div
+              legend.option-title
+                a.hint.priority-multiplier-help(href='https://trello.com/card/priority-multiplier/50e5d3684fe3a7266b0036d6/17', target='_blank', popover-title=env.t('difficultyHelpTitle'), popover-trigger='mouseenter', popover=env.t('difficultyHelpContent'))=env.t('difficulty')
+              ul.priority-multiplier
+                li
+                  button(type='button', ng-class='{active: task.priority==1 || !task.priority}', ng-click='task.challenge.id || (task.priority=1)')=env.t('easy')
+                li
+                  button(type='button', ng-class='{active: task.priority==1.5}', ng-click='task.challenge.id || (task.priority=1.5)')=env.t('medium')
+                li
+                  button(type='button', ng-class='{active: task.priority==2}', ng-click='task.challenge.id || (task.priority=2)')=env.t('hard')
             //span(ng-if='task.type=="daily" && !task.challenge.id')
             span(ng-if='task.type=="daily"')
               legend.option-title.pull-left=env.t('restoreStreak')


### PR DESCRIPTION
Here is my suggestion for how the "weekly" and "monthly" daily types could work. This relates to issue #4173.

As said in that issue, the spec is kind of open. I strongly feel that the feature should be kept very simple and that has been the point of this work. In short;
- Give "dailies" a subtype, ie "daily", "weekly", "monthly"
- Subtype can be selected in daily edit, default is the current "daily"
- Processing only "scores" dailies of subtype "weekly" and "monthly" if we are currently at the end of that particular period.
- Dailies will "uncomplete" only after period, so you only tick them once per period

I know this doesn't cover all the "do every 5 days" or "do every 21st of every 3rd month" cases - but again, simplicity is key. Most users I believe would find it handy to set a weekly or monthly task and not have to micromanage too much.

---

Edit; per discussion below in comments, spec is better clarified for this PR.

Tasks to do:
- [x] Indicate in daily list that task is month/weekly.

> The marker should probably be a clear W or M symbol next to the streak counter (W and M must be translatable; let's hope no languages have the same initial letter for both weekly and monthly words). Unless we can come up with icons that very clearly indicate the concept of week and month?
- [ ] Make sure unit tests cover new logic
- [ ] Make sure weeklies/monthlies only uncomplete at end of period
- [ ] Allow user to choose whether week starts monday or sunday
- [ ] Allow user to override per task the day the task is due

> Instead of hiding the "Repeat" selection for Weeklies, I'd like to see it used to specify the day of the week on which the Weekly will be scored. Thus when a Daily is turned into a Weekly, the heading for the day buttons should change from "Repeat" to "Due On" (or similar). Something should be done to allow the selection of only one day for a Weekly. (This would cover your point above "Allow user to choose whether week starts monday or sunday".)
- [x] Move task subtype (daily/weekly/monthly) buttons to the advanced section
- [x] Add on-hover help text for subtype buttons

> The Daily/Weekly/Monthly buttons should have a suitable heading, and have extra descriptive text appearing on-hover (we can sort out the exact words later).
- [ ] Make sure checklists are handled properly

> Checklists will need to be handled appropriately. I would suggest that ticked checklist items would not become unticked until the Weekly/Monthly itself resets. (See note below about new cron code for skills rebalancing.)
- [ ] Make sure streak counter logic works for weeklies and monthlies

---

Screenshots:

Selection buttons in task advanced section:
![selection_066](https://cloud.githubusercontent.com/assets/1174866/6767092/9a6e3780-d029-11e4-8080-1d5c1021cd29.png)

Tooltip help:
![selection_068](https://cloud.githubusercontent.com/assets/1174866/6767093/9f1f73c0-d029-11e4-9d50-ce7375c581df.png)

Weekly/Monthly in dailies list:
![selection_070](https://cloud.githubusercontent.com/assets/1174866/6949324/65bb758e-d8bc-11e4-9226-6ec33c543030.png)
