### PR TITLE
Gems are now refunded to challenge leader on deletion. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 <a name="">My app - Changelog</a>
-#  (2015-05-02)
+#  (2015-05-04)
 
 
 ## Bug Fixes
 
+- **Spring:** WHO IS LESLIE
+  ([6685e935](watch/commits/6685e93554a1274dedb55dae054e787fb80eb440))
 - **invite-friends:** text should be valid for both parties and guilds
   ([54e82a14](watch/commits/54e82a14a252c3b9923449a7ef7cee6033a5d160))
 - **mystery:** It's 2015 now, Sabe
@@ -16,6 +18,8 @@
 
 ## Features
 
+- **Spring:** Flung
+  ([d50d4ad8](watch/commits/d50d4ad8bb0f89e39ceb6562e0f8f392f94b5444))
 - **emails:** add support for weekly recap emails
   ([37f7db3c](watch/commits/37f7db3c4e3859d03fd55a44e63819e273a06442))
 - **i18n:** upload japanese, serbian and chinese (taiwan)

--- a/test/api.mocha.coffee
+++ b/test/api.mocha.coffee
@@ -503,13 +503,13 @@ describe "API", ->
                 ], (err, results) ->
                   _user = results[0]
                   challenge = results[1]
+                  expect(_user.balance).to.be 5.5
                 cb()
-            expect(_user.balance).to.be 5.5
             done()
 
         it "User deletes a challenge with prize and gets refund", (done) ->
           request.del(baseURL + "/challenges/" + challenge._id).end (res) ->
-            User.findById _user._id, (err, user) ->
+            User.findById _id, (err, user) ->
               expect(user.balance).to.be 8
               done()
 

--- a/test/api.mocha.coffee
+++ b/test/api.mocha.coffee
@@ -506,7 +506,7 @@ describe "API", ->
                 request.del(baseURL + "/challenges/" + challenge._id).end (res) ->
                   User.findById _id, (err, user) ->
                     expect(user.balance).to.be 8
-            done()
+          done()
 
       ###*
       QUESTS

--- a/test/api.mocha.coffee
+++ b/test/api.mocha.coffee
@@ -479,6 +479,32 @@ describe "API", ->
                   cb()
             ], done
 
+        it "Creates a challenge with prize", (done) ->
+          (cb) -> 
+            User.findByIdAndUpdate _id,
+              $set:
+                "balance": 8
+            , cb
+          request.post(baseURL + "/challenges").send(
+            group: group._id
+            prize: 10
+            official: true
+          ).end (res) ->
+            expectCode res, 200
+            async.parallel [
+              (cb) ->
+                User.findById _id, cb
+              (cb) ->
+                Challenge.findById res.body._id, cb
+            ], (err, results) ->
+              _user = results[0]
+              challenge = results[1]
+              expect(_user.balance).to.be 5.5
+              done()
+
+    ###*
+    QUESTS
+    ###
       describe "Quests", ->
         party = undefined
         participating = []

--- a/test/api.mocha.coffee
+++ b/test/api.mocha.coffee
@@ -485,26 +485,24 @@ describe "API", ->
               "balance": 8
           , (err, user) ->
             expect(err).to.not.be.ok()
-            (cb) ->
-              request.post(baseURL + "/challenges").send(
-                group: group._id
-                dailys: []
-                todos: []
-                rewards: []
-                habits: []
-                prize: 10
-              ).end (res) ->
-                expect(res.body.prize).to.be 10
-                async.parallel [
-                  (cb) ->
-                    User.findById _id, cb
-                  (cb) ->
-                    Challenge.findById res.body._id, cb
-                ], (err, results) ->
-                  _user = results[0]
-                  challenge = results[1]
-                  expect(_user.balance).to.be 5.5
-                cb()
+            request.post(baseURL + "/challenges").send(
+              group: group._id
+              dailys: []
+              todos: []
+              rewards: []
+              habits: []
+              prize: 10
+            ).end (res) ->
+              expect(res.body.prize).to.be 10
+              async.parallel [
+                (cb) ->
+                  User.findById _id, cb
+                (cb) ->
+                  Challenge.findById res.body._id, cb
+              ], (err, results) ->
+                _user = results[0]
+                challenge = results[1]
+                expect(_user.balance).to.be 5.5
             done()
 
         it "User deletes a challenge with prize and gets refund", (done) ->

--- a/test/api.mocha.coffee
+++ b/test/api.mocha.coffee
@@ -506,6 +506,7 @@ describe "API", ->
             done()
 
         it "User deletes a challenge with prize and gets refund", (done) ->
+          itThis = this
           request.del(baseURL + "/challenges/" + challenge._id).end (res) ->
             User.findById _id, (err, user) ->
               expect(user.balance).to.be 8

