### PR TITLE
Update README.md link in _README_FIRST.md files and add missing _README_FIRST.md files

### DIFF
--- a/common/locales/cs/_README_FIRST.md
+++ b/common/locales/cs/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg-shared/blob/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md

--- a/common/locales/cs/_README_FIRST.md
+++ b/common/locales/cs/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/locales/README.md

--- a/common/locales/da/_README_FIRST.md
+++ b/common/locales/da/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/locales/README.md

--- a/common/locales/da/_README_FIRST.md
+++ b/common/locales/da/_README_FIRST.md
@@ -1,0 +1,5 @@
+Do not edit any files in this directory!
+
+For more information read:
+
+https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md

--- a/common/locales/de/_README_FIRST.md
+++ b/common/locales/de/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg-shared/blob/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md

--- a/common/locales/de/_README_FIRST.md
+++ b/common/locales/de/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/locales/README.md

--- a/common/locales/en@pirate/_README_FIRST.md
+++ b/common/locales/en@pirate/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/locales/README.md

--- a/common/locales/en@pirate/_README_FIRST.md
+++ b/common/locales/en@pirate/_README_FIRST.md
@@ -1,0 +1,5 @@
+Do not edit any files in this directory!
+
+For more information read:
+
+https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md

--- a/common/locales/en_GB/_README_FIRST.md
+++ b/common/locales/en_GB/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg-shared/blob/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md

--- a/common/locales/en_GB/_README_FIRST.md
+++ b/common/locales/en_GB/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/locales/README.md

--- a/common/locales/es/_README_FIRST.md
+++ b/common/locales/es/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg-shared/blob/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md

--- a/common/locales/es/_README_FIRST.md
+++ b/common/locales/es/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/locales/README.md

--- a/common/locales/es_419/_README_FIRST.md
+++ b/common/locales/es_419/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg-shared/blob/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md

--- a/common/locales/es_419/_README_FIRST.md
+++ b/common/locales/es_419/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/locales/README.md

--- a/common/locales/fr/_README_FIRST.md
+++ b/common/locales/fr/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg-shared/blob/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md

--- a/common/locales/fr/_README_FIRST.md
+++ b/common/locales/fr/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/locales/README.md

--- a/common/locales/he/_README_FIRST.md
+++ b/common/locales/he/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg-shared/blob/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md

--- a/common/locales/he/_README_FIRST.md
+++ b/common/locales/he/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/locales/README.md

--- a/common/locales/hu/_README_FIRST.md
+++ b/common/locales/hu/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg-shared/blob/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md

--- a/common/locales/hu/_README_FIRST.md
+++ b/common/locales/hu/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/locales/README.md

--- a/common/locales/it/_README_FIRST.md
+++ b/common/locales/it/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg-shared/blob/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md

--- a/common/locales/it/_README_FIRST.md
+++ b/common/locales/it/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/locales/README.md

--- a/common/locales/ja/_README_FIRST.md
+++ b/common/locales/ja/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/locales/README.md

--- a/common/locales/ja/_README_FIRST.md
+++ b/common/locales/ja/_README_FIRST.md
@@ -1,0 +1,5 @@
+Do not edit any files in this directory!
+
+For more information read:
+
+https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md

--- a/common/locales/nl/_README_FIRST.md
+++ b/common/locales/nl/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg-shared/blob/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md

--- a/common/locales/nl/_README_FIRST.md
+++ b/common/locales/nl/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/locales/README.md

--- a/common/locales/pl/_README_FIRST.md
+++ b/common/locales/pl/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg-shared/blob/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md

--- a/common/locales/pl/_README_FIRST.md
+++ b/common/locales/pl/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/locales/README.md

--- a/common/locales/pt/_README_FIRST.md
+++ b/common/locales/pt/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg-shared/blob/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md

--- a/common/locales/pt/_README_FIRST.md
+++ b/common/locales/pt/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/locales/README.md

--- a/common/locales/ro/_README_FIRST.md
+++ b/common/locales/ro/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg-shared/blob/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md

--- a/common/locales/ro/_README_FIRST.md
+++ b/common/locales/ro/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/locales/README.md

--- a/common/locales/ru/_README_FIRST.md
+++ b/common/locales/ru/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg-shared/blob/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md

--- a/common/locales/ru/_README_FIRST.md
+++ b/common/locales/ru/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/locales/README.md

--- a/common/locales/sk/_README_FIRST.md
+++ b/common/locales/sk/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg-shared/blob/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md

--- a/common/locales/sk/_README_FIRST.md
+++ b/common/locales/sk/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/locales/README.md

--- a/common/locales/sr/_README_FIRST.md
+++ b/common/locales/sr/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/locales/README.md

--- a/common/locales/sr/_README_FIRST.md
+++ b/common/locales/sr/_README_FIRST.md
@@ -1,0 +1,5 @@
+Do not edit any files in this directory!
+
+For more information read:
+
+https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md

--- a/common/locales/sv/_README_FIRST.md
+++ b/common/locales/sv/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg-shared/blob/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md

--- a/common/locales/sv/_README_FIRST.md
+++ b/common/locales/sv/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/locales/README.md

--- a/common/locales/uk/_README_FIRST.md
+++ b/common/locales/uk/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg-shared/blob/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md

--- a/common/locales/uk/_README_FIRST.md
+++ b/common/locales/uk/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/locales/README.md

--- a/common/locales/zh/_README_FIRST.md
+++ b/common/locales/zh/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg-shared/blob/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md

--- a/common/locales/zh/_README_FIRST.md
+++ b/common/locales/zh/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/locales/README.md

--- a/common/locales/zh_TW/_README_FIRST.md
+++ b/common/locales/zh_TW/_README_FIRST.md
@@ -2,4 +2,4 @@ Do not edit any files in this directory!
 
 For more information read:
 
-https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md
+https://github.com/HabitRPG/habitrpg/blob/develop/common/locales/README.md

--- a/common/locales/zh_TW/_README_FIRST.md
+++ b/common/locales/zh_TW/_README_FIRST.md
@@ -1,0 +1,5 @@
+Do not edit any files in this directory!
+
+For more information read:
+
+https://github.com/HabitRPG/habitrpg/blob/develop/common/develop/locales/README.md


### PR DESCRIPTION
This changes the links in the `_README_FIRST.md` files from the a link to the deprecated `habitrpg-shared` repository to the appropriate file in the `habitrpg` repository. It also adds `_README_FIRST.md` to the `locales` directories that did already contain it.
