### PR TITLE
Refresh if idle > 60min

### DIFF
--- a/test/spec/app.js
+++ b/test/spec/app.js
@@ -1,0 +1,36 @@
+'use strict';
+
+describe('AppJS', function() {
+  describe('Automatic page refresh', function(){
+    var clock;
+    beforeEach(function () {
+      clock = sinon.useFakeTimers();
+      sinon.stub(window, "refresher", function(){return true});
+    });
+
+    afterEach(function () {
+      clock.restore();
+      window.refresher.restore();
+    });
+
+    it('should not call refresher if idle time is less than 6 hours', function() {
+      window.awaitIdle();
+      clock.tick(21599999);
+      expect(window.refresher).to.not.be.called;
+    });
+
+    it('should not call refresher if awaitIdle is called within 6 hours', function() {
+      window.awaitIdle();
+      clock.tick(21500000);
+      window.awaitIdle();
+      clock.tick(21500000);
+      expect(window.refresher).to.not.be.called;
+    });
+
+    it('should call refresher if idle time is 6 hours or greater', function() {
+      window.awaitIdle();
+      clock.tick(21600000);
+      expect(window.refresher).to.be.called;
+    });
+  });
+});

--- a/website/public/js/app.js
+++ b/website/public/js/app.js
@@ -1,7 +1,7 @@
 "use strict";
 
-/* Refresh page if idle > 60m */
-var REFRESH_FREQUENCY = 3600000;
+/* Refresh page if idle > 6h */
+var REFRESH_FREQUENCY = 21600000;
 var refresh;
 var refresher = function() {
   window.location.reload(true);
@@ -14,7 +14,7 @@ var awaitIdle = function() {
 
 awaitIdle();
 $(document).on('mousemove keydown mousedown touchstart', awaitIdle);
-/* Refresh page if idle > 60m */
+/* Refresh page if idle > 6h */
 
 window.habitrpg = angular.module('habitrpg',
     ['ui.bootstrap', 'ui.keypress', 'ui.router', 'chieffancypants.loadingBar', 'At', 'infinite-scroll', 'ui.select2', 'angular.filter', 'ngResource', 'ngSanitize'])

--- a/website/public/js/app.js
+++ b/website/public/js/app.js
@@ -1,5 +1,21 @@
 "use strict";
 
+/* Refresh page if idle > 60m */
+var REFRESH_FREQUENCY = 3600000;
+var refresh;
+var refresher = function() {
+  window.location.reload(true);
+};
+
+var awaitIdle = function() {
+  if(refresh) clearTimeout(refresh);
+  refresh = setTimeout(refresher, REFRESH_FREQUENCY);
+};
+
+awaitIdle();
+$(document).on('mousemove keydown mousedown touchstart', awaitIdle);
+/* Refresh page if idle > 60m */
+
 window.habitrpg = angular.module('habitrpg',
     ['ui.bootstrap', 'ui.keypress', 'ui.router', 'chieffancypants.loadingBar', 'At', 'infinite-scroll', 'ui.select2', 'angular.filter', 'ngResource', 'ngSanitize'])
 


### PR DESCRIPTION
Force-refresh the page if the user is idle (no mousemove, mousedown, keydown, or touchstart) in the past hour.

Can be tested manually on your local instance by setting `REFRESH_FREQUENCY = 10000` (every 10 seconds).
