### PR TITLE
Added focus directive to focus textarea for a private message model box

### DIFF
--- a/website/public/js/directives/directives.js
+++ b/website/public/js/directives/directives.js
@@ -177,7 +177,7 @@ habitrpg
         templateUrl: 'template/popover/popover-html.html'
     };
   }])
-  .directive( 'popoverHtml', [ '$compile', '$timeout', '$parse', '$window', '$tooltip', 
+  .directive( 'popoverHtml', [ '$compile', '$timeout', '$parse', '$window', '$tooltip',
     function ( $compile, $timeout, $parse, $window, $tooltip ) {
       return $tooltip( 'popoverHtml', 'popover', 'click' );
     }
@@ -193,3 +193,16 @@ habitrpg
       "  </div>\n" +
       "</div>\n");
   }]);
+
+habitrpg.directive('focusMe', function($timeout, $parse) {
+ return {
+   link: function(scope, element, attrs) {
+     var model = $parse(attrs.focusMe);
+     scope.$watch(model, function(value) {
+       $timeout(function() {
+         element[0].focus();
+       });
+     });
+   }
+ };
+});

--- a/website/views/shared/modals/members.jade
+++ b/website/views/shared/modals/members.jade
@@ -46,7 +46,7 @@ script(type='text/ng-template', id='modals/private-message.html')
   .modal-header
     h4=env.t('pmHeading', {name: "{{profile.profile.name}}"})
   .modal-body
-    textarea.form-control(type='text',rows='5',ui-keydown='{"meta-enter":"sendPrivateMessage(profile._id, _message)"}',ng-model='_message')
+    textarea.form-control(type='text',rows='5',ui-keydown='{"meta-enter":"sendPrivateMessage(profile._id, _message)"}',ng-model='_message', focus-me)
   .modal-footer
     button.btn.btn-primary(ng-click='sendPrivateMessage(profile._id, _message)')=env.t("send")
     button.btn.btn-default(ng-click='$close()')=env.t('cancel')


### PR DESCRIPTION
This is a fix for https://github.com/HabitRPG/habitrpg/issues/4606 .

I added a focus directive and the respective tag to the private message modal box textarea. Here is where I got the idea: http://stackoverflow.com/questions/25241544/angular-bootstrap-modal-popup-autofocus-not-working .

This seems like overkill to me at first, but after exploring other options, this seems to be the one that works.

I also tried adding autofocus attribute in the HTML, but this would not work when the modal box is pulled up for the second time without a page refresh. https://github.com/twbs/bootstrap/issues/12525

Adding a listener for the bootstrap event doesn't seem to work because of Angular's closures, but I could be wrong since I am not an expert with Angular. http://stackoverflow.com/questions/15474862/twitter-bootstrap-modal-input-field-focus
