### PR TITLE
Display boss damage real-time

### DIFF
--- a/common/locales/en/character.json
+++ b/common/locales/en/character.json
@@ -146,5 +146,6 @@
     "mageWiki": "<a href='http://habitrpg.wikia.com/wiki/Mage' target='_blank'>Mage</a>",
     "rogueWiki": "<a href='http://habitrpg.wikia.com/wiki/Rogue' target='_blank'>Rogue</a>",
     "healerWiki": "<a href='http://habitrpg.wikia.com/wiki/Healer' target='_blank'>Healer</a>",
-    "chooseClassLearn": "<a href='http://habitrpg.wikia.com/wiki/Class_System' target='_blank'>Learn more about classes</a>"
+    "chooseClassLearn": "<a href='http://habitrpg.wikia.com/wiki/Class_System' target='_blank'>Learn more about classes</a>",
+    "hitBoss": "You hit your foe for <%= damage %> damage!"
 }

--- a/website/public/js/controllers/notificationCtrl.js
+++ b/website/public/js/controllers/notificationCtrl.js
@@ -56,6 +56,13 @@ habitrpg.controller('NotificationCtrl',
        Notification.crit(amount);
     });
 
+    $rootScope.$watch('user.party.quest.progress.up', function (after,before) {
+      if (after <= before || !after || !User.user.party.quest.key) return;
+      if (typeof(Content.quests[User.user.party.quest.key].boss) === 'undefined') return;
+      var amount = after - before;
+      Notification.hitBoss(amount);
+    });
+
     $rootScope.$watch('user._tmp.drop', function(after, before){
       // won't work when getting the same item twice?
       if (after == before || !after) return;

--- a/website/public/js/services/notificationServices.js
+++ b/website/public/js/services/notificationServices.js
@@ -89,6 +89,10 @@ angular.module("habitrpg").factory("Notification",
     }
   }
 
+  function hitBoss(val) {
+    _notify(window.env.t('hitBoss', {'damage':_round(val)}), 'crit', 'glyphicon glyphicon-flash');
+  }
+
   //--------------------------------------------------
   // Private Methods
   //--------------------------------------------------
@@ -131,6 +135,7 @@ angular.module("habitrpg").factory("Notification",
     markdown: markdown,
     mp: mp,
     streak: streak,
-    text: text
+    text: text,
+    hitBoss: hitBoss
   };
 }]);


### PR DESCRIPTION
Implements a notification of how much damage the user contributes to a boss battle, at the instant of checking off a task or using a skill.

We may not want to implement this right away, because it's somewhat misleading under the current implementation--the damage is not applied to the boss until the next cron. However, I'd like to get this out there for discussion, because the motivation factor of immediate notification is significant!
