### PR TITLE
Adjust Cron when Custom Day Start is Changed Fixes #4488

### DIFF
--- a/common/script/index.coffee
+++ b/common/script/index.coffee
@@ -350,6 +350,18 @@ Friendly timestamp
 api.friendlyTimestamp = (timestamp) -> moment(timestamp).format('MM/DD h:mm:ss a')
 
 ###
+ISO timestamp
+###
+api.isoTimestamp = (timestamp) -> moment(timestamp).toISOString()
+
+###
+plain timestamp
+###
+api.momentTimestamp = (timestamp) -> moment(timestamp)
+
+
+
+###
 Does user have new chat messages?
 ###
 api.newChatMessages = (messages, lastMessageSeen) ->

--- a/common/script/index.coffee
+++ b/common/script/index.coffee
@@ -66,6 +66,13 @@ api.startOfDay = (options={}) ->
     dayStart.subtract({days:1})
   dayStart
 
+
+api.startOfDayAllowsFuture = (options={}) ->
+  # Use this version to use if you need the result even if the offset would cause today's day start to be in the future.
+  o = sanitizeOptions(options)
+  moment(o.now).startOf('day').add({hours:o.dayStart})
+
+
 api.dayMapping = {0:'su',1:'m',2:'t',3:'w',4:'th',5:'f',6:'s'}
 
 ###

--- a/website/public/js/controllers/settingsCtrl.js
+++ b/website/public/js/controllers/settingsCtrl.js
@@ -66,24 +66,31 @@ habitrpg.controller('SettingsCtrl',
       User.set({'flags.newStuff':true});
     }
 
-    $scope.passDayStart = User.user.preferences.dayStart;
+    $scope.dayStart = User.user.preferences.dayStart;
 
