### PR TITLE
Make quest completion modal always display before quest invite modal

### DIFF
--- a/website/public/js/controllers/notificationCtrl.js
+++ b/website/public/js/controllers/notificationCtrl.js
@@ -148,7 +148,7 @@ habitrpg.controller('NotificationCtrl',
     });
 
     // Quest invitation modal
-    $rootScope.$watch('party.quest.key && !party.quest.active && party.quest.members[user._id] == undefined && user.party.quest.completed == ""', function(after, before){
+    $rootScope.$watch('party.quest.key && !party.quest.active && party.quest.members[user._id] == undefined && (user.party.quest.completed == "" || user.party.quest.completed == undefined)', function(after, before){
       if (after == before || after != true) return;
       $rootScope.openModal('questInvitation');
     });

--- a/website/public/js/controllers/notificationCtrl.js
+++ b/website/public/js/controllers/notificationCtrl.js
@@ -148,7 +148,7 @@ habitrpg.controller('NotificationCtrl',
     });
 
     // Quest invitation modal
-    $rootScope.$watch('party.quest.key && !party.quest.active && party.quest.members[user._id] == undefined && user.party.quest.completed == undefined', function(after, before){
+    $rootScope.$watch('party.quest.key && !party.quest.active && party.quest.members[user._id] == undefined && user.party.quest.completed == ""', function(after, before){
       if (after == before || after != true) return;
       $rootScope.openModal('questInvitation');
     });

--- a/website/public/js/controllers/notificationCtrl.js
+++ b/website/public/js/controllers/notificationCtrl.js
@@ -148,7 +148,7 @@ habitrpg.controller('NotificationCtrl',
     });
 
     // Quest invitation modal
-    $rootScope.$watch('party.quest.key && !party.quest.active && party.quest.members[user._id] == undefined', function(after, before){
+    $rootScope.$watch('party.quest.key && !party.quest.active && party.quest.members[user._id] == undefined && user.party.quest.completed == undefined', function(after, before){
       if (after == before || after != true) return;
       $rootScope.openModal('questInvitation');
     });


### PR DESCRIPTION
Fixes #5229. I haven't fully tested this yet, but it should work. As soon as I figure out how to trigger quest completion via mongodb, I'll know for sure.
