### PR TITLE
Add "novalidate" to New Task field

### DIFF
--- a/website/views/shared/tasks/lists.jade
+++ b/website/views/shared/tasks/lists.jade
@@ -56,7 +56,7 @@ script(id='templates/habitrpg-tasks.html', type="text/ng-template")
           .todos-chart(ng-if='::list.type == "todo"', ng-show='charts.todos')
 
           // Add New
-          form.task-add(name='new{{list.type}}form', ng-hide='obj._locked', ng-submit='addTask(obj[list.type+"s"],list)')
+          form.task-add(name='new{{list.type}}form', ng-hide='obj._locked', ng-submit='addTask(obj[list.type+"s"],list)' novalidate)
             textarea(rows='6', task-focus='list.bulk && list.focus', ng-model='list.newTask', placeholder='{{list.placeHolderBulk}}', ng-if='list.bulk', ui-keydown='{"meta-enter ctrl-enter":"addTask(obj[list.type+\'s\'],list)"}', required)
             input(type='text', task-focus='!list.bulk && list.focus', ng-model='list.newTask', placeholder='{{list.placeHolder}}', ng-if='!list.bulk', required)
             button(type='submit', ng-disabled='new{{list.type}}form.$invalid')


### PR DESCRIPTION
Adds the "novalidate" flag to the task-add form so browser-level form validations don't act on our field. Fixes #3705.
