### PR TITLE
Removed axis resrtiction to ease reordering of large number of tags

### DIFF
--- a/website/public/js/directives/directives.js
+++ b/website/public/js/directives/directives.js
@@ -142,7 +142,6 @@ habitrpg.directive('hrpgSortChecklist', ['User', function(User) {
 habitrpg.directive('hrpgSortTags', ['User', function(User) {
   return function($scope, element, attrs, ngModel) {
     $(element).sortable({
-      axis: "x",
       start: function (event, ui) {
         ui.item.data('startIndex', ui.item.index());
       },


### PR DESCRIPTION
In response to https://github.com/HabitRPG/habitrpg/issues/4945, I have removed the axis restriction on tag reordering. This seems to make reordering a large number of tags much smoother. I'm not sure if this will fix the user's issue though.
