### PR TITLE
Changed button title to match dropdown settings menu titles

### DIFF
--- a/website/views/options/settings.jade
+++ b/website/views/options/settings.jade
@@ -2,7 +2,7 @@ script(id='partials/options.settings.html', type="text/ng-template")
   ul.options-menu
     li(ng-class="{ active: $state.includes('options.settings.settings') }")
       a(ui-sref='options.settings.settings')
-        =env.t('settings')
+        =env.t('site')
     li(ng-class="{ active: $state.includes('options.settings.api') }")
       a(ui-sref='options.settings.api')
         =env.t('API')


### PR DESCRIPTION
The "site" link in the settings dropdown menu didn't match the button title on the settings page. For UI consistency, I changed the settings button to say "site". 
![selection_005](https://cloud.githubusercontent.com/assets/7059890/7339934/1fce7cb0-ec4e-11e4-9471-6a52e518886e.png)

Before:
![selection_006](https://cloud.githubusercontent.com/assets/7059890/7339939/3e1a34d4-ec4e-11e4-933a-c6e95a39406a.png)

After:
![selection_007](https://cloud.githubusercontent.com/assets/7059890/7339940/4261bfe4-ec4e-11e4-847f-0c57e9a0195a.png)
