### PR TITLE
WIP: Allow content to be inactive

### DIFF
--- a/common/script/content.coffee
+++ b/common/script/content.coffee
@@ -2225,6 +2225,7 @@ api.backgrounds =
       text: t('backgroundTwinklyPartyLightsText')
       notes: t('backgroundTwinklyPartyLightsNotes')
   backgrounds092015:
+    inactive: true
     market:
       text: t('backgroundMarketText')
       notes: t('backgroundMarketNotes')

--- a/website/views/options/profile.jade
+++ b/website/views/options/profile.jade
@@ -285,14 +285,16 @@ mixin backgrounds(mobile)
       - var bgsKeys = Object.keys(env.Content.backgrounds);
       - for (var i = bgsKeys.length-1; i >= 0; i--) {
         - var k = bgsKeys[i], bgs = env.Content.backgrounds[k];
-        li.customize-menu
-          menu(label=env.t(k))
-            span(ng-hide="ownsSet('background',#{JSON.stringify(bgs)})")
-              +gemCost(7)
-                button.btn.btn-xs(ng-click="unlock(setKeys('background',#{JSON.stringify(bgs)}))")!= env.t('unlockSet',{cost:15}) + ' <span class="Pet_Currency_Gem1x inline-gems"/>'
-            each bg,k in bgs
-              button.customize-option(type='button', class='background_#{k}', ng-class="user.purchased.background.#{k} ? 'background-unlocked' : 'background-locked'", ng-click='unlock("background.#{k}")', popover-title=bg.text(env.language.code), popover=bg.notes(env.language.code),popover-trigger='mouseenter')
-                i.glyphicon.glyphicon-lock(ng-if="!user.purchased.background.#{k}")
+        - if (!bgs.hidden) {
+          li.customize-menu
+            menu(label=env.t(k))
+              span(ng-hide="ownsSet('background',#{JSON.stringify(bgs)})")
+                +gemCost(7)
+                  button.btn.btn-xs(ng-click="unlock(setKeys('background',#{JSON.stringify(bgs)}))")!= env.t('unlockSet',{cost:15}) + ' <span class="Pet_Currency_Gem1x inline-gems"/>'
+              each bg,k in bgs
+                button.customize-option(type='button', class='background_#{k}', ng-class="user.purchased.background.#{k} ? 'background-unlocked' : 'background-locked'", ng-click='unlock("background.#{k}")', popover-title=bg.text(env.language.code), popover=bg.notes(env.language.code),popover-trigger='mouseenter')
+                  i.glyphicon.glyphicon-lock(ng-if="!user.purchased.background.#{k}")
+        - }
       - }
 
 script(type='text/ng-template', id='partials/options.profile.backgrounds.html')

--- a/website/views/options/profile.jade
+++ b/website/views/options/profile.jade
@@ -285,7 +285,7 @@ mixin backgrounds(mobile)
       - var bgsKeys = Object.keys(env.Content.backgrounds);
       - for (var i = bgsKeys.length-1; i >= 0; i--) {
         - var k = bgsKeys[i], bgs = env.Content.backgrounds[k];
-        - if (!bgs.hidden) {
+        - if (!bgs.inactive) {
           li.customize-menu
             menu(label=env.t(k))
               span(ng-hide="ownsSet('background',#{JSON.stringify(bgs)})")


### PR DESCRIPTION
# :warning: DO NOT MERGE :warning:
## Problem

Content needs to be available on the site in advance of it being released.

_Use Case:_ User sees new quest has been released and immediately invites party to quest. Meanwhile, a party member, who had the site open before the deploy, and thus does not 
## Solution

Provide inactive statuses for content
## Still needs to be done
- [ ] Allow armoire items to be inactive
- [ ] Allow quests to be inactive
- [ ] Allow mystery sets to be inactive
- [ ] Prevent purchasing inactive items via api
- [ ] Prevent inactive items from being passed back in content call
## Concerns

Is this the best way to go?

Maybe it's enough to look up quest details via a content api route?
