### PR TITLE
Enable in app purchase for iOS

### DIFF
--- a/test/api/inAppPurchases.coffee
+++ b/test/api/inAppPurchases.coffee
@@ -103,6 +103,11 @@ describe 'In-App Purchases', ->
 
         expect(res.json).to.not.be.called
 
+      it 'does not calls payments.buyGems function', ->
+        inApp.iosVerify(req, res, next)
+
+        expect(paymentSpy).to.not.be.called
+
     context 'iap is valid but has no purchaseDataList', ->
       before ->
         iapMock.setup = (cb)-> return cb(null)

--- a/test/api/inAppPurchases.coffee
+++ b/test/api/inAppPurchases.coffee
@@ -1,0 +1,160 @@
+'use strict'
+
+app = require('../../website/src/server')
+rewire = require('rewire')
+sinon = require('sinon')
+inApp = rewire('../../website/src/controllers/payments/iap')
+iapMock = { }
+inApp.__set__('iap', iapMock)
+
+describe 'In-App Purchases', ->
+  describe 'iOS', ->
+    req = { body: { transaction: { reciept: 'foo' } } }
+    res = { 
+      locals: { user: { _id: 'user' } } 
+      json: sinon.spy()
+    }
+    next = -> true
+    paymentSpy = sinon.spy()
+    inApp.__set__('payments.buyGems', paymentSpy)
+
+    afterEach ->
+      paymentSpy.reset()
+      res.json.reset()
+
+    context 'successful app purchase', ->
+      before ->
+        iapMock.setup = (cb)-> return cb(null)
+        iapMock.validate = (iapApple, iapBodyReciept, cb)-> return cb(null, true)
+        iapMock.isValidated = (appleRes)-> return appleRes
+        iapMock.getPurchaseData = (appleRes)-> 
+          return [{ productId: 'com.habitrpg.ios.Habitica.20gems' }]
+        iapMock.APPLE = 'apple'
+
+      it 'calls res.json with succesful result object', ->
+        expectedResObj = {
+          ok: true
+          data: true
+        }
+
+        inApp.iosVerify(req, res, next)
+
+        expect(res.json).to.be.calledOnce
+        expect(res.json).to.be.calledWith(expectedResObj)
+
+      it 'calls payments.buyGems function', ->
+        inApp.iosVerify(req, res, next)
+
+        expect(paymentSpy).to.be.calledOnce
+        expect(paymentSpy).to.be.calledWith({user: res.locals.user, paymentMethod:'IAP AppleStore'})
+
+    context 'error in setup', ->
+      before ->
+        iapMock.setup = (cb)-> return cb("error in setup")
+
+      it 'calls res.json with setup error object', ->
+        expectedResObj = {
+          ok: false
+          data: 'IAP Error'
+        }
+
+        inApp.iosVerify(req, res, next)
+
+        expect(res.json).to.be.calledOnce
+        expect(res.json).to.be.calledWith(expectedResObj)
+
+      it 'does not calls payments.buyGems function', ->
+        inApp.iosVerify(req, res, next)
+
+        expect(paymentSpy).to.not.be.called
+
+    context 'error in validation', ->
+      before ->
+        iapMock.setup = (cb)-> return cb(null)
+        iapMock.validate = (iapApple, iapBodyReciept, cb)-> return cb('error in validation', true)
+
+      it 'calls res.json with validation error object', ->
+        expectedResObj = {
+          ok: false
+          data: {
+            code: 6778001
+            message: 'error in validation'
+          }
+        }
+
+        inApp.iosVerify(req, res, next)
+
+        expect(res.json).to.be.calledOnce
+        expect(res.json).to.be.calledWith(expectedResObj)
+
+      it 'does not calls payments.buyGems function', ->
+        inApp.iosVerify(req, res, next)
+
+        expect(paymentSpy).to.not.be.called
+
+    context 'iap is not valid', ->
+      before ->
+        iapMock.setup = (cb)-> return cb(null)
+        iapMock.validate = (iapApple, iapBodyReciept, cb)-> return cb(null, false)
+        iapMock.isValidated = (appleRes)-> return appleRes
+
+      it 'does not call res.json', ->
+        inApp.iosVerify(req, res, next)
+
+        expect(res.json).to.not.be.called
+
+    context 'iap is valid but has no purchaseDataList', ->
+      before ->
+        iapMock.setup = (cb)-> return cb(null)
+        iapMock.validate = (iapApple, iapBodyReciept, cb)-> return cb(null, true)
+        iapMock.isValidated = (appleRes)-> return appleRes
+        iapMock.getPurchaseData = (appleRes)-> 
+          return []
+        iapMock.APPLE = 'apple'
+
+      it 'calls res.json with succesful result object', ->
+        expectedResObj = {
+          ok: false
+          data: {
+            code: 6778001
+            message: 'Incorrect receipt'
+          }
+        }
+
+        inApp.iosVerify(req, res, next)
+
+        expect(res.json).to.be.calledOnce
+        expect(res.json).to.be.calledWith(expectedResObj)
+
+      it 'does not calls payments.buyGems function', ->
+        inApp.iosVerify(req, res, next)
+
+        expect(paymentSpy).to.not.be.called
+
+    context 'iap is valid, has purchaseDataList, but productId does not match', ->
+      before ->
+        iapMock.setup = (cb)-> return cb(null)
+        iapMock.validate = (iapApple, iapBodyReciept, cb)-> return cb(null, true)
+        iapMock.isValidated = (appleRes)-> return appleRes
+        iapMock.getPurchaseData = (appleRes)-> 
+          return [{ productId: 'com.another.company' }]
+        iapMock.APPLE = 'apple'
+
+      it 'calls res.json with incorrect reciept obj', ->
+        expectedResObj = {
+          ok: false
+          data: {
+            code: 6778001
+            message: 'Incorrect receipt'
+          }
+        }
+
+        inApp.iosVerify(req, res, next)
+
+        expect(res.json).to.be.calledOnce
+        expect(res.json).to.be.calledWith(expectedResObj)
+
+      it 'does not calls payments.buyGems function', ->
+        inApp.iosVerify(req, res, next)
+
+        expect(paymentSpy).to.not.be.called

