### PR TITLE
Prevent Herobox click when share this is displayed

### DIFF
--- a/website/public/js/controllers/userCtrl.js
+++ b/website/public/js/controllers/userCtrl.js
@@ -75,6 +75,10 @@ habitrpg.controller("UserCtrl", ['$rootScope', '$scope', '$location', 'User', '$
         return type+'.'+k;
       }).join(',');
     }
-
+    
+    $scope.heroboxClick = function(spell) {
+      if (spell) return castEnd(profile, "user", $event);
+      else if (!$scope.shareIsHovered) return clickMember(profile._id);
+    }
   }
 ]);

--- a/website/views/shared/avatar/appearance.jade
+++ b/website/views/shared/avatar/appearance.jade
@@ -1,7 +1,7 @@
 mixin avatar(opts)
   .character-sprites
     .addthis_native_toolbox(ng-if='::profile._id==user._id',
-      ng-mouseover='siHovered=true' ng-mouseout='siHovered=false' ng-init='siHovered=false'
+      ng-mouseover='shareIsHovered=true' ng-mouseout='shareIsHovered=false'
       data-url="#{env.BASE_URL}/static/front/#?memberId={{::profile._id}}",
       data-title="Check out my HabitRPG progress!")
 

--- a/website/views/shared/avatar/appearance.jade
+++ b/website/views/shared/avatar/appearance.jade
@@ -1,6 +1,7 @@
 mixin avatar(opts)
   .character-sprites
     .addthis_native_toolbox(ng-if='::profile._id==user._id',
+      ng-mouseover='siHovered=true' ng-mouseout='siHovered=false' ng-init='siHovered=false'
       data-url="#{env.BASE_URL}/static/front/#?memberId={{::profile._id}}",
       data-title="Check out my HabitRPG progress!")
 

--- a/website/views/shared/avatar/index.jade
+++ b/website/views/shared/avatar/index.jade
@@ -3,7 +3,7 @@ include appearance
 mixin herobox(opts)
   - if (!opts) {opts = {minimal:false,main:false}}
 
-  - var ngClick = 'spell ? castEnd(profile, "user", $event) : clickMember(profile._id)'
+  - var ngClick = 'spell ? castEnd(profile, "user", $event) : siHovered ? null : clickMember(profile._id)'
 
   - var klass = 'background_{{profile.preferences.background}} ' + opts.main + ' ? "isUser" : ""} ' + opts.minimal + ' ? "minimal" : ""}'
 

--- a/website/views/shared/avatar/index.jade
+++ b/website/views/shared/avatar/index.jade
@@ -3,7 +3,7 @@ include appearance
 mixin herobox(opts)
   - if (!opts) {opts = {minimal:false,main:false}}
 
-  - var ngClick = 'spell ? castEnd(profile, "user", $event) : siHovered ? null : clickMember(profile._id)'
+  - var ngClick = 'heroboxClick(spell)'
 
   - var klass = 'background_{{profile.preferences.background}} ' + opts.main + ' ? "isUser" : ""} ' + opts.minimal + ' ? "minimal" : ""}'
 


### PR DESCRIPTION
**Issue:** #5628  
**Fix:** [Plunk](http://plnkr.co/edit/js6mbyl5lzwDtWoVXw1E?p=preview).

**Update:** Changed variable. However, I don't know (forgot some things about ng..) if, within the UserCtrl scope, we can access `spell, castEnd() and clickMember()`. If we can't, then my code won't work. Using the double ternary was the secure solution for me.
