### PR TITLE
Increase default memory and CPU limits for Vagrant box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,8 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider "virtualbox" do |v|
+    v.memory = 2048
+    v.cpus = 2
     v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/vagrant", "1"]
   end
   config.vm.box = "thepeopleseason/habitrpg"


### PR DESCRIPTION
By default the vagrant box only has access to 384MB of RAM. HabitRPG at idle on my box uses around 768MB, however while running `npm start`, that memory usage spikes up to 1.75GB.

I'm not sure what sort of boxes the majority of people are using, my settings may be aggressive for some. However, development with the default settings is unbearably slow due to excess swapping.
