### PR TITLE
Moved if statement to assign task completion before saving task to user

### DIFF
--- a/test/api/todos.coffee
+++ b/test/api/todos.coffee
@@ -101,8 +101,7 @@ describe "Todos", ->
         upTodo = undefined
         request.post(baseURL + "/user/tasks/withUp/up").send(
             type: "todo"
-            text: "testTitle"
-            complete: true
+            text: "withUp"
             description: "testDesc"
         ).end (res) ->
           expectCode res, 200
@@ -116,12 +115,41 @@ describe "Todos", ->
         downTodo = undefined
         request.post(baseURL + "/user/tasks/withDown/down").send(
             type: "todo"
-            text: "testTitle"
-            complete: true
+            text: "withDown"
             description: "testDesc"
         ).end (res) ->
           expectCode res, 200
           request.get(baseURL + "/user/tasks/withDown")
+          .send().end (res) ->
+            downTodo = res.body
+            expect(downTodo.completed).to.equal false
+            done()
+
+      it "Creates a completed a todo overriding the complete parameter when using up url", (done) ->
+        upTodo = undefined
+        request.post(baseURL + "/user/tasks/withUpWithComplete/up").send(
+            type: "todo"
+            text: "withUpWithComplete"
+            complete: false
+            description: "testDesc"
+        ).end (res) ->
+          expectCode res, 200
+          request.get(baseURL + "/user/tasks/withUpWithComplete")
+          .send().end (res) ->
+            upTodo = res.body
+            expect(upTodo.completed).to.equal true
+            done()
+
+      it "Creates an uncompleted todo verriding the complete when using down url", (done) ->
+        downTodo = undefined
+        request.post(baseURL + "/user/tasks/withDownWithUncomplete/down").send(
+            type: "todo"
+            text: "withDownWithUncomplete"
+            complete: true
+            description: "testDesc"
+        ).end (res) ->
+          expectCode res, 200
+          request.get(baseURL + "/user/tasks/withDownWithUncomplete")
           .send().end (res) ->
             downTodo = res.body
             expect(downTodo.completed).to.equal false

--- a/test/api/todos.coffee
+++ b/test/api/todos.coffee
@@ -97,6 +97,36 @@ describe "Todos", ->
           expect(todo.value).to.equal 0
           done()
 
+      it "Creates a completed a todo when using up url", (done) ->
+        upTodo = undefined
+        request.post(baseURL + "/user/tasks/withUp/up").send(
+            type: "todo"
+            text: "testTitle"
+            complete: true
+            description: "testDesc"
+        ).end (res) ->
+          expectCode res, 200
+          request.get(baseURL + "/user/tasks/withUp")
+          .send().end (res) ->
+            upTodo = res.body
+            expect(upTodo.completed).to.equal true
+            done()
+
+      it "Creates an uncompleted todo when using down url", (done) ->
+        downTodo = undefined
+        request.post(baseURL + "/user/tasks/withDown/down").send(
+            type: "todo"
+            text: "testTitle"
+            complete: true
+            description: "testDesc"
+        ).end (res) ->
+          expectCode res, 200
+          request.get(baseURL + "/user/tasks/withDown")
+          .send().end (res) ->
+            downTodo = res.body
+            expect(downTodo.completed).to.equal false
+            done()
+
       it "Does not create a todo with an id that already exists", (done) ->
         original_todo = {
           type: "todo"
@@ -160,7 +190,7 @@ describe "Todos", ->
         ).end (res) ->
           expectCode res, 200
           body = res.body
-          expect(body).to.be.empty 
+          expect(body).to.be.empty
           done()
 
       it "Does not delete already deleted todo", (done) ->
@@ -184,3 +214,34 @@ describe "Todos", ->
           expect(body.err).to.equal "Task not found."
           done()
 
+describe "habits", ->
+
+  it "Creates a completed a habit when using up url", (done) ->
+    upHabit = undefined
+    request.post(baseURL + "/user/tasks/withUp/up").send(
+        type: "habit"
+        text: "testTitle"
+        complete: true
+        description: "testDesc"
+    ).end (res) ->
+      expectCode res, 200
+      request.get(baseURL + "/user/tasks/withUp")
+      .send().end (res) ->
+        upHabit = res.body
+        expect(upHabit.completed).to.equal true
+        done()
+
+  it "Creates an uncompleted todo when using down url", (done) ->
+    downHabit = undefined
+    request.post(baseURL + "/user/tasks/withDown/down").send(
+        type: "habit"
+        text: "testTitle"
+        complete: true
+        description: "testDesc"
+    ).end (res) ->
+      expectCode res, 200
+      request.get(baseURL + "/user/tasks/withDown")
+      .send().end (res) ->
+        downHabit = res.body
+        expect(downHabit.completed).to.equal false
+        done()

--- a/test/api/todos.coffee
+++ b/test/api/todos.coffee
@@ -184,6 +184,43 @@ describe "Todos", ->
           expect(todo.notes).to.equal "Some notes"
           done()
 
