### PR TITLE
Moved battle gear popover from top to right

### DIFF
--- a/website/views/options/inventory/inventory.jade
+++ b/website/views/options/inventory/inventory.jade
@@ -2,7 +2,7 @@ script(type='text/ng-template', id='partials/options.inventory.equipment.html')
   .container-fluid
     .row
       .col-md-6.border-right
-        h3.equipment-title.hint(popover-trigger='mouseenter', popover-placement='top', popover-append-to-body='true', popover=env.t('battleGearText'))=env.t('battleGear')
+        h3.equipment-title.hint(popover-trigger='mouseenter', popover-placement='right', popover-append-to-body='true', popover=env.t('battleGearText'))=env.t('battleGear')
         div
           button.btn.btn-default(type="button", ng-click='dequip("battleGear");') {{env.t("unequipBattleGear")}}
         li.customize-menu.inventory-gear


### PR DESCRIPTION
The current battle gear popover placement causes it to be cut off by the edge of the screen.
![battle gear right](https://cloud.githubusercontent.com/assets/7059890/7670573/dd738dbc-fc77-11e4-953f-306a9881107f.jpg)

This fixes the issue by moving the popover to the right.

![battle gear fixed](https://cloud.githubusercontent.com/assets/7059890/7670593/25b6f820-fc78-11e4-89a7-5c0b5f25799c.jpg)

This also makes the UI more consistent, since the Costume popover is also on the right.
