### PR TITLE
Removed user.party.quest.key checks from isOnQuest and added check for user ID in quest members

### DIFF
--- a/website/src/models/group.js
+++ b/website/src/models/group.js
@@ -194,7 +194,7 @@ GroupSchema.methods.finishQuest = function(quest, cb) {
 }
 
 function isOnQuest(user,progress,group){
-  return group && progress && group.quest && group.quest.active && group.quest.members[user._id] == true;
+  return group && progress && group.quest && group.quest.active && group.quest.members[user._id] === true;
 }
 
 GroupSchema.statics.collectQuest = function(user, progress, cb) {

--- a/website/src/models/group.js
+++ b/website/src/models/group.js
@@ -193,13 +193,13 @@ GroupSchema.methods.finishQuest = function(quest, cb) {
   mongoose.model('User').update(q, updates, {multi:true}, cb);
 }
 
-function isOnQuest(user,progress,group){
-  return group && progress && user.party.quest.key && group.quest && user.party.quest.key == group.quest.key && group.quest.active;
+function isOnQuest(progress,group){
+  return group && progress && group.quest && group.quest.active;
 }
 
 GroupSchema.statics.collectQuest = function(user, progress, cb) {
   this.findOne({type: 'party', members: {'$in': [user._id]}},function(err, group){
-    if (!isOnQuest(user,progress,group)) return cb(null);
+    if (!isOnQuest(progress,group)) return cb(null);
     var quest = shared.content.quests[group.quest.key];
 
     _.each(progress.collect,function(v,k){
@@ -302,7 +302,7 @@ GroupSchema.statics.tavernBoss = function(user,progress) {
 
 GroupSchema.statics.bossQuest = function(user, progress, cb) {
   this.findOne({type: 'party', members: {'$in': [user._id]}},function(err, group){
-    if (!isOnQuest(user,progress,group)) return cb(null);
+    if (!isOnQuest(progress,group)) return cb(null);
     var quest = shared.content.quests[group.quest.key];
     if (!progress || !quest) return cb(null); // FIXME why is this ever happening, progress should be defined at this point
     var down = progress.down * quest.boss.str; // multiply by boss strength

--- a/website/src/models/group.js
+++ b/website/src/models/group.js
@@ -193,13 +193,13 @@ GroupSchema.methods.finishQuest = function(quest, cb) {
   mongoose.model('User').update(q, updates, {multi:true}, cb);
 }
 
-function isOnQuest(progress,group){
-  return group && progress && group.quest && group.quest.active;
+function isOnQuest(user,progress,group){
+  return group && progress && group.quest && group.quest.active && group.quest.members[user._id] == true;
 }
 
 GroupSchema.statics.collectQuest = function(user, progress, cb) {
   this.findOne({type: 'party', members: {'$in': [user._id]}},function(err, group){
-    if (!isOnQuest(progress,group)) return cb(null);
+    if (!isOnQuest(user,progress,group)) return cb(null);
     var quest = shared.content.quests[group.quest.key];
 
     _.each(progress.collect,function(v,k){
@@ -302,7 +302,7 @@ GroupSchema.statics.tavernBoss = function(user,progress) {
 
 GroupSchema.statics.bossQuest = function(user, progress, cb) {
   this.findOne({type: 'party', members: {'$in': [user._id]}},function(err, group){
-    if (!isOnQuest(progress,group)) return cb(null);
+    if (!isOnQuest(user,progress,group)) return cb(null);
     var quest = shared.content.quests[group.quest.key];
     if (!progress || !quest) return cb(null); // FIXME why is this ever happening, progress should be defined at this point
     var down = progress.down * quest.boss.str; // multiply by boss strength


### PR DESCRIPTION
Related to #5520.

Due to changes made in #5298, `user.party.quest.key` is now set as soon as an invitation is sent out (reasoning for this described [here](https://github.com/HabitRPG/habitrpg/issues/5518#issuecomment-116654743)), making it an inaccurate measure of determining if a user is on a quest. 

~~Removing these checks from `isOnQuest` made passing the user in unnecessary, so `user` has been removed from the function parameters and calls.~~ EDIT: Not true due to added check for `user_id` in `group.quest.members`.

I tested these changes locally by starting multiple quests, including the method that caused #5518 (described [here](https://github.com/HabitRPG/habitrpg/issues/5518#issuecomment-116494333)), and didn't encounter any unexpected behavior or console errors.
