### PR TITLE
new local install Debug option in footer: +2 Missed days

### DIFF
--- a/common/dist/scripts/habitrpg-shared.js
+++ b/common/dist/scripts/habitrpg-shared.js
@@ -7240,6 +7240,7 @@ process.browser = true;
 process.env = {};
 process.argv = [];
 process.version = ''; // empty string to avoid regexp issues
+process.versions = {};
 
 function noop() {}
 

--- a/website/public/js/controllers/footerCtrl.js
+++ b/website/public/js/controllers/footerCtrl.js
@@ -87,6 +87,11 @@ function($scope, $rootScope, User, $http, Notification, ApiUrl) {
         'stats.gp': User.user.stats.gp + 500,
       });
     }
+    $scope.addMana = function(){
+      User.set({
+        'stats.mp': User.user.stats.mp + 500,
+      });
+    }
     $scope.addLevelsAndGold = function(){
       User.set({
         'stats.exp': User.user.stats.exp + 10000,

--- a/website/public/js/controllers/footerCtrl.js
+++ b/website/public/js/controllers/footerCtrl.js
@@ -71,11 +71,11 @@ function($scope, $rootScope, User, $http, Notification, ApiUrl) {
         'stats.hp': 1
       });
     }
-    $scope.addMissedDay = function(){
-      if (!confirm("Are you sure you want to reset the day?")) return;
-      var dayBefore = moment(User.user.lastCron).subtract(1, 'days').toDate();
+    $scope.addMissedDay = function(numberOfDays){
+      if (!confirm("Are you sure you want to reset the day by " + numberOfDays + " day(s)?")) return;
+      var dayBefore = moment(User.user.lastCron).subtract(numberOfDays, 'days').toDate();
       User.set({'lastCron': dayBefore});
-      Notification.text('-1 day, remember to refresh');
+      Notification.text('-' + numberOfDays + ' day(s), remember to refresh');
     }
     $scope.addTenGems = function(){
       $http.post(ApiUrl.get() + '/api/v2/user/addTenGems').success(function(){

--- a/website/views/shared/footer.jade
+++ b/website/views/shared/footer.jade
@@ -77,7 +77,8 @@ footer.footer(ng-controller='FooterCtrl')
           h4 Debug
           .btn-group-vertical
             a.btn.btn-default(ng-click='setHealthLow()') Health = 1
-            a.btn.btn-default(ng-click='addMissedDay()') +1 Missed Day
+            a.btn.btn-default(ng-click='addMissedDay(1)') +1 Missed Day
+            a.btn.btn-default(ng-click='addMissedDay(2)') +2 Missed Days
             a.btn.btn-default(ng-click='addTenGems()') +10 Gems
             a.btn.btn-default(ng-click='addGold()') +GP
             a.btn.btn-default(ng-click='addLevelsAndGold()') +Exp +GP +MP

--- a/website/views/shared/footer.jade
+++ b/website/views/shared/footer.jade
@@ -81,6 +81,7 @@ footer.footer(ng-controller='FooterCtrl')
             a.btn.btn-default(ng-click='addMissedDay(2)') +2 Missed Days
             a.btn.btn-default(ng-click='addTenGems()') +10 Gems
             a.btn.btn-default(ng-click='addGold()') +GP
+            a.btn.btn-default(ng-click='addMana()') +MP
             a.btn.btn-default(ng-click='addLevelsAndGold()') +Exp +GP +MP
             a.btn.btn-default(ng-click='addOneLevel()') +1 Level
             a.btn.btn-default(ng-click='addBossQuestProgressUp()') +1000 Boss Quest Progress Up

--- a/website/views/shared/modals/settings.jade
+++ b/website/views/shared/modals/settings.jade
@@ -46,7 +46,7 @@ script(type='text/ng-template', id='modals/restore.html')
         label.control-label=env.t('fix21Streaks')
     //- This is causing too many problems for users
       h3=env.t('other')
-      a.btn.btn-sm.btn-warning(ng-controller='FooterCtrl', ng-click='addMissedDay()')=env.t('triggerDay')
+      a.btn.btn-sm.btn-warning(ng-controller='FooterCtrl', ng-click='addMissedDay(1)')=env.t('triggerDay')
   .modal-footer
     button.btn.btn-default(ng-click='$close()')=env.t('discardChanges')
     button.btn.btn-primary(ng-click='restore(); $close();')=env.t('saveAndClose')


### PR DESCRIPTION
This takes effect on local installs only. It adds an extra option to the Debug menu in the footer to miss 2 days. Useful when testing cron.

It also adjusts the existing addMissedDay function so that it now takes a parameter for the number of days to miss.
