### PR TITLE
Fixed Ethereal Surge notification split

### DIFF
--- a/common/script/content.coffee
+++ b/common/script/content.coffee
@@ -550,7 +550,8 @@ api.spells =
       cast: (user, target)->
         _.each target, (member) ->
           bonus = user._statsComputed.int
-          member.stats.mp += Math.ceil(diminishingReturns(bonus, 25, 125)) # maxes out at 25
+          if user._id != member._id
+            member.stats.mp += Math.ceil(diminishingReturns(bonus, 25, 125)) # maxes out at 25
 
     earth:
       # Earthquake


### PR DESCRIPTION
Fixes #5228. Big thank you to @Alys for pointing me in the right direction and being helpful as always :)

![selection_001](https://cloud.githubusercontent.com/assets/7059890/7674504/6569d9f4-fcf7-11e4-9e8c-8f1faab3c829.png)

The problem was that the spell added MP to every user in the party, including the user casting the spell. As far as I can tell, when the mana for casting the spell was deducted, the number displayed was the result of `30 - <number of MP added>`, instead of 30. Then, when `User.sync()` was run, `<number of MP added>` MP was deducted from the user, causing the second notification. 

Essentially, the user was giving themselves MP that was then immediately deducted. This PR fixes that by ensuring that the user never gives themselves MP in the first place, eliminating the second notification.
