### PR TITLE
add track by statement to all ng-repeat attributes

### DIFF
--- a/website/views/main/filters.jade
+++ b/website/views/main/filters.jade
@@ -28,13 +28,13 @@
             button(ng-click='createTag()')=env.t('add')
       div(ng-if='!areTagsHidden || _editing')
         ul(ng-if='_editing')
-          li.filters-edit(ng-class='{active: user.filters[tag.id]}', ng-repeat='tag in user.tags', bindonce='user.tags')
+          li.filters-edit(ng-class='{active: user.filters[tag.id]}', ng-repeat='tag in user.tags track by $index', bindonce='user.tags')
             form.hrpg-input-group
               input(type='text', ng-model='tag.name', ui-keyup="{13: 'saveOrEdit()'}")
               button(type='button', ng-click='user.ops.deleteTag({params:{id:tag.id}})')
                 span.glyphicon.glyphicon-trash
         ul(ng-if='!_editing', hrpg-sort-tags)
-          li.filters-tags(ng-class='{active: user.filters[tag.id], challenge: tag.challenge}', ng-repeat='tag in user.tags', bindonce='user.tags')
+          li.filters-tags(ng-class='{active: user.filters[tag.id], challenge: tag.challenge}', ng-repeat='tag in user.tags track by $index', bindonce='user.tags')
             a(ng-click='toggleFilter(tag)')
               span.glyphicon.glyphicon-bullhorn(ng-if="::tag.challenge")
               markdown(text='tag.name')

--- a/website/views/main/filters.jade
+++ b/website/views/main/filters.jade
@@ -28,13 +28,13 @@
             button(ng-click='createTag()')=env.t('add')
       div(ng-if='!areTagsHidden || _editing')
         ul(ng-if='_editing')
-          li.filters-edit(ng-class='{active: user.filters[tag.id]}', ng-repeat='tag in user.tags track by $index', bindonce='user.tags')
+          li.filters-edit(ng-class='{active: user.filters[tag.id]}', ng-repeat='tag in user.tags', bindonce='user.tags')
             form.hrpg-input-group
               input(type='text', ng-model='tag.name', ui-keyup="{13: 'saveOrEdit()'}")
               button(type='button', ng-click='user.ops.deleteTag({params:{id:tag.id}})')
                 span.glyphicon.glyphicon-trash
         ul(ng-if='!_editing', hrpg-sort-tags)
-          li.filters-tags(ng-class='{active: user.filters[tag.id], challenge: tag.challenge}', ng-repeat='tag in user.tags track by $index', bindonce='user.tags')
+          li.filters-tags(ng-class='{active: user.filters[tag.id], challenge: tag.challenge}', ng-repeat='tag in user.tags', bindonce='user.tags')
             a(ng-click='toggleFilter(tag)')
               span.glyphicon.glyphicon-bullhorn(ng-if="::tag.challenge")
               markdown(text='tag.name')

--- a/website/views/options/inventory/inventory.jade
+++ b/website/views/options/inventory/inventory.jade
@@ -6,8 +6,8 @@ script(type='text/ng-template', id='partials/options.inventory.equipment.html')
         div
           button.btn.btn-default(type="button", ng-click='dequip("battleGear");') {{env.t("unequipBattleGear")}}
         li.customize-menu.inventory-gear
-          menu.pets-menu(label='{{::label}}', ng-repeat='(klass,label) in {warrior:env.t("warrior"), wizard:env.t("mage"), rogue:env.t("rogue"), healer:env.t("healer"), special:env.t("special"), mystery:env.t("mystery"), armoire:env.t("armoireText")}', ng-show='gear[klass]')
-            div(ng-repeat='item in gear[klass]')
+          menu.pets-menu(label='{{::label}}', ng-repeat='(klass,label) in {warrior:env.t("warrior"), wizard:env.t("mage"), rogue:env.t("rogue"), healer:env.t("healer"), special:env.t("special"), mystery:env.t("mystery"), armoire:env.t("armoireText")} track by $index', ng-show='gear[klass]')
+            div(ng-repeat='item in gear[klass] track by $index')
               button.customize-option(popover='{{::item.notes()}}', popover-title='{{::item.text()}}', popover-trigger='mouseenter', popover-placement='right', popover-append-to-body='true', ng-click='user.ops.equip({params:{key:item.key}})', class='shop_{{::item.key}}', ng-class='{selectableInventory: user.items.gear.equipped[item.type] == item.key}')
       .col-md-6
         h3.equipment-title.hint(popover-trigger='mouseenter', popover-placement='right', popover-append-to-body='true', popover=env.t('costumeText'))=env.t('costume')
@@ -20,8 +20,8 @@ script(type='text/ng-template', id='partials/options.inventory.equipment.html')
           button.btn.btn-default(type="button", ng-click='dequip("costume");') {{env.t("unequipCostume")}}
           button.btn.btn-default(type="button", ng-click='dequip("petMountBackground");') {{env.t("unequipPetMountBackground")}}
         li.customize-menu(ng-if='user.preferences.costume')
-          menu.pets-menu(label='{{::label}}', ng-repeat='(klass,label) in {warrior:env.t("warrior"), wizard:env.t("mage"), rogue:env.t("rogue"), healer:env.t("healer"), special:env.t("special"), mystery:env.t("mystery"), armoire:env.t("armoireText")}', ng-show='gear[klass]')
-            div(ng-repeat='item in gear[klass]')
+          menu.pets-menu(label='{{::label}}', ng-repeat='(klass,label) in {warrior:env.t("warrior"), wizard:env.t("mage"), rogue:env.t("rogue"), healer:env.t("healer"), special:env.t("special"), mystery:env.t("mystery"), armoire:env.t("armoireText")} track by $index', ng-show='gear[klass]')
+            div(ng-repeat='item in gear[klass] track by $index')
               button.customize-option(popover='{{::item.notes()}}', popover-title='{{::item.text()}}', popover-trigger='mouseenter', popover-placement='right', popover-append-to-body='true', ng-click='user.ops.equip({params:{type:"costume", key:item.key}})', class='shop_{{::item.key}}', ng-class='{selectableInventory: user.items.gear.costume[item.type] == item.key}')
 
 script(type='text/ng-template', id='partials/options.inventory.seasonalshop.html')
