### PR TITLE
Option to hide spells in Party Chat

### DIFF
--- a/common/locales/en/groups.json
+++ b/common/locales/en/groups.json
@@ -33,6 +33,7 @@
     "chat": "Chat",
     "sendChat": "Send Chat",
     "toolTipMsg": "Fetch Recent Messages",
+    "hideSystemMsgs": "Hide System Messages",
     "guildBankPop1": "Guild Bank",
     "guildBankPop2": "Gems which your guild leader can use for challenge prizes.",
     "guildGems": "Guild Gems",

--- a/website/public/css/game-pane.styl
+++ b/website/public/css/game-pane.styl
@@ -99,9 +99,6 @@
     border-left: 4px solid #333
     padding-left: 2px
 
-  .hide-spell
-    display: none
-
   markdown
     p:first-child
       display:inline

--- a/website/public/css/game-pane.styl
+++ b/website/public/css/game-pane.styl
@@ -98,7 +98,10 @@
   .own-message
     border-left: 4px solid #333
     padding-left: 2px
-    
+
+  .hide-spell
+    display: none
+
   markdown
     p:first-child
       display:inline

--- a/website/public/js/controllers/groupsCtrl.js
+++ b/website/public/js/controllers/groupsCtrl.js
@@ -308,6 +308,11 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '
       return message.highlight;
     }
 
+    $scope.hideSpellMessage = function(message) {
+      var regex = new RegExp('`.+ casts .+ for the party\.`$', 'gi')
+      return $scope.hideSpells && regex.test(message.text);
+    }
+
     $scope.postChat = function(group, message){
       if (_.isEmpty(message) || $scope._sending) return;
       $scope._sending = true;

--- a/website/public/js/controllers/groupsCtrl.js
+++ b/website/public/js/controllers/groupsCtrl.js
@@ -308,6 +308,11 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '
       return message.highlight;
     }
 
+    $scope.togglehidingSystemMessages = function() {
+      // Intentionally flip the boolean state
+      $scope.hideSystemMessages = $scope.hideSystemMessages ? false : true;
+    }
+
     $scope.postChat = function(group, message){
       if (_.isEmpty(message) || $scope._sending) return;
       $scope._sending = true;

--- a/website/public/js/controllers/groupsCtrl.js
+++ b/website/public/js/controllers/groupsCtrl.js
@@ -308,11 +308,6 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '
       return message.highlight;
     }
 
