### PR TITLE
add Trivial difficulty/priority setting to task Advanced Options

### DIFF
--- a/common/locales/en/tasks.json
+++ b/common/locales/en/tasks.json
@@ -23,6 +23,7 @@
     "difficulty": "Difficulty",
     "difficultyHelpTitle": "How difficult is this task?",
     "difficultyHelpContent": "The harder a task, the more Experience and Gold it awards you when you check it off... but the more it damages you if it is a Daily or Bad Habit!",
+    "trivial": "Trivial",
     "easy": "Easy",
     "medium": "Medium",
     "hard": "Hard",

--- a/common/script/index.coffee
+++ b/common/script/index.coffee
@@ -316,7 +316,9 @@ api.taskClasses = (task, filters=[], dayStart=0, lastCron=+new Date, showComplet
     classes += ' habit-wide' if task.down and task.up
     classes += ' habit-narrow' if !task.down and !task.up
 
-  if priority == 1
+  if priority == 0.1
+    classes += ' difficulty-trivial'
+  else if priority == 1
     classes += ' difficulty-easy'
   else if priority == 1.5
     classes += ' difficulty-medium'

--- a/website/views/shared/tasks/edit/advanced_options.jade
+++ b/website/views/shared/tasks/edit/advanced_options.jade
@@ -32,15 +32,19 @@ div(ng-if='::task.type!="reward"')
       a.hint.priority-multiplier-help(href='http://habitrpg.wikia.com/wiki/Difficulty', target='_blank', popover-title=env.t('difficultyHelpTitle'), popover-trigger='mouseenter', popover=env.t('difficultyHelpContent'))=env.t('difficulty')
     ul.priority-multiplier
       li
-        button(type='button', ng-class='{active: task.priority==1 || !task.priority}', 
+        button(type='button', ng-class='{active: task.priority==0.1}',
+          ng-click='task.challenge.id || (task.priority=0.1)')
+          =env.t('trivial')
+      li
+        button(type='button', ng-class='{active: task.priority==1 || !task.priority}',
           ng-click='task.challenge.id || (task.priority=1)')
           =env.t('easy')
       li
-        button(type='button', ng-class='{active: task.priority==1.5}', 
+        button(type='button', ng-class='{active: task.priority==1.5}',
           ng-click='task.challenge.id || (task.priority=1.5)')
           =env.t('medium')
       li
-        button(type='button', ng-class='{active: task.priority==2}', 
+        button(type='button', ng-class='{active: task.priority==2}',
           ng-click='task.challenge.id || (task.priority=2)')
           =env.t('hard')
 
@@ -52,19 +56,19 @@ div(ng-if='::task.type!="reward"')
       legend.option-title.pull-left=env.t('attributes')
       ul.task-attributes
         li
-          button(type='button', ng-class='{active: task.attribute=="str"}', 
+          button(type='button', ng-class='{active: task.attribute=="str"}',
             ng-click='task.attribute="str"')
             =env.t('physical')
         li
-          button(type='button', ng-class='{active: task.attribute=="int"}', 
+          button(type='button', ng-class='{active: task.attribute=="int"}',
             ng-click='task.attribute="int"')
             =env.t('mental')
         li
-          button(type='button', ng-class='{active: task.attribute=="con"}', 
+          button(type='button', ng-class='{active: task.attribute=="con"}',
             ng-click='task.attribute="con"')
             =env.t('social')
         li
-          button(type='button', ng-class='{active: task.attribute=="per"}', 
-            ng-click='task.attribute="per"', 
+          button(type='button', ng-class='{active: task.attribute=="per"}',
+            ng-click='task.attribute="per"',
             popover=env.t('otherExamples'), popover-trigger='mouseenter', popover-placement='top')
             =env.t('other')


### PR DESCRIPTION
This implement's @efim's Trivial difficulty setting, from https://github.com/HabitRPG/habitrpg/pull/3887 (I copied efim's code to make this PR). The setting applies to Habits, Dailies, and To-Dos. It reduces the XP and GP earned from a task (or HP lost from a Habit) to about one-tenth of what you'd get from an Easy difficulty.

@lemoness Assuming you approve of this, I think it's worth mentioning a Bailey because players who don't normally look in Advanced Options won't notice it.

![screen shot 2015-06-28 at 2 50 18 pm](https://cloud.githubusercontent.com/assets/1495809/8395204/eb79fc3a-1da5-11e5-9983-c34a0e150196.png)
