### PR TITLE
make api.shouldDo use the day being checked as the default date instead of today

### DIFF
--- a/common/script/index.coffee
+++ b/common/script/index.coffee
@@ -83,11 +83,14 @@ api.shouldDo = (day, dailyTask, options = {}) ->
   o = sanitizeOptions options
   startOfDayWithCDSTime = api.startOfDay(_.defaults {now:day}, o)  # a moment()
 
-  # Work out if the Daily's Start Date (taskStartDate) is in the future.
+  # If the Daily does not have a Start Date (old tasks predating the Start Date feature), we assume it starts on the day being checked. This does not cause a bug with the Every X Days option because if the user had edited the task to select X days, then a start date would have been saved to the task at the same time.
+  taskStartDate = dailyTask.startDate || day
+
   # The time portion of the Start Date is never visible to or modifiable by the user so we must ignore it.
   # Therefore, we must also ignore the time portion of the user's day start (startOfDayWithCDSTime), otherwise the date comparison will be wrong for some times.
   # NB: The user's day start date has already been converted to the PREVIOUS day's date if the time portion was before CDS.
-  taskStartDate = moment(dailyTask.startDate || now()).startOf('day');
+  taskStartDate = moment(taskStartDate).startOf('day');
+
   if taskStartDate > startOfDayWithCDSTime.startOf('day')
     return false # Daily starts in the future
 


### PR DESCRIPTION
fixes https://github.com/HabitRPG/habitrpg/issues/5521

This PR changes api.shouldDo for the case when the task being examined does not have its own start date (i.e., for a task created before the start date code was added to Dailies). The incorrect behaviour currently in production is to consider the start date as today, which means that when cron is using shouldDo to work out if the Daily should have been done yesterday, it always considers the Daily to not be due. The new behaviour is to set the start date to whatever date is passed to shouldDo.

I should (and will) add tests for the case where a start date is not defined, but I am not sure how long that will take me and I'd like to get this fix deployed to stop the bug happening. So, I'm PRing this now, and I'm about to start looking at the tests.
