### PR TITLE
make cron count multiple missed days as one missed day

### DIFF
--- a/common/script/index.coffee
+++ b/common/script/index.coffee
@@ -1717,12 +1717,16 @@ api.wrap = (user, main=true) ->
           daily.completed = false
         return
 
+      multiDaysCountAsOneDay = true
+      # If the user does not log in for two or more days, cron (mostly) acts as if it were only one day.
+      # When site-wide difficulty settings are introduced, this can be a user preference option.
+
       # Tally each task
       todoTally = 0
       user.todos.forEach (task) -> # make uncompleted todos redder
         return unless task
         {id, completed} = task
-        delta = user.ops.score({params:{id:task.id, direction:'down'}, query:{times:(daysMissed), cron:true}})
+        delta = user.ops.score({params:{id:task.id, direction:'down'}, query:{times:(multiDaysCountAsOneDay ? 1 : daysMissed), cron:true}})
         absVal = if (completed) then Math.abs(task.value) else task.value
         todoTally += absVal
 
@@ -1740,14 +1744,22 @@ api.wrap = (user, main=true) ->
           dailyChecked += 1
         else
           # dailys repeat, so need to calculate how many they've missed according to their own schedule
+          console.log("task: " + task.text) # XXX Alys to remove these
           scheduleMisses = 0
+          keepGoing = true # XXX Alys to improve how we break out of _.times
           _.times daysMissed, (n) ->
-            thatDay = moment(now).subtract({days: n + 1})
-            if api.shouldDo(thatDay.toDate(), task, user.preferences)
-              scheduleMisses++
-              if user.stats.buffs.stealth
-                user.stats.buffs.stealth--
-                EvadeTask++
+            if keepGoing
+              console.log("n: " + n)
+              thatDay = moment(now).subtract({days: n + 1})
+              if api.shouldDo(thatDay.toDate(), task, user.preferences)
+                console.log("damage")
+                scheduleMisses++
+                if user.stats.buffs.stealth
+                  user.stats.buffs.stealth--
+                  EvadeTask++
+                if multiDaysCountAsOneDay
+                  console.log("end")
+                  keepGoing = false
 
           if scheduleMisses > EvadeTask
             perfect = false
@@ -1757,7 +1769,7 @@ api.wrap = (user, main=true) ->
               dailyChecked += fractionChecked
             else
              dailyDueUnchecked += 1
-            delta = user.ops.score({params:{id:task.id, direction:'down'}, query:{times:(scheduleMisses-EvadeTask), cron:true}})
+            delta = user.ops.score({params:{id:task.id, direction:'down'}, query:{times:(multiDaysCountAsOneDay ? 1 : (scheduleMisses-EvadeTask)), cron:true}})
 
             # Apply damage from a boss, less damage for Trivial priority (difficulty)
             user.party.quest.progress.down += delta * (if task.priority < 1 then task.priority else 1)

--- a/test/common/dailies.coffee
+++ b/test/common/dailies.coffee
@@ -49,8 +49,8 @@ newUser = (addTasks=true)->
       user.ops.addTask {body: {type: task, id: shared.uuid()}}
   user
 
-cron = (usr) ->
-  usr.lastCron = moment().subtract(1,'days')
+cron = (usr, missedDays=1) ->
+  usr.lastCron = moment().subtract(missedDays,'days')
   usr.fns.cron()
 
 describe 'daily/weekly that repeats everyday (default)', ->

--- a/website/views/shared/footer.jade
+++ b/website/views/shared/footer.jade
@@ -79,6 +79,15 @@ footer.footer(ng-controller='FooterCtrl')
             a.btn.btn-default(ng-click='setHealthLow()') Health = 1
             a.btn.btn-default(ng-click='addMissedDay(1)') +1 Missed Day
             a.btn.btn-default(ng-click='addMissedDay(2)') +2 Missed Days
+            // XXX Alys to remove these excess ones when testing is done:
+            a.btn.btn-default(ng-click='addMissedDay(3)') +3 Missed Days
+            a.btn.btn-default(ng-click='addMissedDay(4)') +4 Missed Days
+            a.btn.btn-default(ng-click='addMissedDay(5)') +5 Missed Days
+            a.btn.btn-default(ng-click='addMissedDay(6)') +6 Missed Days
+            a.btn.btn-default(ng-click='addMissedDay(7)') +7 Missed Days
+            a.btn.btn-default(ng-click='addMissedDay(8)') +8 Missed Days
+            a.btn.btn-default(ng-click='addMissedDay(9)') +9 Missed Days
+            a.btn.btn-default(ng-click='addMissedDay(10)') +10 Missed Day
             a.btn.btn-default(ng-click='addTenGems()') +10 Gems
             a.btn.btn-default(ng-click='addGold()') +GP
             a.btn.btn-default(ng-click='addMana()') +MP


### PR DESCRIPTION
fixes https://github.com/HabitRPG/habitrpg/issues/4630

**DO NOT MERGE**. Seeking advice (see notes I'll add in the diffs). Needs tests (I will write them). Code contains test lines that will be removed by me before merging.

This PR causes cron to behave as if only one day has been missed when the user has not logged in for two or more days.
- **Habits**: No change (they already don't have code for handling multiple missed days).
- **Dailies**: 
  - If a Daily was due at any time in the user's absence, it will be counted as missed but only once (only one day's worth of damage to the player and party will be done) and checklist items will be unticked. For Rogues, only one Stealth point will be used up by that Daily.
  - If the Daily was not due at all during the user's absence, checklist items will not be unticked (and no damage of course).
- **To-Dos**: Their values will be changed by only one's days worth of reddening. It could be said that this is a disadvantage because redder To-Dos are more valuable, but some users find red To-Dos demotivating, especially after an absence (all your yellow To-Dos now being bright red is startling and scary). Also, since we're removing most of the punishment from multiple days of missed Dailies, it seems fair that we also remove most of the rewards from multiple days of reddened To-Dos.

The code change has been done in a way that lets us easily go back to counting multiple missed days. For example, if we implement site-wide difficulty settings, we could have a setting to make cron NOT ignore multiple missed days.
