### PR TITLE
API wording adjustments (specify task types, describe when authentication is not required)

### DIFF
--- a/website/src/routes/apiv2.coffee
+++ b/website/src/routes/apiv2.coffee
@@ -35,13 +35,13 @@ module.exports = (swagger, v2) ->
 
     '/status':
       spec:
-        description: "Returns the status of the server (up or down)"
+        description: "Returns the status of the server (up or down). Does not require authentication."
       action: (req, res) ->
         res.json status: "up"
 
     '/content':
       spec:
-        description: "Get all available content objects. This is essential, since Habit often depends on item keys (eg, when purchasing a weapon)."
+        description: "Get all available content objects. This is essential, since Habit often depends on item keys (eg, when purchasing a weapon). Does not require authentication."
         parameters: [
           query("language","Optional language to use for content's strings. Default is english.","string")
         ]
@@ -49,7 +49,7 @@ module.exports = (swagger, v2) ->
 
     '/content/paths':
       spec:
-        description: "Show user model tree"
+        description: "Show user model tree. Does not require authentication."
       action: user.getModelPaths
 
     "/export/history":
@@ -68,7 +68,7 @@ module.exports = (swagger, v2) ->
     "/user/tasks/{id}/{direction}":
       spec:
         #notes: "Simple scoring of a task."
-        description: "Simple scoring of a task. This is most-likely the only API route you'll be using as a 3rd-party developer. The most common operation is for the user to gain or lose points based on some action (browsing Reddit, running a mile, 1 Pomodor, etc). Call this route, if the task you're trying to score doesn't exist, it will be created for you. When random events occur, the <b>user._tmp</b> variable will be filled. Critical hits can be accessed through <b>user._tmp.crit</b>. The Streakbonus can be accessed through <b>user._tmp.streakBonus</b>. Both will contain the multiplier value. When random drops occur, the following values are available: <b>user._tmp.drop = {text,type,dialog,value,key,notes}</b>"
+        description: "Simple scoring of a task (Habit, Daily, To-Do, or Reward). This is most-likely the only API route you'll be using as a 3rd-party developer. The most common operation is for the user to gain or lose points based on some action (browsing Reddit, running a mile, 1 Pomodor, etc). Call this route, if the task you're trying to score doesn't exist, it will be created for you. When random events occur, the <b>user._tmp</b> variable will be filled. Critical hits can be accessed through <b>user._tmp.crit</b>. The Streakbonus can be accessed through <b>user._tmp.streakBonus</b>. Both will contain the multiplier value. When random drops occur, the following values are available: <b>user._tmp.drop = {text,type,dialog,value,key,notes}</b>"
         parameters: [
           path("id", "ID of the task to score. If this task doesn't exist, a task will be created automatically", "string")
           path("direction", "Either 'up' or 'down'", "string")

--- a/website/views/static/api.jade
+++ b/website/views/static/api.jade
@@ -86,8 +86,9 @@ html
         li POST to the URL <code>/api/v2/user/tasks/{id}/{direction}</code>
           ul
            li <code>{direction}</code> is 'up' or 'down'
-           li <code>{id}</code> is a unique identifier for a task, which you make up, consisting of lowercase letters. Try to make it something common, like 'productivity' or 'fitness' - because other services may piggy-back off <em>your</em> task. For example, the Chrome extension down-scores a <code>productivity</code> task when you visit vice websites (reddit, 9gag, etc). However, Pomodoro up-scores <code>productivity</code> when you complete a task. So the two services share a single task to score your overall productivity. If the task doesn't yet exist, it is created the first time you POST to this URL.
+           li <code>{id}</code> is a unique identifier for a Habit, which you make up, consisting of lowercase letters. Try to make it something common, like 'productivity' or 'fitness' - because other services may piggy-back off <em>your</em> Habit. For example, the Chrome extension down-scores a <code>productivity</code> Habit when you visit vice websites (reddit, 9gag, etc). However, Pomodoro up-scores <code>productivity</code> when you complete a Pomodoro task. So the two services share a single Habit to score your overall productivity. If the Habit doesn't yet exist, it is created the first time you POST to this URL.
            li <code>apiToken</code> (POST body) <em>required</em>
+      p A more advanced version that allows modification of other types of tasks is available in the /user/tasks/{id}/{direction} route in the full API below.
       h2 Full API
       p All API requests should be prefaced by <code>https://habitrpg.com</code>. Every authenticated request should include two headers. Your api key (<code>x-api-key</code>) and your user id (<code>x-api-user</code>). Do not include <code>{}</code> braces in your header (<code>-H 'x-api-user: a94b6d9d-6b64-43ae-856c-2c3f211bd426'</code>)
       h2 Requirements:


### PR DESCRIPTION
Wording changes to the API Swagger interface:
- States that the /status and /content and /content/paths routes do not need authentication (suggested by @gisikw at https://github.com/HabitRPG/habitrpg/pull/4934#issuecomment-87216157)
- For the full API `/api/v2/user/tasks/{id}/{direction}` route, states that all four task types can be modified (a third-party coder was asking me about that once).
- For simple scoring, states that it's only Habits and explains that the full API can be used for more advanced use (that tripped me up once).

I'll merge this in a couple of days if there's no complaints.
