### PR TITLE
Small login form attribute improvements

### DIFF
--- a/website/views/static/login-modal.jade
+++ b/website/views/static/login-modal.jade
@@ -16,9 +16,9 @@ script(id='modals/login.html', type='text/ng-template')
       tab(heading=env.t('login'))
         form#login-tab(ng-submit='auth()', method='POST')
           .form-group
-            input.form-control(type='text', ng-model='loginUsername', placeholder=env.t('username')+' or Email', name='username')
+            input.form-control(type='text', ng-model='loginUsername', placeholder=env.t('username')+' or Email', name='username', spellcheck='false', required)
           .form-group
-            input.form-control(type='password', ng-model='loginPassword', placeholder=env.t('password'), name='password')
+            input.form-control(type='password', ng-model='loginPassword', placeholder=env.t('password'), name='password', required)
             //-.control-group
               label.checkbox
                 input(type='checkbox', ng-click='useUUID = !useUUID')
@@ -51,7 +51,7 @@ script(id='modals/login.html', type='text/ng-template')
       tab(heading=env.t('register'))
         form#registrationForm(ng-submit='register()', name='registrationForm')
           .form-group
-            input.form-control(type='text', ng-model='registerVals.username', placeholder=env.t('username'), required)
+            input.form-control(type='text', ng-model='registerVals.username', placeholder=env.t('username'), spellcheck='false', required)
           .form-group
             input.form-control(type='email', ng-model='registerVals.email', placeholder=env.t('email'), required)
           .form-group


### PR DESCRIPTION
Added `spellcheck='false'` to username inputs to make it less annoying to use on some devices/OSes where some usernames will be "corrected" by default.
Added `required` to user/email and password inputs on the login form.
