### PR TITLE
Increased Carousel Sliding Time on Static.Front

### DIFF
--- a/website/views/static/front.jade
+++ b/website/views/static/front.jade
@@ -150,7 +150,7 @@ html(ng-app='habitrpg', ng-controller='RootCtrl')
       section#uses
         h2 Players use HabitRPG to manage...
         .container-fluid
-          #myCarousel.carousel.slide(data-interval='4000', data-ride='carousel')
+          #myCarousel.carousel.slide(data-interval='10000', data-ride='carousel')
             ul.nav.nav-pills.nav-justified
               li.active(data-target='#myCarousel', data-slide-to='0')
                 a(href='#') Work


### PR DESCRIPTION
Increased carousel sliding time for front page in the "Players use HabitRPG to Manage" section. Increased time from 4 seconds to 10 seconds. Not too slow and not too fast. fixes https://github.com/HabitRPG/habitrpg/issues/5047
