### PR TITLE
Fix Mana rounding on the stats page. Fixes #4820

### DIFF
--- a/website/views/shared/profiles/stats.jade
+++ b/website/views/shared/profiles/stats.jade
@@ -11,7 +11,7 @@ table.table.table-striped
   tr
     td
       strong=env.t('gold')
-      | : {{profile.stats.gp}}
+      | : {{Math.floor(profile.stats.gp)}}
   tr
     td
       strong=env.t('level')

--- a/website/views/shared/profiles/stats.jade
+++ b/website/views/shared/profiles/stats.jade
@@ -11,7 +11,7 @@ table.table.table-striped
   tr
     td
       strong=env.t('gold')
-      | : {{profile.stats.gp | number:0}}
+      | : {{profile.stats.gp}}
   tr
     td
       strong=env.t('level')

--- a/website/views/shared/profiles/stats.jade
+++ b/website/views/shared/profiles/stats.jade
@@ -7,7 +7,7 @@ table.table.table-striped
   tr(ng-if='profile.stats.lvl >= 10 && !profile.preferences.disableClasses')
     td
       strong=env.t('mana')
-      | : {{profile.stats.mp | number:0}} / {{profile._statsComputed.maxMP}}
+      | : {{Math.floor(profile.stats.mp)}} / {{profile._statsComputed.maxMP}}
   tr
     td
       strong=env.t('gold')

--- a/website/views/shared/profiles/stats.jade
+++ b/website/views/shared/profiles/stats.jade
@@ -3,7 +3,7 @@ table.table.table-striped
   tr
     td
       strong=env.t('health')
-      | : {{profile.stats.hp | number:0}} / 50
+      | : {{Math.ceil(profile.stats.hp)}} / 50
   tr(ng-if='profile.stats.lvl >= 10 && !profile.preferences.disableClasses')
     td
       strong=env.t('mana')
@@ -19,7 +19,7 @@ table.table.table-striped
   tr
     td
       strong=env.t('experience')
-      | : {{profile.stats.exp | number:0}} / {{Shared.tnl(profile.stats.lvl)}}
+      | : {{Math.floor(profile.stats.exp)}} / {{Shared.tnl(profile.stats.lvl)}}
 
 // FIXME get translations working before can use this
 unless mobile


### PR DESCRIPTION
In #4820 @Blablux saw that the Mana was being rounded differently in the header hero-stats and on the stats page.  In the header the number is rounded down to the next integer (using Math.floor), but on the stats page the number is just rounded to the nearest integer (using angular's built in number filter: https://docs.angularjs.org/api/ng/filter/number).  Rounding mana up from 43.7 to 44 doesn't make sense because there are only 43 full mana available.  
I noticed that this discrepancy exists for HP and EXP but being my first PR here I didn't want to overstep...