--- a/test/api.mocha.coffee
+++ b/test/api.mocha.coffee
@@ -504,9 +504,9 @@ describe "API", ->
               expect(_user.balance).to.be 5.5
               done()
 
-    ###*
-    QUESTS
-    ###
+      ###*
+      QUESTS
+      ###
       describe "Quests", ->
         party = undefined
         participating = []

--- a/test/api.mocha.coffee
+++ b/test/api.mocha.coffee
@@ -499,8 +499,14 @@ describe "API", ->
                   cb()
               (cb) ->
                 User.findById _id, cb
-            ], (err, result) ->
-              expect(result.balance).to.be 5.5
+            ], (err, user) ->
+              expect(user.balance).to.be 5.5
+              done()
+
+        it "User deletes a challenge with prize and gets refund", (done) ->
+          request.del(baseURL + "/challenges/" + body._id).end (res) ->
+            User.findById user._id, (err, user) ->
+              expect(user.balance).to.be 8
               done()
 
       ###*

--- a/test/api.mocha.coffee
+++ b/test/api.mocha.coffee
@@ -479,13 +479,13 @@ describe "API", ->
                   cb()
             ], done
 
-        it "Creates a challenge with prize", (done) ->
+        it "User creates a challenge with prize", (done) ->
           User.findByIdAndUpdate _id,
             $set:
               "balance": 8
           , (err, _user) ->
             expect(err).to.not.be.ok()
-            async.parallel [
+            async.waterfall [
               (cb) ->
                 request.post(baseURL + "/challenges").send(
                   group: group._id

--- a/test/api.mocha.coffee
+++ b/test/api.mocha.coffee
@@ -480,24 +480,26 @@ describe "API", ->
             ], done
 
         it "Creates a challenge with prize", (done) ->
-          (cb) -> 
-            User.findByIdAndUpdate _id,
-              $set:
-                "balance": 8
-            , cb
-          request.post(baseURL + "/challenges").send(
-            group: group._id
-            prize: 10
-            official: true
-          ).end (res) ->
-            expectCode res, 200
+          User.findByIdAndUpdate _id,
+            $set:
+              "balance": 8
+          , (err, _user) ->
+            expect(err).to.not.be.ok()
             async.parallel [
               (cb) ->
-                User.findById _id, cb
+                request.post(baseURL + "/challenges").send(
+                  group: group._id
+                  dailys: []
+                  todos: []
+                  rewards: []
+                  habits: []
+                  prize: 10
+                ).end (res) ->
+                  expect(res.body.prize).to.be 10
+                  cb()
               (cb) ->
-                Challenge.findById res.body._id, cb
-            ], (err, results) ->
-              _user = results[0]
+                Challenge.findById group._id, cb
+            ], (err, result) ->
               challenge = results[1]
               expect(_user.balance).to.be 5.5
               done()

--- a/test/api.mocha.coffee
+++ b/test/api.mocha.coffee
@@ -506,11 +506,8 @@ describe "API", ->
                 request.del(baseURL + "/challenges/" + challenge._id).end (res) ->
                   User.findById _id, (err, user) ->
                     expect(user.balance).to.be 8
-          done()
+                    done()
 
-      ###*
-      QUESTS
-      ###
       describe "Quests", ->
         party = undefined
         participating = []

--- a/test/api.mocha.coffee
+++ b/test/api.mocha.coffee
@@ -497,15 +497,21 @@ describe "API", ->
                 ).end (res) ->
                   expect(res.body.prize).to.be 10
                   cb()
-              (cb) ->
-                User.findById _id, cb
-            ], (err, user) ->
-              expect(user.balance).to.be 5.5
+              async.parallel [
+                (cb) ->
+                  User.findById _id, cb
+                (cb) ->
+                  Challenge.findById res.body._id, cb
+              ], (err, results) ->
+                _user = results[0]
+                challenge = results[1]
+            ], (err, result) ->
+              expect(_user.balance).to.be 5.5
               done()
 
         it "User deletes a challenge with prize and gets refund", (done) ->
-          request.del(baseURL + "/challenges/" + body._id).end (res) ->
-            User.findById user._id, (err, user) ->
+          request.del(baseURL + "/challenges/" + challenge._id).end (res) ->
+            User.findById _user._id, (err, user) ->
               expect(user.balance).to.be 8
               done()
 

--- a/test/api.mocha.coffee
+++ b/test/api.mocha.coffee
@@ -479,7 +479,7 @@ describe "API", ->
                   cb()
             ], done
 
-        it "User creates a challenge with prize", (done) ->
+        it "User creates a challenge with prize, deletes it, gets refund", (done) ->
           User.findByIdAndUpdate _id,
             $set:
               "balance": 8
@@ -503,14 +503,10 @@ describe "API", ->
                 _user = results[0]
                 challenge = results[1]
                 expect(_user.balance).to.be 5.5