@@ -37,14 +37,14 @@ script(type='text/ng-template', id='partials/options.inventory.seasonalshop.html
             p!=env.t('seasonalShopSummerText')
     .well(ng-if='User.user.achievements.rebirths > 0')=env.t('seasonalShopRebirth')
     li.customize-menu.inventory-gear
-      menu.pets-menu(label='{{::label}}', ng-repeat='(set,label) in ::{summerWarrior:env.t("daringSwashbucklerSet"), summerMage:env.t("emeraldMermageSet"), summerHealer:env.t("reefSeahealerSet"), summerRogue:env.t("roguishPirateSet")}')
-        div(ng-repeat='item in ::getSeasonalShopArray(set)' ng-class="{transparent: user.items.gear.owned[item.key] === true ||user.items.gear.owned[item.key] === false}")
+      menu.pets-menu(label='{{::label}}', ng-repeat='(set,label) in ::{summerWarrior:env.t("daringSwashbucklerSet"), summerMage:env.t("emeraldMermageSet"), summerHealer:env.t("reefSeahealerSet"), summerRogue:env.t("roguishPirateSet")} track by $index')
+        div(ng-repeat='item in ::getSeasonalShopArray(set) track by $index' ng-class="{transparent: user.items.gear.owned[item.key] === true ||user.items.gear.owned[item.key] === false}")
           button.customize-option(popover='{{::item.notes()}}', popover-title='{{::item.text()}}', popover-trigger='mouseenter', popover-placement='right', popover-append-to-body='true', ng-click='purchase(item.type,item)', class='shop_{{::item.key}}')
           .text-left
             | {{((item.specialClass == "wizard") && (item.type == "weapon")) + 1}}&nbsp;
             span.Pet_Currency_Gem1x.inline-gems
       // menu.pets-menu(label=env.t('quests'))
-        div(ng-repeat='quest in ::getSeasonalShopQuests()')
+        div(ng-repeat='quest in ::getSeasonalShopQuests() track by $index')
           button.customize-option(data-popover-html="{{::quest.previous && !user.achievements.quests[quest.previous] ? env.t('scrollsPre') : questPopover(quest) | markdown}}", popover-append-to-body='true', popover-title='{{::quest.text()}}', popover-trigger='mouseenter', popover-placement='right', ng-click='buyQuest(quest.key)', ng-class='(quest.previous && !user.achievements.quests[quest.previous]) ? "inventory_quest_scroll_locked inventory_quest_scroll_{{::quest.key}}_locked locked" : "inventory_quest_scroll inventory_quest_scroll_{{::quest.key}}"')
           p
             | {{::quest.value}}&nbsp;
@@ -92,8 +92,8 @@ script(type='text/ng-template', id='partials/options.inventory.timetravelers.htm
 
       .col-md-12
         li.customize-menu.inventory-gear
-          menu.pets-menu(label='{{::set.text}}', ng-repeat='set in Content.timeTravelerStore(user.items.gear.owned)')
-            div(ng-repeat='item in set.items')
+          menu.pets-menu(label='{{::set.text}}', ng-repeat='set in Content.timeTravelerStore(user.items.gear.owned) track by $index')
+            div(ng-repeat='item in set.items track by $index')
               button.customize-option(popover='{{::item.notes()}}', popover-title='{{::item.text()}}', popover-trigger='mouseenter', popover-placement='right', popover-append-to-body='true', ng-click='user.ops.buyMysterySet({params:{key:set.key}})', class='shop_{{::item.key}}')
 
 script(type='text/ng-template', id='partials/options.inventory.drops.html')
@@ -107,7 +107,7 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
           li.customize-menu
             menu.pets-menu(label=(env.t('eggs') + ' ({{eggCount}})'))
               p.muted(ng-show='eggCount < 1')=env.t('noEggs')
-              div(ng-repeat='(egg,points) in ownedItems(user.items.eggs)')
+              div(ng-repeat='(egg,points) in ownedItems(user.items.eggs) track by $index')
                 //TODO move positioning this styling to css
                 button.customize-option(popover='{{::Content.eggs[egg].notes()}}', popover-title!=env.t("egg", {eggType: "{{::Content.eggs[egg].text()}}"}), popover-trigger='mouseenter', popover-placement='right', popover-append-to-body='true', ng-click='chooseEgg(egg)', class='Pet_Egg_{{::egg}}', ng-class='{selectableInventory: selectedPotion && !(user.items.pets[egg+"-"+selectedPotion.key]>0)}')
                   .badge.badge-info.stack-count {{points}}
@@ -116,7 +116,7 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
           li.customize-menu
             menu.hatchingPotion-menu(label=(env.t('hatchingPotions') + ' ({{potCount}})'))
               p.muted(ng-show='potCount < 1')=env.t('noHatchingPotions')
-              div(ng-repeat='(pot,points) in ownedItems(user.items.hatchingPotions)')
+              div(ng-repeat='(pot,points) in ownedItems(user.items.hatchingPotions) track by $index')
                 button.customize-option(popover='{{::Content.hatchingPotions[pot].notes()}}', popover-title!=env.t("potion", {potionType: "{{::Content.hatchingPotions[pot].text()}}"}), popover-trigger='mouseenter', popover-placement='right', popover-append-to-body='true', ng-click='choosePotion(pot)', class='Pet_HatchingPotion_{{::pot}}', ng-class='{selectableInventory: selectedEgg && !(user.items.pets[selectedEgg.key+"-"+pot]>0)}')
                   .badge.badge-info.stack-count {{points}}
 
@@ -124,14 +124,14 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
             menu.pets-menu(label=(env.t('quests') + ' ({{questCount}})'))
               p.muted(ng-show='questCount < 1')=env.t('noScrolls')
               p.muted!=env.t('scrollsText1') + ' <a href="/#/options/groups/party">' + env.t('scrollsText2') + '</a>'
-              div(ng-repeat='(quest_key,points) in ownedItems(user.items.quests)', ng-init='quest = Content.quests[quest_key]')
+              div(ng-repeat='(quest_key,points) in ownedItems(user.items.quests) track by $index', ng-init='quest = Content.quests[quest_key]')
                 button.customize-option(data-popover-html="{{:: quest.previous && !user.achievements.quests[quest.previous] ? env.t('scrollsPre') : questPopover(quest) | markdown}}", popover-title='{{::quest.text()}}', popover-trigger='mouseenter', popover-placement='right', popover-append-to-body='true', ng-click='showQuest(quest_key)', ng-class='(quest.previous && !user.achievements.quests[quest.previous]) ? "inventory_quest_scroll_locked inventory_quest_scroll_{{::quest.key}}_locked locked" : "inventory_quest_scroll inventory_quest_scroll_{{::quest.key}}"')
                   .badge.badge-info.stack-count {{points}}
 
           li.customize-menu
             menu.pets-menu(label=env.t('food') + ' ({{foodCount}})')
               p.muted(ng-show='foodCount < 1')=env.t('noFood')
-              div(ng-repeat='(food,points) in ownedItems(user.items.food)')
+              div(ng-repeat='(food,points) in ownedItems(user.items.food) track by $index')
                 button.customize-option(popover='{{::Content.food[food].notes()}}', popover-title='{{::Content.food[food].text()}}', popover-trigger='mouseenter', popover-placement='right', popover-append-to-body='true', ng-click='chooseFood(food)', class='Pet_Food_{{::food}}')
                   .badge.badge-info.stack-count {{points}}
 
@@ -184,7 +184,7 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
             li.customize-menu
               menu.pets-menu(label=env.t('eggs'))
                 p.muted!=env.t('dropsExplanation')
-                div(ng-repeat='egg in Content.eggs', ng-if='egg.canBuy')
+                div(ng-repeat='egg in Content.eggs track by $index', ng-if='egg.canBuy')
                   button.customize-option(popover='{{::egg.notes()}}', popover-title!=env.t("egg", {eggType: "{{::egg.text()}}"}), popover-trigger='mouseenter', popover-placement='top', popover-append-to-body='true', ng-click='purchase("eggs", egg)', class='Pet_Egg_{{::egg.key}}')
                   p
                     |  {{::egg.value}}&nbsp;
@@ -205,7 +205,7 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
             li.customize-menu
               menu.pets-menu(label=env.t('hatchingPotions'))
                 p.muted!=env.t('dropsExplanation')
-                div(ng-repeat='pot in Content.hatchingPotions')
+                div(ng-repeat='pot in Content.hatchingPotions track by $index')
                   button.customize-option(popover='{{::pot.notes()}}', popover-title!=env.t("potion", {potionType: "{{::pot.text()}}"}), popover-trigger='mouseenter', popover-placement='top', popover-append-to-body='true', ng-click='purchase("hatchingPotions", pot)', class='Pet_HatchingPotion_{{::pot.key}}')
                   p
                     |  {{::pot.value}}&nbsp;
@@ -214,7 +214,7 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
             li.customize-menu
               menu.pets-menu(label=env.t('food'))
                 p.muted!=env.t('dropsExplanation')
-                div(ng-repeat='food in Content.food', ng-if='food.canBuy')
+                div(ng-repeat='food in Content.food track by $index', ng-if='food.canBuy')
                   button.customize-option(popover='{{::food.notes()}}', popover-title='{{::food.text()}}', popover-trigger='mouseenter', popover-placement='top', popover-append-to-body='true', ng-click='purchase("food", food)', class='Pet_Food_{{::food.key}}')
                   p
                     |  {{::food.value}}&nbsp;
@@ -223,7 +223,7 @@ script(type='text/ng-template', id='partials/options.inventory.drops.html')
             li.customize-menu
               menu.pets-menu(label=env.t('quests'))
                 p.muted!=env.t('scrollsText1') + ' <a href="/#/options/groups/party">' + env.t('scrollsText2') + '</a>'
-                div(ng-repeat='quest in Content.quests', ng-if='quest.canBuy')
+                div(ng-repeat='quest in Content.quests track by $index', ng-if='quest.canBuy')
                   button.customize-option(data-popover-html="{{::quest.previous && !user.achievements.quests[quest.previous] ? env.t('scrollsPre') : questPopover(quest) | markdown}}", popover-title='{{::quest.text()}}', popover-append-to-body="true", popover-trigger='mouseenter', ng-click='buyQuest(quest.key)', ng-class='(quest.previous && !user.achievements.quests[quest.previous]) ? "inventory_quest_scroll_locked inventory_quest_scroll_{{::quest.key}}_locked locked" : "inventory_quest_scroll inventory_quest_scroll_{{::quest.key}}"')
                   p
                     |  {{::quest.value}}&nbsp;

--- a/website/views/options/inventory/stable.jade
+++ b/website/views/options/inventory/stable.jade
@@ -91,7 +91,7 @@ script(type='text/ng-template', id='partials/options.inventory.pets.html')
       menu.inventory-list(type='list', ng-if='foodCount > 0')
         li.customize-menu
           menu.pets-menu(label=env.t('food'))
-            div(ng-repeat='(food,points) in ownedItems(user.items.food)')
+            div(ng-repeat='(food,points) in ownedItems(user.items.food) track by $index')
               button.customize-option(popover-append-to-body='true', popover='{{:: Content.food[food].notes()}}', popover-title='{{:: Content.food[food].text()}}', popover-trigger='mouseenter', popover-placement='top', ng-click='chooseFood(food)', ng-class='{selectableInventory: selectedFood == Content.food[food]}', class='Pet_Food_{{::food}}')
                 .badge.badge-info.stack-count {{points}}
               // Remove this once we have images in

--- a/website/views/options/profile.jade
+++ b/website/views/options/profile.jade
@@ -62,7 +62,7 @@ mixin customizeProfile(mobile)
           span(ng-hide='#{showPath("user.items.gear.owned", gearGroup("animal"), "&&")}')
             +gemCost(2)
               button.btn.btn-xs(ng-click='#{unlockPath("items.gear.owned", gearGroup("animal"))}')!= env.t('unlockSet', {cost: 5}) + ' <span class="Pet_Currency_Gem1x inline-gems"/>'
-          button.customize-option(ng-repeat='item in ::getGearArray("animal")' ng-class="{locked: user.items.gear.owned[item.key] == undefined, selectableInventory: user.preferences.costume ? user.items.gear.costume.headAccessory == item.key : user.items.gear.equipped.headAccessory == item.key}", popover='{{::item.notes()}}', popover-title='{{::item.text()}}', popover-trigger='mouseenter', popover-placement='right', popover-append-to-body='true', ng-click='purchase(item.type,item)', class='{{::item.key}}')
+          button.customize-option(ng-repeat='item in ::getGearArray("animal") track by $index' ng-class="{locked: user.items.gear.owned[item.key] == undefined, selectableInventory: user.preferences.costume ? user.items.gear.costume.headAccessory == item.key : user.items.gear.equipped.headAccessory == item.key}", popover='{{::item.notes()}}', popover-title='{{::item.text()}}', popover-trigger='mouseenter', popover-placement='right', popover-append-to-body='true', ng-click='purchase(item.type,item)', class='{{::item.key}}')
 
     .col-md-4
         h3(class=mobile?'item item-divider':'')=env.t('bodyHead')

--- a/website/views/options/settings.jade
+++ b/website/views/options/settings.jade
@@ -205,7 +205,7 @@ script(type='text/ng-template', id='partials/options.settings.api.html')
               th Webhook URL
               th
           tbody
-            tr(ng-repeat="webhook in user.preferences.webhooks track by $index | toArray:true | orderBy:'sort'")
+            tr(ng-repeat="webhook in user.preferences.webhooks | toArray:true | orderBy:'sort' track by $index")
               td
                 input(type='checkbox', ng-model='webhook.enabled', ng-change='saveWebhook(webhook.$key,webhook)')
               td
@@ -370,7 +370,7 @@ script(id='partials/options.settings.subscription.html',type='text/ng-template')
               li Mystic Hourglasses: {{user.purchased.plan.consecutive.trinkets}}
         div(ng-if='!user.purchased.plan.customerId || (user.purchased.plan.customerId && user.purchased.plan.dateTerminated)')
           .form-group
-            .radio(ng-repeat='block in Content.subscriptionBlocks track by $index | toArray | omit: "discount==true" | orderBy:"months"')
+            .radio(ng-repeat='block in Content.subscriptionBlocks | toArray | omit: "discount==true" | orderBy:"months" track by $index')
               label
                 input(type="radio", name="subRadio", ng-value="block.key", ng-model='_subscription.key')
                 span(ng-show='block.original')

--- a/website/views/options/settings.jade
+++ b/website/views/options/settings.jade
@@ -205,7 +205,7 @@ script(type='text/ng-template', id='partials/options.settings.api.html')
               th Webhook URL
               th
           tbody
-            tr(ng-repeat="webhook in user.preferences.webhooks | toArray:true | orderBy:'sort'")
+            tr(ng-repeat="webhook in user.preferences.webhooks track by $index | toArray:true | orderBy:'sort'")
               td
                 input(type='checkbox', ng-model='webhook.enabled', ng-change='saveWebhook(webhook.$key,webhook)')
               td
@@ -370,7 +370,7 @@ script(id='partials/options.settings.subscription.html',type='text/ng-template')
               li Mystic Hourglasses: {{user.purchased.plan.consecutive.trinkets}}
         div(ng-if='!user.purchased.plan.customerId || (user.purchased.plan.customerId && user.purchased.plan.dateTerminated)')
           .form-group
-            .radio(ng-repeat='block in Content.subscriptionBlocks | toArray | omit: "discount==true" | orderBy:"months"')
+            .radio(ng-repeat='block in Content.subscriptionBlocks track by $index | toArray | omit: "discount==true" | orderBy:"months"')
               label
                 input(type="radio", name="subRadio", ng-value="block.key", ng-model='_subscription.key')
                 span(ng-show='block.original')

--- a/website/views/options/social/challenge-box.jade
+++ b/website/views/options/social/challenge-box.jade
@@ -8,7 +8,7 @@
   .panel-body.modal-fixed-height(bindonce='group.challenges')
     div(ng-if='group.challenges.length > 0')
       table.table.table-striped
-        tr(ng-repeat='challenge in group.challenges')
+        tr(ng-repeat='challenge in group.challenges track by $index')
           td
             a(ui-sref='options.social.challenges.detail({cid:challenge._id})') {{challenge.name}}
     div(ng-if='group.challenges.length == 0')

--- a/website/views/options/social/challenges.jade
+++ b/website/views/options/social/challenges.jade
@@ -3,7 +3,7 @@ script(type='text/ng-template', id='partials/options.social.challenges.detail.cl
   h5= '- ' + env.t('or') + ' -'
   select(ui-select2, ng-required=true, ng-model='closingChal.winner', data-placeholder=env.t('selectWinner'), ng-change='selectWinner(closingChal)', style='display:block')
     option(value='')
-    option(ng-repeat='u in closingChal.members', value='{{u._id}}') {{u.profile.name}}
+    option(ng-repeat='u in closingChal.members track by $index', value='{{u._id}}') {{u.profile.name}}
 
   .text-right
     small.btn-link(ng-click='cancelClosing(closingChal)')=env.t('cancel')
@@ -56,7 +56,7 @@ script(type='text/ng-template', id='partials/options.social.challenges.detail.ht
   // Accordion version if we choose that instead
   //- div(ng-if='challenge.members')
     h4=env.t('hows')
-    .accordion-group(bindonce='challenge.members', ng-repeat='member in challenge.members')
+    .accordion-group(bindonce='challenge.members', ng-repeat='member in challenge.members track by $index')
       .accordion-heading
         a.accordion-toggle(ng-click='toggleMember(challenge._id, member._id)') {{member.profile.name}}
       .accordion-body(ng-class='{collapse: $stateParams.uid != member._id}')
@@ -74,7 +74,7 @@ script(type='text/ng-template', id='partials/options.social.challenges.html')
             a.btn.btn-xs.btn-default.pull-left(ng-click='selectAll()')=env.t('all')
             a.btn.btn-xs.btn-default(ng-click='selectNone()')=env.t('none')
           br
-          .checkbox(ng-repeat='group in groupsFilter')
+          .checkbox(ng-repeat='group in groupsFilter track by $index')
             label
               input(type='checkbox', ng-model='search.group[group._id]')
               | {{group.name}}

--- a/website/views/options/social/chat-box.jade
+++ b/website/views/options/social/chat-box.jade
@@ -14,7 +14,7 @@ form.chat-form(ng-if='user.flags.communityGuidelinesAccepted' ng-submit='postCha
     textarea.form-control(rows=4, ui-keydown='{"meta-enter":"postChat(group,message.content)"}', ui-keypress='{13:"postChat(group,message.content)"}', ng-model='message.content', updateinterval='250', flag='@', at-user, auto-complete placeholder="{{group._id == 'habitrpg' ? env.t('tavernCommunityGuidelinesPlaceholder') : ''}}", ng-disabled='_sending == true')
     span.user-list
       ul.list-at-user(ng-show="query")
-        li(ng-repeat='msg in response track by $index | filter:filterUser | limitTo: 5', ng-click='performCompletion(msg)')
+        li(ng-repeat='msg in response | filter:filterUser | limitTo: 5 track by $index', ng-click='performCompletion(msg)')
           span.username.label.label-default(ng-class=':: userLevelStyle(msg)') {{::msg.user}}
   .chat-controls.clearfix
     .chat-buttons

--- a/website/views/options/social/chat-box.jade
+++ b/website/views/options/social/chat-box.jade
@@ -14,7 +14,7 @@ form.chat-form(ng-if='user.flags.communityGuidelinesAccepted' ng-submit='postCha
     textarea.form-control(rows=4, ui-keydown='{"meta-enter":"postChat(group,message.content)"}', ui-keypress='{13:"postChat(group,message.content)"}', ng-model='message.content', updateinterval='250', flag='@', at-user, auto-complete placeholder="{{group._id == 'habitrpg' ? env.t('tavernCommunityGuidelinesPlaceholder') : ''}}", ng-disabled='_sending == true')
     span.user-list
       ul.list-at-user(ng-show="query")
-        li(ng-repeat='msg in response | filter:filterUser | limitTo: 5', ng-click='performCompletion(msg)')
+        li(ng-repeat='msg in response track by $index | filter:filterUser | limitTo: 5', ng-click='performCompletion(msg)')
           span.username.label.label-default(ng-class=':: userLevelStyle(msg)') {{::msg.user}}
   .chat-controls.clearfix
     .chat-buttons

--- a/website/views/options/social/chat-message.jade
+++ b/website/views/options/social/chat-message.jade
@@ -1,6 +1,6 @@
 mixin chatMessages(inbox)
   ul.list-unstyled.tavern-chat
-    - var ngRepeat = inbox ? 'message in user.inbox.messages | toArray:true | orderBy:"sort":true' : 'message in group.chat track by message.id'
+    - var ngRepeat = inbox ? 'message in user.inbox.messages track by $index | toArray:true | orderBy:"sort":true' : 'message in group.chat track by message.id'
     li.chat-message(ng-repeat=ngRepeat, ng-class=':: {highlight: isUserMentioned(user,message) || message.uuid=="system", "own-message": user._id == message.uuid}', ng-if="!message.flagCount || message.flagCount < 2 || user.contributor.admin")
       span.pull-right.text-danger(ng-if="user.contributor.admin && message.flagCount > 0")
         | {{message.flagCount > 1 ? "Message Hidden" : "1 flag"}}

--- a/website/views/options/social/chat-message.jade
+++ b/website/views/options/social/chat-message.jade
@@ -1,6 +1,6 @@
 mixin chatMessages(inbox)
   ul.list-unstyled.tavern-chat
-    - var ngRepeat = inbox ? 'message in user.inbox.messages track by $index | toArray:true | orderBy:"sort":true' : 'message in group.chat track by message.id'
+    - var ngRepeat = inbox ? 'message in user.inbox.messages | toArray:true | orderBy:"sort":true track by $index' : 'message in group.chat track by message.id'
     li.chat-message(ng-repeat=ngRepeat, ng-class=':: {highlight: isUserMentioned(user,message) || message.uuid=="system", "own-message": user._id == message.uuid}', ng-if="!message.flagCount || message.flagCount < 2 || user.contributor.admin")
       span.pull-right.text-danger(ng-if="user.contributor.admin && message.flagCount > 0")
         | {{message.flagCount > 1 ? "Message Hidden" : "1 flag"}}

--- a/website/views/options/social/group.jade
+++ b/website/views/options/social/group.jade
@@ -101,7 +101,7 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
 
           h4(ng-show='group.invites.length > 0')=env.t('invited')
           table.table.table-striped
-            tr(ng-repeat='invite in group.invites')
+            tr(ng-repeat='invite in group.invites track by $index')
               td.media
                 // allow leaders to ban members
                 div.pull-left(ng-show='group.leader._id == user.id')

--- a/website/views/options/social/hall.jade
+++ b/website/views/options/social/hall.jade
@@ -76,7 +76,7 @@ script(type='text/ng-template', id='partials/options.social.hall.heroes.html')
         th=env.t('title')
         th=env.t('contributions')
     tbody
-      tr(ng-repeat='hero in heroes')
+      tr(ng-repeat='hero in heroes track by $index')
         td
           span(ng-if='hero.contributor.admin',popover=env.t('gamemaster'),popover-trigger='mouseenter',popover-placement='right')
             a.label.label-default(ng-class='userLevelStyle(hero)', ng-click='clickMember(hero._id, true)')
@@ -98,7 +98,7 @@ script(type='text/ng-template', id='partials/options.social.hall.patrons.html')
         th(ng-if='user.contributor.admin')=env.t('UUID')
         th=env.t('backerTier')
     tbody
-      tr(ng-repeat='patron in patrons')
+      tr(ng-repeat='patron in patrons track by $index')
         td
           a.label.label-default(ng-class='userLevelStyle(patron)', ng-click='clickMember(patron._id, true)') {{patron.profile.name}}
         td(ng-if='user.contributor.admin') {{patron._id}}

--- a/website/views/options/social/index.jade
+++ b/website/views/options/social/index.jade
@@ -49,7 +49,7 @@ script(type='text/ng-template', id='partials/options.social.guilds.public.html')
   div.container-fluid(style='margin-bottom: 1.5em')
     input.form-control(type='text',ng-model='guildSearch', placeholder=env.t('search'))
   table.table.table-striped(style='clear:left;')
-    tr(ng-repeat='group in groups.public track by $index | filter:guildSearch track by group._id')
+    tr(ng-repeat='group in groups.public | filter:guildSearch track by group._id')
       td
         ul.pull-right.challenge-accordion-header-specs
           li='{{::group.memberCount}} ' + env.t('members')

--- a/website/views/options/social/index.jade
+++ b/website/views/options/social/index.jade
@@ -41,7 +41,7 @@ script(type='text/ng-template', id='partials/options.social.party.html')
       include ./create-group
 
 script(type='text/ng-template', id='partials/options.social.guilds.public.html')
-  div.col-xs-12(ng-repeat='invitation in user.invitations.guilds' style='margin-bottom: 1.5em')
+  div.col-xs-12(ng-repeat='invitation in user.invitations.guilds track by $index' style='margin-bottom: 1.5em')
     h3=env.t('invitedTo', {name: '{{invitation.name}}'})
     a.btn.btn-success(data-type='guild', ng-click='join(invitation)')=env.t('accept')
     a.btn.btn-danger(ng-click='reject(invitation)')=env.t('reject')
@@ -49,7 +49,7 @@ script(type='text/ng-template', id='partials/options.social.guilds.public.html')
   div.container-fluid(style='margin-bottom: 1.5em')
     input.form-control(type='text',ng-model='guildSearch', placeholder=env.t('search'))
   table.table.table-striped(style='clear:left;')
-    tr(ng-repeat='group in groups.public | filter:guildSearch track by group._id')
+    tr(ng-repeat='group in groups.public track by $index | filter:guildSearch track by group._id')
       td
         ul.pull-right.challenge-accordion-header-specs
           li='{{::group.memberCount}} ' + env.t('members')

--- a/website/views/options/social/quests/collectionStats.jade
+++ b/website/views/options/social/quests/collectionStats.jade
@@ -1,7 +1,7 @@
 div(class="quest_{{::group.quest.key}}")
 h4=env.t('collected') + ':'
 table.table.table-striped
-  tr(ng-repeat='(item,number) in group.quest.progress.collect', 
+  tr(ng-repeat='(item,number) in group.quest.progress.collect track by $index', 
     class='quest_collected_{{number >= Content.quests[group.quest.key].collect[item].count}}')
     td
       .pull-left(class='quest_{{::group.quest.key}}_{{::item}}')

--- a/website/views/options/social/quests/questNotActive.jade
+++ b/website/views/options/social/quests/questNotActive.jade
@@ -10,7 +10,7 @@ div(ng-if='group.quest.active==false')
         p: strong=env.t('bossHP') + ': {{::Content.quests[group.quest.key].boss.hp}}'
         p: strong=env.t('bossStrength') + ':  {{::Content.quests[group.quest.key].boss.str}}'
       div(ng-if='::Content.quests[group.quest.key].collect')
-        p(ng-repeat='(k,v) in ::Content.quests[group.quest.key].collect')
+        p(ng-repeat='(k,v) in ::Content.quests[group.quest.key].collect track by $index')
           strong=env.t('collect') + ': '
           | {{::Content.quests[group.quest.key].collect[k].count}} {{::Content.quests[group.quest.key].collect[k].text()}}
       div(ng-bind-html='::Content.quests[group.quest.key].notes()')

--- a/website/views/options/social/tavern.jade
+++ b/website/views/options/social/tavern.jade
@@ -144,7 +144,7 @@
       include ./chat-box
       .alert.alert-info.alert-sm
         != ' ' + env.t('tavernAlert1') + ' <a href="https://github.com/HabitRPG/habitrpg/issues/2760" target="_blank">' + env.t('tavernAlert2') + '</a>.<br />' + env.t('moderatorIntro1')
-        span(ng-repeat='mod in env.mods')
+        span(ng-repeat='mod in env.mods track by $index')
           |&nbsp; &nbsp;
           span(ng-if='::mod.contributor.admin',popover=env.t('gamemaster'),popover-trigger='mouseenter',popover-placement='right')
             a.label.label-default(ng-class='::userLevelStyle(mod)', ng-click='clickMember(mod._id, true)')

--- a/website/views/shared/header/header.jade
+++ b/website/views/shared/header/header.jade
@@ -35,5 +35,5 @@
       button.party-invite.pull-right.btn.btn-primary(ng-click="inviteOrStartParty(group)",
         ng-if="(!party.members || party.memberCount === 1) && user.preferences.displayInviteToPartyWhenPartyIs1",
         popover="{{!party.members ? env.t('startAParty') : env.t('addToParty')}}", popover-placement="left", popover-trigger="mouseenter")=env.t("inviteFriends")
-      .herobox-wrap(ng-repeat='profile in partyMinusSelf')
+      .herobox-wrap(ng-repeat='profile in partyMinusSelf track by $index')
         +herobox()

--- a/website/views/shared/header/menu.jade
+++ b/website/views/shared/header/menu.jade
@@ -188,7 +188,7 @@ nav.toolbar(ng-controller='AuthCtrl', ng-class='{active: isToolbarHidden}')
                 a(ui-sref='options.social.party', ng-click='expandMenu(null)')
                   span.glyphicon.glyphicon-user
                   span=env.t('invitedTo', {name: '{{user.invitations.party.name}}'})
-              li(ng-repeat='guild in user.invitations.guilds')
+              li(ng-repeat='guild in user.invitations.guilds track by $index')
                 a(ui-sref='options.social.guilds.public', ng-click='expandMenu(null)')
                   span.glyphicon.glyphicon-user
                   span=env.t('invitedTo', {name: '{{guild.name}}'})
@@ -196,7 +196,7 @@ nav.toolbar(ng-controller='AuthCtrl', ng-class='{active: isToolbarHidden}')
                 a(ui-sref='options.profile.stats', ng-click='expandMenu(null)')
                   span.glyphicon.glyphicon-plus-sign
                   span=env.t('haveUnallocated', {points: '{{user.stats.points}}'})
-              li(ng-repeat='(k,v) in user.newMessages', ng-if='v.value')
+              li(ng-repeat='(k,v) in user.newMessages track by $index', ng-if='v.value')
                 a(ng-click='k==party._id ? $state.go("options.social.party") : $state.go("options.social.guilds.detail",{gid:k}); expandMenu(null)')
                   span.glyphicon.glyphicon-comment
                   span {{v.name}}

--- a/website/views/shared/modals/invite-friends.jade
+++ b/website/views/shared/modals/invite-friends.jade
@@ -22,7 +22,7 @@ script(type='text/ng-template', id='modals/invite-friends.html')
             th=env.t('name')
             th=env.t('email')
         tbody
-          tr(ng-repeat='email in emails')
+          tr(ng-repeat='email in emails track by $index')
             td
               input.form-control(type='text', ng-model='email.name')
             td

--- a/website/views/shared/modals/members.jade
+++ b/website/views/shared/modals/members.jade
@@ -84,7 +84,7 @@ script(type='text/ng-template', id='modals/send-gift.html')
       .panel-heading=env.t('subscription')
       .panel-body
         .form-group
-          .radio(ng-repeat='block in Content.subscriptionBlocks track by $index | toArray | omit:"discount==true" | orderBy:"months"')
+          .radio(ng-repeat='block in Content.subscriptionBlocks | toArray | omit:"discount==true" | orderBy:"months" track by $index')
             label
               input(type="radio", name="subRadio", ng-value="block.key", ng-model='gift.subscription.key')
               =env.t('sendGiftSubscription', {price: '{{::block.price}}', months: '{{::block.months}}'})

--- a/website/views/shared/modals/members.jade
+++ b/website/views/shared/modals/members.jade
@@ -84,7 +84,7 @@ script(type='text/ng-template', id='modals/send-gift.html')
       .panel-heading=env.t('subscription')
       .panel-body
         .form-group
-          .radio(ng-repeat='block in Content.subscriptionBlocks | toArray | omit:"discount==true" | orderBy:"months"')
+          .radio(ng-repeat='block in Content.subscriptionBlocks track by $index | toArray | omit:"discount==true" | orderBy:"months"')
             label
               input(type="radio", name="subRadio", ng-value="block.key", ng-model='gift.subscription.key')
               =env.t('sendGiftSubscription', {price: '{{::block.price}}', months: '{{::block.months}}'})

--- a/website/views/shared/modals/quest-rewards.jade
+++ b/website/views/shared/modals/quest-rewards.jade
@@ -2,7 +2,7 @@ script(id='partials/options.social.party.quest-rewards.html', type='text/ng-temp
   hr
   h5 {{::header}}
   table.table.table-striped
-    tr(ng-repeat='drop in quest.drop.items')
+    tr(ng-repeat='drop in quest.drop.items track by $index')
       td {{::drop.text()}}
     tr(ng-if='::quest.drop.exp > 0')
       td {{::quest.drop.exp}} 

--- a/website/views/shared/modals/quests.jade
+++ b/website/views/shared/modals/quests.jade
@@ -26,7 +26,7 @@ script(type='text/ng-template', id='modals/showQuest.html')
           strong=env.t('bossStrength') + ': '
           | {{::selectedQuest.boss.str}}
       div(ng-if='::selectedQuest.collect')
-        p(ng-repeat='(k,v) in ::selectedQuest.collect')
+        p(ng-repeat='(k,v) in ::selectedQuest.collect track by $index')
           strong=env.t('collect') + ': '
           | {{::selectedQuest.collect[k].count}} {{::selectedQuest.collect[k].text()}} 
 
@@ -55,7 +55,7 @@ script(type='text/ng-template', id='modals/buyQuest.html')
           strong=env.t('bossStrength') + ': '
           | {{::selectedQuest.boss.str}}
       div(ng-if='::selectedQuest.collect')
-        p(ng-repeat='(k,v) in ::selectedQuest.collect')
+        p(ng-repeat='(k,v) in ::selectedQuest.collect track by $index')
           strong=env.t('collect') + ': '
           | {{::selectedQuest.collect[k].count}} {{::selectedQuest.collect[k].text()}} 
     div(ng-bind-html='::selectedQuest.notes()')
@@ -80,7 +80,7 @@ script(type='text/ng-template', id='modals/questInvitation.html')
           strong=env.t('bossStrength') + ': '
           | {{::Content.quests[party.quest.key].boss.str}}
       div(ng-if='::Content.quests[party.quest.key].collect')
-        p(ng-repeat='(k,v) in ::Content.quests[party.quest.key].collect')
+        p(ng-repeat='(k,v) in ::Content.quests[party.quest.key].collect track by $index')
           strong=env.t('collect') + ': '
           | {{::Content.quests[party.quest.key].collect[k].count}} {{::Content.quests[party.quest.key].collect[k].text()}} 
     div(ng-bind-html='::Content.quests[party.quest.key].notes()')

--- a/website/views/shared/profiles/achievements.jade
+++ b/website/views/shared/profiles/achievements.jade
@@ -167,7 +167,7 @@ div(ng-if='::profile.achievements.quests || user._id == profile._id')
   div(ng-class='::{muted: !profile.achievements.quests}')
     h5=env.t('completedQuests')
     table.table.table-striped
-      tr(ng-repeat='(k,v) in profile.achievements.quests')
+      tr(ng-repeat='(k,v) in profile.achievements.quests track by $index')
         td {{::Content.quests[k].text()}}
         td x{{::v}}
   hr

--- a/website/views/shared/profiles/stats.jade
+++ b/website/views/shared/profiles/stats.jade
@@ -25,10 +25,10 @@ table.table.table-striped
 unless mobile
   h4.stats-equipment(class=mobile?'item item-divider':'',ng-show='user.flags.itemsEnabled')=env.t('equipment')
   table.table.table-striped(ng-show='user.flags.itemsEnabled')
-    tr(ng-repeat='(k,v) in profile.items.gear.equipped', ng-init='piece=Content.gear.flat[v]', ng-show='piece')
+    tr(ng-repeat='(k,v) in profile.items.gear.equipped track by $index', ng-init='piece=Content.gear.flat[v]', ng-show='piece')
       td
         strong {{piece.text()}}:&nbsp;
-        span(ng-repeat='stat in ["str","con","per","int"]', ng-show='piece[stat]') {{piece[stat]}} {{stat.toUpperCase()}}&nbsp;
+        span(ng-repeat='stat in ["str","con","per","int"] track by $index', ng-show='piece[stat]') {{piece[stat]}} {{stat.toUpperCase()}}&nbsp;
 
 h4(class=mobile?'item item-divider':'')=env.t('attributes')
 table.table.table-striped

--- a/website/views/shared/tasks/edit/checklist.jade
+++ b/website/views/shared/tasks/edit/checklist.jade
@@ -13,7 +13,7 @@
         span.hint(popover=env.t('checklistText'), popover-trigger='mouseenter', popover-placement='bottom')
           =env.t('checklist')
       ul(hrpg-sort-checklist)
-        li(ng-repeat='item in task.checklist')
+        li(ng-repeat='item in task.checklist track by $index')
           //input(type='checkbox',ng-model='item.completed',ng-change='saveTask(task,true)')
           //-,ng-blur='saveTask(task,true)')
           span.checklist-icon.glyphicon.glyphicon-resize-vertical

--- a/website/views/shared/tasks/edit/tags.jade
+++ b/website/views/shared/tasks/edit/tags.jade
@@ -1,5 +1,5 @@
 fieldset.option-group(ng-if='!$state.includes("options.social.challenges")')
   p.option-title.mega(ng-click='task._tags = !task._tags', tooltip=env.t('expandCollapse'))=env.t('tags')
-  label.checkbox(ng-repeat='tag in user.tags', ng-if='task._tags')
+  label.checkbox(ng-repeat='tag in user.tags track by $index', ng-if='task._tags')
     input(type='checkbox', ng-model='task.tags[tag.id]')
     markdown(text='tag.name')

--- a/website/views/shared/tasks/index.jade
+++ b/website/views/shared/tasks/index.jade
@@ -6,7 +6,7 @@ include ./task_view/mixins
 script(id='templates/habitrpg-tasks.html', type="text/ng-template")
   .tasks-lists.container-fluid
     .row
-      .col-md-3.col-sm-6(ng-repeat='list in lists', ng-class='::{"rewards-module": list.type==="reward"}')
+      .col-md-3.col-sm-6(ng-repeat='list in lists track by $index', ng-class='::{"rewards-module": list.type==="reward"}')
         .task-column(class='{{::list.type}}s')
 
           include ./task_view/graph

--- a/website/views/shared/tasks/task.jade
+++ b/website/views/shared/tasks/task.jade
@@ -1,5 +1,5 @@
 li(id='task-{{::task.id}}', 
-  ng-repeat='task in obj[list.type+"s"] | filterByTextAndNotes: obj.filterQuery | conditionalOrderBy: list.view=="dated":"date"', 
+  ng-repeat='task in obj[list.type+"s"] track by $index | filterByTextAndNotes: obj.filterQuery | conditionalOrderBy: list.view=="dated":"date"', 
   class='task {{Shared.taskClasses(task, user.filters, user.preferences.dayStart, user.lastCron, list.showCompleted, main)}}', 
   ng-class='{"cast-target":spell && (list.type != "reward"), "locked-task":obj._locked === true}', 
   ng-click='spell && (list.type != "reward") && castEnd(task, "task", $event)', 

--- a/website/views/shared/tasks/task.jade
+++ b/website/views/shared/tasks/task.jade
@@ -1,5 +1,5 @@
 li(id='task-{{::task.id}}', 
-  ng-repeat='task in obj[list.type+"s"] track by $index | filterByTextAndNotes: obj.filterQuery | conditionalOrderBy: list.view=="dated":"date"', 
+  ng-repeat='task in obj[list.type+"s"] | filterByTextAndNotes: obj.filterQuery | conditionalOrderBy: list.view=="dated":"date"',
   class='task {{Shared.taskClasses(task, user.filters, user.preferences.dayStart, user.lastCron, list.showCompleted, main)}}', 
   ng-class='{"cast-target":spell && (list.type != "reward"), "locked-task":obj._locked === true}', 
   ng-click='spell && (list.type != "reward") && castEnd(task, "task", $event)', 

--- a/website/views/shared/tasks/task_view/index.jade
+++ b/website/views/shared/tasks/task_view/index.jade
@@ -30,6 +30,6 @@
 
   div(ng-if='task.checklist && !$state.includes("options.social.challenges") && !task.collapseChecklist && !task._editing')
     fieldset.option-group.task-checklist
-      label.checkbox(ng-repeat='item in task.checklist')
+      label.checkbox(ng-repeat='item in task.checklist track by $index')
         input(type='checkbox', ng-model='item.completed', ng-change='saveTask(task,true)')
         markdown(text='item.text', target='_blank')

--- a/website/views/shared/tasks/task_view/spells.jade
+++ b/website/views/shared/tasks/task_view/spells.jade
@@ -10,7 +10,7 @@ ul.items.rewards(ng-if='main && list.type=="reward" && (user.items.special.snowb
 
 // Spells
 ul.items(ng-if='main && list.type=="reward" && user.stats.class && !user.preferences.disableClasses')
-  li.task.reward-item(ng-repeat='(k,skill) in Content.spells[user.stats.class]', ng-if='user.stats.lvl >= skill.lvl',popover-trigger='mouseenter', popover-placement='top', popover='{{skill.notes()}}')
+  li.task.reward-item(ng-repeat='(k,skill) in Content.spells[user.stats.class] track by $index', ng-if='user.stats.lvl >= skill.lvl',popover-trigger='mouseenter', popover-placement='top', popover='{{skill.notes()}}')
     .task-meta-controls
       span.task-notes
         span.glyphicon.glyphicon-comment

--- a/website/views/shared/tasks/task_view/static_rewards.jade
+++ b/website/views/shared/tasks/task_view/static_rewards.jade
@@ -1,5 +1,5 @@
 ul.items.rewards(ng-if='main && list.type=="reward"')
-  li.task.reward-item(ng-repeat='item in itemStore',popover-trigger='mouseenter', popover-placement='top', popover='{{item.key == "armoire" && !user.flags.armoireEmpty ? env.t("armoireNotesFull") + armoireCount(user.items.gear.owned) : item.notes()}}')
+  li.task.reward-item(ng-repeat='item in itemStore track by $index',popover-trigger='mouseenter', popover-placement='top', popover='{{item.key == "armoire" && !user.flags.armoireEmpty ? env.t("armoireNotesFull") + armoireCount(user.items.gear.owned) : item.notes()}}')
     // right-hand side control buttons
     .task-meta-controls
       span.task-notes


### PR DESCRIPTION
Going off of information seen in [PR#3993](https://github.com/HabitRPG/habitrpg/pull/3993), this adds a track by statement to every instance of the ngRepeat directive. Hoping this makes noticeable impact on Issue #3486 - screens with large numbers of chat messages are slowing to extreme levels, notably the chat box itself is working slowly.

I did some cursory testing with this on my local site, and it seemed to make a performance increase.
