### PR TITLE
Show Extra Notes icon regardless of task ownership.

### DIFF
--- a/website/views/shared/tasks/meta_controls.jade
+++ b/website/views/shared/tasks/meta_controls.jade
@@ -51,6 +51,8 @@
       span.glyphicon.glyphicon-signal
       | &nbsp;
     // notes
-    a.task-notes(ng-show='task.notes && !task._editing', ng-click='task.popoverOpen = !task.popoverOpen', popover-trigger='click', data-popover-html="{{task.notes | markdown}}", popover-placement="top", popover-append-to-body='{{::modal ? "false":"true"}}')
-      span.glyphicon.glyphicon-comment
-      | &nbsp;
+
+  // Make this icon available regardless of task ownership  
+  a.task-notes(ng-show='task.notes && !task._editing', ng-click='task.popoverOpen = !task.popoverOpen', popover-trigger='click', data-popover-html="{{task.notes | markdown}}", popover-placement="top", popover-append-to-body='{{::modal ? "false":"true"}}')
+    span.glyphicon.glyphicon-comment
+    | &nbsp;


### PR DESCRIPTION
fixes #5552 by showing Extra Notes icon on tasks in a challenge