-    $scope.saveDayStart = function(newDayStart){
-      var oldDayStart = User.user.preferences.dayStart;
-      var dayStart = newDayStart;
+    function updateLastCron(oldDayStart, newDayStart){
+      var getOldStart = Shared.startOfDayAllowsFuture({ dayStart: oldDayStart});
+      var getNewStart = Shared.startOfDayAllowsFuture({ dayStart: newDayStart});
       var lastCron = User.user.lastCron;
-      var getOldStart = Shared.startOfDay({ dayStart: oldDayStart});
-      var getNewStart = Shared.startOfDay({ dayStart: dayStart});
+      var momentLastCron = Shared.momentTimestamp(lastCron);
       var isoNewStart = Shared.isoTimestamp(getNewStart);
-
-      if (dayStart == undefined || _.isNaN(dayStart) || dayStart < 0 || dayStart > 24) {
-        dayStart = 0;
-        return alert(window.env.t('enterNumber'));
-      }
-      if (Shared.momentTimestamp(getOldStart) <= Shared.momentTimestamp(lastCron) && Shared.momentTimestamp(lastCron) <  Shared.momentTimestamp(getNewStart)) {
+      alert('Times are oldstart'+Shared.friendlyTimestamp(getOldStart)+' lastcron '+Shared.friendlyTimestamp(lastCron)+' and newstart '+Shared.friendlyTimestamp(getNewStart));
+      if (getOldStart < momentLastCron && momentLastCron <  getNewStart) {
+        alert('Setting lastcron to '+Shared.friendlyTimestamp(getNewStart));
         User.set({ 'lastCron' : isoNewStart});
       }
-      User.set({'preferences.dayStart': dayStart});
+    };
+
+    $scope.saveDayStart = function(varDayStart){
+      var oldDayStart = User.user.preferences.dayStart;
+      var newDayStart = varDayStart;
+
+      if ( newDayStart != Math.floor(newDayStart) || newDayStart < 0 || newDayStart > 24 ) {
+        newDayStart = 0;
+        return alert(window.env.t('enterNumber'));
+      }
+      updateLastCron( oldDayStart, newDayStart);
+      User.set({'preferences.dayStart': Math.floor(newDayStart)});
     }
 
     $scope.language = window.env.language;

--- a/website/public/js/controllers/settingsCtrl.js
+++ b/website/public/js/controllers/settingsCtrl.js
@@ -66,11 +66,22 @@ habitrpg.controller('SettingsCtrl',
       User.set({'flags.newStuff':true});
     }
 
-    $scope.saveDayStart = function(){
-      var dayStart = +User.user.preferences.dayStart;
-      if (_.isNaN(dayStart) || dayStart < 0 || dayStart > 24) {
+    $scope.passDayStart = User.user.preferences.dayStart;
+
+    $scope.saveDayStart = function(newDayStart){
+      var oldDayStart = User.user.preferences.dayStart;
+      var dayStart = newDayStart;
+      var lastCron = User.user.lastCron;
+      var getOldStart = Shared.startOfDay({ dayStart: oldDayStart});
+      var getNewStart = Shared.startOfDay({ dayStart: dayStart});
+      var isoNewStart = Shared.isoTimestamp(getNewStart);
+
+      if (dayStart == undefined || _.isNaN(dayStart) || dayStart < 0 || dayStart > 24) {
         dayStart = 0;
         return alert(window.env.t('enterNumber'));
+      }
+      if (Shared.momentTimestamp(getOldStart) <= Shared.momentTimestamp(lastCron) && Shared.momentTimestamp(lastCron) <  Shared.momentTimestamp(getNewStart)) {
+        User.set({ 'lastCron' : isoNewStart});
       }
       User.set({'preferences.dayStart': dayStart});
     }

--- a/website/views/options/settings.jade
+++ b/website/views/options/settings.jade
@@ -83,7 +83,7 @@ script(type='text/ng-template', id='partials/options.settings.settings.html')
               h5(ng-if='showCustomDayStartInfo')!=env.t('customDayStartInfo4')
               .form-group
                 .input-group
-                  input.form-control(type='number', min='0', max='23', ng-model='user.preferences.dayStart', ng-blur='saveDayStart()')
+                  input.form-control(type='number', min='0', max='23', ng-model='passDayStart', ng-blur='saveDayStart(passDayStart)')
                   span.input-group-addon= ':00 (' + env.t('24HrClock') + ')'
 
       .personal-options.col-md-6
@@ -270,7 +270,7 @@ script(id='partials/options.settings.notifications.html', type="text/ng-template
             =env.t('emailNotifications')
           .panel-body
 
-            each notification in ['newPM', 'wonChallenge', 'giftedGems', 'giftedSubscription', 'invitedParty', 'invitedGuild', 'kickedGroup', 'questStarted', 'invitedQuest', 'inactivityEmails', 'weeklyRecaps'] 
+            each notification in ['newPM', 'wonChallenge', 'giftedGems', 'giftedSubscription', 'invitedParty', 'invitedGuild', 'kickedGroup', 'questStarted', 'invitedQuest', 'inactivityEmails', 'weeklyRecaps']
               -var preference = 'user.preferences.emailNotifications.' + notification
               -var unsubscribeFromAll = 'user.preferences.emailNotifications.unsubscribeFromAll'
 

--- a/website/views/options/settings.jade
+++ b/website/views/options/settings.jade
@@ -83,7 +83,7 @@ script(type='text/ng-template', id='partials/options.settings.settings.html')
               h5(ng-if='showCustomDayStartInfo')!=env.t('customDayStartInfo4')
               .form-group
                 .input-group
-                  input.form-control(type='number', min='0', max='23', ng-model='passDayStart', ng-blur='saveDayStart(passDayStart)')
+                  input.form-control(type='number', min='0', max='23', ng-model='dayStart', ng-blur='saveDayStart(dayStart)')
                   span.input-group-addon= ':00 (' + env.t('24HrClock') + ')'
 
       .personal-options.col-md-6


### PR DESCRIPTION
The problem was that cron could be tricked into running over and over again by pushing the offset of dayStart forward an hour at a time. This solution will only allow cron to be run twice in quick succession if the user changes dayStart backward (the extreme case is allowing cron to run with a dayStart of 23 and then changing the dayStart offset to 0). But this behavior is much more logical than having cron run again if a player allows cron to run and then sets the offset to one hour in the future.

Modified common/script/index.coffee to display dayStart, but send back a variable of dayStart for processing, instead of having the object directly updated at the time of edit.

Modified website/views/options/settings.jade to allow a timestamp to be
cast to an iso timestamp because lastCron is saved as an iso timestamp,
and as a straight moment()-based timestamp in order to compare timestamps.

Modified website/public/js/controllers/settingsCtrl.js to do the
following:
   Accept the new proposed dayStart
   Calculate the timestamp of the old dayStart and the new dayStart

   These two steps were necessary because dayStart is an integer between
   and including 0 and 23. I tested and confirmed the current production
   dayStart does not allow 24 to be entered but does allow 0. I was
   careful to NOT change how that worked.

   Cast the old dayStart, the new dayStart and lastCron to the moment()
   version of time so they could be compared.

   Cast the new dayStart to the iso timestamp for storage in lastCron

   The important change is the following:

   if oldDayStart < lastCron AND lastCron < newDayStart then lastCron
   should be set to newDayStart. I modified this to include if oldDayStart
   = lastCron, although I think that's pretty unlikely to be possible.
   When I tested this, my lastCron was a mere 17 seconds after my
   oldDayStart, so it seemed to me that the equal case should be included
   with the less than case.
