### PR TITLE
Make challenge participant's name clickable in progress modal

### DIFF
--- a/website/views/options/social/challenges.jade
+++ b/website/views/options/social/challenges.jade
@@ -14,7 +14,8 @@ script(type='text/ng-template', id='partials/options.social.challenges.detail.me
       .modal-content
         .modal-header
           button.close(type='button', ng-click='$state.go("^")', aria-hidden='true') ×
-          h3 {{obj.profile.name}}
+          a(ng-click='clickMember(obj._id, true)')
+            h3 {{obj.profile.name}}
         .modal-body
           habitrpg-tasks(main=false, modal='true')
         .modal-footer


### PR DESCRIPTION
Challenge participant's names are now clickable (see blue `blabla` in screenshot)

![image](https://cloud.githubusercontent.com/assets/3625477/9022128/8c3e9d56-3868-11e5-9cb0-8cdd588d7abf.png)

I was able to display a "Send private message" icon in the corner, but wasn't able to connect it with the member. The api call that was triggered in the private message modal didn't have all the info it needed, and I couldn't figure it out. Pretty new to all that AngularJS magic

here is what I had in /website/views/options/social/challenges.jade

``` diff
script(type='text/ng-template', id='partials/options.social.challenges.detail.member.html')
  .modal.bs-modal-lg(style='display: block')
    .modal-dialog.modal-lg
      .modal-content
        .modal-header
          button.close(type='button', ng-click='$state.go("^")', aria-hidden='true') ×
          a(ng-click='clickMember(obj._id, true)')
            h3 {{obj.profile.name}}
        .modal-body
          habitrpg-tasks(main=false, modal='true')
        .modal-footer
+         .btn-group.pull-left
+            button.btn.btn-md.btn-default(tooltip=env.t('sendPM'), ng-click="openModal('private-message',{controller:'MemberModalCtrl', scope: $scope})", tooltip-placement='right')
+              span.glyphicon.glyphicon-envelope
          a.btn.btn-default(ng-click='$state.go("^")')=env.t('close')
```

Maybe someone can jump in or give me a hint? Having the link is probably enough, though

My User ID: 5ddc7667-7bbe-4466-a043-c290443bf17f
