### PR TITLE
replace &#9776; with glyphicon-align-justify for visibility on Android browsers

### DIFF
--- a/website/views/shared/header/menu.jade
+++ b/website/views/shared/header/menu.jade
@@ -7,7 +7,7 @@ nav.toolbar(ng-controller='AuthCtrl', ng-class='{active: isToolbarHidden}')
     ul.toolbar-mobile-nav
       li.toolbar-mobile
         a(ng-click='expandMenu("mobile")', ng-class='{active: _expandedMenu=="mobile"}')
-          span  &#9776;
+          span.glyphicon.glyphicon-align-justify
         div(ng-if='_expandedMenu=="mobile"', ng-click='expandMenu(null)')
           h4=env.t('menu')
           div


### PR DESCRIPTION
Fixes https://github.com/HabitRPG/habitrpg/issues/4691 in which we learn that the main menu icon on the mobile version of the website is not visible on Android devices. This glyphicon will be visible.

This change affects **only** the website when viewed on mobile browsers. It does not apply to PC browsers. See https://github.com/HabitRPG/habitrpg/issues/4691#issuecomment-80525599 for details.
