### PR TITLE
Server-side mixpanel should only load in a production env

### DIFF
--- a/website/src/utils.js
+++ b/website/src/utils.js
@@ -179,8 +179,11 @@ module.exports.setupConfig = function(){
   baseUrl = nconf.get('BASE_URL');
 
   module.exports.ga = require('universal-analytics')(nconf.get('GA_ID'));
-  var mixpanel = require('mixpanel')
-  module.exports.mixpanel = mixpanel.init(nconf.get('MP_ID'));
+
+  var mixpanel = isProd && require('mixpanel');
+  module.exports.mixpanel = mixpanel
+    ? mixpanel.init(nconf.get('MP_ID'))
+    : { track: function() {} };
 };
 
 var algorithm = 'aes-256-ctr';


### PR DESCRIPTION
Requires mixpanel in a prod environment, otherwise sets the export to a stub.
