### PR TITLE
Changed task notes icon from 'span' to 'a' element to cause cursor to show icon as clickable

### DIFF
--- a/website/views/shared/tasks/meta_controls.jade
+++ b/website/views/shared/tasks/meta_controls.jade
@@ -36,7 +36,7 @@
     //challenges
     span(ng-if='task.challenge.id')
       span(ng-if='task.challenge.broken')
-        span.glyphicon.glyphicon-bullhorn(style='background-color:red;', ng-click='task._editing = true', tooltip=env.t('brokenChaLink') tooltip-placement='right')
+        a.glyphicon.glyphicon-bullhorn(style='background-color:red;', ng-click='task._editing = true', tooltip=env.t('brokenChaLink') tooltip-placement='right')
         | &nbsp;
       span(ng-if='!task.challenge.broken')
         span.glyphicon.glyphicon-bullhorn(tooltip=env.t('challenge'))

--- a/website/views/shared/tasks/meta_controls.jade
+++ b/website/views/shared/tasks/meta_controls.jade
@@ -51,6 +51,6 @@
       span.glyphicon.glyphicon-signal
       | &nbsp;
     // notes
-    span.task-notes(ng-show='task.notes && !task._editing', ng-click='task.popoverOpen = !task.popoverOpen', popover-trigger='click', data-popover-html="{{task.notes | markdown}}", popover-placement="top", popover-append-to-body='{{::modal ? "false":"true"}}')
+    a.task-notes(ng-show='task.notes && !task._editing', ng-click='task.popoverOpen = !task.popoverOpen', popover-trigger='click', data-popover-html="{{task.notes | markdown}}", popover-placement="top", popover-append-to-body='{{::modal ? "false":"true"}}')
       span.glyphicon.glyphicon-comment
       | &nbsp;


### PR DESCRIPTION
Related to #5536.

This changes the notes icon from a `span` to an `a` element to cause the cursor to indicate that the icon is clickable. All of the other clickable icons in the task meta controls are already `a` elements. 

I had no idea that clicking on this icon was a possibility until @crookedneighbor explained it, and this was exclusively because the cursor didn't indicate that it was clickable.
