### PR TITLE
Add summary reporters to gulp tests and make protractor specs verbose

### DIFF
--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -19,6 +19,8 @@ exports.config = {
   // Options to be passed to Jasmine-node.
   jasmineNodeOpts: {
     showColors: true,
-    defaultTimeoutInterval: 90000
+    defaultTimeoutInterval: 90000,
+    isVerbose: true,
+    displayPendingSpec: true
   }
 };


### PR DESCRIPTION
Put test summary back in (and improved upon its display, so counts show up).

Example Output:
![screenshot 2015-06-08 05 29 29](https://cloud.githubusercontent.com/assets/10201/8031855/af1168de-0d9f-11e5-8cd5-c0f9abda5d0c.png)

And in TravisLand:
![screenshot 2015-06-08 05 35 27](https://cloud.githubusercontent.com/assets/10201/8031920/392adb40-0da0-11e5-95cc-e1c25ce80a56.png)

/cc @crookedneighbor 
