### PR TITLE
Inject RootCtrl into MemberModalCtrl to expose shared methods

### DIFF
--- a/website/public/js/controllers/groupsCtrl.js
+++ b/website/public/js/controllers/groupsCtrl.js
@@ -153,8 +153,11 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '
     };
   }])
 
-  .controller("MemberModalCtrl", ['$scope', '$rootScope', 'Members', 'Shared', '$http', 'Notification', 'Groups',
-    function($scope, $rootScope, Members, Shared, $http, Notification, Groups) {
+  .controller("MemberModalCtrl", ['$scope', '$rootScope', 'Members', 'Shared', '$http', 'Notification', 'Groups', '$controller',
+    function($scope, $rootScope, Members, Shared, $http, Notification, Groups, $controller) {
+
+      $controller('RootCtrl', {$scope: $scope});
+
       $scope.timestamp = function(timestamp){
         return moment(timestamp).format($rootScope.User.user.preferences.dateFormat.toUpperCase());
       }


### PR DESCRIPTION
Fixes #5052 

The shared methods used to determine contributor text and coloring and such live inside `RootCtrl`, which was not part of the controller heirarchy for the `MemberModalCtrl`. We explicitly require it, so now everything works again.