--- a/test/api/inAppPurchases.coffee
+++ b/test/api/inAppPurchases.coffee
@@ -209,8 +209,15 @@ describe 'In-App Purchases', ->
 
       it 'does not call res.json', ->
         inApp.iosVerify(req, res, next)
-
-        expect(res.json).to.not.be.called
+        expectedResObj = {
+          ok: false
+          data: {
+            code: 6778001
+            message: 'Invalid receipt'
+          }
+        }
+        expect(res.json).to.be.calledOnce
+        expect(res.json).to.be.calledWith(expectedResObj)
 
       it 'does not calls payments.buyGems function', ->
         inApp.iosVerify(req, res, next)
@@ -231,7 +238,7 @@ describe 'In-App Purchases', ->
           ok: false
           data: {
             code: 6778001
-            message: 'Incorrect receipt'
+            message: 'Incorrect receipt content'
           }
         }
 
@@ -259,7 +266,7 @@ describe 'In-App Purchases', ->
           ok: false
           data: {
             code: 6778001
-            message: 'Incorrect receipt'
+            message: 'Incorrect receipt content'
           }
         }
 

--- a/website/src/controllers/payments/iap.js
+++ b/website/src/controllers/payments/iap.js
@@ -84,7 +84,7 @@ exports.iosVerify = function(req, res, next) {
 
     }
 
-    // iap is ready
+    //iap is ready
     iap.validate(iap.APPLE, iapBody.transaction.receipt, function (err, appleRes) {
       if (err) {
         var resObj = {
@@ -102,6 +102,7 @@ exports.iosVerify = function(req, res, next) {
         var purchaseDataList = iap.getPurchaseData(appleRes);
         if (purchaseDataList.length > 0) {
           if (purchaseDataList[0].productId === "com.habitrpg.ios.Habitica.20gems") {
+            //Correct receipt
             payments.buyGems({user:user, paymentMethod:'IAP AppleStore'});
             var resObj = {
               ok: true,
@@ -111,16 +112,26 @@ exports.iosVerify = function(req, res, next) {
             return res.json(resObj);
           }
         }
+        //wrong receipt content
         var resObj = {
           ok: false,
           data: {
             code: INVALID_PAYLOAD,
-            message: "Incorrect receipt"
+            message: "Incorrect receipt content"
           }
         };
-
         return res.json(resObj);
       }
+      //invalid receipt
+      var resObj = {
+        ok: false,
+        data: {
+          code: INVALID_PAYLOAD,
+          message: "Invalid receipt"
+        }
+      };
+
+      return res.json(resObj);
     });
   });
 };

--- a/website/src/controllers/payments/iap.js
+++ b/website/src/controllers/payments/iap.js
@@ -6,7 +6,7 @@ var nconf = require('nconf');
 var inAppPurchase = require('in-app-purchase');
 inAppPurchase.config({
   // this is the path to the directory containing iap-sanbox/iap-live files
-  googlePublicKeyPath: nconf.get("IAP_GOOGLE_KEYDIR") 
+  googlePublicKeyPath: nconf.get("IAP_GOOGLE_KEYDIR")
 });
 
 // Validation ERROR Codes
@@ -24,15 +24,14 @@ exports.androidVerify = function(req, res, next) {
         ok: false,
         data: 'IAP Error'
       };
-    
+
       console.error('IAP Setup ERROR');
       console.error(error);
-        
-      res.json(resObj);
-        
-      return;
+
+      return res.json(resObj);
+
     }
