### PR TITLE
Ensure Bailey always displays the most recent message.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ config.json
 npm-debug.log
 lib
 website/public/bower_components
+website/public/new-stuff.html
 website/build
 newrelic_agent.log
 .bower-tmp

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -229,8 +229,8 @@ module.exports = function(grunt) {
 
   // Register tasks.
   grunt.registerTask('compile:sprites', ['clean:sprite', 'sprite', 'cssmin']);
-  grunt.registerTask('build:prod', ['loadManifestFiles', 'clean:build', 'browserify', 'uglify', 'stylus', 'cssmin', 'copy:build', 'hashres']);
-  grunt.registerTask('build:dev', ['browserify', 'stylus']);
+  grunt.registerTask('build:prod', ['loadManifestFiles', 'clean:build', 'browserify', 'uglify', 'stylus', 'cssmin', 'copy:build', 'hashres','prepare:staticNewStuff']);
+  grunt.registerTask('build:dev', ['browserify', 'stylus', 'prepare:staticNewStuff']);
   grunt.registerTask('build:test', ['test:prepare:translations', 'build:dev']);
 
   grunt.registerTask('run:dev', [ 'build:dev', 'concurrent' ]);
@@ -242,6 +242,15 @@ module.exports = function(grunt) {
     fs.writeFileSync('test/spec/translations.js',
       "if(!window.env) window.env = {};\n" +
       "window.env.translations = " + JSON.stringify(i18n.translations['en']) + ';');
+  });
+
+  grunt.registerTask('prepare:staticNewStuff', function() {
+    var jade  = require('jade'),
+        fs    = require('fs');
+    fs.writeFileSync(
+      './website/public/new-stuff.html',
+      jade.compileFile('./website/views/shared/new-stuff.jade')()
+    );
   });
 
   if(process.env.NODE_ENV == 'production')

--- a/website/public/js/controllers/rootCtrl.js
+++ b/website/public/js/controllers/rootCtrl.js
@@ -3,8 +3,8 @@
 /* Make user and settings available for everyone through root scope.
  */
 
-habitrpg.controller("RootCtrl", ['$scope', '$rootScope', '$location', 'User', '$http', '$state', '$stateParams', 'Notification', 'Groups', 'Shared', 'Content', '$modal', '$timeout', 'ApiUrl', 'Payments',
-  function($scope, $rootScope, $location, User, $http, $state, $stateParams, Notification, Groups, Shared, Content, $modal, $timeout, ApiUrl, Payments) {
+habitrpg.controller("RootCtrl", ['$scope', '$rootScope', '$location', 'User', '$http', '$state', '$stateParams', 'Notification', 'Groups', 'Shared', 'Content', '$modal', '$timeout', 'ApiUrl', 'Payments','$sce',
+  function($scope, $rootScope, $location, User, $http, $state, $stateParams, Notification, Groups, Shared, Content, $modal, $timeout, ApiUrl, Payments,$sce) {
     var user = User.user;
 
     var initSticky = _.once(function(){
@@ -105,11 +105,29 @@ habitrpg.controller("RootCtrl", ['$scope', '$rootScope', '$location', 'User', '$
     $rootScope.set = User.set;
     $rootScope.authenticated = User.authenticated;
 
+    var forceLoadBailey = function(template, options) {
+      $http.get('/new-stuff.html')
+        .success(function(data) {
+          $rootScope.latestBaileyMessage = $sce.trustAsHtml(data);
+          $modal.open({
+            templateUrl: 'modals/' + template + '.html',
+            controller: options.controller, // optional
+            scope: options.scope, // optional
+            resolve: options.resolve, // optional
+            keyboard: (options.keyboard === undefined ? true : options.keyboard), // optional
+            backdrop: (options.backdrop === undefined ? true : options.backdrop), // optional
+            size: options.size, // optional, 'sm' or 'lg'
+            windowClass: options.windowClass // optional
+          });
+        });
+    };
+
     // Open a modal from a template expression (like ng-click,...)
     // Otherwise use the proper $modal.open
     $rootScope.openModal = function(template, options){//controller, scope, keyboard, backdrop){
       if (!options) options = {};
       if (options.track) window.ga && ga('send', 'event', 'button', 'click', options.track);
+      if(template === 'newStuff') return forceLoadBailey(template, options);
       return $modal.open({
         templateUrl: 'modals/' + template + '.html',
         controller: options.controller, // optional

--- a/website/views/shared/modals/new-stuff.jade
+++ b/website/views/shared/modals/new-stuff.jade
@@ -6,7 +6,7 @@ script(type='text/ng-template', id='modals/newStuff.html')
     div(class="#{env.worldDmg.bailey ? 'npc_bailey_broken' : 'npc_bailey'}")
     br
     br
-    include ../new-stuff
+    div(ng-bind-html='latestBaileyMessage')
   .modal-footer
-    button.btn.btn-default(ng-click='$close()')=env.t('cool') 
+    button.btn.btn-default(ng-click='$close()')=env.t('cool')
     button.btn.btn-warning(ng-click='dismissAlert(); $close()')=env.t('dismissAlert')


### PR DESCRIPTION
The Bailey modal should now reflect the latest new-stuff.jade.
- Added a Grunt task to precompile website/views/shared/new-stuff.jade to a
  static html file.
- Updated the new-stuff.jade modal template to use a $rootScope property.
- Added a special case to openModal for the newStuff template, by which it
  fetches the flat file, marks it as trusted HTML, and sets it to the
  $rootScope property before rendering the modal.

To test:
- Load the app, look at Bailey modal.
- Make a change to `website/views/shared/new-stuff.jade`
- Run `grunt prepare:staticNewStuff`
- Click Bailey again - latest changes are reflected

Works as a stopgap as suggested by @crookedneighbor in #4940, pending the updates being managed via internal CMS.
