### PR TITLE
Adjust error messages on home page to prompt user to use facebook login

### DIFF
--- a/test/e2e/e2e.js
+++ b/test/e2e/e2e.js
@@ -37,7 +37,7 @@ describe('front page', function() {
     var login = element(by.css("#login-tab input[value='Login']"));
     login.click();
     var alertDialog = browser.switchTo().alert();
-    expect(alertDialog.getText()).toMatch(/Uh-oh - your username or password is incorrect.\n- Make sure your username or email is typed correctly.\n- You may have signed up with Facebook, not email. Double-check by trying Facebook login.\n- If you forgot your password, click "Forgot Password"."Username or password incorrect./);
+    expect(alertDialog.getText()).toMatch("Uh-oh - your username or password is incorrect.\n- Make sure your username or email is typed correctly.\n- You may have signed up with Facebook, not email. Double-check by trying Facebook login.\n- If you forgot your password, click \"Forgot Password\".");
     alertDialog.accept();
   });
 

--- a/test/e2e/e2e.js
+++ b/test/e2e/e2e.js
@@ -37,7 +37,7 @@ describe('front page', function() {
     var login = element(by.css("#login-tab input[value='Login']"));
     login.click();
     var alertDialog = browser.switchTo().alert();
-    expect(alertDialog.getText()).toMatch(/Username or password incorrect./);
+    expect(alertDialog.getText()).toMatch(/Uh-oh - your username or password is incorrect.\n- Make sure your username or email is typed correctly.\n- You may have signed up with Facebook, not email. Double-check by trying Facebook login.\n- If you forgot your password, click "Forgot Password"."Username or password incorrect./);
     alertDialog.accept();
   });
 

--- a/website/src/controllers/auth.js
+++ b/website/src/controllers/auth.js
@@ -138,7 +138,7 @@ api.loginLocal = function(req, res, next) {
   var login = validator.isEmail(username) ? {'auth.local.email':username} : {'auth.local.username':username};
   User.findOne(login, {auth:1}, function(err, user){
     if (err) return next(err);
-    if (!user) return res.json(401, {err:"Username or password incorrect. Click 'Forgot Password' for help with either. (Note: usernames are case-sensitive)"});
+    if (!user) return res.json(401, {err:"Uh-oh - your username or password is incorrect.\n- Make sure your username or email is typed correctly.\n- You may have signed up with Facebook, not email. Double-check by trying Facebook login.\n- If you forgot your password, click \"Forgot Password\"."});
     if (user.auth.blocked) return res.json(401, accountSuspended(user._id));
     // We needed the whole user object first so we can get his salt to encrypt password comparison
     User.findOne(
@@ -146,7 +146,7 @@ api.loginLocal = function(req, res, next) {
     , {_id:1, apiToken:1}
     , function(err, user){
       if (err) return next(err);
-      if (!user) return res.json(401,{err:"Username or password incorrect. Click 'Forgot Password' for help with either. (Note: usernames are case-sensitive)"});
+      if (!user) return res.json(401,{err:"Uh-oh - your username or password is incorrect.\n- Make sure your username or email is typed correctly.\n- You may have signed up with Facebook, not email. Double-check by trying Facebook login.\n- If you forgot your password, click \"Forgot Password\"."});
       res.json({id: user._id,token: user.apiToken});
       password = null;
     });
@@ -227,7 +227,7 @@ api.resetPassword = function(req, res, next){
 
   User.findOne({'auth.local.email': RegexEscape(email)}, function(err, user){
     if (err) return next(err);
-    if (!user) return res.send(401, {err:"Couldn't find a user registered for email " + email});
+    if (!user) return res.send(401, {err:"Sorry, we can't find a user registered with email " + email + "\n- Make sure your email address is typed correctly.\n- You may have signed up with Facebook, not email. Double-check by trying Facebook login."});
     user.auth.local.salt = salt;
     user.auth.local.hashed_password = hashed_password;
     utils.sendEmail({


### PR DESCRIPTION
fixes #5103
Altered the error messages that are part of the login and forgotten password processes.
These messages now remind the the user that they may have created an account through facebook.

Screenshots:
![screenshot from 2015-05-01 13 05 25](https://cloud.githubusercontent.com/assets/1052548/7426181/ea5ceb8a-f002-11e4-9ec8-c13d5e7c17b6.png)
![screenshot from 2015-05-01 13 06 03](https://cloud.githubusercontent.com/assets/1052548/7426182/ef94363a-f002-11e4-8969-40a322944d7e.png)
