### PR TITLE
Add resync when challenges are updated

### DIFF
--- a/website/public/js/controllers/challengesCtrl.js
+++ b/website/public/js/controllers/challengesCtrl.js
@@ -57,6 +57,9 @@ habitrpg.controller("ChallengesCtrl", ['$rootScope','$scope', 'Shared', 'User', 
           // TODO figure out a more elegant way about this
           //challenge._editing = false;
           challenge._locked = true;
+
+          //Resynce challenges after edit
+          $scope.challenges = Challenges.Challenge.query();
         }
       });
     };


### PR DESCRIPTION
This should fix issue: https://github.com/HabitRPG/habitrpg/issues/1719 . Also, any updated challenge information should now refresh automatically. 
