### PR TITLE
Ultimate gear fix

### DIFF
--- a/common/script/index.coffee
+++ b/common/script/index.coffee
@@ -698,7 +698,7 @@ api.wrap = (user, main=true) ->
         pd.push(item) unless i != -1
 
         cb? null, user.pushDevices
-      
+
       # ------
       # Inbox
       # ------
@@ -1579,7 +1579,7 @@ api.wrap = (user, main=true) ->
           _.merge plan.consecutive, {count:0, offset:0, gemCapExtra:0}
           user.markModified? 'purchased.plan'
 
-      # User is resting at the inn. 
+      # User is resting at the inn.
       # On cron, buffs are cleared and all dailies are reset without performing damage
       if user.preferences.sleep is true
         user.stats.buffs = clearBuffs
@@ -1715,7 +1715,7 @@ api.wrap = (user, main=true) ->
       owned = if window? then user.items.gear.owned else user.items.gear.owned.toObject()
       user.achievements.ultimateGearSets ?= {healer: false, wizard: false, rogue: false, warrior: false}
       content.classes.forEach (klass) ->
-        if user.achievements.ultimateGearSets[klass] is not true
+        if user.achievements.ultimateGearSets[klass] isnt true
           user.achievements.ultimateGearSets[klass] = _.reduce ['armor', 'shield', 'head', 'weapon'], (soFarGood, type) ->
             found = _.find content.gear.tree[type][klass], {last:true}
             soFarGood and (!found or owned[found.key]==true) #!found only true when weapon is two-handed (mages)

--- a/test/common/user.fns.js
+++ b/test/common/user.fns.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var shared = require('../../common/script/index.coffee');
+shared.i18n.translations = require('../../website/src/i18n.js').translations
+
+require('./test_helper');
+
+describe('User.fns', function() {
+  describe('.ultimateGear', function() {
+
+    it('sets armoirEnabled when partial achievement already achieved', function() {
+      var user = shared.wrap({
+        items: { gear: { owned: {
+          toObject: function() { return {
+            armor_warrior_5:  true,
+            shield_warrior_5: true,
+            head_warrior_5:   true,
+            weapon_warrior_6: true
+          }}
+        }}},
+        achievements: {
+          ultimateGearSets: {}
+        },
+        flags: {}
+      });
+      user.fns.ultimateGear();
+      expect(user.flags.armoireEnabled).to.equal(true);
+    });
+  });
+});


### PR DESCRIPTION
Fixed a data-dependency issue with the Armoire achievement.

@SabreCat quick note (this is a CoffeeScript idiosyncrasy), but `is not` is semantically different from `isnt`, which was causing an issue in cases where the `ultimateGearSets` attribute was already defined. 

Specifically:

``` coffee
if user.achievements.ultimateGearSets[klass] is not true
```

...compiles to:

``` js
if (user.achievements.ultimateGearSets[klass] === !true)
```

Whereas

``` coffee
if user.achievements.ultimateGearSets[klass] isnt true
```

...translates to:

``` js
if (user.achievements.ultimateGearSets[klass] !== true)
```

One of those quirks of CoffeeScript, but it ended up causing an edge-case error in this case. Should be all set now (and we should be moving away from CS eventually anyway :smile:)

@Alys this should address the existing bug for any new data that wasn't covered by the migration. Test has been added to verify behavior going forward.
