### PR TITLE
Add markdown to guild description in public guild list

### DIFF
--- a/website/views/options/social/index.jade
+++ b/website/views/options/social/index.jade
@@ -62,7 +62,7 @@ script(type='text/ng-template', id='partials/options.social.guilds.public.html')
               span.glyphicon.glyphicon-ok
               =env.t('join')
         h4 {{::group.name}}
-        p {{::group.description}}
+        markdown(text="group.description")
 
 script(type='text/ng-template', id='partials/options.social.guilds.detail.html')
   include ./group


### PR DESCRIPTION
I have reservations about merging this in, because guilds that use large headers or images in their descriptions could clutter up the page. IE:

![screen shot 2015-05-24 at 11 00 42 pm](https://cloud.githubusercontent.com/assets/2916945/7791626/fc3540dc-0268-11e5-9ff0-9630fce0735d.png)

Thoughts @lemoness @Alys @deilann @SabreCat?

Fixes #5273
