### PR TITLE
Removed extraneous logic on "Release Both" kennel key

### DIFF
--- a/website/views/shared/modals/drops.jade
+++ b/website/views/shared/modals/drops.jade
@@ -45,9 +45,8 @@ script(type='text/ng-template', id='modals/pet-key.html')
         =env.t('petKeyMounts')
         | : 4&nbsp;
         span.Pet_Currency_Gem1x.inline-gems
-    span(ng-if='(user.balance >= 1.5 || user.achievements.triadBingo) && petCount >= 90 && mountCount >= 90', ng-controller='SettingsCtrl')
+    // Free, but only accessible to those who achieve triad bingo
+    span(ng-if='user.achievements.triadBingo', ng-controller='SettingsCtrl')
       a.btn.btn-danger(ng-click='$close(); releaseBoth()')
         =env.t('petKeyBoth')
-        span(ng-if='!user.achievements.triadBingo')
-          | : 6&nbsp;
           span.Pet_Currency_Gem1x.inline-gems

--- a/website/views/shared/modals/drops.jade
+++ b/website/views/shared/modals/drops.jade
@@ -49,4 +49,3 @@ script(type='text/ng-template', id='modals/pet-key.html')
     span(ng-if='user.achievements.triadBingo', ng-controller='SettingsCtrl')
       a.btn.btn-danger(ng-click='$close(); releaseBoth()')
         =env.t('petKeyBoth')
-          span.Pet_Currency_Gem1x.inline-gems


### PR DESCRIPTION
Due to the update that caused the "release both" key to the kennels to be free to anyone who achieves triad bingo, the old logic is no longer needed. Specifically, the following were removed:
1) `petCount` and `mountCount` `>= 90` checks
2) Never-traversed `ng-if` that adds a price if the user doesn't have triad bingo.
