### PR TITLE
Invite a new party member to a quest if the quest is still in the invitation stage (fixes #5598)

### DIFF
--- a/website/src/controllers/groups.js
+++ b/website/src/controllers/groups.js
@@ -442,6 +442,7 @@ api.join = function(req, res, next) {
     user.save();
     // invite new user to pending quest
     if (group.quest.key && !group.quest.active) {
+      User.update({_id:user._id},{$set: {'party.quest.RSVPNeeded': true, 'party.quest.key': group.quest.key}}).exec();
       group.quest.members[user._id] = undefined;
       group.markModified('quest.members');
     }


### PR DESCRIPTION
Added a line that sets `user.party.quest.RSVPNeeded` to `true` and `user.party.quest.key` to `group.quest.key` when a user joins a party and a quest is in the invitation stage (it's the same line that was added in #5298 to the `questAccept` function). Worked as expected on my local install.
