### PR TITLE
Fixed sync button display before community guildlines are accepted

### DIFF
--- a/website/views/options/social/chat-box.jade
+++ b/website/views/options/social/chat-box.jade
@@ -7,8 +7,7 @@ div.chat-form.guidelines-not-accepted(ng-if='!user.flags.communityGuidelinesAcce
     div
       button.btn.btn-warning(ng-click='acceptCommunityGuidelines()')=env.t('iAcceptCommunityGuidelines')
     .chat-buttons
-      button(type="button", ng-click='sync(group)', tooltip=env.t('toolTipMsg'))
-        span.glyphicon.glyphicon-refresh
+      button(type="button", ng-click='sync(group)')=env.t('toolTipMsg')
 
 form.chat-form(ng-if='user.flags.communityGuidelinesAccepted' ng-submit='postChat(group,message.content)')
   div(ng-controller='AutocompleteCtrl')


### PR DESCRIPTION
As requested by @Alys via PM, this fixes how the sync button appears before a user accepts the community guidelines in the tavern.

Before (screenshot from Alys; the "bad" one is what's being fixed):

![](http://i.gyazo.com/4e35cc9c2293828a3cc5b6e649d95d87.png)

After:
![selection_006](https://cloud.githubusercontent.com/assets/7059890/7728013/a2856e68-feda-11e4-9b61-e8ee87f3c6ed.png)
