### PR TITLE
Prevent "Resting in the Inn" message when viewing challenges.

### DIFF
--- a/website/views/shared/tasks/index.jade
+++ b/website/views/shared/tasks/index.jade
@@ -19,7 +19,7 @@ script(id='templates/habitrpg-tasks.html', type="text/ng-template")
 
           include ./task_view/add_new
 
-          alert.alert-warning.dailiesRestingInInn(ng-if='::list.type == "daily" && user.preferences.sleep')
+          alert.alert-warning.dailiesRestingInInn(ng-if='::list.type == "daily" && user.preferences.sleep &&!$state.includes("options.social.challenges")')
             i.glyphicon.glyphicon-warning-sign &nbsp;
             =env.t('dailiesRestingInInn')
 


### PR DESCRIPTION
This should fix #5559 by not displaying the alert when the challenge page is loaded.
