### PR TITLE
Refactored avatar.jade to use ternary operators instead of two spans

### DIFF
--- a/website/views/shared/header/avatar.jade
+++ b/website/views/shared/header/avatar.jade
@@ -36,7 +36,7 @@ mixin avatar(opts)
       // Armor
       span(ng-class="profile.preferences.costume ? profile.preferences.size + '_' + profile.items.gear.costume.armor : profile.preferences.size + '_' + profile.items.gear.equipped.armor")
 
-      //- Cape collar
+      // Cape collar
       span(ng-class="profile.preferences.costume ? profile.items.gear.costume.back + '_collar' : profile.items.gear.equipped.back + '_collar'")
 
       // Body

--- a/website/views/shared/header/avatar.jade
+++ b/website/views/shared/header/avatar.jade
@@ -4,7 +4,7 @@
 //-figure.herobox(ng-click='clickMember(profile._id)', data-name='{{profile.profile.name}}', ng-class='{isUser: profile.id==user.id, hasPet: profile.items.currentPet}', data-level='{{profile.stats.lvl}}', data-uid='{{profile.id}}', rel='popover', data-placement='bottom', data-trigger='hover', data-html='true', data-content="<div ng-hide='profile.id == user.id'> <div class='progress progress-danger' style='height:5px;'> <div class='bar' style='height: 5px; width: {{percent(profile.stats.hp, 50)}}%;'></div> </div> <div class='progress progress-warning' style='height:5px;'> <div class='bar' style='height: 5px; width: {{percent(profile.stats.exp, tnl(profile.stats.lvl))}}%;'></div> </div> <div>Level: {{profile.stats.lvl}}</div> <div>GP: {{profile.stats.gp | number:0}}</div> <div>{{count(profile.items.pets)}} / 90 Pets Found</div> </div>")
 
 mixin costumeSetting(pref)
-  span(ng-class="profile.preferences.costume ? profile.items.gear.costume.#{pref}' : profile.items.gear.equipped.#{pref}")
+  span(ng-class="profile.preferences.costume ? profile.items.gear.costume.#{pref} : profile.items.gear.equipped.#{pref}")
 
 mixin avatar(opts)
 


### PR DESCRIPTION
There were multiple instances of two spans being used to display a single item. Only one span would display at a time based on the evaluation of an `ng-if` with a Boolean setting (`profile.preferences.costume` or `profile.preferences.sleep`). This PR changes each of these to use a single span using a ternary operator and `ng-class`. 
