### PR TITLE
pets.jade: IE better support

### DIFF
--- a/website/views/options/inventory/pets.jade
+++ b/website/views/options/inventory/pets.jade
@@ -8,7 +8,7 @@ mixin petList(source)
             div(popover-trigger='mouseenter', popover=env.t('petName', {potion: potion.text(env.language.code), egg: egg.text(env.language.code)}), popover-placement='bottom')
               button(class="pet-button Pet-#{pet}", ng-if='user.items.pets["#{pet}"]>0', ng-class='{active: user.items.currentPet == "#{pet}", selectableInventory: #{!egg.noMount} && selectedFood && !user.items.mounts["#{pet}"]}', ng-click='choosePet("#{egg.key}", "#{potion.key}")')
                 .progress(ng-show='!user.items.mounts["#{pet}"]')
-                  .progress-bar.progress-bar-success(style='width:{{user.items.pets["#{pet}"]/.5}}%')
+                  .progress-bar.progress-bar-success(ng-style='{width: user.items.pets["#{pet}"]/.5 + "%"}')
               button(class="pet-button pet-not-owned", ng-if='!user.items.pets["#{pet}"]')
                 .PixelPaw
               button(class="pet-evolved pet-button Pet-#{pet}", ng-if='user.items.pets["#{pet}"]<0')


### PR DESCRIPTION
It is currently impossible to see how fed a pet is in IE. The width of the .progress-bar-success is "{{user.items.pets["Wolf-Base"]/.5}}%".
Now, it works.
