### PR TITLE
message about Resting in the Inn at top of Dailies column when resting

### DIFF
--- a/common/locales/en/tasks.json
+++ b/common/locales/en/tasks.json
@@ -77,5 +77,6 @@
     "streakCoins": "Streak Bonus!",
     "pushTaskToTop": "Push task to top",
     "pushTaskToBottom": "Push task to bottom",
-    "emptyTask": "Enter the task's title first."
+    "emptyTask": "Enter the task's title first.",
+    "dailiesRestingInInn": "You're Resting in the Inn! Your Dailies will NOT hurt you tonight, but they WILL still refresh every day. If you're in a quest, you won't deal damage/collect items until you check out of the Inn, but you can still be injured by a Boss if your Party mates skip their own Dailies."
 }

--- a/website/public/css/tasks.styl
+++ b/website/public/css/tasks.styl
@@ -188,6 +188,11 @@ for $stage in $stages
   .empty-task-notification
     height: 100%;
 
+// message in Dailies column when Resting in Inn
+// ------------------------
+.dailiesRestingInInn
+  clear: both
+
 // an individual task entry
 // ------------------------
 .task

--- a/website/views/shared/tasks/lists.jade
+++ b/website/views/shared/tasks/lists.jade
@@ -70,6 +70,8 @@ script(id='templates/habitrpg-tasks.html', type="text/ng-template")
               span(ng-if='!list.bulk')=env.t('addmultiple')
               span(ng-if='list.bulk')=env.t('addsingle')
 
+          div.dailiesRestingInInn(ng-if='::list.type == "daily" && user.preferences.sleep')=env.t('dailiesRestingInInn')
+
           mixin taskColumnTabs(position)
             // Habits Tabs
             div(ng-if='::main && list.type=="habit"', class='tabbable tabs-below')


### PR DESCRIPTION
ping @lemoness - is this okay?

This PR adds a message to the top of the Dailies column when the user is resting in the inn, but not otherwise (a non-resting user will see the Dailies column looking exactly as normal).

Note that it's important that this goes live at the same time as the change that will be deployed to production "late morning/midday tomorrow" in @SabreCat's timezone. I think that's in about eight to ten hours from now. I'll be asleep for almost all of that time. Therefore, if this PR is not ideal but is acceptable, could it be merged as is and then I'll work on making it ideal tomorrow or the next day? Alternatively, other programmers could make any essential changes over the next few hours.

If this PR doesn't go live tomorrow, the new behaviour for Resting in the Inn could come as a nasty shock to anyone who sees their Dailies reset before they've had a chance to read the Bailey message. I'd like to avoid bug reports and Tavern questions about that, and this PR will help.

![screen shot 2015-05-13 at 5 14 44 pm](https://cloud.githubusercontent.com/assets/1495809/7606874/3a621bc2-f9a0-11e4-8ff9-3bc33566e825.png)