-    $scope.hideSpellMessage = function(message) {
-      var regex = new RegExp('`.+ casts .+ for the party\.`$', 'gi')
-      return $scope.hideSpells && regex.test(message.text);
-    }
-
     $scope.postChat = function(group, message){
       if (_.isEmpty(message) || $scope._sending) return;
       $scope._sending = true;

--- a/website/views/options/social/chat-box.jade
+++ b/website/views/options/social/chat-box.jade
@@ -18,7 +18,7 @@ form.chat-form(ng-if='user.flags.communityGuidelinesAccepted' ng-submit='postCha
           span.username.label.label-default(ng-class=':: userLevelStyle(msg)') {{::msg.user}}
   .chat-controls.clearfix
     .chat-buttons
-      button.btn(type='button', ng-click='togglehidingSystemMessages()')=env.t('hideSystemMsgs')
+      button.btn(type='button', ng-click='togglehidingSystemMessages()', ng-if='group.type == "party"')=env.t('hideSystemMsgs')
       button.btn(type="button", ng-click='sync(group)', ng-disabled='_sending')=env.t('toolTipMsg')
       input.btn(type='submit', value=env.t('sendChat'), ng-disabled='_sending')
     include ../../shared/formatting-help

--- a/website/views/options/social/chat-box.jade
+++ b/website/views/options/social/chat-box.jade
@@ -11,14 +11,14 @@ div.chat-form.guidelines-not-accepted(ng-if='!user.flags.communityGuidelinesAcce
 
 form.chat-form(ng-if='user.flags.communityGuidelinesAccepted' ng-submit='postChat(group,message.content)')
   div(ng-controller='AutocompleteCtrl')
-    textarea.form-control(rows=4, ui-keydown='{"meta-enter":"postChat(group,message.content)"}', ui-keypress='{13:"postChat(group,message.content)"}', ng-model='message.content', updateinterval='250', flag='@', at-user, auto-complete placeholder="{{group._id == 'habitrpg' ? env.t('tavernCommunityGuidelinesPlaceholder') : ''}}", ng-disabled='_sending == true')
+    textarea.form-control(rows=4, ui-keydown='{"meta-enter":"postChat(group,message.content)"}', ui-keypress='{13:"postChat(group,message.content)"}', ng-model='message.content', updateinterval='250', flag='@', at-user, auto-complete placeholder="{{group._id == 'habitrpg' ? env.t('tavernCommunityGuidelinesPlaceholder') : ''}}", ng-disabled='_sending == true', tabindex='1')
     span.user-list
       ul.list-at-user(ng-show="query")
         li(ng-repeat='msg in response | filter:filterUser | limitTo: 5', ng-click='performCompletion(msg)')
           span.username.label.label-default(ng-class=':: userLevelStyle(msg)') {{::msg.user}}
   .chat-controls.clearfix
     .chat-buttons
-      button.btn(type='button', ng-click='togglehidingSystemMessages()', ng-if='group.type == "party"')=env.t('hideSystemMsgs')
-      button.btn(type="button", ng-click='sync(group)', ng-disabled='_sending')=env.t('toolTipMsg')
-      input.btn(type='submit', value=env.t('sendChat'), ng-disabled='_sending')
+      button.btn(type='button', ng-click='togglehidingSystemMessages()', ng-if='group.type == "party"', tabindex='4')=env.t('hideSystemMsgs')
+      button.btn(type="button", ng-click='sync(group)', ng-disabled='_sending', tabindex='3')=env.t('toolTipMsg')
+      input.btn-primary(type='submit', value=env.t('sendChat'), ng-disabled='_sending', tabindex='2')
     include ../../shared/formatting-help

--- a/website/views/options/social/chat-box.jade
+++ b/website/views/options/social/chat-box.jade
@@ -18,6 +18,7 @@ form.chat-form(ng-if='user.flags.communityGuidelinesAccepted' ng-submit='postCha
           span.username.label.label-default(ng-class=':: userLevelStyle(msg)') {{::msg.user}}
   .chat-controls.clearfix
     .chat-buttons
-      input.btn(type='submit', value=env.t('sendChat'), ng-disabled='_sending')
+      button.btn(type='button', ng-click='togglehidingSystemMessages()')=env.t('hideSystemMsgs')
       button.btn(type="button", ng-click='sync(group)', ng-disabled='_sending')=env.t('toolTipMsg')
+      input.btn(type='submit', value=env.t('sendChat'), ng-disabled='_sending')
     include ../../shared/formatting-help

--- a/website/views/options/social/chat-message.jade
+++ b/website/views/options/social/chat-message.jade
@@ -1,7 +1,7 @@
 mixin chatMessages(inbox)
   ul.list-unstyled.tavern-chat
     - var ngRepeat = inbox ? 'message in user.inbox.messages | toArray:true | orderBy:"sort":true' : 'message in group.chat track by message.id'
-    li.chat-message(ng-repeat=ngRepeat, ng-class='{highlight: isUserMentioned(user,message) || message.uuid=="system", "own-message": user._id == message.uuid, "hide-spell": hideSpellMessage(message)}', ng-if="!message.flagCount || message.flagCount < 2 || user.contributor.admin")
+    li.chat-message(ng-repeat=ngRepeat, ng-class=':: {highlight: isUserMentioned(user,message) || message.uuid=="system", "own-message": user._id == message.uuid}', ng-if="!message.flagCount || message.flagCount < 2 || user.contributor.admin", ng-hide='hideSystemMessages && message.uuid == "system"')
       span.pull-right.text-danger(ng-if="user.contributor.admin && message.flagCount > 0")
         | {{message.flagCount > 1 ? "Message Hidden" : "1 flag"}}
       .scrollable-message(ng-class='{"transparent": message.sent || message.flags[user._id] || (user.contributor.admin && message.flagCount > 1)}')

--- a/website/views/options/social/chat-message.jade
+++ b/website/views/options/social/chat-message.jade
@@ -1,7 +1,7 @@
 mixin chatMessages(inbox)
   ul.list-unstyled.tavern-chat
     - var ngRepeat = inbox ? 'message in user.inbox.messages | toArray:true | orderBy:"sort":true' : 'message in group.chat track by message.id'
-    li.chat-message(ng-repeat=ngRepeat, ng-class=':: {highlight: isUserMentioned(user,message) || message.uuid=="system", "own-message": user._id == message.uuid}', ng-if="!message.flagCount || message.flagCount < 2 || user.contributor.admin")
+    li.chat-message(ng-repeat=ngRepeat, ng-class='{highlight: isUserMentioned(user,message) || message.uuid=="system", "own-message": user._id == message.uuid, "hide-spell": hideSpellMessage(message)}', ng-if="!message.flagCount || message.flagCount < 2 || user.contributor.admin")
       span.pull-right.text-danger(ng-if="user.contributor.admin && message.flagCount > 0")
         | {{message.flagCount > 1 ? "Message Hidden" : "1 flag"}}
       .scrollable-message(ng-class='{"transparent": message.sent || message.flags[user._id] || (user.contributor.admin && message.flagCount > 1)}')

--- a/website/views/options/social/group.jade
+++ b/website/views/options/social/group.jade
@@ -121,9 +121,6 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
               .popover-content
                 markdown(text='group.leaderMessage')
       div(ng-controller='ChatCtrl')
-        label
-          input(type='checkbox', ng-model='hideSystemMessages')
-          | &nbsp;Hide Spells
         h3=env.t('chat')
         include ./chat-box
 

--- a/website/views/options/social/group.jade
+++ b/website/views/options/social/group.jade
@@ -122,7 +122,7 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
                 markdown(text='group.leaderMessage')
       div(ng-controller='ChatCtrl')
         label
-          input(type='checkbox', ng-model='hideSpells')
+          input(type='checkbox', ng-model='hideSystemMessages')
           | &nbsp;Hide Spells
         h3=env.t('chat')
         include ./chat-box

--- a/website/views/options/social/group.jade
+++ b/website/views/options/social/group.jade
@@ -121,6 +121,9 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
               .popover-content
                 markdown(text='group.leaderMessage')
       div(ng-controller='ChatCtrl')
+        label
+          input(type='checkbox', ng-model='hideSpells')
+          | &nbsp;Hide Spells
         h3=env.t('chat')
         include ./chat-box
 


### PR DESCRIPTION
Often during quests, it is difficult to review a party's chat history due to the number of spells. I'd like to be able to temporarily toggle off spells for a quicker recap of the day.

I coded up a quick prototype and wanted to get some feedback on this idea.

![image](https://cloud.githubusercontent.com/assets/509966/8028203/76f450cc-0d65-11e5-92a1-caeaedab1308.png)
![image](https://cloud.githubusercontent.com/assets/509966/8028206/9278ad48-0d65-11e5-95d7-739a740988c0.png)

If you like it, there are some problems with this PR that I should fix:

I added a checkbox in what seemed like the easiest place, it probably is not the best place so I'd like feedback on where you would like it.

Also, I had trouble with the data-bindings. I wasn't able to figure out how to combine one-time and two-way data bindings in the `ng-class`. This is my first time working with angular, so I might be missing an easy solution.

Also, would tests be required for this sort of feature? If so, could you please direct me to the right file?
