### PR TITLE
prevent challenge tasks being deleted when challenge ID has been lost

### DIFF
--- a/website/src/models/user.js
+++ b/website/src/models/user.js
@@ -539,6 +539,9 @@ UserSchema.pre('save', function(next) {
 
 UserSchema.methods.unlink = function(options, cb) {
   var cid = options.cid, keep = options.keep, tid = options.tid;
+  if (!cid) {
+    return cb("Could not remove challenge tasks. Please delete them manually.");
+  }
   var self = this;
   switch (keep) {
     case 'keep':


### PR DESCRIPTION
This is a possible fix for https://github.com/HabitRPG/habitrpg/issues/4466
In that issue, people report that they attempted to delete the tasks from one challenge, but instead all of their own non-challenge tasks were deleted. I've seen this happen often enough now that I'm certain it's a real bug.

The only explanation I can think of so far is that the challenge ID (cid) has become lost somewhere between the points where the challenge is selected and where the tasks are deleted. I've seen nothing in the code that could cause that, but HabitRPG does have odd behaviour at times.

This PR modifies the code that deletes challenge tasks. It prevents the deletion of any tasks if a cid is not passed.

It's not an ideal solution because if the user is deleting the tasks as part of leaving an active challenge, they will still leave the challenge, which means they have to delete the tasks manually (or rejoin the challenge and leave again). However the effects of this bug are devastating enough that I think a quick, non-ideal fix is worth doing.

After/If this is merged, I'll create an issue for modifying the challenge-leaving code so that if the tasks can't be deleted, the user stays in the challenge.

I'll merge this in a day if there's no complaints.