+                request.del(baseURL + "/challenges/" + challenge._id).end (res) ->
+                  User.findById _id, (err, user) ->
+                    expect(user.balance).to.be 8
             done()
-
-        it "User deletes a challenge with prize and gets refund", (done) ->
-          itThis = this
-          request.del(baseURL + "/challenges/" + challenge._id).end (res) ->
-            User.findById _id, (err, user) ->
-              expect(user.balance).to.be 8
-              done()
 
       ###*
       QUESTS

--- a/test/api.mocha.coffee
+++ b/test/api.mocha.coffee
@@ -500,7 +500,7 @@ describe "API", ->
               (cb) ->
                 Challenge.findById group._id, cb
             ], (err, result) ->
-              challenge = results[1]
+              challenge = result
               expect(_user.balance).to.be 5.5
               done()
 

--- a/test/api.mocha.coffee
+++ b/test/api.mocha.coffee
@@ -498,10 +498,9 @@ describe "API", ->
                   expect(res.body.prize).to.be 10
                   cb()
               (cb) ->
-                Challenge.findById group._id, cb
+                User.findById _id, cb
             ], (err, result) ->
-              challenge = result
-              expect(_user.balance).to.be 5.5
+              expect(result.balance).to.be 5.5
               done()
 
       ###*

--- a/test/api.mocha.coffee
+++ b/test/api.mocha.coffee
@@ -483,31 +483,29 @@ describe "API", ->
           User.findByIdAndUpdate _id,
             $set:
               "balance": 8
-          , (err, _user) ->
+          , (err, user) ->
             expect(err).to.not.be.ok()
-            async.waterfall [
-              (cb) ->
-                request.post(baseURL + "/challenges").send(
-                  group: group._id
-                  dailys: []
-                  todos: []
-                  rewards: []
-                  habits: []
-                  prize: 10
-                ).end (res) ->
-                  expect(res.body.prize).to.be 10
-                  cb()
-              async.parallel [
-                (cb) ->
-                  User.findById _id, cb
-                (cb) ->
-                  Challenge.findById res.body._id, cb
-              ], (err, results) ->
-                _user = results[0]
-                challenge = results[1]
-            ], (err, result) ->
-              expect(_user.balance).to.be 5.5
-              done()
+            (cb) ->
+              request.post(baseURL + "/challenges").send(
+                group: group._id
+                dailys: []
+                todos: []
+                rewards: []
+                habits: []
+                prize: 10
+              ).end (res) ->
+                expect(res.body.prize).to.be 10
+                async.parallel [
+                  (cb) ->
+                    User.findById _id, cb
+                  (cb) ->
+                    Challenge.findById res.body._id, cb
+                ], (err, results) ->
+                  _user = results[0]
+                  challenge = results[1]
+                cb()
+            expect(_user.balance).to.be 5.5
+            done()
 
         it "User deletes a challenge with prize and gets refund", (done) ->
           request.del(baseURL + "/challenges/" + challenge._id).end (res) ->

--- a/website/src/controllers/challenges.js
+++ b/website/src/controllers/challenges.js
@@ -309,12 +309,16 @@ api['delete'] = function(req, res, next){
       chal = _chal;
       if (!chal) return cb('Challenge ' + cid + ' not found');
       if (chal.leader != user._id) return cb("You don't have permissions to edit this challenge");
-      User.findById(user._id, cb) //Refunds to challenge leader
+      //Refunds to challenge leader
+      User.findById(user._id, cb) 
     },
     function(leader, cb){
       leader.balance += chal.prize/4;
       leader.save(cb);
-      closeChal(req.params.cid, {broken: 'CHALLENGE_DELETED'}, cb); //Not descriptive enough
+    },
+    function(save, num, cb){
+      //Add prizeRefundedTo: save.profile.name?
+      closeChal(req.params.cid, {broken: 'CHALLENGE_DELETED'}, cb);
     }
   ], function(err){
     if (err) return next(err);

--- a/website/src/controllers/challenges.js
+++ b/website/src/controllers/challenges.js
@@ -317,7 +317,7 @@ api['delete'] = function(req, res, next){
       leader.save(cb);
     },
     function(save, num, cb){
-      //Add prizeRefundedTo: save.profile.name?
+      //Deletes challenge and adds broken link (same as before) add prizeRefundedTo: save.profile.name?
       closeChal(req.params.cid, {broken: 'CHALLENGE_DELETED'}, cb);
     }
   ], function(err){


### PR DESCRIPTION
Fixed #2094 I think.

Is this the intended outcome? Since gems can also be used by groups. So does the origin of gems matter in this case? Or is the guild leader assumed to give back to group as needed.

Also, needs better description in "broken" field. Currently it is {broken: 'CHALLENGE_DELETED'}.

I didn't want to make a {broken: 'CHALLENGE_DELETED', prizeRefundedTo: leaderid} since I am not sure if we enforce a schema.
