### PR TITLE
Gulp Tests now report summaries even when some tests fail.

### DIFF
--- a/tasks/gulp-tests.js
+++ b/tasks/gulp-tests.js
@@ -219,8 +219,8 @@ gulp.task('test', [
     `\x1b[36mPending: ${totals[2]}\t`
   );
 
-	if (totals[1] > 0) throw "ERROR: There are failing tests!"
-	else {
-		console.log('\n\x1b[36mThanks for helping keep Habitica clean!\x1b[0m');
-	}
+  if (totals[1] > 0) throw "ERROR: There are failing tests!"
+  else {
+    console.log('\n\x1b[36mThanks for helping keep Habitica clean!\x1b[0m');
+  }
 });

--- a/tasks/gulp-tests.js
+++ b/tasks/gulp-tests.js
@@ -94,7 +94,7 @@ gulp.task('test:api:safe', ['test:prepare:mongo'], (cb) => {
 	  cb();
     }
   );
-  pipe(runner)
+  pipe(runner);
 });
 
 gulp.task('test:api:clean', (cb) => {

--- a/tasks/gulp-tests.js
+++ b/tasks/gulp-tests.js
@@ -48,13 +48,23 @@ gulp.task('test:common', ['test:prepare:build'], (cb) => {
   let runner = exec(
     testBin('mocha test/common'),
     (err, stdout, stderr) => {
+    	cb(err);
+    }
+  );
+  pipe(runner);
+});
+
+gulp.task('test:common:safe', ['test:prepare:build'], (cb) => {
+  let runner = exec(
+    testBin('mocha test/common'),
+    (err, stdout, stderr) => {
       testResults.push({
         suite: 'Common Specs\t',
         pass: testCount(stdout, /(\d+) passing/),
         fail: testCount(stderr, /(\d+) failing/),
         pend: testCount(stdout, /(\d+) pending/)
       });
-      cb(err);
+      cb();
     }
   );
   pipe(runner);
@@ -65,16 +75,26 @@ gulp.task('test:api', ['test:prepare:mongo'], (cb) => {
   let runner = exec(
     testBin("istanbul cover -i 'website/src/**' --dir coverage/api ./node_modules/.bin/_mocha -- test/api"),
     (err, stdout, stderr) => {
+      cb(err);
+    }
+  );
+  pipe(runner);
+});
+
+gulp.task('test:api:safe', ['test:prepare:mongo'], (cb) => {
+  let runner = exec(
+    testBin("istanbul cover -i 'website/src/**' --dir coverage/api ./node_modules/.bin/_mocha -- test/api"),
+    (err, stdout, stderr) => {
       testResults.push({
         suite: 'API Specs\t',
         pass: testCount(stdout, /(\d+) passing/),
         fail: testCount(stderr, /(\d+) failing/),
         pend: testCount(stdout, /(\d+) pending/)
       });
-      cb(err);
+	  cb();
     }
   );
-  pipe(runner);
+  pipe(runner)
 });
 
 gulp.task('test:api:clean', (cb) => {
@@ -92,19 +112,54 @@ gulp.task('test:karma', ['test:prepare:build'], (cb) => {
   let runner = exec(
     testBin('karma start --single-run'),
     (err, stdout) => {
+    	cb(err);
+    }
+  );
+  pipe(runner);
+});
+
+gulp.task('test:karma:safe', ['test:prepare:build'], (cb) => {
+  let runner = exec(
+    testBin('karma start --single-run'),
+    (err, stdout) => {
       testResults.push({
         suite: 'Karma Specs\t',
         pass: testCount(stdout, /(\d+) tests completed/),
         fail: testCount(stdout, /(\d+) tests failed/),
         pend: testCount(stdout, /(\d+) tests skipped/)
       });
-      cb(err);
+      cb();
     }
   );
   pipe(runner);
 });
 
 gulp.task('test:e2e', ['test:prepare'], (cb) => {
+  let support = [
+    'Xvfb :99 -screen 0 1024x768x24 -extension RANDR',
+    `NODE_DB_URI="${TEST_DB_URI}" PORT="${TEST_SERVER_PORT}" node ./website/src/server.js`,
+    './node_modules/protractor/bin/webdriver-manager start',
+  ].map(exec);
+
+  Q.all([
+    awaitPort(3001),
+    awaitPort(4444)
+  ]).then(() => {
+    let runner = exec(
+      'DISPLAY=:99 NODE_ENV=testing ./node_modules/protractor/bin/protractor protractor.conf.js',
+      (err, stdout, stderr) => {
+        /*
+         * Note: As it stands, protractor wont report pending specs
+         */
+        support.forEach(kill);
+        cb(err);
+      }
+    );
+    pipe(runner);
+  });
+});
+
+gulp.task('test:e2e:safe', ['test:prepare'], (cb) => {
   let support = [
     'Xvfb :99 -screen 0 1024x768x24 -extension RANDR',
     `NODE_DB_URI="${TEST_DB_URI}" PORT="${TEST_SERVER_PORT}" node ./website/src/server.js`,
@@ -129,7 +184,7 @@ gulp.task('test:e2e', ['test:prepare'], (cb) => {
           pend: 0
         });
         support.forEach(kill);
-        cb(err);
+        cb();
       }
     );
     pipe(runner);
@@ -137,10 +192,10 @@ gulp.task('test:e2e', ['test:prepare'], (cb) => {
 });
 
 gulp.task('test', [
-  'test:common',
-  'test:karma',
-  'test:api',
-  'test:e2e'
+  'test:common:safe',
+  'test:karma:safe',
+  'test:api:safe',
+  'test:e2e:safe'
 ], () => {
   let totals = [0,0,0];
 
@@ -164,5 +219,8 @@ gulp.task('test', [
     `\x1b[36mPending: ${totals[2]}\t`
   );
 
-  console.log('\n\x1b[36mThanks for helping keep Habitica clean!\x1b[0m');
+	if (totals[1] > 0) throw "ERROR: There are failing tests!"
+	else {
+		console.log('\n\x1b[36mThanks for helping keep Habitica clean!\x1b[0m');
+	}
 });

--- a/website/views/options/social/index.jade
+++ b/website/views/options/social/index.jade
@@ -6,6 +6,7 @@ include ./hall
 include ./quests/index
 include ./chat-message
 
+
 script(type='text/ng-template', id='partials/options.social.inbox.html')
   .container-fluid
     .row

--- a/website/views/options/social/index.jade
+++ b/website/views/options/social/index.jade
@@ -6,7 +6,6 @@ include ./hall
 include ./quests/index
 include ./chat-message
 
-
 script(type='text/ng-template', id='partials/options.social.inbox.html')
   .container-fluid
     .row


### PR DESCRIPTION
Address issue #5539.

Created safe versions of tests for Common, API, Karma, and E2E in gulp-tests.js which no longer callback their errors. 

Removed the pushing to testResults by the non-safe versions of these tests since they will now only be run independently. 

Lastly, after the summary is displayed an error will be thrown if any of the tests did fail, thus preserving the operation of Travis CI.
