### PR TITLE
Corrected ordering that tasks appear in when user enters multiple tasks

### DIFF
--- a/website/public/js/controllers/tasksCtrl.js
+++ b/website/public/js/controllers/tasksCtrl.js
@@ -38,7 +38,10 @@ habitrpg.controller("TasksCtrl", ['$scope', '$rootScope', '$location', 'User','N
     $scope.addTask = function(addTo, listDef) {
       if (listDef.bulk) {
         var tasks = listDef.newTask.split(/[\n\r]+/);
+        //Reverse the order of tasks so the tasks will appear in the order the user entered them
+        tasks.reverse();
         _.each(tasks, function(t) {
+          console.log(t)
           addTask(addTo, listDef, t);
         });
         listDef.bulk = false;
@@ -166,7 +169,7 @@ habitrpg.controller("TasksCtrl", ['$scope', '$rootScope', '$location', 'User','N
           focusChecklist(task,$index-1);
         // Don't allow the backspace key to navigate back now that the field is gone
         $event.preventDefault();
-      } 
+      }
     }
     $scope.swapChecklistItems = function(task, oldIndex, newIndex) {
       var toSwap = task.checklist.splice(oldIndex, 1)[0];
@@ -186,7 +189,7 @@ habitrpg.controller("TasksCtrl", ['$scope', '$rootScope', '$location', 'User','N
 
     /*
      ------------------------
-     Items 
+     Items
      ------------------------
      */
 

--- a/website/public/js/controllers/tasksCtrl.js
+++ b/website/public/js/controllers/tasksCtrl.js
@@ -41,7 +41,6 @@ habitrpg.controller("TasksCtrl", ['$scope', '$rootScope', '$location', 'User','N
         //Reverse the order of tasks so the tasks will appear in the order the user entered them
         tasks.reverse();
         _.each(tasks, function(t) {
-          console.log(t)
           addTask(addTo, listDef, t);
         });
         listDef.bulk = false;


### PR DESCRIPTION
I reversed the array that holds multiples tasks before sending the tasks to the server so that the tasks will appear in the order the users enters them. 

https://github.com/HabitRPG/habitrpg/issues/4935

![screen shot 2015-04-07 at 2 50 27 pm](https://cloud.githubusercontent.com/assets/1253400/7032075/c9378274-dd35-11e4-8a2e-aa8058f72aba.png)

![screen shot 2015-04-07 at 2 50 31 pm](https://cloud.githubusercontent.com/assets/1253400/7032073/c69fab36-dd35-11e4-9d25-7e5760fc92b0.png)
