### PR TITLE
Marked group messages as seen when user syncs new messages

### DIFF
--- a/website/public/js/controllers/groupsCtrl.js
+++ b/website/public/js/controllers/groupsCtrl.js
@@ -86,7 +86,7 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '
         });
       }else{
         $scope.removeMemberData = undefined;
-      }  
+      }
     }
 
     $scope.openInviteModal = function(group){
@@ -118,7 +118,7 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '
         $rootScope.openModal('private-message',{controller:'MemberModalCtrl'});
       });
     }
-    
+
   }])
 
   .controller('InviteToGroupCtrl', ['$scope', 'User', 'Groups', 'injectedGroup', '$http', 'Notification', function($scope, User, Groups, injectedGroup, $http, Notification){
@@ -335,6 +335,8 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '
 
     $scope.sync = function(group){
       group.$get();
+      //When the user clicks fetch recent messages we need to update that the user has seen the new messages
+      Groups.seenMessage(group._id);
     }
 
     // List of Ordering options for the party members list


### PR DESCRIPTION
This should fix: https://github.com/HabitRPG/habitrpg/issues/2933 . The issue was the Groups.seenMessage was not being called when the chat message sync. In app.js, this function is called when viewing a group's detail view.
