### PR TITLE
Groups now make joining user the leader when they are empty

### DIFF
--- a/test/api/groups.coffee
+++ b/test/api/groups.coffee
@@ -249,7 +249,6 @@ describe "Guilds", ->
             done()
 
   describe "Public Guilds", ->
-    guild = undefined
     before (done) ->
       async.waterfall [
         (cb) ->
@@ -257,62 +256,125 @@ describe "Guilds", ->
             User.findByIdAndUpdate user._id, {$set: { "balance": 10 } }, (err, _user) ->
               cb()
           , true
-        (cb) ->
-          request.post(baseURL + "/groups").send(
-            name: "TestPublicGroup"
-            type: "guild"
-            privacy: "public"
-          ).end (res) ->
-            guild = res.body
-            expect(guild.members.length).to.equal 1
-            expect(guild.leader).to.equal user._id
-            #Add members to guild
-            cb()
-
-        (cb) ->
-          registerManyUsers 15, cb
-
-        (_members, cb) ->
-          members = _members
-
-          joinGuild = (member, callback) ->
-            request.post(baseURL + "/groups/" + guild._id + "/join")
-              .set("X-API-User", member._id)
-              .set("X-API-Key", member.apiToken)
-              .end ->
-                callback(null, null)
-
-          async.map members, joinGuild, (err, results) -> cb()
-
       ], done
 
-    context "is a member", ->
+    context "joining groups", ->
+      it "makes user a group leader when group is empty", (done) ->
+        guildToEmptyAndAssignLeader = undefined
+        members = undefined
+        userToBecomeLeader = undefined
+        request.post(baseURL + "/groups").send(
+          name: "TestGuildToEmptyAndAssignLeader"
+          type: "guild"
+        ).end (res) ->
+          guildToEmptyAndAssignLeader = res.body
+          #Add members to guild
+          async.waterfall [
+            (cb) ->
+              registerManyUsers 1, cb
+
+            (_members, cb) ->
+              userToBecomeLeader = _members[0]
+              members = _members
+              inviteURL = baseURL + "/groups/" + guildToEmptyAndAssignLeader._id + "/invite"
+              request.post(inviteURL).send(
+                uuids: [userToBecomeLeader._id]
+              )
+              .end ->
+                cb()
+
+            (cb) ->
+              request.post(baseURL + "/groups/" + guildToEmptyAndAssignLeader._id + "/leave")
+                .send()
+                .end (res) ->
+                  expectCode res, 204
+                  cb()
+
+            (cb) ->
+              request.post(baseURL + "/groups/" + guildToEmptyAndAssignLeader._id + "/join")
+                .set("X-API-User", userToBecomeLeader._id)
+                .set("X-API-Key", userToBecomeLeader.apiToken)
+                .end (res) ->
+                  expectCode res, 200
+                  cb()
+
+            (cb) ->
+              request.get(baseURL + "/groups/" + guildToEmptyAndAssignLeader._id)
+              .set("X-API-User", userToBecomeLeader._id)
+              .set("X-API-Key", userToBecomeLeader.apiToken)
+              .send()
+              .end (res) ->
+                expectCode res, 200
+                g = res.body
+                expect(g.leader._id).to.equal(userToBecomeLeader._id)
+                cb()
+
+          ], done
+
+    context "viewing", ->
+      guild = undefined
       before (done) ->
-        registerNewUser ->
-          request.post(baseURL + "/groups/" + guild._id + "/join")
-            .end (res)->
+        async.waterfall [
+          (cb) ->
+            registerNewUser ->
+              User.findByIdAndUpdate user._id, {$set: { "balance": 10 } }, (err, _user) ->
+                cb()
+            , true
+          (cb) ->
+            request.post(baseURL + "/groups").send(
+              name: "TestPublicGroup"
+              type: "guild"
+              privacy: "public"
+            ).end (res) ->
+              guild = res.body
+              expect(guild.members.length).to.equal 1
+              expect(guild.leader).to.equal user._id
+              #Add members to guild
+              cb()
+
+          (cb) ->
+            registerManyUsers 15, cb
+
+          (_members, cb) ->
+            members = _members
+
+            joinGuild = (member, callback) ->
+              request.post(baseURL + "/groups/" + guild._id + "/join")
+                .set("X-API-User", member._id)
+                .set("X-API-Key", member.apiToken)
+                .end ->
+                  callback(null, null)
+
+            async.map members, joinGuild, (err, results) -> cb()
+
+        ], done
+
+      context "is a member", ->
+        before (done) ->
+          registerNewUser ->
+            request.post(baseURL + "/groups/" + guild._id + "/join")
+              .end (res)->
+                done()
+          , true
+
+        it "includes user in public group member list", (done) ->
+          request.get(baseURL + "/groups/" + guild._id)
+            .end (res) ->
+              g = res.body
+              expect(g.members.length).to.equal 15
+              userInGroup = _.find g.members, (member) -> return member._id == user._id
+              expect(userInGroup).to.exist
               done()
-        , true
 
-      it "includes user in public group member list", (done) ->
-        request.get(baseURL + "/groups/" + guild._id)
-          .end (res) ->
-            g = res.body
-            expect(g.members.length).to.equal 15
-            userInGroup = _.find g.members, (member) -> return member._id == user._id
-            expect(userInGroup).to.exist
-            done()
+      context "is not a member", ->
+        before (done) ->
+          registerNewUser done, true
 
-
-    context "is not a member", ->
-      before (done) ->
-        registerNewUser done, true
-
-      it "excludes user in public group member list", (done) ->
-        request.get(baseURL + "/groups/" + guild._id)
-          .end (res) ->
-            g = res.body
-            expect(g.members.length).to.equal 15
-            userInGroup = _.find g.members, (member) -> return member._id == user._id
-            expect(userInGroup).to.not.exist
-            done()
+        it "excludes user in public group member list", (done) ->
+          request.get(baseURL + "/groups/" + guild._id)
+            .end (res) ->
+              g = res.body
+              expect(g.members.length).to.equal 15
+              userInGroup = _.find g.members, (member) -> return member._id == user._id
+              expect(userInGroup).to.not.exist
+              done()

--- a/website/src/controllers/groups.js
+++ b/website/src/controllers/groups.js
@@ -462,6 +462,9 @@ api.join = function(req, res, next) {
   if(!isUserInvited) return res.json(401, {err: "Can't join a group you're not invited to."});
 
   if (!_.contains(group.members, user._id)){
+    if (group.members.length === 0) {
+      group.leader = user._id;
+    }
     group.members.push(user._id);
     if (group.invites.length > 0) {
      group.invites.splice(_.indexOf(group.invites, user._id), 1);


### PR DESCRIPTION
This is to address one of the requirements on #5871 . When a group is empty, we add the first user to join as the leader. 
