### PR TITLE
Removed 'freeRebirth' from user model and everywhere else in codebase

### DIFF
--- a/common/locales/en/rebirth.json
+++ b/common/locales/en/rebirth.json
@@ -21,11 +21,5 @@
     "rebirthOrb": "Used an Orb of Rebirth to start over after attaining Level",
     "rebirthPop": "Begin a new character at Level 1 while retaining achievements, collectibles, and tasks with history.",
     "rebirthName": "Orb of Rebirth",
-    "reborn": "Reborn, max level <%= reLevel %>",
-    "welcome100": "Welcome to Level 100!",
-    "intro100": "Now that you've hit level 100, you have the option to use the Orb of Rebirth for free at any time.",
-    "followup100": "While you can continue to level up, it will no longer boost your stats and no more content will unlock, to keep Habit fun for folks of all play styles.",
-    "rebirth100Info": "If you're ready to start a new adventure, you can Rebirth now... or see how much further you can push yourself.",
-    "rebirthWait": "I'll wait...",
-    "rebirthNow": "Rebirth Now!"
+    "reborn": "Reborn, max level <%= reLevel %>"
 }

--- a/common/script/index.coffee
+++ b/common/script/index.coffee
@@ -1515,8 +1515,6 @@ api.wrap = (user, main=true) ->
             dialog: i18n.t('messageFoundQuest', {questText: content.quests[k].text(req.language)}, req.language)
       if !user.flags.rebirthEnabled and (user.stats.lvl >= 50 or user.achievements.ultimateGear or user.achievements.beastMaster)
         user.flags.rebirthEnabled = true
-      if user.stats.lvl >= api.maxLevel and !user.flags.freeRebirth
-        user.flags.freeRebirth = true
 
     ###
       ------------------------------------------------------

--- a/test/common/algos.mocha.coffee
+++ b/test/common/algos.mocha.coffee
@@ -703,9 +703,6 @@ describe 'Cron', ->
 
     user.lastCron = +moment().subtract(1,'days')
 
-    # this is hacky but should fix things for the moment
-    user.flags.freeRebirth = true
-
     paths = {};user.fns.cron {paths}
     expect(user.lastCron).to.be.greaterThan 0
 

--- a/website/src/models/user.js
+++ b/website/src/models/user.js
@@ -145,7 +145,6 @@ var UserSchema = new Schema({
     classSelected: {type: Boolean, 'default': false},
     mathUpdates: Boolean,
     rebirthEnabled: {type: Boolean, 'default': false},
-    freeRebirth: {type: Boolean, 'default': false},
     levelDrops: {type:Schema.Types.Mixed, 'default':{}},
     chatRevoked: Boolean,
     // Used to track the status of recapture emails sent to each user,

--- a/website/views/shared/modals/rebirth.jade
+++ b/website/views/shared/modals/rebirth.jade
@@ -50,14 +50,3 @@ script(type='text/ng-template', id='modals/rebirth.html')
       span.gem-cost(ng-if='user.stats.lvl < 100')
         | 8&nbsp;
         =env.t('gems')
-script(type='text/ng-template', id='modals/freeRebirth.html')
-  .modal-header
-    h4=env.t('welcome100')
-    figure
-      .rebirth_orb
-    p=env.t('intro100')
-    p=env.t('followup100')
-    p=env.t('rebirth100Info')
-  .modal-footer
-    button.btn.btn-default(ng-click='$close()')=env.t('rebirthWait')
-    a.btn.btn-danger(ng-click='$close(); rebirth()')=env.t('rebirthNow')


### PR DESCRIPTION
`freeRebirth` was added by @deilann for a watch that has since been removed (the watch was used to determine whether the free rebirth modal should pop-up when a user hits level 100). It isn't used anywhere in the code except for code that sets it to `true` or `false`.

This was discussed in the Wizards of the Wiki guild with @Alys and @deilann. 
