### PR TITLE
Ensure correct join/leave button for parties

### DIFF
--- a/test/spec/groupCtrlSpec.js
+++ b/test/spec/groupCtrlSpec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 describe('Groups Controller', function() {
-  var scope, ctrl, groups, user, guild, $rootScope;
+  var scope, ctrl, groups, user, guild, party, $rootScope;
 
   beforeEach(function() {
     module(function($provide) {
@@ -21,6 +21,19 @@ describe('Groups Controller', function() {
 
       groups = Groups;
     });
+  });
+
+  it("isMemberOfGroup returns true if group is the user's party", function() {
+    party = specHelper.newGroup("test-party");
+    party._id = "unique-party-id";
+    party.type = 'party';
+    party.members = []; // Ensure we wouldn't pass automatically.
+
+    var partyStub = sinon.stub(groups,"party", function() {
+      return party;
+    });
+
+    expect(scope.isMemberOfGroup(user._id, party)).to.be.ok;
   });
 
   it('isMemberOfGroup returns true if guild is included in myGuilds call', function(){

--- a/website/public/js/controllers/groupsCtrl.js
+++ b/website/public/js/controllers/groupsCtrl.js
@@ -23,6 +23,12 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '
         return _.detect(Groups.myGuilds(), function(g) { return g._id === group._id });
       }
 
+      // Similarly, if we're dealing with the user's current party, return true.
+      if(group.type === 'party') {
+        var currentParty = Groups.party();
+        if(currentParty._id && currentParty._id === group._id) return true;
+      }
+
       if (!group.members) return false;
       var memberIds = _.map(group.members, function(x){return x._id});
       return ~(memberIds.indexOf(userid));


### PR DESCRIPTION
Addresses #5077 

Similar logic to our fix for checking Guild membership - if the group is the user's current party, return true early from the isMemberOfGroup function.

And also a spec. :sunglasses: 
