### PR TITLE
Repair broken e2e test by changes in copy and IDs

### DIFF
--- a/common/dist/scripts/habitrpg-shared.js
+++ b/common/dist/scripts/habitrpg-shared.js
@@ -2641,12 +2641,16 @@ api.spells = {
       target: 'task',
       notes: t('spellWizardFireballNotes'),
       cast: function(user, target) {
-        var bonus;
+        var bonus, req;
         bonus = user._statsComputed.int * user.fns.crit('per');
         target.value += diminishingReturns(bonus * .02, 4);
         bonus *= Math.ceil((target.value < 0 ? 1 : target.value + 1) * .075);
         user.stats.exp += diminishingReturns(bonus, 75);
-        return user.party.quest.progress.up += diminishingReturns(bonus * .1, 50, 30);
+        user.party.quest.progress.up += diminishingReturns(bonus * .1, 50, 30);
+        req = {
+          language: user.preferences.language
+        };
+        return user.fns.updateStats(user.stats, req);
       }
     },
     mpheal: {
@@ -2772,12 +2776,16 @@ api.spells = {
       target: 'task',
       notes: t('spellRogueBackStabNotes'),
       cast: function(user, target) {
-        var bonus, _crit;
+        var bonus, req, _crit;
         _crit = user.fns.crit('str', .3);
         target.value += _crit * .03;
         bonus = (target.value < 0 ? 1 : target.value + 1) * _crit;
         user.stats.exp += bonus;
-        return user.stats.gp += bonus;
+        user.stats.gp += bonus;
+        req = {
+          language: user.preferences.language
+        };
+        return user.fns.updateStats(user.stats, req);
       }
     },
     toolsOfTrade: {

--- a/test/e2e/e2e.js
+++ b/test/e2e/e2e.js
@@ -25,7 +25,7 @@ describe('front page', function() {
 
   it('shows the front page', function(){
     var button = element(by.className('btn'));
-    expect(button.getText()).toEqual('Play');
+    expect(button.getText()).toEqual('Play HabitRPG');
   });
 
   it("don't login when using wrong credentials", function(){
@@ -51,7 +51,7 @@ describe('front page', function() {
     element(by.model('registerVals.email')).sendKeys('user@example.com');
     element(by.model('registerVals.password')).sendKeys('pass');
     element(by.model('registerVals.confirmPassword')).sendKeys('pass');
-    var register = element(by.css("#register-tab input[value='Register']"));
+    var register = element(by.css("#registrationForm input[value='Register']"));
     register.click();
     browser.sleep(1000);
     browser.getCurrentUrl().then(function(url){

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -48,7 +48,7 @@ fi
 
 # If we're only running protractor, we need to let the server spin up.
 if [ "$1" == "protractor" ]; then
-  sleep 2
+  sleep 10
 fi
 
 if [ -z "$TRAVIS" ]; then


### PR DESCRIPTION
- Switch the "Play" button to check for "Play HabitRPG"
- Change "#register-tab" selector to use "#registrationForm"
- Increase delay when only running protractor specs, to ensure the server has
  time to spin up

Travis isn't running our e2e specs (and honestly, we don't have many), but the new frontpage had some minor changes to IDs and to copy that broke these specs.

These changes can be reviewed via `npm test protractor` - though you'll need to run them in an environment where Firefox can be run in a GUI (since xvfb/firefox-headless has had issues).

_Note: It's probably valuable for us to have some sort of e2e specs, but if we do, we want to be able to include them in the CI build. I'll play around with Sauce Labs offerings against my forked repo to see if I can get things going that way._
