### PR TITLE
Removed unnecessary 'env.language.code' in calls to Content functions

### DIFF
--- a/website/views/options/inventory/mounts.jade
+++ b/website/views/options/inventory/mounts.jade
@@ -6,7 +6,7 @@ mixin mountList(source)
           menu
             each potion in env.Content.hatchingPotions
               - mount = egg.key+"-"+potion.key
-              div(popover-trigger='mouseenter', popover=env.t('mountName', {potion: potion.text(env.language.code), mount: egg.mountText(env.language.code)}), popover-placement='bottom')
+              div(popover-trigger='mouseenter', popover=env.t('mountName', {potion: potion.text(), mount: egg.mountText()}), popover-placement='bottom')
                 button(class="pet-button Mount_Head_#{mount}", ng-show='user.items.mounts["#{mount}"]', ng-class='{active: user.items.currentMount == "#{mount}"}', ng-click='chooseMount("#{egg.key}", "#{potion.key}")')
                   //div(class='Mount_Head_{{mount}}')
                 button(class="pet-button mount-not-owned", ng-hide='user.items.mounts["#{mount}"]')

--- a/website/views/options/inventory/pets.jade
+++ b/website/views/options/inventory/pets.jade
@@ -5,7 +5,7 @@ mixin petList(source)
         menu
           each potion in env.Content.hatchingPotions
             - pet = egg.key+"-"+potion.key
-            div(popover-trigger='mouseenter', popover=env.t('petName', {potion: potion.text(env.language.code), egg: egg.text(env.language.code)}), popover-placement='bottom')
+            div(popover-trigger='mouseenter', popover=env.t('petName', {potion: potion.text(), egg: egg.text()}), popover-placement='bottom')
               button(class="pet-button Pet-#{pet}", ng-if='user.items.pets["#{pet}"]>0', ng-class='{active: user.items.currentPet == "#{pet}", selectableInventory: #{!egg.noMount} && selectedFood && !user.items.mounts["#{pet}"]}', ng-click='choosePet("#{egg.key}", "#{potion.key}")')
                 .progress(ng-show='!user.items.mounts["#{pet}"]')
                   .progress-bar.progress-bar-success(ng-style='{width: user.items.pets["#{pet}"]/.5 + "%"}')

--- a/website/views/options/profile.jade
+++ b/website/views/options/profile.jade
@@ -291,7 +291,7 @@ mixin backgrounds(mobile)
               +gemCost(7)
                 button.btn.btn-xs(ng-click="unlock(setKeys('background',#{JSON.stringify(bgs)}))")!= env.t('unlockSet',{cost:15}) + ' <span class="Pet_Currency_Gem1x inline-gems"/>'
             each bg,k in bgs
-              button.customize-option(type='button', class='background_#{k}', ng-class="user.purchased.background.#{k} ? 'background-unlocked' : 'background-locked'", ng-click='unlock("background.#{k}")', popover-title=bg.text(env.language.code), popover=bg.notes(env.language.code),popover-trigger='mouseenter')
+              button.customize-option(type='button', class='background_#{k}', ng-class="user.purchased.background.#{k} ? 'background-unlocked' : 'background-locked'", ng-click='unlock("background.#{k}")', popover-title=bg.text(), popover=bg.notes(),popover-trigger='mouseenter')
                 i.glyphicon.glyphicon-lock(ng-if="!user.purchased.background.#{k}")
       - }
 


### PR DESCRIPTION
Originally mentioned in [#5422](https://github.com/HabitRPG/habitrpg/pull/5422#issuecomment-121241206). 

There were a few instances of Content functions (specifically, `hatchingPotions.XXX.text`, `dropEggs.XXX.text`, `questEggs.XXX.text`, `backgrounds.XXX.XXX.text` and `backgrounds.XXX.XXX.notes`) being called with `env.language.code` passed as a parameter. This doesn't appear to be necessary. When these functions are called elsewhere, they are called without parameters, and work as expected.
