### PR TITLE
Add a 'gulp console' method which preloads Mongo, models

### DIFF
--- a/tasks/gulp-console.js
+++ b/tasks/gulp-console.js
@@ -1,0 +1,52 @@
+import 'coffee-script';
+
+import mongoose from 'mongoose';
+import autoinc  from 'mongoose-id-autoinc';
+import logging  from '../website/src/logging';
+import nconf    from 'nconf';
+import utils    from '../website/src/utils';
+import repl     from 'repl';
+import gulp     from 'gulp';
+
+// Add additional properties to the repl's context
+let improveRepl = (context) => {
+
+  // Let "exit" and "quit" terminate the console
+  ['exit', 'quit'].forEach((term) => {
+    Object.defineProperty(context, term, { get() { process.exit(); }});
+  });
+
+  // "clear" clears the screen
+  Object.defineProperty(context, 'clear', { get() {
+    process.stdout.write('\u001B[2J\u001B[0;0f');
+  }});
+
+  utils.setupConfig();
+
+  context.Challenge = require('../website/src/models/challenge').model;
+  context.Group     = require('../website/src/models/group').model;
+  context.User      = require('../website/src/models/user').model;
+
+  var isProd = nconf.get('NODE_ENV') === 'production';
+  var mongooseOptions = !isProd ? {} : {
+    replset: { socketOptions: { keepAlive: 1, connectTimeoutMS: 30000 } },
+    server: { socketOptions: { keepAlive: 1, connectTimeoutMS: 30000 } }
+  };
+  autoinc.init(
+    mongoose.connect(
+      nconf.get('NODE_DB_URI'),
+      mongooseOptions,
+      function(err) {
+        if (err) throw err;
+        logging.info('Connected with Mongoose');
+      }
+    )
+  );
+
+};
+
+gulp.task('console', (cb) => {
+  improveRepl(repl.start({
+    prompt: 'Habitica > '
+  }).context);
+});


### PR DESCRIPTION
Usage: `gulp console`. Loads up a Node REPL and loads Mongoose and models, throwing them onto the repl's context. Also provides no-frills "exit", "quit", and "clear" commands.

![screenshot 2015-07-14 23 24 16](https://cloud.githubusercontent.com/assets/10201/8690222/98b9e32a-2a7f-11e5-86eb-0afbda7b6191.png)

tl;dr, no manually requiring models and such.
