### PR TITLE
allow public guild list to have links to guilds for previewing without joining

### DIFF
--- a/website/views/options/social/index.jade
+++ b/website/views/options/social/index.jade
@@ -61,7 +61,8 @@ script(type='text/ng-template', id='partials/options.social.guilds.public.html')
             a.btn.btn-sm.btn-success(ng-if="::!group._isMember", ng-click='join(group)')
               span.glyphicon.glyphicon-ok
               =env.t('join')
-        h4 {{::group.name}}
+        h4
+          a(href='/#/options/groups/guilds/{{::group._id}}'){{::group.name}}
         p {{::group.description}}
 
 script(type='text/ng-template', id='partials/options.social.guilds.detail.html')


### PR DESCRIPTION
Don't merge without approval. Pinging @lemoness 

This PR adjusts the [index page of PUBLIC guilds](https://habitrpg.com/#/options/groups/guilds/public) so that each guild name is a link to the guild. Private guilds are NOT affected.

This allows you to view a public guild's chat and challenges without joining the guild. I suspect this might be controversial so the rest of this comment is a description of why I think it's good. There's a screenshot of the list page at the bottom. 

Having direct, non-join links from the guild list page significantly speeds up the process of deciding which guilds to join. 

**At the moment on the production site, to view a guild that you might be interested in, you have to:**
- click its join button from the guild list page
- wait for a sync 
- wait for the page to reload

Then if you decide you don't want to be in the guild:
- click leave 
- wait for another sync 
- wait for another reload, and then if you want to view more guilds:
- find your previous place in the guild list (requires a lot of scrolling or a new search).

**With this PR, the process is just:**
- click on the guild's name, 
- wait for a sync (no reload)

Then if you decide you don't want to be in the guild:
- click your browser's back button (instantaneous, no sync nor reload), and you're back to your previous place in the guild list (no scrolling or searching, although that might be browser-dependent; it works in Chrome).

With this PR, the only time you have to wait for a reload is if you decide to join the guild, and even after that you can click back to instantly get to your previous page in the guild list.

This PR also allows you to have more control over your own behaviour in following guild chat. Instead of being tempted to stop work and read chat every time there's a notification, you can avoid joining the guild and only read its chat once a day, or once every few days (that's already possible if you bookmark the guild's URL, but links from the guild list page make it easier).

The disadvantage of this PR is that people can view a guild without being a member, but I don't think that's a significant disadvantage at all. You can already do that if someone gives you a link to the guild, or if you join once and copy the link and then leave, or if you use the API to get data about the guild. Also, for most guilds it's not possible to see all the guild members so the guild leader and other members aren't disadvantaged by not seeing the names of people who are reading chat without being members.

This does also allow you to join a challenge without being a member of a guild (ref https://github.com/HabitRPG/habitrpg/issues/5168 for why this might be considered bad), but, again, you can already do that.

**Screenshot - the only visible difference is the blue colour for the guilds' names:**

![screen shot 2015-06-28 at 4 07 26 pm](https://cloud.githubusercontent.com/assets/1495809/8395361/ddc33e12-1daf-11e5-8be5-5181a096c5dc.png)
