### PR TITLE
Prevent negative experience when a user unchecks a todo or daily

### DIFF
--- a/common/script/index.coffee
+++ b/common/script/index.coffee
@@ -1088,7 +1088,9 @@ api.wrap = (user, main=true) ->
           # TODO Increases Experience gain by .2% per point.
           intBonus = 1 + (user._statsComputed.int * .025)
           stats.exp += Math.round (delta * intBonus * task.priority * _crit * 6)
-
+          #Prevent negative experience
+          if stats.exp < 0 then stats.exp = 0
+          
           # GP modifier
           # ===== PERCEPTION =====
           # TODO Increases Gold gained from tasks by .3% per point.


### PR DESCRIPTION
Fixes #663 . 

This fix is simple, but I promise it took me forever to understand the share code between client and server. Although, that is probably my fault.

Either way, here are some screenshots for show:
![screen shot 2015-04-12 at 8 28 22 pm](https://cloud.githubusercontent.com/assets/1253400/7108702/c62ef572-e153-11e4-82db-42b6db318467.png)
![screen shot 2015-04-12 at 8 28 35 pm](https://cloud.githubusercontent.com/assets/1253400/7108704/c630912a-e153-11e4-8e42-3935e7708877.png)
![screen shot 2015-04-12 at 8 28 40 pm](https://cloud.githubusercontent.com/assets/1253400/7108703/c62f2470-e153-11e4-8db5-594ca32f4997.png)

Basically, when scoring, the addPoints function is called and modifies stats including exp. So, if the exp is negative, I simply raised the exp to 0. This works on the client and server, thus preventing the exp from going negative. 
