### PR TITLE
New tag field correctly clears when new tag added.

### DIFF
--- a/test/spec/filtersCtrlSpec.js
+++ b/test/spec/filtersCtrlSpec.js
@@ -11,6 +11,7 @@ describe('Filters Controller', function() {
   }));
 
   it('creates a tag', function(){
+    scope._newTag = {name:'tagName'}
     scope.createTag('tagName');
     expect(user.tags).to.have.length(1);
     expect(user.tags[0].name).to.eql('tagName');

--- a/test/spec/filtersCtrlSpec.js
+++ b/test/spec/filtersCtrlSpec.js
@@ -12,7 +12,7 @@ describe('Filters Controller', function() {
 
   it('creates a tag', function(){
     scope._newTag = {name:'tagName'}
-    scope.createTag('tagName');
+    scope.createTag();
     expect(user.tags).to.have.length(1);
     expect(user.tags[0].name).to.eql('tagName');
     expect(user.tags[0]).to.have.property('id');

--- a/website/public/js/controllers/filtersCtrl.js
+++ b/website/public/js/controllers/filtersCtrl.js
@@ -32,6 +32,6 @@ habitrpg.controller("FiltersCtrl", ['$scope', '$rootScope', 'User', 'Shared',
 
     $scope.createTag = function() {
       User.user.ops.addTag({body:{name:$scope._newTag.name, id:Shared.uuid()}});
-      $scope._newTag = '';
+      $scope._newTag.name = '';
     };
 }]);

--- a/website/public/js/controllers/filtersCtrl.js
+++ b/website/public/js/controllers/filtersCtrl.js
@@ -4,6 +4,7 @@ habitrpg.controller("FiltersCtrl", ['$scope', '$rootScope', 'User', 'Shared',
   function($scope, $rootScope, User, Shared) {
     var user = User.user;
     $scope._editing = false;
+    $scope._newTag = {name:''};
 
     var tagsSnap; // used to compare which tags need updating
 

--- a/website/public/js/controllers/filtersCtrl.js
+++ b/website/public/js/controllers/filtersCtrl.js
@@ -31,6 +31,6 @@ habitrpg.controller("FiltersCtrl", ['$scope', '$rootScope', 'User', 'Shared',
 
     $scope.createTag = function(name) {
       User.user.ops.addTag({body:{name:name, id:Shared.uuid()}});
-      $scope._newTag = '';
+      this._newTag = '';
     };
 }]);

--- a/website/public/js/controllers/filtersCtrl.js
+++ b/website/public/js/controllers/filtersCtrl.js
@@ -4,6 +4,7 @@ habitrpg.controller("FiltersCtrl", ['$scope', '$rootScope', 'User', 'Shared',
   function($scope, $rootScope, User, Shared) {
     var user = User.user;
     $scope._editing = false;
+    $scope._newTag = {name:''};
 
     var tagsSnap; // used to compare which tags need updating
 
@@ -29,8 +30,8 @@ habitrpg.controller("FiltersCtrl", ['$scope', '$rootScope', 'User', 'Shared',
       // User.save();
     };
 
-    $scope.createTag = function(name) {
-      User.user.ops.addTag({body:{name:name, id:Shared.uuid()}});
-      this._newTag = '';
+    $scope.createTag = function(newTag) {
+      User.user.ops.addTag({body:{name:newTag.name, id:Shared.uuid()}});
+      $scope._newTag.name = '';
     };
 }]);

--- a/website/public/js/controllers/filtersCtrl.js
+++ b/website/public/js/controllers/filtersCtrl.js
@@ -4,7 +4,6 @@ habitrpg.controller("FiltersCtrl", ['$scope', '$rootScope', 'User', 'Shared',
   function($scope, $rootScope, User, Shared) {
     var user = User.user;
     $scope._editing = false;
-    $scope._newTag = {name:''};
 
     var tagsSnap; // used to compare which tags need updating
 
@@ -30,8 +29,8 @@ habitrpg.controller("FiltersCtrl", ['$scope', '$rootScope', 'User', 'Shared',
       // User.save();
     };
 
-    $scope.createTag = function(newTag) {
-      User.user.ops.addTag({body:{name:newTag.name, id:Shared.uuid()}});
-      $scope._newTag.name = '';
+    $scope.createTag = function() {
+      User.user.ops.addTag({body:{name:$scope._newTag.name, id:Shared.uuid()}});
+      $scope._newTag = '';
     };
 }]);

--- a/website/views/main/filters.jade
+++ b/website/views/main/filters.jade
@@ -20,7 +20,7 @@
         //- Add new tag
         li.filters-edit(ng-show='_editing')
           form.hrpg-input-group
-            input(type='text', ng-model='_newTag', placeholder=env.t('newTag'))
+            input(type='text', ng-model='_newTag.name', placeholder=env.t('newTag'))
             button(ng-click='createTag(_newTag)')=env.t('add')
       div(ng-if='!areTagsHidden || _editing')
         ul(ng-if='_editing')

--- a/website/views/main/filters.jade
+++ b/website/views/main/filters.jade
@@ -20,8 +20,8 @@
         //- Add new tag
         li.filters-edit(ng-show='_editing')
           form.hrpg-input-group
-            input(type='text', ng-model='_newTag.name', placeholder=env.t('newTag'))
-            button(ng-click='createTag(_newTag)')=env.t('add')
+            input(type='text', ng-model='_newTag', placeholder=env.t('newTag'))
+            button(ng-click='createTag()')=env.t('add')
       div(ng-if='!areTagsHidden || _editing')
         ul(ng-if='_editing')
           li.filters-edit(ng-class='{active: user.filters[tag.id]}', ng-repeat='tag in user.tags', bindonce='user.tags')

--- a/website/views/main/filters.jade
+++ b/website/views/main/filters.jade
@@ -20,7 +20,7 @@
         //- Add new tag
         li.filters-edit(ng-show='_editing')
           form.hrpg-input-group
-            input(type='text', ng-model='_newTag', placeholder=env.t('newTag'))
+            input(type='text', ng-model='_newTag.name', placeholder=env.t('newTag'))
             button(ng-click='createTag()')=env.t('add')
       div(ng-if='!areTagsHidden || _editing')
         ul(ng-if='_editing')


### PR DESCRIPTION
When you add a new tag, the code looks like it should clear out that text field, but it doesn't, and a user might not realize the tag was added and end up adding multiple identical tags that need to be cleaned up later.  Now it correctly clears the new tag text field after a tag is added.
