### PR TITLE
Removed user.achievements.ultimateGear checks from orb of rebirth logic

### DIFF
--- a/common/script/index.coffee
+++ b/common/script/index.coffee
@@ -558,7 +558,7 @@ api.wrap = (user, main=true) ->
         user.preferences.costume = false
         # Remove unlocked features
         flags = user.flags
-        if not (user.achievements.ultimateGear or user.achievements.beastMaster)
+        if not user.achievements.beastMaster
           flags.rebirthEnabled = false
         flags.itemsEnabled = false
         flags.dropsEnabled = false
@@ -1513,7 +1513,7 @@ api.wrap = (user, main=true) ->
           user._tmp.drop = _.defaults content.quests[k],
             type: 'Quest'
             dialog: i18n.t('messageFoundQuest', {questText: content.quests[k].text(req.language)}, req.language)
-      if !user.flags.rebirthEnabled and (user.stats.lvl >= 50 or user.achievements.ultimateGear or user.achievements.beastMaster)
+      if !user.flags.rebirthEnabled and (user.stats.lvl >= 50 or user.achievements.beastMaster)
         user.flags.rebirthEnabled = true
       if user.stats.lvl >= api.maxLevel and !user.flags.freeRebirth
         user.flags.freeRebirth = true


### PR DESCRIPTION
Fixes #5352.

This removes two checks for `user.achievements.ultimateGear` from the orb of rebirth logic. 
1) From the code that's run when rebirth occurs, when determining if `flags.rebirthEnabled` should be set to false.
2) From the code that unlocks the orb of rebirth (i.e., sets `flags.rebirthEnabled` to true)
