### PR TITLE
fixes #5148 ("Add Task plus not vertically centered")

### DIFF
--- a/website/public/css/tasks.styl
+++ b/website/public/css/tasks.styl
@@ -181,6 +181,8 @@ for $stage in $stages
     width: 20%
     span
       font-size: 0.8em
+    .glyphicon-plus
+      vertical-align: text-bottom;
   .help-block a
     border: 0
     float: right


### PR DESCRIPTION
just add
.task-add.button.glyphicon-plus {
      vertical-align: text-bottom;
}
maybe its a bad solution, but works
