### PR TITLE
Removed unused 'armorSet' attribute in user model

### DIFF
--- a/website/src/models/user.js
+++ b/website/src/models/user.js
@@ -296,7 +296,6 @@ var UserSchema = new Schema({
     }
   },
   preferences: {
-    armorSet: String,
     dayStart: {type:Number, 'default': 0, min: 0, max: 23},
     size: {type:String, enum: ['broad','slim'], 'default': 'slim'},
     hair: {


### PR DESCRIPTION
I couldn't find any instance of `armorSet` being used throughout the code, and did a recursive `grep` to be sure. It only shows up in migrations, and the [most recent migration](https://github.com/HabitRPG/habitrpg/blob/develop/migrations/20131214_classes.coffee#L30) is from December 2013.
