### PR TITLE
Added quest rewards to pending quest display

### DIFF
--- a/website/views/options/social/quests/questNotActive.jade
+++ b/website/views/options/social/quests/questNotActive.jade
@@ -14,6 +14,7 @@ div(ng-if='group.quest.active==false')
           strong=env.t('collect') + ': '
           | {{::Content.quests[group.quest.key].collect[k].count}} {{::Content.quests[group.quest.key].collect[k].text()}}
       div(ng-bind-html='::Content.quests[group.quest.key].notes()')
+      quest-rewards(key='{{::group.quest.key}}')
 
   hr
 


### PR DESCRIPTION
I thought this was already done in #5157, but apparently not. Whoops!

Before:
![selection_030](https://cloud.githubusercontent.com/assets/7059890/8213963/e39b7e7c-14f3-11e5-97ac-e4ea6ee0f9eb.png)

After:
![selection_031](https://cloud.githubusercontent.com/assets/7059890/8213965/e8c4d2cc-14f3-11e5-9fe6-ffba3955bd49.png)

@crookedneighbor, I noticed that in your refactor of #5157, you switched the order of the tabs depending on whether the quest is active or pending ("participants" -> "quest details" when pending; "quest details" -> "participants" when active). Was that intentional?