+      it "It completes a todo when using up url", (done) ->
+        unCompletedTodo = undefined
+        request.post(baseURL + "/user/tasks").send(
+            type: "todo"
+            text: "Sample Todo"
+        ).end (res) ->
+          expectCode res, 200
+          unCompletedTodo = res.body
+          expect(unCompletedTodo.completed).to.equal false
+          request.post(baseURL + "/user/tasks/"+unCompletedTodo._id+"/up").send(
+          ).end (res) ->
+            expectCode res, 200
+            request.get(baseURL + "/user/tasks/"+unCompletedTodo._id)
+            .send().end (res) ->
+              unCompletedTodo = res.body
+              expect(unCompletedTodo.completed).to.equal true
+              done()
+
+      it "It uncompletes a todo when using down url", (done) ->
+        completedTodo = undefined
+        request.post(baseURL + "/user/tasks").send(
+            type: "todo"
+            text: "Sample Todo"
+            completed: true
+        ).end (res) ->
+          expectCode res, 200
+          completedTodo = res.body
+          expect(completedTodo.completed).to.equal true
+          request.post(baseURL + "/user/tasks/"+completedTodo._id+"/down").send(
+          ).end (res) ->
+            expectCode res, 200
+            request.get(baseURL + "/user/tasks/"+completedTodo._id)
+            .send().end (res) ->
+              completedTodo = res.body
+              expect(completedTodo.completed).to.equal false
+              done()
+
     describe "Deleting todos", ->
       it "Does delete todo", (done) ->
         request.del(baseURL + "/user/tasks/" + todo.id).send(

--- a/test/api/todos.coffee
+++ b/test/api/todos.coffee
@@ -253,32 +253,34 @@ describe "Todos", ->
 
 describe "habits", ->
 
-  it "Creates a completed a habit when using up url", (done) ->
+  it "Creates and scores up a habit when using up url", (done) ->
     upHabit = undefined
-    request.post(baseURL + "/user/tasks/withUp/up").send(
+    request.post(baseURL + "/user/tasks/habitWithUp/up").send(
         type: "habit"
         text: "testTitle"
         complete: true
         description: "testDesc"
     ).end (res) ->
       expectCode res, 200
-      request.get(baseURL + "/user/tasks/withUp")
+      request.get(baseURL + "/user/tasks/habitWithUp")
       .send().end (res) ->
         upHabit = res.body
-        expect(upHabit.completed).to.equal true
+        expect(upHabit.value).to.be.at.least(1);
+        expect(upHabit.type).to.equal("habit");
         done()
 
-  it "Creates an uncompleted todo when using down url", (done) ->
+  it "Creates and scores down a habit when using down url", (done) ->
     downHabit = undefined
-    request.post(baseURL + "/user/tasks/withDown/down").send(
+    request.post(baseURL + "/user/tasks/habitWithDown/down").send(
         type: "habit"
         text: "testTitle"
         complete: true
         description: "testDesc"
     ).end (res) ->
       expectCode res, 200
-      request.get(baseURL + "/user/tasks/withDown")
+      request.get(baseURL + "/user/tasks/habitWithDown")
       .send().end (res) ->
         downHabit = res.body
-        expect(downHabit.completed).to.equal false
+        expect(downHabit.value).to.have.at.most(-1);
+        expect(downHabit.type).to.equal("habit");
         done()

--- a/website/src/controllers/user.js
+++ b/website/src/controllers/user.js
@@ -99,9 +99,11 @@ api.score = function(req, res, next) {
       text: req.body && req.body.text,
       notes: (req.body && req.body.notes) || "This task was created by a third-party service. Feel free to edit, it won't harm the connection to that service. Additionally, multiple services may piggy-back off this task."
     };
-    task = user.ops.addTask({body:task});
+
     if (task.type === 'daily' || task.type === 'todo')
       task.completed = direction === 'up';
+      
+    task = user.ops.addTask({body:task});
   }
   var delta = user.ops.score({params:{id:task.id, direction:direction}, language: req.language});
 


### PR DESCRIPTION
It seems like the if statement need to be moved up to fix https://github.com/HabitRPG/habitrpg/issues/4891 .

Here are some tests:

**New Todo with Up**
![screen shot 2015-04-07 at 7 31 58 pm](https://cloud.githubusercontent.com/assets/1253400/7036794/5942b60e-dd5e-11e4-9c24-1a9db971559a.png)
![screen shot 2015-04-07 at 7 31 36 pm](https://cloud.githubusercontent.com/assets/1253400/7036817/9670bc4c-dd5e-11e4-94b7-9bd54cc28d59.png)

**New Todo with Down**
![screen shot 2015-04-07 at 7 32 27 pm](https://cloud.githubusercontent.com/assets/1253400/7036821/9676ce2a-dd5e-11e4-9531-e73551ad91b5.png)
![screen shot 2015-04-07 at 7 32 21 pm](https://cloud.githubusercontent.com/assets/1253400/7036820/9676ca74-dd5e-11e4-9201-bcb09bd75601.png)

**New Habit Down**
![screen shot 2015-04-07 at 7 33 48 pm](https://cloud.githubusercontent.com/assets/1253400/7036822/967828c4-dd5e-11e4-8b7d-9b61a3dc36aa.png)

**New Habit Up (Notice the previous habit is under the new green habit)**
![screen shot 2015-04-07 at 7 34 11 pm](https://cloud.githubusercontent.com/assets/1253400/7036823/967dabdc-dd5e-11e4-880c-5b225a1cc75e.png)
