### PR TITLE
check for duplicate task ID when adding a new task (Fixes #4838)

### DIFF
--- a/common/dist/scripts/habitrpg-shared.js
+++ b/common/dist/scripts/habitrpg-shared.js
@@ -5608,6 +5608,12 @@ api.wrap = function(user, main) {
       addTask: function(req, cb) {
         var task;
         task = api.taskDefaults(req.body);
+        if (user.tasks[task.id] != null) {
+          return typeof cb === "function" ? cb({
+            code: 404,
+            message: i18n.t('messageDuplicateTaskID', req.language)
+          }) : void 0;
+        }
         user["" + task.type + "s"].unshift(task);
         if (user.preferences.newTaskEdit) {
           task._editing = true;

--- a/common/locales/en/messages.json
+++ b/common/locales/en/messages.json
@@ -1,6 +1,7 @@
 {
   "messageLostItem": "Your <%= itemText %> broke.",
   "messageTaskNotFound": "Task not found.",
+  "messageDuplicateTaskID": "A task with that ID already exists.",
   "messageTagNotFound": "Tag not found.",
   "messagePetNotFound": ":pet not found in user.items.pets",
   "messageFoodNotFound": ":food not found in user.items.food",

--- a/common/script/index.coffee
+++ b/common/script/index.coffee
@@ -580,7 +580,7 @@ api.wrap = (user, main=true) ->
 
       addTask: (req, cb) ->
         task = api.taskDefaults(req.body)
-        return cb?({code:404,message:i18n.t('messageDuplicateTaskID', req.language)}) if user.tasks[task.id]?
+        return cb?({code:409,message:i18n.t('messageDuplicateTaskID', req.language)}) if user.tasks[task.id]?
         user["#{task.type}s"].unshift(task)
         if user.preferences.newTaskEdit then task._editing = true
         if user.preferences.tagsCollapsed then task._tags = true

--- a/common/script/index.coffee
+++ b/common/script/index.coffee
@@ -580,6 +580,7 @@ api.wrap = (user, main=true) ->
 
       addTask: (req, cb) ->
         task = api.taskDefaults(req.body)
+        return cb?({code:404,message:i18n.t('messageDuplicateTaskID', req.language)}) if user.tasks[task.id]?
         user["#{task.type}s"].unshift(task)
         if user.preferences.newTaskEdit then task._editing = true
         if user.preferences.tagsCollapsed then task._tags = true


### PR DESCRIPTION
@Alys @vIiRuS I don't have a way to test the remote API (having never dealt with it or even looked at it much), but I _think_ this should fix the issue of duplicate IDs when adding a task.