-    
+
     /*
       google receipt must be provided as an object
       {
@@ -44,7 +43,7 @@ exports.androidVerify = function(req, res, next) {
       data: iapBody.transaction.receipt,
       signature: iapBody.transaction.signature
     };
-    
+
     // iap is ready
     iap.validate(iap.GOOGLE, testObj, function (err, googleRes) {
       if (err) {
@@ -56,9 +55,7 @@ exports.androidVerify = function(req, res, next) {
           }
         };
 
-        res.json(resObj);
-        console.error(err);
-        return;
+        return res.json(resObj);
       }
 
       if (iap.isValidated(googleRes)) {
@@ -78,7 +75,7 @@ exports.androidVerify = function(req, res, next) {
 
 exports.iosVerify = function(req, res, next) {
   console.info(req.body);
-  
+
   var iapBody = req.body;
   var user = res.locals.user;
 
@@ -92,11 +89,10 @@ exports.iosVerify = function(req, res, next) {
       console.error('IAP Setup ERROR');
       console.error(error);
 
-      res.json(resObj);
+      return res.json(resObj);
 
-      return;
     }
-    
+
     // iap is ready
     iap.validate(iap.APPLE, iapBody.transaction.receipt, function (err, appleRes) {
       if (err) {
@@ -108,9 +104,7 @@ exports.iosVerify = function(req, res, next) {
           }
         };
 
-        res.json(resObj);
-        console.error(err);
-        return;
+        return res.json(resObj);
       }
 
       if (iap.isValidated(appleRes)) {
@@ -123,8 +117,7 @@ exports.iosVerify = function(req, res, next) {
               data: appleRes
             };
             // yay good!
-            res.json(resObj);
-            return;
+            return res.json(resObj);
           }
         }
         var resObj = {
@@ -135,8 +128,7 @@ exports.iosVerify = function(req, res, next) {
           }
         };
 
-        res.json(resObj);
-        return;
+        return res.json(resObj);
       }
     });
   });

--- a/website/src/controllers/payments/iap.js
+++ b/website/src/controllers/payments/iap.js
@@ -25,9 +25,6 @@ exports.androidVerify = function(req, res, next) {
         data: 'IAP Error'
       };
 
-      console.error('IAP Setup ERROR');
-      console.error(error);
-
       return res.json(resObj);
 
     }
@@ -74,8 +71,6 @@ exports.androidVerify = function(req, res, next) {
 };
 
 exports.iosVerify = function(req, res, next) {
-  console.info(req.body);
-
   var iapBody = req.body;
   var user = res.locals.user;
 
@@ -85,9 +80,6 @@ exports.iosVerify = function(req, res, next) {
         ok: false,
         data: 'IAP Error'
       };
-
-      console.error('IAP Setup ERROR');
-      console.error(error);
 
       return res.json(resObj);
 

--- a/website/src/controllers/payments/iap.js
+++ b/website/src/controllers/payments/iap.js
@@ -114,15 +114,29 @@ exports.iosVerify = function(req, res, next) {
       }
 
       if (iap.isValidated(appleRes)) {
+        var purchaseDataList = iap.getPurchaseData(appleRes);
+        if (purchaseDataList.length > 0) {
+          if (purchaseDataList[0].productId === "com.habitrpg.ios.Habitica.20gems") {
+            payments.buyGems({user:user, paymentMethod:'IAP AppleStore'});
+            var resObj = {
+              ok: true,
+              data: appleRes
+            };
+            // yay good!
+            res.json(resObj);
+            return;
+          }
+        }
         var resObj = {
-          ok: true,
-          data: appleRes
+          ok: false,
+          data: {
+            code: INVALID_PAYLOAD,
+            message: "Incorrect receipt"
+          }
         };
 
-        payments.buyGems({user:user, paymentMethod:'IAP AppleStore'});
-            
-        // yay good!
         res.json(resObj);
+        return;
       }
     });
   });

--- a/website/src/controllers/payments/iap.js
+++ b/website/src/controllers/payments/iap.js
@@ -63,8 +63,7 @@ exports.androidVerify = function(req, res, next) {
 
         payments.buyGems({user:user, paymentMethod:'IAP GooglePlay'});
 
-        // yay good!
-        res.json(resObj);
+        return res.json(resObj);
       }
     });
   });

--- a/website/src/routes/payments.js
+++ b/website/src/routes/payments.js
@@ -18,7 +18,7 @@ router.post("/stripe/subscribe/edit", auth.auth, i18n.getUserLanguage, payments.
 router.get("/stripe/subscribe/cancel", auth.authWithUrl, i18n.getUserLanguage, payments.stripeSubscribeCancel);
 
 router.post("/iap/android/verify", auth.authWithUrl, /*i18n.getUserLanguage, */payments.iapAndroidVerify);
-router.post("/iap/ios/verify", /*auth.authWithUrl, i18n.getUserLanguage, */ payments.iapIosVerify);
+router.post("/iap/ios/verify", auth.auth, /*i18n.getUserLanguage, */ payments.iapIosVerify);
 
 router.get("/api/v2/coupons/valid-discount/:code", /*auth.authWithUrl, i18n.getUserLanguage, */ payments.validCoupon);
 


### PR DESCRIPTION
Adds authentication to the iOS IAP route (without it, it never worked, because _res.locals.user_ wasn't populated )
Also adds a check that the sent receipt has the correct identifier for gem purchases.
