### PR TITLE
Fix broken meters in IE

### DIFF
--- a/website/views/shared/header/header.jade
+++ b/website/views/shared/header/header.jade
@@ -10,22 +10,22 @@
       .meter-label(tooltip=env.t('health'))
         span.glyphicon.glyphicon-heart
       .meter.health(tooltip='{{Math.round(user.stats.hp * 100) / 100}}')
-        .bar(style='width: {{Shared.percent(user.stats.hp, 50)}}%;')
+        .bar(ng-style='{"width": Shared.percent(user.stats.hp, 50)+"%"}')
         span.meter-text.value
           | {{Math.ceil(user.stats.hp)}} / 50
       .meter-label(tooltip=env.t('experience'))
         span.glyphicon.glyphicon-star
       .meter.experience(tooltip='{{Math.round(user.stats.exp * 100) / 100}}')
-        .bar(style='width: {{Shared.percent(user.stats.exp,Shared.tnl(user.stats.lvl))}}%;')
+        .bar(ng-style='{"width": Shared.percent(user.stats.exp,Shared.tnl(user.stats.lvl))+"%"}')
         span.meter-text.value
           span(ng-show='user.history.exp', tooltip=env.t('progress'))
-            a(ng-click='toggleChart("exp")').glyphicon.glyphicon-signal 
+            a(ng-click='toggleChart("exp")').glyphicon.glyphicon-signal
           span
           | {{Math.floor(user.stats.exp) | number:0}} / {{Shared.tnl(user.stats.lvl) | number:0}}
       .meter-label(tooltip='Mana', ng-if='user.flags.classSelected && !user.preferences.disableClasses')
         span.glyphicon.glyphicon-fire
       .meter.mana(ng-if='user.flags.classSelected && !user.preferences.disableClasses', tooltip='{{Math.round(user.stats.mp * 100) / 100}}')
-        .bar(style='width: {{user.stats.mp / user._statsComputed.maxMP * 100}}%;')
+        .bar(ng-style='{"width": (user.stats.mp / user._statsComputed.maxMP * 100) + "%"}')
         span.meter-text.value
           span
           | {{Math.floor(user.stats.mp)}} / {{user._statsComputed.maxMP}}


### PR DESCRIPTION
Addresses #4876
## The Issue

Health, XP, and Mana bars were broken in IE, due to the use of `{{ }}` within
`style` properties. Using Angular's string interpolation within `style` properties
doesn't work in IE, as IE will actually strip the property immediately upon DOM
render. Thus, the bars were rendering with no width attribute, and showed as full.

_Note: See https://github.com/angular/angular.js/issues/2186 for further discussion of this issue_

![Broken IE11](https://cloud.githubusercontent.com/assets/10201/6826190/0805e226-d2d6-11e4-96bd-62ef2e4236f4.png)
## The Fix

Using `ng-style` allows properties to be preserved, and renders
cross-browser correctly.

Screenshots after the `style` -> `ng-style` change (pulled from my local build) are provided for convenience:
### IE11

![IE11](https://cloud.githubusercontent.com/assets/10201/6826119/958d1b9c-d2d5-11e4-9e22-d3af3a2369ca.png)
### Chrome

![Chrome](https://cloud.githubusercontent.com/assets/10201/6826124/9a051e0e-d2d5-11e4-8ffc-74bedc71b386.png)
### Firefox

![Firefox](https://cloud.githubusercontent.com/assets/10201/6826127/9c291b72-d2d5-11e4-8845-d1b719fb81d9.png)
