### PR TITLE
Update the look of the static old news page (Fix for #5836)

### DIFF
--- a/website/public/css/index.styl
+++ b/website/public/css/index.styl
@@ -110,7 +110,7 @@ html, body
 //move
 
 .new-stuff-modal // a .modal-body
-  h5
+  h4, h5
     font-weight: 700
 
 .modal-fixed-height

--- a/website/public/css/index.styl
+++ b/website/public/css/index.styl
@@ -110,8 +110,10 @@ html, body
 //move
 
 .new-stuff-modal // a .modal-body
-  h4, h5
+  h2, h3
     font-weight: 700
+    font-size: 14px
+    margin-top: 10px
 
 .modal-fixed-height
   overflow-y: auto

--- a/website/public/css/static.styl
+++ b/website/public/css/static.styl
@@ -39,7 +39,7 @@ body
   text-transform: uppercase
   border-bottom: 1px solid rgba(0, 0, 0, 0.1)
     
-h5
+h5.big_news_header
   hr
     display: none
     

--- a/website/public/css/static.styl
+++ b/website/public/css/static.styl
@@ -27,13 +27,15 @@ body
   text-align: center
   
 .static-old-news
-  h4
+  h2
     font-weight: 700
+    font-size: 16px
     padding-left: 20px
     margin-top: 30px
     text-transform: uppercase
-  h5
+  h3
     font-weight: 700
+    font-size: 14px
     margin-top: 20px
   .pull-right
     margin-left: 5px

--- a/website/public/css/static.styl
+++ b/website/public/css/static.styl
@@ -35,6 +35,8 @@ body
   h5
     font-weight: 700
     margin-top: 20px
+  .pull-right
+    margin-left: 5px
     
 .remove-on-static
   display: none

--- a/website/public/css/static.styl
+++ b/website/public/css/static.styl
@@ -25,6 +25,26 @@ body
 
 .marketing
   text-align: center
+  
+.small_news_header
+  font-weight: 700
+  margin-top: 20px
+    
+.big_news_header
+  font-weight: 700
+  font-size: 120%
+  padding-left: 20px
+  padding-bottom: 15px
+  margin-top: 30px
+  text-transform: uppercase
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1)
+    
+h5
+  hr
+    display: none
+    
+.remove_on_static
+  display: none
 
 #frontpage-play-button
   //box-shadow: 0 0 40px #494141;

--- a/website/public/css/static.styl
+++ b/website/public/css/static.styl
@@ -26,24 +26,17 @@ body
 .marketing
   text-align: center
   
-.small_news_header
-  font-weight: 700
-  margin-top: 20px
+.static-old-news
+  h4
+    font-weight: 700
+    padding-left: 20px
+    margin-top: 30px
+    text-transform: uppercase
+  h5
+    font-weight: 700
+    margin-top: 20px
     
-.big_news_header
-  font-weight: 700
-  font-size: 120%
-  padding-left: 20px
-  padding-bottom: 15px
-  margin-top: 30px
-  text-transform: uppercase
-  border-bottom: 1px solid rgba(0, 0, 0, 0.1)
-    
-h5.big_news_header
-  hr
-    display: none
-    
-.remove_on_static
+.remove-on-static
   display: none
 
 #frontpage-play-button

--- a/website/public/css/static.styl
+++ b/website/public/css/static.styl
@@ -48,10 +48,10 @@ h5
 
 #frontpage-play-button
   //box-shadow: 0 0 40px #494141;
-  display:inline
+  display: inline
   font-size: 20px
-  min-width:100px
-  height:50px
+  min-width: 100px
+  height: 50px
 
 #about-page
   img

--- a/website/views/shared/new-stuff.jade
+++ b/website/views/shared/new-stuff.jade
@@ -1,14 +1,14 @@
-h5 NEW ITEMS IN THE ENCHANTED ARMOIRE AND SEPTEMBER BACKGROUNDS!
+h5.big_news_header NEW ITEMS IN THE ENCHANTED ARMOIRE AND SEPTEMBER BACKGROUNDS!
   hr
   tr
     td
       .background_tavern.pull-right
-      h5 September Backgrounds Revealed
+      h5.small_news_header September Backgrounds Revealed
       p There are three new avatar backgrounds in the <a href='/#/options/profile/backgrounds'>Background Shop</a>! Now your avatar can visit the Habitica Tavern, shop in the Habitica Market, or ride mounts in the Habitica Stable! 
   tr
     td
       .promo_enchanted_armoire_201509.pull-right
-      h5 New Items in the Enchanted Armoire!
+      h5.small_news_header New Items in the Enchanted Armoire!
       p There is new equipment in the Enchanted Armoire, a 100 GP Reward in the Rewards Column which unlocks after you've attained Ultimate Gear! 
       br
       p Click on the Enchanted Armoire for a random chance at special Equipment, including the Yellow Hairbow, Red Floppy Hat, Gold Winged Staff, and the Plague Doctor Item Set! It may also give you random XP or food items. We'll be adding new equipment to it during the first week of each month, but even when you've exhausted the current supply, you can keep clicking for a chance at food and XP.
@@ -17,51 +17,51 @@ h5 NEW ITEMS IN THE ENCHANTED ARMOIRE AND SEPTEMBER BACKGROUNDS!
       p.small.muted by Lemoness and SabreCat
       p.small.muted Art by Starsystemic and Kiwibot
 
-hr
-a(href='/static/old-news', target='_blank') Read older news
+hr.remove_on_static
+a(href='/static/old-news', target='_blank').remove_on_static Read older news
 
 mixin oldNews
-  h5 LAST CHANCE FOR CHEETAH COSTUME! COSTUME CHALLENGE ANNOUNCED!
+  h5.big_news_header LAST CHANCE FOR CHEETAH COSTUME! COSTUME CHALLENGE ANNOUNCED!
     tr
       td
         .promo_mystery_201508.pull-right
-        h5 Last Chance for Cheetah Costume Set
+        h5.small_news_header Last Chance for Cheetah Costume Set
         p Reminder: this is the final day to <a href='/#/options/settings/subscription'>subscribe</a> and receive the Cheetah Costume Item Set! If you want the Cheetah Hat or the Cheetah Costume, now's the time. Thanks so much for your support - it's your generosity that keeps Habitica alive.
     tr
       td
-        h5 Get Ready for the Community Costume Challenge!
+        h5.small_news_header Get Ready for the Community Costume Challenge!
         p On October 1st, we will launch the second annual Community Costume Challenge! Dress up in real-life versions of your avatar's armor to receive a special badge. (No, just wearing a colored shirt doesn't count. Where's the fun in that?)
         br
         p We're announcing the Challenge early so that people will have time to prepare costumes. You can see some of the excellent costumes from last year <a href='http://blog.habitrpg.com/tagged/cosplay' target='_blank'>here</a>.
         br
         p Instructions on how to take part in the CCC will be posted on October 1st. We can't wait to see your costumes!
 
-  h5 8/27/2015 - OFFICIAL BACK TO SCHOOL ADVICE CHALLENGE
+  h5.big_news_header 8/27/2015 - OFFICIAL BACK TO SCHOOL ADVICE CHALLENGE
     hr
     tr
       td
         .promo_backtoschool.pull-right
-        h5 Official Back to School Advice Challenge!
+        h5.small_news_header Official Back to School Advice Challenge!
         p We've launched another Official Challenge: the Back To School Advice Challenge! Use social media to tell us how you use Habitica to improve study habits, share stories of scholarly success with the app, or just give us your advice on using Habitica to be the best you can be.
         br
         p The contest ends on September 27th, and the 10 winners will each get 30 Gems! For the full rules, <a href='/#/options/groups/challenges/533cac3f-f431-424f-9eaa-4d509f015a75'>check out the challenge here</a>.
-  h5 8/24/2015 - AUGUST SUBSCRIBER ITEM SET: CHEETAH COSTUME!
+  h5.big_news_header 8/24/2015 - AUGUST SUBSCRIBER ITEM SET: CHEETAH COSTUME!
     tr
       td
         .promo_mystery_201508.pull-right
-        h5 August Subscriber Item Set: Cheetah Costume!
+        h5.small_news_header August Subscriber Item Set: Cheetah Costume!
         p The August Subscriber Items have been revealed: the Cheetah Costume Item Set! All August subscribers will receive the Cheetah Costume and the Cheetah Hat. You still have six days to <a href='/#/options/settings/subscription'>subscribe</a> and receive the item set! Thank you so much for your support - we really do rely on you to keep Habitica free to use and running smoothly.
         p.small.muted by Lemoness
-  h5 8/19/2015 - CHEETAH PET QUEST, iPAD APP, and GRYPHON CONTEST WINNER!
+  h5.big_news_header 8/19/2015 - CHEETAH PET QUEST, iPAD APP, and GRYPHON CONTEST WINNER!
     tr
       td
         .Pet-Cheetah-Base.pull-right
-        h5 Cheetah Pet Quest
+        h5.small_news_header Cheetah Pet Quest
         p A new pet quest is available in the <a href='/#/options/inventory/quests'>Quests Page</a>: Such a Cheetah! A Cheetah is speeding past incomplete tasks and burning them up before people can complete them. Can you put on the brakes? If so, you’ll be awarded with some cheetah eggs!
         p.small.muted by PainterProphet, tivaquinn, Unruly Hyena, Crawford, janetmango, Lemoness, and SabreCat
     tr
       td
-        h5 iOS Update and iPad App
+        h5.small_news_header iOS Update and iPad App
         p There’s a new iOS update! One of our awesome open-source contributors, Shadallark, has made our Habitica iOS app Universal so that it natively supports iPads. Enjoy all the new space for your tasks! We've also fixed several bugs, and excellent contributor kylefox has added a search bar.
         br
         p If you like the direction that we’ve been taking the app, please consider leaving us a review. It means a lot to us :) Questions? Concerns? Don't hesitate to email <a href='mailto:mobile@habitica.com' target='_blank'>mobile@habitica.com</a> and we will happily help you!
@@ -74,35 +74,35 @@ mixin oldNews
       td
         span.Mount_Body_Gryphon-RoyalPurple.pull-right
           span.Mount_Head_Gryphon-RoyalPurple.pull-right(style='margin:0')
-        h5 Gryphon Contest Winner
+        h5.small_news_header Gryphon Contest Winner
         p After sorting through over 1600 entries, we finally have a name for our Royal Purple Gryphon: MELIOR! "Melior" is Latin for "better," because Habitica is a place where everyone is striving to become better at their goals in their quest to improve their lives.
         br
         p The name "Melior" was submitted by awesome user NobleTheSecond, who has received their prize. Congratulations! A secondary prize has also been awarded to TangyDragonBBQ, who independently submitted a slightly different variant of that name. 
         br
         p Thank you so much to everyone who submitted names! They were very well-thought-out and very entertaining, and it was extremely difficult for the staff to make a decision. We hope you will join with us in welcoming Melior into the Habitica family!
 
-  h5 8/13/2015 - GOLD-PURCHASABLE CARDS
+  h5.big_news_header 8/13/2015 - GOLD-PURCHASABLE CARDS
     tr
       td
         .inventory_special_greeting.pull-right
         .inventory_special_thankyou.pull-right
-        h5 Gold-Purchasable Cards
+        h5.small_news_header Gold-Purchasable Cards
         p There are two new types of Card available in the <a href='/#/options/inventory/drops'>Market</a> that you can send to the people in your Party: Greeting Cards and Thank-You Cards! Both cost 10 Gold, and will be available year-round. Sending or receiving these cards will give you some fun achievements!
         br
         p Enjoy!
         p.small.muted by PainterProphet, Teto Is Great, Lemoness, and SabreCat
 
-  h5 8/4/2015 - NEW ITEMS IN THE ENCHANTED ARMOIRE AND AUGUST BACKGROUNDS
+  h5.big_news_header 8/4/2015 - NEW ITEMS IN THE ENCHANTED ARMOIRE AND AUGUST BACKGROUNDS
     tr
       td
         .background_pyramids.pull-right
-        h5 August Backgrounds Revealed
+        h5.small_news_header August Backgrounds Revealed
         p There are three new avatar backgrounds in the <a href='/#/options/profile/backgrounds'>Background Shop</a>! Now your avatar can admire the Pyramids, stalk across the Sunset Savannah, or dance under Twinkly Party Lights!
         p.small.muted by (in order): minac1, Bambin, and rosiesully
     tr
       td
         .promo_enchanted_armoire_201508.pull-right
-        h5 New Items in the Enchanted Armoire!
+        h5.small_news_header New Items in the Enchanted Armoire!
         p There is new equipment in Enchanted Armoire, a 100 GP Reward in the Rewards Column which unlocks after you've attained Ultimate Gear!
         br
         p Click on the Enchanted Armoire for a random chance at special Equipment, including the Golden Toga Item Set and the Horned Iron Item Set.! It may also give you random XP or food items. We'll be adding new equipment to it during the first week of each month, but even when you've exhausted the current supply, you can keep clicking for a chance at food and XP.
@@ -111,17 +111,17 @@ mixin oldNews
         br
         p.small.muted by Lemoness and SabreCat
         p.small.muted Art by Kiwibot, Starsystemic, Podcod, and UncommonCriminal
-  h5 8/2/2015 - AUGUST MYSTERY BOX!
+  h5.big_news_header 8/2/2015 - AUGUST MYSTERY BOX!
     tr
       td
         .inventory_present_08.pull-right
-        h5 August Mystery Box
+        h5.small_news_header August Mystery Box
         p How curious! All Habiticans who are <a href='/#/options/settings/subscription'>subscribed</a> during the month of August will receive the August Mystery Item Set, as well as the ability to buy Gems with Gold! The August Item Set will be revealed on the 24th, so keep your eyes peeled. Thanks for supporting the site <3
-  h5 7/31/2015 - HABITICA NAMING DAY AND LAST CHANCE FOR SUMMER SPLASH
+  h5.big_news_header 7/31/2015 - HABITICA NAMING DAY AND LAST CHANCE FOR SUMMER SPLASH
     tr
       td
         .achievement_habiticaDay.pull-right
-        h5 Habitica Naming Day!
+        h5.small_news_header Habitica Naming Day!
         p It's finally here! HabitRPG has become Habitica. Your accounts should still stay exactly the same and work normally, just with some of the names and references changed. (For example, habitrpg.com now redirects to habitica.com.)
         br
         p In honor of the first annual Habitica Naming Day, we've given everyone an achievement, as well as some awesome treats...
@@ -130,7 +130,7 @@ mixin oldNews
       td
         span.Mount_Body_Gryphon-RoyalPurple.pull-right
           span.Mount_Head_Gryphon-RoyalPurple.pull-right(style='margin:0')
-        h5 Habitica Gryphon Mount and Contest
+        h5.small_news_header Habitica Gryphon Mount and Contest
         p Our new logo features a Gryphon, and now, so does your stable! We've given everyone a Royal Purple Gryphon Mount, under <a href='/#/options/inventory/mounts'>Inventory &gt; Mounts.</a>
         br
         p Furthermore, we need your help to give our Gryphon a name! Check out the Official Name the Gryphon Challenge <a href='/#/options/groups/challenges/a4898d49-9ed4-4029-974a-ff702f5b8b14'>here</a>. If we choose your name for the Gryphon in our logo, you'll win 30 Gems. You have until August 10th to submit a name.
@@ -138,29 +138,29 @@ mixin oldNews
     tr
       td
         .promo_veteran_pets.pull-right
-        h5 Veteran Pets
+        h5.small_news_header Veteran Pets
         p Since you are all veterans who have weathered the name change to Habitica, we've awarded everyone a Veteran Pet! If this is your first Veteran Pet, you've received the Veteran Wolf; if you already had the Wolf, you got the Veteran Tiger. You can find it under <a href='/#/options/inventory/pets'>Inventory &gt; Pets</a>, in the Rare Pets section.
         p.small.muted by Lemoness and Shaner
     tr
       td
         .promo_summer_classes_2015.pull-right
-        h5 Last Chance for Summer Splash Outfits, Hair and Skins, and Seafoam!
+        h5.small_news_header Last Chance for Summer Splash Outfits, Hair and Skins, and Seafoam!
         p Today is the final day of the Summer Splash Festival, so if you still have any remaining Summer Splash Items that you want to buy, you'd better do it now! The <a href='/#/tasks'>Seasonal Edition items</a>, <a href='/#/options/profile/avatar'>Skins</a>, and <a href='/#/options/profile/avatar'>Hair Colors</a> won't be back until next June, and if the Limited Edition items return they will have increased prices or changed art, so strike while the iron is hot!
     tr
       td
         .promo_mystery_201507.pull-right
-        h5 Last Chance for Rad Surfer Item Set
+        h5.small_news_header Last Chance for Rad Surfer Item Set
         p Reminder: this is the final day to <a href='/#/options/settings/subscription'>subscribe</a> and receive the Rad Surfer Item Set! If you want the Rad Surfboard or the Rad Sunglasses, now's the time! Thanks so much for your support <3
-  h5 7/29/2015 - HABITICA NAMING DAY ON JULY 31ST!
+  h5.big_news_header 7/29/2015 - HABITICA NAMING DAY ON JULY 31ST!
     tr
       td
-        h5 Habitica Naming Day is July 31st!
+        h5.small_news_header Habitica Naming Day is July 31st!
         p We are pleased to announce that the final day of the Summer Splash Festival, July 31st, will be the inaugural Habitica Naming Day! On this day, HabitRPG will officially become Habitica. Our old name was unfortunately very confusing to people ("HabitZPR? HabitGRG?"), so we've decided to name our app and website after the land of Habitica, where all these adventures take place.
         br
         p We will be celebrating with some fun surprises, so get excited!
     tr
       td
-        h5 What will change?
+        h5.small_news_header What will change?
         p In almost all cases, your accounts will still stay exactly the same and work normally! Only some of the names and references will be different. Here is a list of the changes:
         br
         ul
@@ -171,35 +171,35 @@ mixin oldNews
           li We don't anticipate any issues with third-party tools, but we will be actively working with developers to help them make any necessary updates. You can help us by reporting broken third-party tools at <a href='https://github.com/HabitRPG/habitrpg/issues/2760' target='_blank'>Help -&gt; Report a Bug</a>.
     tr
       td
-        h5 When will it change?
+        h5.small_news_header When will it change?
         p Changing our name is a pretty enormous task, so it won't all happen in an instant! Some changes may start switching over slightly before the 31st, and some may take slightly longer, but the majority of the changes and all of the celebration will take place on July 31st. Thank you for being patient with us!
     tr
       td
-        h5 More questions?
+        h5.small_news_header More questions?
         p If you have any more questions, drop by <a href='/#/options/groups/guilds/5481ccf3-5d2d-48a9-a871-70a7380cee5a'>the Newbies Guild</a> and we'll be happy to answer them!
-  h5 7/24/2015 - JULY SUBSCRIBER ITEM SET: RAD SURFER!
+  h5.big_news_header 7/24/2015 - JULY SUBSCRIBER ITEM SET: RAD SURFER!
     tr
       td
         .promo_mystery_201507.pull-right
-        h5 July Subscriber Items Revealed!
+        h5.small_news_header July Subscriber Items Revealed!
         p The July Subscriber Items have been revealed: the Rad Surfer Item Set! All July subscribers will receive the Rad Surfboard and the Rad Sunglasses. You still have six days to <a href='/#/options/settings/subscription'>subscribe</a> and receive the item set, along with the ability to buy Gems with Gold! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         p.small.muted by Lemoness
-  h5 7/22/2015 - NEW iOS UPDATE, INCLUDING FACEBOOK LOGIN!
+  h5.big_news_header 7/22/2015 - NEW iOS UPDATE, INCLUDING FACEBOOK LOGIN!
     tr
       td
         .promo_habitica.pull-right
-        h5 Habitica App Update with Facebook Login
+        h5.small_news_header Habitica App Update with Facebook Login
         p We've released a new update to our iOS Habitica app, including Facebook Login, Accessories, and much more. <a href='https://itunes.apple.com/us/app/habitica/id994882113?mt=8' target='_blank'>Check it out now!</a>
         br
         p If you like what we've been doing with the app, please consider leaving us a review. It means so much to us, and really helps us out. Thanks for being awesome! If you have any feedback or concerns, feel free to email us at <a href='mailto:mobile@habitrpg.com' target='_blank'>mobile@habitrpg.com</a>, or use the in-app Report a Bug feature under Menu > About.
         br
         p We're still hard at work on the native Android app, don't worry! Our Blacksmiths are toiling away. Stay tuned for further information!
         p.small.muted by Viirus
-  h5 7/14/2015 - GOLD-PURCHASABLE QUESTS, NEW EQUIPMENT IN THE ENCHANTED ARMOIRE, AND TRIVIAL TASK DIFFICULTY SETTING!
+  h5.big_news_header 7/14/2015 - GOLD-PURCHASABLE QUESTS, NEW EQUIPMENT IN THE ENCHANTED ARMOIRE, AND TRIVIAL TASK DIFFICULTY SETTING!
     tr
       td
         .promo_dilatoryDistress.pull-right
-        h5 Gold-Purchasable Quest Line: Dilatory Distress
+        h5.small_news_header Gold-Purchasable Quest Line: Dilatory Distress
         p We've moved the quests to <a href='/#/options/inventory/quests'>their own separate page</a>, and added a new category: GOLD PURCHASABLE QUESTS!
         br
         p Now you can use Gold to purchase the Dilatory Distress Quest Line! King Manta's daughter has disappeared, and monsters are laying siege to the underwater city of Dilatory. Can you intervene to save them all? If so, you'll earn the exclusive Oceanic Armor Set.
@@ -211,7 +211,7 @@ mixin oldNews
     tr
       td
         .promo_enchanted_armoire_201507.pull-right
-        h5 New Equipment in the Enchanted Armoire
+        h5.small_news_header New Equipment in the Enchanted Armoire
         p There is new equipment in Enchanted Armoire, a 100 GP Reward in the Rewards Column which unlocks after you've attained Ultimate Gear!
         br
         p Click on the Enchanted Armoire for a random chance at special Equipment, including the Rancher Robes, Rancher Lasso, Blue Hairbow, and Royal Crown! It may also give you random XP or food items. We'll be adding new equipment to it during the first week of each month, but even when you've exhausted the current supply, you can keep clicking for a chance at food and XP.
@@ -221,32 +221,32 @@ mixin oldNews
         p.small.muted Art by podcod, Kiwibot, and Megan
     tr
       td
-        h5 Trivial Task Difficulty
+        h5.small_news_header Trivial Task Difficulty
         p There's a new difficulty for Tasks available under task edit: Trivial! Trivial tasks reward you or damage you at the rate of one tenth of the amount that Easy tasks would. Likewise, Trivial tasks cause much less damage during boss battles!
         p.small.muted by efim
-  h5 7/9/2015 - DERBY DAY! FREE ORCA MOUNT AND WHALE QUEST
+  h5.big_news_header 7/9/2015 - DERBY DAY! FREE ORCA MOUNT AND WHALE QUEST
     tr
       td
-        h5 Derby Day!
+        h5.small_news_header Derby Day!
         p On this day, Habitica defeated the worst of its ancient bugs! We celebrate with the Dilatory Derby, which means that Habiticans get aquatic mounts to ride!
     tr
       td
         .promo_orca.pull-right
-        h5 Free Orca Mount
+        h5.small_news_header Free Orca Mount
         p Everyone has received a rare Orca Mount in honor of the Dilatory Derby! Now you can race through the waves on the back of your Orca, which is found under <a href='/#/options/inventory/mounts'>Mounts</a>.
         p.small.muted by Uncommon Criminal
     tr
       td
         .quest_whale.pull-right
-        h5 New Pet Quest: Whales!
+        h5.small_news_header New Pet Quest: Whales!
         p Want more whales? Check out the The Wail of the Whale, a new pet quest in the <a href='/#/options/inventory/drops'>Market</a>! On your way to the Dilatory Derby, you encounter a whale in distress. Can you calm her down? If so, you may gain some whale eggs...
         p.small.muted Art by krazjega, zoebeagle, and Uncommon Criminal
         p.small.muted Writing by Calae
-  h5 7/7/2015 - NEW iOS APP: HABITICA!
+  h5.big_news_header 7/7/2015 - NEW iOS APP: HABITICA!
     tr
       td
         .promo_habitica.pull-right
-        h5 New iOS App: Habitica!
+        h5.small_news_header New iOS App: Habitica!
         p We are proud to announce the beta release of our new native iOS app: <a href='https://itunes.apple.com/us/app/habitica/id994882113?ls=1&mt=8' target='_blank'>Habitica</a>! It features an all-new interface, smoother performance, reminders to complete Dailies, and tons of features including skills and better party chat! <a href='https://itunes.apple.com/us/app/habitica/id994882113?ls=1&mt=8' target='_blank'>Click here to download it</a> - it's a new app, not an upgrade of the clunky old one.
         br
         p This is a beta release, so please report any issues using the in-app Send Feedback and Report a Bug buttons, under Menu > About. <a href='https://github.com/HabitRPG/habitrpg-ios/' target='_blank'>The repository is open source</a>, so anyone can jump in and help out.
@@ -255,135 +255,135 @@ mixin oldNews
         p.small.muted by Viirus
     tr
       td
-        h5 What about Android?
+        h5.small_news_header What about Android?
         p We are hard at work on the native Android app as we speak! It's coming along very well. We will announce as soon as it is ready to download, never fear.
     tr
       td
-        h5 Why Habitica?
+        h5.small_news_header Why Habitica?
         p Habitica is the land where HabitRPG takes place - a land where players ride dragons and slay Dailies. Plus, it's now the name of the mobile app. Soon, it will also be the name of the site!
         br
         p The decision to switch from HabitRPG to Habitica is a big one, and we've been talking it over for a long time. We've gotten feedback since the beginning that it was confusing, especially for the many people who aren't familiar with the acronym. ("HabitPGR? HabitRZG? What was your name again?") We feel that "Habitica" keeps the fantasy flair without the confusing abbreviation, so it's the best of both realms.
         br
         p So far, habitica.com redirects to habitrpg.com, and it's the name of the native mobile apps. Look forward to an upcoming announcement of the switchover date, when we will be ringing in the name change with our inaugural Habitica Day celebration!
-  h5 7/1/2015 - SEAFOAM TRANSFORMATION ITEM , JULY BACKGROUNDS REVEALED, SUBSCRIBE WITH AMAZON PAYMENTS AND JULY SUBSCRIBER BOX
+  h5.big_news_header 7/1/2015 - SEAFOAM TRANSFORMATION ITEM , JULY BACKGROUNDS REVEALED, SUBSCRIBE WITH AMAZON PAYMENTS AND JULY SUBSCRIBER BOX
     tr
       td
         .inventory_special_seafoam.pull-right
-        h5 Seafoam Transformation Item
+        h5.small_news_header Seafoam Transformation Item
         p Splash some Seafoam on your friends and they will undergo a mysterious transformation until their next cron! You can buy the Seafoam in the <a href='/#/options/inventory/seasonalshop'>Seasonal Shop</a> for Gold. Don't want to be transformed? Just buy some Sand from the <a href='/#/tasks'>Rewards Store</a> to reverse it.
         p.small.muted by Lemoness
     tr
       td
         .background_giant_wave.pull-right
-        h5 July Backgrounds Revealed
+        h5.small_news_header July Backgrounds Revealed
         p There are three new avatar backgrounds in the <a href='/#/options/profile/backgrounds'>Background Shop</a>! Now your avatar can surf on a Giant Wave, explore a Sunken Ship, or dive to the Ruins of Dilatory!
         p.small.muted by (in order): minac1, Mimi Alves, and Twitching
     tr
       td
         .inventory_present_07.pull-left
-        h5 Subscribe with Amazon Payments
+        h5.small_news_header Subscribe with Amazon Payments
         p Want to subscribe to get the July Mystery Item and the ability to buy Gems with Gold? Now you have a new way to pay for a subscription: Amazon Payments! The July Subscriber Item Set will be revealed on the 24th, so keep your eyes peeled.
         br
         p Right now, we only support Amazon Payments for subscriptions, but in the future, we will make it possible to use Amazon Payments to buy Gems as well. Thanks for supporting the site <3
-  h5 6/30/2015 - LAST CHANCE FOR NEON SNORKELER, CLONE CHALLENGES, AND CHALLENGER CONTRIBUTOR TITLE
+  h5.big_news_header 6/30/2015 - LAST CHANCE FOR NEON SNORKELER, CLONE CHALLENGES, AND CHALLENGER CONTRIBUTOR TITLE
     tr
       td
         .promo_mystery_201506.pull-right
-        h5 Last Chance for Neon Snorkeler Item Set
+        h5.small_news_header Last Chance for Neon Snorkeler Item Set
         p Reminder: this is the final day to <a href='/#/options/settings/subscription'>subscribe</a> and receive the Neon Snorkeler Item Set! If you want the Snorkeler Suit or the Neon Snorkel, now's the time! Thanks so much for your support <3
         p.small.muted by Lemoness
     tr
       td
-        h5 Clone Challenges
+        h5.small_news_header Clone Challenges
         p It's now easier than ever to create a recurring Challenge! Just go to a previously created challenge and click the clone button. This creates a new Challenge with all the same information (name, description, prize, tasks) pre-populated, so the challenge creator can adjust only as needed. We hope this saves you time!
         p.small.muted by TheHollidayInn and Blade
     tr
       td
-        h5 Challenger Contributor Title
+        h5.small_news_header Challenger Contributor Title
         p Speaking of recurring Challenges, we've decided to create a new Contributor title, "Challenger", to honor the Habiticans who have been working to improve the community by consistently creating many valuable Challenges. The Challenger title is awarded at the discretion of the staff and mods. Many thanks to our creative and dedicated Challengers!
-  h5 6/25/2015 - JUNE SUBSCRIBER ITEM SET, SPLASHY SKIN SET, AND NEW SOUND EFFECTS
+  h5.big_news_header 6/25/2015 - JUNE SUBSCRIBER ITEM SET, SPLASHY SKIN SET, AND NEW SOUND EFFECTS
     tr
       td
         .promo_mystery_201506.pull-right
-        h5 June Subscriber Item Set!
+        h5.small_news_header June Subscriber Item Set!
         p The June Subscriber Item has been revealed: the Neon Snorkeler Item Set! All June subscribers will receive the Neon Snorkel and the Snorkel Suit. You still have five days to <a href='https://habitrpg-staging.herokuapp.com/#/options/settings/subscription'>subscribe</a> and receive the item set, along with the ability to buy Gems with Gold! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         p.small.muted by Lemoness
     tr
       td
         .promo_splashyskins.pull-right
-        h5 Splashy Skin Set
+        h5.small_news_header Splashy Skin Set
         p There's a new set of Seasonal Edition Skins available in the <a href='/#/options/profile/avatar'>Avatar Customization page</a> until July 31st! Get them while you can, or they won't be available until next year.
         p.small.muted by UncommonCriminal
     tr
       td
-        h5 New Sound Effects
+        h5.small_news_header New Sound Effects
         p There's a new Sound Effects theme on the site: Gokul Theme! You can enable it by clicking on the megaphone in the upper right hand corner and selecting "Gokul Theme" from the dropdown list.
         p.small.muted by NomindTR
-  h5 6/20/2015 - SUMMER SPLASH EVENT: LIMITED EDITION OUTFITS, SEASONAL SHOP OPENS, AND SUMMER NPCS!
+  h5.big_news_header 6/20/2015 - SUMMER SPLASH EVENT: LIMITED EDITION OUTFITS, SEASONAL SHOP OPENS, AND SUMMER NPCS!
     tr
       td
-        h5 Summer Splash Begins!
+        h5.small_news_header Summer Splash Begins!
         p The Summer Splash festival has arrived, and Habitica has moved to the undersea city of Dilatory for the summer! From today until July 31st, join us for fun in the sun.
     tr
       td
         .promo_summer_classes_2015.pull-right
-        h5 Limited Edition Class Outfits
+        h5.small_news_header Limited Edition Class Outfits
         p From now until July 31st, limited edition outfits are available in the Rewards column. Depending on your class, you can be a Reef Renegade, Sunfish Warrior, Strapping Sailor, or Ship Soothsayer! You'd better get productive to earn enough gold before they disappear. Good luck!
         p.small.muted by Lemoness
     tr
       td
         .promo_summer_classes_2014.pull-right
-        h5 Seasonal Shop Opens
+        h5.small_news_header Seasonal Shop Opens
         p The <a href='/#/options/inventory/seasonalshop'>Seasonal Shop</a> has opened! It's stocking summertime Seasonal Edition goodies at the moment, including last year's summer outfits. Everything there will be available to purchase during the Summer Splash event each year, but it's only open until July 31st, so be sure to stock up now, or you'll have to wait a year to buy these items again.
         p.small.muted by Lemoness
     tr
       td
         .seasonalshop_summer2015.pull-right
-        h5 Summer NPCs
+        h5.small_news_header Summer NPCs
         p Looks like the NPCs are really getting in to the summer spirit. Ian, Bailey, Matt, and the Seasonal Sorceress are having fun under the sea in the sunken city of Dilatory, and Alex and Daniel have moved down to the beach. Even the Time Travelers are getting into the fun, although... oh dear... they seem to have overshot the season...
         p.small.muted by Lemoness
-  h5 6/17/2015 - CUTTLEFISH PET QUEST AND QUEST DISPLAY IMPROVEMENTS
+  h5.big_news_header 6/17/2015 - CUTTLEFISH PET QUEST AND QUEST DISPLAY IMPROVEMENTS
     tr
       td
         .quest_kraken.pull-right
-        h5 Cuttlefish Pet Quest
+        h5.small_news_header Cuttlefish Pet Quest
         p A new pet quest is available in the <a href='/#/options/inventory/drops' target='_blank'>Market</a>: The Kraken of Inkomplete! A pleasant day sailing is ruined when a Kraken attacks. Can you strike down the tasks and tentacles that keep cropping up? If so, you'll be awarded with some cuttlefish eggs!
         p.small.muted art by Lemoness and Wolvenhalo
         p.small.muted writing by Lemoness
     tr
       td
-        h5 Quest Display Improvements
+        h5.small_news_header Quest Display Improvements
         p Now you can see the details of a pending quest on the Party Page by clicking the new "Quest Details" tab above the quest invitations. We hope this helps you decide whether or not you want to accept the quest!
         p.small.muted by hairlessbear
-  h5 6/16/2015 - SEARCH BAR, CHALLENGES FILTER, INTERMITTENT REFRESH, AND VISUAL TWEAKS
+  h5.big_news_header 6/16/2015 - SEARCH BAR, CHALLENGES FILTER, INTERMITTENT REFRESH, AND VISUAL TWEAKS
     tr
       td
-        h5 Search Bar
+        h5.small_news_header Search Bar
         p You can now easily search for a specific task by using the handy search bar on the upper right of the task page!
         p.small.muted by Jiří Chára
     tr
       td
-        h5 New Challenges Filter
+        h5.small_news_header New Challenges Filter
         p Now you can filter Challenges based on whether or not you own the Challenge! Easily see all the Challenges that you've created with a single click.
         p.small.muted by theHollidayInn
     tr
       td
-        h5 Intermittent Refresh
+        h5.small_news_header Intermittent Refresh
         p To improve performance, HabitRPG now refreshes automatically after 6 hours of inactivity to combat bugs and make sure that you have the most up-to-date code. You're always welcome to refresh more frequently, of course.
         p.small.muted by cheerskevin
     tr
       td
-        h5 Visual Tweaks
+        h5.small_news_header Visual Tweaks
         p We now have a highlighted Help button, to remind people about those resources, and a denser task edit style!
         p.small.muted by excentris and nthomsn
-  h5 6/11/2015 - REPEATING TASKS, START DATE, AND MOBILE APP UPDATES!
+  h5.big_news_header 6/11/2015 - REPEATING TASKS, START DATE, AND MOBILE APP UPDATES!
     p
     br
     p.small.muted by Blade and fallenpanda
     hr
     tr
       td
-        h5 New Repeat Option for Dailies
+        h5.small_news_header New Repeat Option for Dailies
         p Dailies now have a new Advanced Option: Repeat Every X Days. You've wanted this feature for a long time, and it's finally here!
         br
         p First, please note that this new option is OPT-IN only. We won't make any changes to your preexisting Dailies without you knowing it. We wouldn't do that!
@@ -391,29 +391,29 @@ mixin oldNews
         p That being said, here are the new features:
     tr
       td
-        h5 Repeating Tasks
+        h5.small_news_header Repeating Tasks
         p Use the "Every X Days" function under Dailies Advanced Options to create tasks that repeat after a certain number of days have passed, whether every 2 days, every 15 days, every 30 days... You choose the number that works for you!
         br
         p These Dailies are only due on those given dates. Need to pay your rent every 30 days? Take medicine every other day? Water your plants every 4 days? No longer a problem.
     tr
       td
-        h5 Start Date
+        h5.small_news_header Start Date
         p Dailies now have a Start Date. They will not be due before this date. This means that if you want to add a new Daily while you're thinking about it, but not have it be due until later, you can achieve that by setting a future Start Date!
     tr
       td
-        h5 Mobile App Updates
+        h5.small_news_header Mobile App Updates
         p New <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg' target='_blank'>Android</a> and <a href='https://itunes.apple.com/us/app/habitrpg/id689569235?mt=8' target='_blank'>iOS</a> updates are available to support this feature. Please, update your apps before using it, or the new repeating Dailies will not display normally on the mobile apps!
     tr
       td
-        h5 Other Notes
+        h5.small_news_header Other Notes
         p For a short period of time, the <a href='http://data.habitrpg.com' target='_blank'>Data Display Tool</a> will not be able to calculate damage correctly for Repeat Every X Dailies. We'll get that updated very soon so that it will be accurate again!
         br
         p If you still have questions about Repeat Every X Dailies, don't hesitate to ask in <a href='/#/options/groups/guilds/5481ccf3-5d2d-48a9-a871-70a7380cee5a' target='_blank'>the Newbies Guild</a>!
-  h5 6/1/2015 - NEW EQUIPMENT: THE ENCHANTED ARMOIRE, JUNE BACKGROUNDS, AND NEW MOUNT POSITIONING!
+  h5.big_news_header 6/1/2015 - NEW EQUIPMENT: THE ENCHANTED ARMOIRE, JUNE BACKGROUNDS, AND NEW MOUNT POSITIONING!
     tr
       td
         .promo_enchanted_armoire.pull-right
-        h5 New Equipment: The Enchanted Armoire!
+        h5.small_news_header New Equipment: The Enchanted Armoire!
         p Now after you achieve Ultimate Gear, you'll unlock a new Reward: THE ENCHANTED ARMOIRE!
         br
         p Click on the Enchanted Armoire, a 100 GP Reward in the Rewards Column, for a random chance at special Equipment! It may also give you random XP or food items. We'll be adding new equipment to it every month, but even when you've exhausted the current supply, you can keep clicking for a chance at food and XP.
@@ -424,57 +424,57 @@ mixin oldNews
     tr
       td
         .background_island_waterfalls.pull-right
-        h5 June Backgrounds Revealed
+        h5.small_news_header June Backgrounds Revealed
         p There are three new avatar backgrounds in the <a href='/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can paddle a Drifting Raft, float through a sea of Shimmery Bubbles, or picnic near Island Waterfalls!
         p.small.muted by (in order): Teto is Great, beffymaroo, and UncommonCriminal
     tr
       td
-        h5 New Mount Positioning!
+        h5.small_news_header New Mount Positioning!
         p The mount positioning has been fixed for all the base mounts where it looked like the avatar was riding extreme sidesaddle. Now avatars sit properly, no longer clinging to the sides of their mounts for dear life.
         p.small.muted by Kiwibot, Lemoness, and SabreCat
-  h5 6/1/2015 - JUNE MYSTERY ITEM!
+  h5.big_news_header 6/1/2015 - JUNE MYSTERY ITEM!
     tr
       td
         .inventory_present_06.pull-right
-        h5 June Mystery Item!
+        h5.small_news_header June Mystery Item!
         p Ooh, how mysterious! All Habiticans who are <a href='/#/options/settings/subscription' target='_blank'>subscribed</a> during the month of June will receive the June Mystery Item Set, as well as the ability to buy Gems with Gold! The June Item Set will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
-  h5 5/31/2015 - PUSH NOTIFICATIONS FOR ANDROID, AND LAST CHANCE FOR GREEN KNIGHT SUBSCRIBER ITEMS!
+  h5.big_news_header 5/31/2015 - PUSH NOTIFICATIONS FOR ANDROID, AND LAST CHANCE FOR GREEN KNIGHT SUBSCRIBER ITEMS!
     tr
       td
         .promo_mystery_201505.pull-right
-        h5 Last Chance for Green Knight Item Set
+        h5.small_news_header Last Chance for Green Knight Item Set
         p Reminder: this is the final day to <a href='/#/options/settings/subscription' target='_blank'>subscribe</a> and receive the Green Knight Item Set! If you want the Green Knight Helm or the Green Knight Lance, now's the time! Thanks so much for your support <3
         p.small.muted by Lemoness
     tr
       td
-        h5 Push Notifications for Android
+        h5.small_news_header Push Notifications for Android
         p We've released an update to the Android app that includes new types of push notification! Now it's easier than ever to remember to stay productive. Get the Android update <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg' target='_blank'>here</a>!
         p.small.muted by Negue
-  h5 5/25/2015 - MAY SUBSCRIBER ITEM SET: GREEN KNIGHT!
+  h5.big_news_header 5/25/2015 - MAY SUBSCRIBER ITEM SET: GREEN KNIGHT!
     tr
       td
         .promo_mystery_201505.pull-right
-        h5 May Subscriber Item Set Revealed: Green Knight!
+        h5.small_news_header May Subscriber Item Set Revealed: Green Knight!
         p The May Subscriber Item has been revealed: the Green Knight Item Set! All May subscribers will receive the Green Knight Helm and the Green Knight Lance. You still have six days to <a href='/#/options/settings/subscription' target='_blank'>subscribe</a> and receive the item set, along with the ability to buy Gems with Gold! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         p.small.muted by Lemoness
-  h5 5/20/2015 - NEW PET QUEST: SHEEP!
+  h5.big_news_header 5/20/2015 - NEW PET QUEST: SHEEP!
     tr
       td
         .quest_sheep.pull-right
-        h5 New Pet Quest: Sheep!
+        h5.small_news_header New Pet Quest: Sheep!
         p It looks like there's some ba-a-a-ad weather in the Taskan countryside! Can you and your party be diligent enough to defeat the Thunder Ram? If so, you may find yourself with some wooly sheep pets...
         p.small.muted art by Starsystemic and Misceo
         p.small.muted writing by Salambander, Leephon, and Lemoness
-  h5 5/13/2015 - NEW ANIMAL SKINS AND ACCESSORIES, INN IMPROVEMENTS, COPY CHAT TO TO-DO, AND EXTRA INFO
+  h5.big_news_header 5/13/2015 - NEW ANIMAL SKINS AND ACCESSORIES, INN IMPROVEMENTS, COPY CHAT TO TO-DO, AND EXTRA INFO
     tr
       td
         .promo_pet_skins.pull-right
-        h5 New Animal Skins and Accessories Available!
+        h5.small_news_header New Animal Skins and Accessories Available!
         p They say that owners resemble their pets, and now that's truer than ever for Habiticans! The Animal Skin Set and Animal Accessory Set are now available in the <a href='/#/options/profile/avatar' target='_blank'>Customization shop</a>. Time to let your avatar walk on the wild side.
         p.small.muted by Painter de Cluster and SabreCat
     tr
       td
-        h5 Inn Improvements
+        h5.small_news_header Inn Improvements
         p Now even when you Rest in the Inn, your Dailies will refresh each day. <strong>Important note: your Dailies still do NOT hurt you while you're in the Inn.</strong> We wouldn't do that to you!
         br
         p It used to be that the Resting in the Inn froze all your Dailies so that they wouldn't refresh the next day - even for important Dailies like "take medicine" or "feed pets." This was very frustrating to a lot of users who relied on these features, even during periods of time when they needed to rest in the Inn for finals, illness, vacation, etc.
@@ -485,118 +485,118 @@ mixin oldNews
         p.small.muted by hairlessbear and Blade
     tr
       td
-        h5 Copy Chat to To-Do
+        h5.small_news_header Copy Chat to To-Do
         p Now you can copy any chat message into your To-Do list! If your roommate posted in party chat and asked you to grab groceries, or your friend reminded you about the history quiz tomorrow, you can save it right into your To-Do list. Awesome! 
         p.small.muted by Negue and Redphoenix
     tr
       td
-        h5 Extra Info
+        h5.small_news_header Extra Info
         p We know that HabitRPG can be confusing, so now you can easily double-check what each task type does by clicking the question mark next to its name.
         p.small.muted by Lemoness, lefnire, and SabreCat
-  h5 5/06/2015 - MAY BACKGROUNDS REVEALED
+  h5.big_news_header 5/06/2015 - MAY BACKGROUNDS REVEALED
     tr
       td
         .background_mountain_lake.pull-right
-        h5 May Backgrounds Revealed
+        h5.small_news_header May Backgrounds Revealed
         p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can climb to the top of Pagodas, pose in front of a Marble Temple, or dip toes in a Mountain Lake!
         p.small.muted by (in order) Teto is Great, Painter de Cluster, and Hazel40
 
-  h5 5/01/2015 - Skills Rebalancing
+  h5.big_news_header 5/01/2015 - Skills Rebalancing
     tr
       td
         p After over a year's worth of complaints on Trello and countless bug reports on Github, and after almost five months of dedicated debating, coding, and testing, we have finally rolled out an overhaul of the skills and mana system. Thank you so much to everyone who contributed opinions, time, and effort! Here's what happened:
     tr
       td
-        h5 HABITS DAMAGE BOSSES
+        h5.small_news_header HABITS DAMAGE BOSSES
         p Now it's even easier to damage a Boss without skills! It was definitely high time that HabitRPG counted Habits towards battles. We were not living up to our name.
     tr
       td
-        h5 MANA DIRECTLY LINKED TO PROGRESS
+        h5.small_news_header MANA DIRECTLY LINKED TO PROGRESS
         p Mana was pretty broken: you gained it overnight no matter what you'd done the day before, and it was only linked to To-Dos. This meant that using skills was pretty detached from how well you were doing in your real life, which defeated the purpose of the game!
         p Now you can gain Mana from Dailies and positive Habits as well as To-Dos! You still gain Mana overnight, but how much you gain depends on how many of your Dailies you did.
         p You can also lose Mana by hitting negative Habits. Yikes! Better not indulge...
     tr
       td
-        h5 SKILLS STRENGTHENED AND WEAKENED
+        h5.small_news_header SKILLS STRENGTHENED AND WEAKENED
         p Some notoriously overpowered skills have been weakened, like Backstab (which often granted over 1000GP per cast), Burst of Flames (which allowed you to 1-hit KO most bosses regardless of how much or how little you'd done that day), and Valorous Presence (which caused the notorious "I checked off one Daily and gained 997 levels" bug reports).
         p Some painfully UNDERpowered skills have been strengthened, such as Tools of the Trade and Searing Brightness. We think you'll like these much better now!
         p For a full description of what changed, <a href='http://habitrpg.wikia.com/wiki/User_blog:LadyAlys/Skills_Rebalancing_and_Other_Changes' target='_blank'>check out this blog post</a>.
     tr
       td
-        h5 GIVING FEEDBACK
+        h5.small_news_header GIVING FEEDBACK
         p We understand that these changes may be disruptive to some of you. We're sorry! We hope that with time, you will find them to be a drastic improvement. We will be waiting two weeks (so that everyone can get used to the new system), and then on May 15th will open up a new Trello card for comments and feedback.
         p For those of you who want to reallocate stats now that you have the new system, please post your User ID in this <a href='https://github.com/HabitRPG/habitrpg/issues/5082' target='_blank'>Github ticket</a>. (Your UUID is found under Settings > API; do NOT post your API Token.) That ticket is also being used to debate a possibility to make it so that reallocating stats does not cost gems. If that's a feature you would like (or would hate), definitely drop by that ticket and let us know!
         p.small.muted by Alys, Verabird, brandonjreid, ShilohT, betaveros, SabreCat, chimericdream, and everyone who commented with feedback on Trello and Github. You all are great!
 
-  h5 4/30/2015 - LAST CHANCE FOR BUSY BEE AND SPRING FLING ITEMS, AND SOON-TO-APPEAR NEW EQUIPMENT!
+  h5.big_news_header 4/30/2015 - LAST CHANCE FOR BUSY BEE AND SPRING FLING ITEMS, AND SOON-TO-APPEAR NEW EQUIPMENT!
     tr
       td
         .promo_shimmer_hair.pull-right
-        h5 Last Chance for Spring Fling Outfits, Hair Colors, and Shiny Seeds!
+        h5.small_news_header Last Chance for Spring Fling Outfits, Hair Colors, and Shiny Seeds!
         p Tomorrow everything will be back to normal in Habitica, so if you still have any remaining Spring Fling Items that you want to buy, you'd better do it now! The <a href='https://habitrpg.com/#/options/inventory/seasonalshop' target='_blank'>Seasonal Edition items</a> and <a href='https://habitrpg.com/#/options/profile/avatar' target='_blank'>Hair Colors</a> won't be back until next March, and if the Limited Edition items return they will have increased prices or changed art, so strike while the iron is hot!
     tr
       td
         .promo_mystery_201504.pull-right
-        h5 Last Chance for Busy Bee Item Set
+        h5.small_news_header Last Chance for Busy Bee Item Set
         p Reminder: this is the final day to <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribe</a> and receive the Busy Bee Item Set! If you want the Busy Bee Robe or the Busy Bee Robes, now's the time! Thanks so much for your support <3
     tr
       td
-        h5 New Equipment Soon
+        h5.small_news_header New Equipment Soon
         p If you're sad to see the extra gold-purchasable equipment disappear, don't worry! We have something fun in the works...
 
-  h5 4/24/2015 - APRIL SUBSCRIBER ITEM SET AND NEW LANGUAGES
+  h5.big_news_header 4/24/2015 - APRIL SUBSCRIBER ITEM SET AND NEW LANGUAGES
     tr
       td
         .promo_mystery_201504.pull-right
-        h5 April Subscriber Item Set: Busy Bee!
+        h5.small_news_header April Subscriber Item Set: Busy Bee!
         p The April Subscriber Item has been revealed: the Busy Bee Item Set! All April subscribers will receive the Busy Bee Robe and the Busy Bee Wings. You still have six days to <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribe</a> and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         p.small.muted by Lemoness
     tr
       td
-        h5 New Languages
+        h5.small_news_header New Languages
         p We've added three new languages to the site: Japanese, Serbian and Chinese (Traditional)!
         p.small.muted by Paglias, the <a href='https://www.transifex.com/projects/p/habitrpg/language/ja/' target='_blank'>Japanese Translation Team</a>, the <a href='https://www.transifex.com/projects/p/habitrpg/language/sr/' target='_blank'>Serbian Translation Team</a>, and the <a href='https://www.transifex.com/projects/p/habitrpg/language/zh_TW/' target='_blank'>Chinese (Traditional) Translation Team</a>
 
-  h5 4/15/2015 - MARSHMALLOW SLIMES, KEY TO THE KENNELS CHANGE, AND CHALLENGE IMPROVEMENTS
+  h5.big_news_header 4/15/2015 - MARSHMALLOW SLIMES, KEY TO THE KENNELS CHANGE, AND CHALLENGE IMPROVEMENTS
     tr
       td
         .Pet-Slime-Base.pull-right
-        h5 Marshmallow Slime Pet Quest!
+        h5.small_news_header Marshmallow Slime Pet Quest!
         p There is a new Pet Quest available in the <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>Market</a>: The Jelly Regent! Gooey slime is gumming up the works, and Habiticans are having a tough time finishing their tasks. Can you mop the floor with the Jelly Regent? If so, you'll get some adorable Marshmallow Slime pets!
         p.small.muted art by Starsystemic, Leephon, LordDarkly, Overomega, and Shaner
         p.small.muted writing by Bethany Woll and Theothermeme
     tr
       td
-        h5 Key to the Kennels Free with Triad Bingo
+        h5.small_news_header Key to the Kennels Free with Triad Bingo
         .pet_key.pull-right
         p The Key to the Kennels is now free if you have the Triad Bingo achievement and if you choose to release your pets and mounts together! Rejoice, collectors! Note that the Key will not be free if you release only pets or only mounts.
         p.small.muted by gisikw
     tr
       td
-        h5 Challenge Improvements
+        h5.small_news_header Challenge Improvements
         p Now Challenge links take you directly to that Challenge, instead of the top of the list, and when you edit a Challenge, the name is automatically updated!
         p.small.muted by gisikw, chrisdotcode, and TheHollidayInn
-  h5 4/7/2015 - APRIL BACKGROUNDS REVEALED
+  h5.big_news_header 4/7/2015 - APRIL BACKGROUNDS REVEALED
     tr
       td
         .background_cherry_trees.pull-right
-        h5 April Backgrounds
+        h5.small_news_header April Backgrounds
         p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can picnic in a Flowering Meadow, nibble the scenery of Gumdrop Land, or admire the Cherry Trees!
         p.small.muted by Rattify, Painter de Cluster, and kmcallah
-  h5 4/2/2015 - MARCH AND APRIL ITEM SETS; SHINY SEEDS; MESSAGE CHALLENGE CREATORS; ITEM DROP ICONS
+  h5.big_news_header 4/2/2015 - MARCH AND APRIL ITEM SETS; SHINY SEEDS; MESSAGE CHALLENGE CREATORS; ITEM DROP ICONS
     tr
       td
-        h5 Last Chance for March Item Set
+        h5.small_news_header Last Chance for March Item Set
         p Reminder: this is the final day to <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribe</a> and receive the Aquamarine Item Set! If you want the Aquamarine Eyewear or the Aquamarine Armor, now's the time! Thanks so much for your support <3
     tr
       td
-        h5 April Mystery Box
+        h5.small_news_header April Mystery Box
         .inventory_present.pull-right
         p Cool! What could it be? All Habiticans who are subscribed during the month of April will receive the April Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
         p.small.muted by Lemoness
     tr
       td
-        h5 Shiny Seeds
+        h5.small_news_header Shiny Seeds
         .inventory_special_shinySeed.pull-right
         p Phew! It was tough, but we overthrew the flowers that had taken over the site. However, they've left behind some of their Shiny Seeds!
         br
@@ -606,61 +606,61 @@ mixin oldNews
         p.small.muted by Lemoness and SabreCat
     tr
       td
-        h5 Message Challenge Creators
+        h5.small_news_header Message Challenge Creators
         p Now on the Challenges page, you can to click on the challenge creator's name to view their profile, message them, or to see how long ago they last logged in if you are curious about whether the challenge might still be active.
         p.small.muted by TheHollidayInn
     tr
       td
         .promo_item_notif.pull-right
-        h5 Icons in Notifications
+        h5.small_news_header Icons in Notifications
         p Now, when you find an item from scoring a task, an image of the item appears in the drop notification. Instant gratification when that egg or potion you've been hunting for finally appears!
         p.small.muted by TheHollidayInn
-  h5 4/1/2015 - HOSTILE FLOWER TAKEOVER OF JOY AND DOOM
+  h5.big_news_header 4/1/2015 - HOSTILE FLOWER TAKEOVER OF JOY AND DOOM
     tr
       td
-        h5 Joy and Doom to All!
+        h5.small_news_header Joy and Doom to All!
         p THE SPRING FLING HAS FLUNG TOO FAR! Run while you can, Habiticans! The floral theme has come to life and is taking over Habitica with horrifying cheer, repeat, the flowers are taking over HMMMPH MMPH MMMHPPPH....
         .avatar_floral_wizard
         p CELEBRATE FLOWER POWER.
         br
         p RESISTANCE IS SILLY.
         p.small.muted by Lemoness and Baconsaur
-  h5 3/29/2015 - PASTEL SKIN, SHIMMER HAIR COLORS, SURVEY BADGES AWARDED, AND PARTY SORT ORDER
+  h5.big_news_header 3/29/2015 - PASTEL SKIN, SHIMMER HAIR COLORS, SURVEY BADGES AWARDED, AND PARTY SORT ORDER
     tr
       td
         .promo_pastel_skin.pull-right
-        h5 Pastel Skin
+        h5.small_news_header Pastel Skin
         p The Seasonal Edition Pastel Skin Set is now available for purchase in the <a href='https://habitrpg.com/#/options/profile/avatar' target='_blank'>avatar customizations page</a>! This skin set will only be available until April 30th, and then it will disappear until next Spring Fling.
         p.small.muted by McCoyly
     tr
       td
         .promo_shimmer_hair.pull-right
-        h5 Shimmer Hair Colors
+        h5.small_news_header Shimmer Hair Colors
         p The Seasonal Edition Shimmer Hair Colors are now available for purchase in the <a href='https://habitrpg.com/#/options/profile/avatar' target='_blank'>avatar customizations page</a>! Now you can dye your avatar's hair Shimmer Pink, Shimmer Purple, Shimmer Blue, Shimmer Green, Shimmer Orange, or Shimmer Yellow.
         br
         p Seasonal Edition items recur unchanged every year, but they are only available to purchase during a short period of time. This is different from Limited Edition Items, which only recur if something is changed, such as the art or the price. These hair colors may remind some of you of the Pastel Hair Colors that were available last spring. The Pastel Hair Colors have been retired in favor of the similar Seasonal Edition Shimmer Hair Colors. Read more about the difference between Seasonal and Limited Edition items <a href='http://habitrpg.wikia.com/wiki/Item_Availability' target='_blank'>here</a>!
         p.small.muted by Lemoness, crystalphoenix, and mariahm
     tr
       td
-        h5 Survey Badges Awarded
+        h5.small_news_header Survey Badges Awarded
         p The Survey badges have been awarded to everyone who took the survey and provided their user ID! Unfortunately, some people did not include their User ID with the survey. As a result, we have no way of linking the survey with their accounts, and could not give them the "Helped Habit Grow" badge. If you have any questions, please email <a href='mailto:leslie@habitrpg.com'>Leslie</a>.
         p.small.muted by Sugarfiend and Alys
     tr
       td
-        h5 Party Sort Order
+        h5.small_news_header Party Sort Order
         p Now when you change the sort order for your party, it takes effect immediately. You can change the sort order under Social > Party.
         p.small.muted by ChokesMcGee
-  h5 3/25/2015 - MARCH SUBSCRIBER ITEM, FREE EGG HUNT QUEST, EGG MOUNTS, AND NEW MODERATOR!
+  h5.big_news_header 3/25/2015 - MARCH SUBSCRIBER ITEM, FREE EGG HUNT QUEST, EGG MOUNTS, AND NEW MODERATOR!
     tr
       td
         .promo_mystery_201503.pull-right
-        h5 March Subscriber Item
+        h5.small_news_header March Subscriber Item
         p The March Subscriber Item has been revealed: the Aquamarine Item Set! All March subscribers will receive the Aquamarine Eyewear and the Aquamarine Armor. You still have six days to <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribe</a> and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         p.small.muted by Lemoness
     tr
       td
         .Pet-Egg-CottonCandyPink.pull-right
-        h5 Egg Hunt Quest and Egg Mounts
+        h5.small_news_header Egg Hunt Quest and Egg Mounts
         p In celebration of the season, everyone has received a free Egg Hunt collection quest scroll! You can find it in the <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>Inventory</a>. Collect eggs by completing your tasks, and you'll be rewarded with some egg pets.
         br
         p Furthermore, the Egg Pets can now be fed... and grow into some glorious Egg Mounts!
@@ -669,104 +669,104 @@ mixin oldNews
         p.small.muted by Beffymaroo and Megan
     tr
       td
-        h5 New Moderator
+        h5.small_news_header New Moderator
         p Finally, we have a new moderator on the site: @Beffymaroo! Hooray! Be sure to say hello to her in the Tavern.
-  h5 3/20/2015 - SPRING FLING EVENT! LIMITED EDITION OUTFITS, SEASONAL SHOP OPENS, AND SPRING NPCS
+  h5.big_news_header 3/20/2015 - SPRING FLING EVENT! LIMITED EDITION OUTFITS, SEASONAL SHOP OPENS, AND SPRING NPCS
     tr
       td
-        h5 Spring Fling!
+        h5.small_news_header Spring Fling!
         p The Spring Fling is here! From today until April 30th, join Habitica in its sweet celebration.
     tr
       td
         .promo_springclasses2015.pull-right
-        h5 Limited Edition Class Outfits
+        h5.small_news_header Limited Edition Class Outfits
         p From now until April 30th, limited edition outfits are available in the Rewards column. Depending on your class, you can be a Beware Dog, Magician's Bunny, Sneaky Squeaker, or Comforting Kitty! You'd better get productive to earn enough gold before they disappear. Good luck!
         p.small.muted by Lemoness
     tr
       td
         .promo_springclasses2014.pull-right
-        h5 Seasonal Shop Opens
+        h5.small_news_header Seasonal Shop Opens
         p The <a href='https://habitrpg.com/#/options/inventory/seasonalshop' target='_blank'>Seasonal Shop</a> has opened! It's stocking springtime Seasonal Edition goodies at the moment, including last year's spring outfits. Everything there will be available to purchase during the Spring Fling event each year, but it's only open until April 30th, so be sure to stock up now, or you'll have to wait a year to buy these items again.
         p.small.muted by Lemoness
     tr
       td
         .seasonalshop_spring2015.pull-left
-        h5 Spring NPCs
+        h5.small_news_header Spring NPCs
         p Looks like the NPCs are really getting in to the springtime fun around the site. Who wouldn't? After all, there's plenty more to come!
         p.small.muted by Lemoness and Shaner
-  h5 3/17/2015 - BUNNY PET QUEST, EGG PURCHASING CHANGE, LAST DAY FOR SURVEY AND ACHIEVEMENT, AND UNEQUIP BUTTONS
+  h5.big_news_header 3/17/2015 - BUNNY PET QUEST, EGG PURCHASING CHANGE, LAST DAY FOR SURVEY AND ACHIEVEMENT, AND UNEQUIP BUTTONS
     tr
       td
-        h5 New Pet Quest: Killer Bunny
+        h5.small_news_header New Pet Quest: Killer Bunny
         p There's a new quest scroll in the <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>Market</a>! Deep within Mount Procrastination lies a once-sweet beast grown horrifying with neglect. Can you rally your strength to defeat the Killer Bunny? If so, you'll get some bunny eggs!
         p.small.muted by Draayder, Gully, and TetoIsGreat
     tr
       td
-        h5 Egg Purchasing Change
+        h5.small_news_header Egg Purchasing Change
         p You can now purchase quest eggs from the <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>Market</a> after defeating the corresponding boss at least once! Previously, you had to defeat the boss at least twice before being able to purchase the eggs.
         p.small.muted by Blade
     tr
       td
-        h5 Last Day for Survey and Achievement
+        h5.small_news_header Last Day for Survey and Achievement
         p March 18th is the final day to complete <a href='https://www.surveymonkey.com/s/62RXRF3' target='_blank'>this survey</a> to receive or stack the Helped Habit Grow survey! After it is closed, it will take us several days to award the badges. Thanks so much for sharing your feedback with us!
         p.small.muted by sugarfiend and SabreCat
     tr
       td
-        h5 Unequip Buttons
+        h5.small_news_header Unequip Buttons
         p It’s now easier to switch your avatar’s costume! You can now unequip all your battle gear, costume pieces, and/or pets from the Equipment page using the new Unequip buttons.
         p.small.muted by TheHolidayInn
-  h5 3/10/2015 - SURVEY, TESTIMONIALS GUILD, AND CHAT EXTENSION
+  h5.big_news_header 3/10/2015 - SURVEY, TESTIMONIALS GUILD, AND CHAT EXTENSION
     hr
     tr
       td
-        h5 Survey and Achievement
+        h5.small_news_header Survey and Achievement
         .achievement.achievement-tree.pull-right
         p We're giving out the rare Helped Habit Grow achievement to all users who help us out by completing <a href='https://www.surveymonkey.com/s/62RXRF3' target='_blank'>this 10-question survey</a>! If you already received this badge, taking this new survey will stack your achievement. Thanks for sparing a minute to let us know what you think about HabitRPG!
         p.small.muted by sugarfiend and SabreCat
     tr
       td
-        h5 Testimonials Guild
+        h5.small_news_header Testimonials Guild
         p We're collecting testimonials from users to display on the front page along with pictures of their avatars. If HabitRPG has been helpful to you and you feel comfortable leaving a short testimonial for us, you can post it <a href='https://habitrpg.com/#/options/groups/guilds/ae985ab0-fcc3-410d-bdb3-ae4defe712bb' target='_blank'>here</a>. Thanks for all your help! <3
     tr
       td
-        h5 Chat Extension
+        h5.small_news_header Chat Extension
         p Horacious Moreau has made a <a href='https://chrome.google.com/webstore/detail/habitrpg-chat-client/hidkdfgonpoaiannijofifhjidbnilbb' target='_blank'>chat extension</a> for HabitRPG! It creates a chat box for Tavern, parties, and Guilds. :)
         br
         p The Chat Client is also open-source! You can check out the project <a href='https://github.com/Horacious/HabitRPG-Chat-Extension' target='_blank'>here</a>.
         p.small.muted by Horacious Moreau
-  h5 3/3/2015 - MARCH BACKGROUNDS, ANDROID APP NOTIFICATIONS, AND MARCH MYSTERY BOX
+  h5.big_news_header 3/3/2015 - MARCH BACKGROUNDS, ANDROID APP NOTIFICATIONS, AND MARCH MYSTERY BOX
     tr
       td
-        h5 March Backgrounds Revealed
+        h5.small_news_header March Backgrounds Revealed
         p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can dance in the Spring Rain, admire some Stained Glass, or frolic through the Rolling Hills!
         p.small.muted by (in order) Sunstroke, Kiwibot, and Uncommon Criminal
     tr
       td
-        h5 Android App Notifications
+        h5.small_news_header Android App Notifications
         p The <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg' target='_blank'>Android app</a> can now remind you to log in! Simply go to Settings and select the time that you want the reminder.
         p.small.muted by Negue
     tr
       td
         .inventory_present.pull-right
-        h5 March Mystery Box
+        h5.small_news_header March Mystery Box
         p Wow! What could it be? All Habiticans who are <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribed</a> during the month of March will receive the March Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
         p.small.muted by Lemoness
-  h5 2/24/2015 - FEBRUARY SUBSCRIBER ITEM AND ADD MULTIPLE TASKS!
+  h5.big_news_header 2/24/2015 - FEBRUARY SUBSCRIBER ITEM AND ADD MULTIPLE TASKS!
     tr
       td
         .promo_mystery_201502.pull-right
-        h5 February Subscriber Item
+        h5.small_news_header February Subscriber Item
         p The February Subscriber Item has been revealed: the Winged Enchanter Item Set! All February subscribers will receive the Wings of Thought and the Shimmery Winged Staff of Love and Also Truth. You still have four days to <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribe</a> and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         p.small.muted by Lemoness
     tr
       td
-        h5 Add Multiple Tasks
+        h5.small_news_header Add Multiple Tasks
         p Got a bunch of tasks you need to add all at once? No problem! Now you can add a batch of tasks all at once by clicking "Add Multiple" under the task entry bar. We hope that this will save you time!
         p.small.muted by ChimericDream
-  h5 2/24/2015 - SITE DOWNTIME EXPLANATION (AND SLEEPING AVATARS)
+  h5.big_news_header 2/24/2015 - SITE DOWNTIME EXPLANATION (AND SLEEPING AVATARS)
     tr
       td
-        h5
+        h5.small_news_header
         p As most of you probably noticed, the site was down yesterday. We got a surge of new users from Imgur who absolutely flattened the servers by registering all at once, and it proved very difficult to start up again. You can read the technical details <a href="https://github.com/HabitRPG/habitrpg/issues/4737" target="_blank">in this Github ticket</a>. We're sorry about all of the frustration!
         br
         p At about midnight PST we checked all active users into the inn, "freezing" their accounts so that their incomplete Dailies would not hurt them, in hopes that this would prevent most of the undeserved deaths due to server troubles. That's why your avatar is sleeping! To check yourself out of the inn, go to Social > Tavern > Check out of inn.
@@ -778,17 +778,17 @@ mixin oldNews
         p And welcome, Imgurians! Sorry your introduction was so rocky, but we can't wait to get to know you. There is a <a href="https://habitrpg.com/#/options/groups/guilds/4709ba62-2ba0-43ff-a5a5-494c774236ec">Camp Imgur Guild</a> that you might enjoy.
         br
         p Now, back to productivity!
-  h5 2/17/2015 - NEW PET QUEST AND COMMUNITY GUIDELINE UPDATES
+  h5.big_news_header 2/17/2015 - NEW PET QUEST AND COMMUNITY GUIDELINE UPDATES
     hr
     tr
       td
         .quest_rock.pull-right
-        h5 New Pet Quest: Rocks!
+        h5.small_news_header New Pet Quest: Rocks!
         p It seemed like a simple hike... until we discovered that the cave was alive! You can get the newest Pet Quest, "Escape the Cave Creature," in the <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>Market</a>. If you defeat it, you'll get some cuddly pet rocks!
         p.small.muted by itokro, Pfeffernusse, Painter de Cluster, and intone
     tr
       td
-        h5 Community Guideline Updates
+        h5.small_news_header Community Guideline Updates
         p We've updated the <a href='https://habitrpg.com/static/community-guidelines' target='_blank'>Community Guidelines</a> to include the following:
         ul
           li Blade, a new mod, is listed!
@@ -797,122 +797,122 @@ mixin oldNews
           li Sexism has been added to the list of unacceptable behaviors.
           li Making duplicate accounts to circumvent consequences is now expressly forbidden.
 
-  h5 2/12/2015
+  h5.big_news_header 2/12/2015
     tr
       td
-        h5 Happy Valentine's Day!
+        h5.small_news_header Happy Valentine's Day!
         p Help motivate all of the lovely people in your life by sending them a caring valentine. Valentines can be purchased for 10 gold from the Market. For spreading love and joy throughout the community, both the giver AND the receiver get a coveted "adoring friends" badge. Hooray!
         p.small.muted by Lemoness and SabreCat
     tr
       td
-        h5 New Hairstyles!
+        h5.small_news_header New Hairstyles!
         .promo_updos.pull-right
         p There are a new set of updo hairstyles available in the <a href='https://habitrpg.com/#/options/profile/avatar' target='_blank'>Avatar Customization page</a>! Have fun customizing your characters.
         p.small.muted by Crystalphoenix, Mariahm, Painter de Cluster, Leephon, Beffymaroo, Sungabraverday, Lemoness, and Bailey
-  h5 2/8/2015
+  h5.big_news_header 2/8/2015
     tr
       td
-        h5 Email Notifications
+        h5.small_news_header Email Notifications
         p We've implemented email notifications for a variety of events, including receiving a Private Message, being invited to a Party, Guild, or Quest, and receiving a gift of Gems or a Subscription! We've got some more coming up, too, including the much-requested check-in reminders.
         p Don't want to receive a certain type of notification? No problem! Just go to <a href='https://habitrpg.com/#/options/settings/notifications' target='_blank'>Notification Settings</a> to tell us exactly which ones you do and do not want to receive. Our messenger dragons will be happy to comply!
         p.small.muted by paglias and Lemoness
     tr
       td
-        h5 Login Type Switching
+        h5.small_news_header Login Type Switching
         p Want to change your email address, or switch from Facebook login to email login? Good news! Now you can switch it yourself, under <a href='https://habitrpg.com/#/options/settings/settings' target='_blank'>Settings</a>!
         p.small.muted by Lefnire
-  h5 2/3/2015
+  h5.big_news_header 2/3/2015
     tr
       td
-        h5 February Backgrounds Revealed
+        h5.small_news_header February Backgrounds Revealed
         .background_distant_castle.pull-right
         p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can survey a Distant Castle, toil in the Blacksmithy, or explore a Crystal Cave!
         p.small.muted by Holseties, Hanztan, and Twitching
-  h5 2/2/2015
+  h5.big_news_header 2/2/2015
     tr
       td
-        h5 February Mystery Box
+        h5.small_news_header February Mystery Box
         .inventory_present.pull-right
         p Ooh... What could it be? All Habiticans who are subscribed during the month of February will receive the February Mystery Item Set! It will be revealed on the 24th, so keep your eyes peeled. Thanks for supporting the site <3
         p.small.muted by Lemoness
     tr
       td
-        h5 New Quest Descriptions
+        h5.small_news_header New Quest Descriptions
         p We've updated quest descriptions so that when you hover over them, you can now see the Boss or Collection stats and the Rewards that you will gain when you complete the quest!
         p.small.muted by Blade
     tr
       td
-        h5 Spread the Word Challenge Has Ended
+        h5.small_news_header Spread the Word Challenge Has Ended
         p The Spread the Word Challenge has ended! Thank you to all the participants. It will be some time before the winners are announced because we have to go over all the entries ourselves. Thanks for your patience!
-  h5 1/30/2015
+  h5.big_news_header 1/30/2015
     tr
       td
         .npc_alex.pull-left
-        h5 HabitRPG Birthday Bash
+        h5.small_news_header HabitRPG Birthday Bash
         p January 31st is HabitRPG's Birthday! All of the NPCs are celebrating, and we've awarded you a bunch of cake for your pets and mounts!
     tr
       td
-        h5 Party Robes
+        h5.small_news_header Party Robes
         .shop_armor_special_birthday.pull-right
         .shop_armor_special_birthday2015.pull-right
         p Until February 1st only, there are Party Robes available for free in the Rewards store! If this is your first Birthday bash with us, you can find some Absurd Party Robes; if you already got some last year, then you will find the Silly Party Robes.
     tr
       td
         .promo_mystery_201501.pull-left
-        h5 Last Chance for Starry Knight Item Set
+        h5.small_news_header Last Chance for Starry Knight Item Set
         p Reminder: this is the final day to <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribe</a> and receive the Starry Knight Item Set! If you want the Starry Helm or the Starry Armor, now's the time! Thanks so much for your support <3
     tr
       td
-        h5 Last Chance for Winter Wonderland Outfits + Hair Colors
+        h5.small_news_header Last Chance for Winter Wonderland Outfits + Hair Colors
         .promo_winterclasses2015.pull-right
         p Tomorrow everything will be back to normal in Habitica, so if you still have any remaining Winter Wonderland Items that you want to buy, you'd better do it now! The <a href='https://habitrpg.com/#/options/inventory/seasonalshop' target='_blank'>Seasonal Edition items</a> and <a href='https://habitrpg.com/#/options/profile/avatar' target='_blank'>Hair Colors</a> won't be back until next December, and if the Limited Edition items return they will have increased prices or changed art, so strike while the iron is hot!
-  h5 1/26/2015
+  h5.big_news_header 1/26/2015
     tr
       td
-        h5 Subscriber Outfit Revealed
+        h5.small_news_header Subscriber Outfit Revealed
         .promo_mystery_201501.pull-right
         p The January Subscriber Item has been revealed: the Starry Knight Item Set! All January subscribers will receive the Starry Helm and the Starry Armor. You still have five days to <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribe</a> and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         p.small.muted by Lemoness
     tr
       td
-        h5 New Audio Theme
+        h5.small_news_header New Audio Theme
         p A new audio theme is available: Watts' Theme! You can toggle between Watts' Theme and Daniel the Bard's Theme by selecting the megaphone in the upper right-hand corner. Watts' Theme was created by Harry Pepe. You can visit his <a href='https://www.linkedin.com/in/hpepe4' target='_blank'>LinkedIn page here</a>.
         p.small.muted by Hpepe4 and Blade
     tr
       td
-        h5 Quest Scroll Redesign
+        h5.small_news_header Quest Scroll Redesign
         p We've redesigned the quest scrolls so that they are visually unique! Quest type and difficulty is determined by the scroll lining (Easy Boss = Green, Medium Boss = Yellow, Hard Boss = Red, Collection Quest = Blue, Rage Bar Boss = Purple speckles), and an icon symbolizing the quest is located in the lower left.
         p.small.muted by UncommonCriminal and Rattify
     tr
       td
-        h5 Spread the Word Challenge Ending Soon
+        h5.small_news_header Spread the Word Challenge Ending Soon
         p Reminder: January 31st is the last day to enter the <a href='https://habitrpg.com/#/options/groups/challenges/e1ad6d92-587d-4137-848e-4a1f643603ba' target='_blank'>Spread the Word Challenge</a> for your chance at winning 100 gems! We will stop accepting new applications on February 1st, but it will be some time before the winners are announced because we have to go over all the entries ourselves. Good luck!
-  h5 1/23/2015
+  h5.big_news_header 1/23/2015
     tr
       td
-        h5 The Abominable Stressbeast is DEFEATED!
+        h5.small_news_header The Abominable Stressbeast is DEFEATED!
         p We've done it! With a final bellow, the Abominable Stressbeast dissipates into a cloud of snow. The flakes twinkle down through the air as cheering Habiticans embrace their pets and mounts. Our animals and our NPCs are safe once more!
     tr
       td
-        h5 Stoïkalm is Saved!
+        h5.small_news_header Stoïkalm is Saved!
         p SabreCat speaks gently to a small sabertooth. "Please find the citizens of the Stoïkalm Steppes and bring them to us," he says. Several hours later, the sabertooth returns, with a herd of mammoth riders following slowly behind. You recognize the head rider as Lady Glaciate, the leader of Stoïkalm.
         p "Mighty Habiticans," she says, "My citizens and I owe you the deepest thanks, and the deepest apologies. In an effort to protect our Steppes from turmoil, we began to secretly banish all of our stress into the icy mountains. We had no idea that it would build up over generations into the Stressbeast that you saw! When it broke loose, it trapped all of us in the mountains in its stead and went on a rampage against our beloved animals." Her sad gaze follows the falling snow. "We put everyone at risk with our foolishness. Rest assured that in the future, we will come to you with our problems before our problems come to you."
         .Pet-Mammoth-Base.pull-right
         p She turns to where @Baconsaur is snuggling with some of the baby mammoths. "We have brought your animals an offering of food to apologize for frightening them, and as a symbol of trust, we will leave some of our pets and mounts with you. We know that you will all take care good care of them."
         p.small.muted by everyone who completed a Daily or a To-Do during the battle!
-  h5 1/21/2015
+  h5.big_news_header 1/21/2015
     tr
       td
-        h5 THIRD STRESS STRIKE!
+        h5.small_news_header THIRD STRESS STRIKE!
         .npc_justin_broken.pull-right
         p The World Boss in the <a href='https://habitrpg.com/#/options/groups/tavern' target='_blank'>Tavern</a> has used a third Stress Strike!
         p Justin the Guide is trying to distract the Stressbeast by running around its ankles, yelling productivity tips! The Abominable Stressbeast is stomping madly, but it seems like we're really wearing this beast down. I doubt it has enough energy for another strike. Don't give up... we're so close to finishing it off!
         p Complete Dailies and To-Dos to damage the World Boss! A World Boss will never damage individual players or accounts in any way. Only active accounts who are not resting in the inn will have their incomplete Dailies tallied.
         p.small.muted by Lemoness, Kiwibot, and SabreCat
-  h5 1/20/2015
+  h5.big_news_header 1/20/2015
     tr
       td
-        h5 Mount Master and Triad Bingo Achievements
+        h5.small_news_header Mount Master and Triad Bingo Achievements
         .achievement.achievement-wolf
         .achievement.achievement-triadbingo
         p There are two new achievements you can earn: Mount Master and Triad Bingo! Mount Master is awarded to users who have collected all 90 standard mounts, and Triad Bingo is for those who have collected all 90 standard pets, grown all 90 into mounts, and then rehatched 90 more standard pets. Wow!
@@ -921,61 +921,61 @@ mixin oldNews
         p.small.muted by Taldin, Blade, Lorian, Aiseant, and Hanztan
     tr
       td
-        h5 Party Sorting Options
+        h5.small_news_header Party Sorting Options
         p In the <a href="/#/options/groups/party">Party Page</a> you can now sort your friends' avatars in ascending or descending order! To make the change take effect, you'll have to refresh the page.
 
         p.small.muted by Blade and Viirus
     tr
       td
-        h5 Dated To-Dos
+        h5.small_news_header Dated To-Dos
         p Now you can use To-Do tabs to sort and see your dated To-Dos! Simply click the "Dated" tab and only To-Dos with a due date will be displayed. They are not currently sorted by date, but we will be implementing that feature in the future.
 
         p.small.muted by Alys
     tr
       td
-        h5 Stressbeast Desperation Triggered
+        h5.small_news_header Stressbeast Desperation Triggered
 
         p We're almost there, Habiticans! With diligence and Dailies, we've whittled the Stressbeast's health down to only 500K! The creature roars and flails in desperation, rage building faster than ever. The monster is --- AHHH! --- swinging me and Matt around at a terrifying pace, raising a blinding snowstorm that makes it harder to hit.
         p We'll have to redouble our efforts, but take heart - this is a sign that the Stressbeast knows it is about to be defeated. Don't give up now! Please?
 
         p The Stressbeast raises its Rage and Defense! Complete Dailies and To-Dos to damage the World Boss. A World Boss will never damage individual players or accounts in any way. Only active accounts who are not resting in the inn will have their incomplete Dailies tallied.
         p.small.muted by Lemoness, Kiwibot, and SabreCat
-  h5 1/19/2015
+  h5.big_news_header 1/19/2015
     tr
       td
-        h5 WORLD BOSS: SECOND STRESS STRIKE!
+        h5.small_news_header WORLD BOSS: SECOND STRESS STRIKE!
         p AHHHHHHHH!!!!! IT'S GOT ME!!!!! Oh, Habiticans, why didn't you do your Dailies?!
         p The World Boss in the <a href='https://habitrpg.com/#/options/groups/tavern' target='_blank'>Tavern</a> has used another Stress Strike, and this time it's attacked me, Bailey the Town Crier! To save me and the other NPCs, complete Dailies and To-Dos to damage the World Boss! Incomplete Dailies fill the Stress Strike Bar. When the Stress Strike bar is full, the World Boss will attack an NPC and regain some health. A World Boss will never damage individual players or accounts in any way. Only active accounts who are not resting in the inn will have their incomplete Dailies tallied.
         p.small.muted by Lemoness, Kiwibot, and SabreCat
 
-  h5 1/15/2015
+  h5.big_news_header 1/15/2015
     tr
       td
-        h5 Tyrannosaur Pet Quest
+        h5.small_news_header Tyrannosaur Pet Quest
         p In the <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>Market</a> there are now two new pet quests: King of the Dinosaurs and The Dinosaur Unearthed! They both give out the same rewards, including pet Tyrannosaur eggs. The difference is that "King of the Dinosaurs" is a normal pet quest, like all the others, whereas "The Dinosaur Unearthed" has less HP - but also a Rage bar (a la World Bosses) that allows it to heal if you skip too many of your Dailies. Both bosses still attack your party based on how many Dailies are incomplete. Users will be able to buy Tyrannosaur eggs after defeating either boss twice or both bosses once.
         p Have fun!
         p.small.muted by Baconsaur, Urse, Lemoness, and SabreCat
     tr
       td
-        h5 Spread the Word Challenge Reminder
+        h5.small_news_header Spread the Word Challenge Reminder
         p In case you missed it, we're running our second Spread the Word Challenge! The rules are simple: make a post some time between December 31st 2014 and January 31st 2015 on some form of blog or social media that tells people about HabitRPG. The top post will be awarded 100 GEMS, and the next nineteen top posts will be awarded 80 GEMS each. Learn more and join in <a href='https://habitrpg.com/#/options/groups/challenges/e1ad6d92-587d-4137-848e-4a1f643603ba' target='_blank'>here</a>!
     tr
       td
-        h5 World Boss: First Stress Strike!
+        h5.small_news_header World Boss: First Stress Strike!
         p The World Boss in the <a href='https://habitrpg.com/#/options/groups/tavern' target='_blank'>Tavern</a> has used its first Stress Strike!
         p Despite our best efforts, we've let some Dailies get away from us, and their dark-red color has infuriated the Abominable Stressbeast and caused it to regain some of its health! The horrible creature lunges for the Stables, but Matt the Beast Master heroically leaps into the fray to protect the pets and mounts. The Stressbeast has seized Matt in its vicious grip, but at least it's distracted for the moment.
         p Complete Dailies and To-Dos to damage the World Boss! Incomplete Dailies fill the Stress Strike Bar. When the Stress Strike bar is full, the World Boss will attack an NPC. A World Boss will never damage individual players or accounts in any way. Only active accounts who are not resting in the inn will have their incomplete Dailies tallied.
         p.small.muted by Lemoness, Kiwibot, and SabreCat
-  h5 1/8/2015
+  h5.big_news_header 1/8/2015
     tr
       td
-        h5 World Boss: The Abominable Stressbeast!
+        h5.small_news_header World Boss: The Abominable Stressbeast!
         .quest_stressbeast.pull-right
         p A new World Boss has appeared in the <a href='https://habitrpg.com/#/options/groups/tavern' target='_blank'>Tavern</a>! All of the completed Dailies and To-Dos of Habiticans damage the World Boss. Incomplete Dailies fill the Stress Strike Bar. When the Stress Strike bar is full, the World Boss will attack an NPC.
         p A World Boss will never damage individual players or accounts in any way. Only active accounts who are not resting in the inn will have their incomplete Dailies tallied. Read on for the details!
     tr
       td
-        h5 Winter Plot-Line: The Abominable Stressbeast Attacks!
+        h5.small_news_header Winter Plot-Line: The Abominable Stressbeast Attacks!
         p The first thing we hear are the footsteps, slower and more thundering than the stampede. One by one, Habiticans look outside their doors, and words fail us.
         p We've all seen Stressbeasts before, of course - tiny vicious creatures that attack during difficult times. But this? This towers taller than the buildings, with paws that could crush a dragon with ease. Frost swings from its stinking fur, and as it roars, the icy blast rips the roofs off our houses. A monster of this magnitude has never been mentioned outside of distant legend.
         p "Beware, Habiticans!" SabreCat cries. "Barricade yourselves indoors - this is the Abominable Stressbeast itself!"
@@ -983,393 +983,393 @@ mixin oldNews
         p "The Stoïkalm Steppes," Lemoness says, face grim. "All this time, we thought they were placid and untroubled, but they must have been secretly hiding their stress somewhere. Over generations, it grew into this, and now it's broken free and attacked them - and us!"
         p There's only one way to drive away a Stressbeast, Abominable or otherwise, and that's to attack it with completed Dailies and To-Dos! Let's all band together and fight off this fearsome foe - but be sure not to slack on your tasks, or our undone Dailies may enrage it so much that it lashes out...
         p.small.muted by Lemoness, Kiwibot, and SabreCat
-  h5 1/5/2015
+  h5.big_news_header 1/5/2015
     tr
       td
-        h5 January Backgrounds
+        h5.small_news_header January Backgrounds
         p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can summit a Frigid Peak, shiver in an Ice Cave, or wander through the Snowy Pines!
         p.small.muted by Kiwibot, Sunstroke, and Rattify
     tr
       td
-        h5 Testing Fix for Cron Bug
+        h5.small_news_header Testing Fix for Cron Bug
         p Today we will be testing a possible fix for a bug that sometimes causes Dailies to not reset correctly on the following day. It's a big change, so we will be keeping a close watch on the site to make sure that it doesn't break anything. If you experience any problems with day start or Dailies reseting in the next few days, please let us know immediately on <a href='https://github.com/HabitRPG/habitrpg/issues/1057' target='_blank'>GitHub</a>. Thanks!
     tr
       td
-        h5 Date Format Adjustment
+        h5.small_news_header Date Format Adjustment
         p There's a new option under <a href='https://habitrpg.com/#/options/settings/settings' target='_blank'>Settings</a> that lets you adjust the date format. Now you can list dates as MM/DD/YYYY, DD/MM/YYYY, or YYYY/MM/DD.
         p.small.muted by Verabird
-  h5 1/3/2015
+  h5.big_news_header 1/3/2015
     tr
       td
-        h5 January Mystery Item Set
+        h5.small_news_header January Mystery Item Set
         .inventory_present.pull-right
         p Sparkly! What could it be? All Habiticans who are subscribed during the month of January will receive the January Mystery Item Set! It will be revealed on the 26th, so keep your eyes peeled. Thanks for supporting the site <3
         p.small.muted by Lemoness
     tr
       td
-        h5 Spread the Word Challenge
+        h5.small_news_header Spread the Word Challenge
         p In honor of the season of New Year's resolutions, we're running our second Spread the Word Challenge! The rules are simple: make a post some time between December 31st 2014 and January 31st 2015 on some form of blog or social media that tells people about HabitRPG. The top post will be awarded 100 GEMS, and the next nineteen top posts will be awarded 80 GEMS each. Learn more and join in <a href='https://habitrpg.com/#/options/groups/challenges/e1ad6d92-587d-4137-848e-4a1f643603ba' target='_blank'>here</a>!
     tr
       td
-        h5 Winter Plot-Line Continues
+        h5.small_news_header Winter Plot-Line Continues
         p After a fun-filled New Year's Eve, Habiticans wake to a rumbling that shakes them out of their Absurd Party Hats. Running to their windows reveals.... a stampede?
         p A thundering herd of mammoths charges past, sabertooths roar, and dinosaurs both feathery and scaly slither by at top speed. Habiticans stare open-mouthed, but before anyone can react, the stampede has swept through Habit City and is gone into the distance, leaving only pawprints in the snow, the howling wind, and some trampled New Year's cards.
         p Habiticans are advised to keep calm and not give in to stress during this confusing and difficult time. We've sent SabreCat after the frightened animals from the Stoïkalm Steppes, and he is working to calm them down so that we can bring them back to the safety of the Stables. We hope to have an explanation for this strangeness soon. In the meantime, keep all of your own pets and mounts indoors.
         p.small.muted Read the previous installments of the Winter Plot-Line <a href='http://habitrpg.wikia.com/wiki/Winter_Wonderland#Winter_Mystery_Plot' target='_blank'>here</a>!
-  h5 12/31/2014
+  h5.big_news_header 12/31/2014
     tr
       td
-        h5 Party Hats
+        h5.small_news_header Party Hats
         .promo_partyhats.pull-right
         p In honor of the new year, some free Party Hats are available in the Rewards store! New users get the ever-handsome Absurd Party Hat, and users who already received one last year get the Silly Party Hat. These hats will be available to purchase until January 31st, but once you've bought them, you'll have them forever. Enjoy!
         p.small.muted by Lemoness and SabreCat
     tr
       td
-        h5 New Year's Cards (Until Jan 1st Only!)
+        h5.small_news_header New Year's Cards (Until Jan 1st Only!)
         .inventory_special_nye.pull-right
         p Until January 1st only, the <a href='https://habitrpg.com/#/options/inventory/seasonalshop' target='_blank'>Seasonal Shop</a> is stocking New Year's Cards! Now you can send cards to your friends (and yourself) to wish them a Happy Habit New Year. All senders and recipients will receive the Auld Acquaintance badge! When you receive a card, it will appear in your <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>Inventory</a>. Click it to receive a seasonal message!
         p.small.muted by Lemoness and SabreCat
     tr
       td
-        h5 Snowballs
+        h5.small_news_header Snowballs
         .inventory_special_snowball.pull-right
         p The <a href='https://habitrpg.com/#/options/inventory/seasonalshop' target='_blank'>Seasonal Shop</a> is also stocking Snowballs for gold! Throw them at your friends to have an exciting effect. Anyone hit with a snowball earns the Annoying Friends badge. The results of being hit with a Snowball will last until the end of your day, but you can also reverse them early by buying Salt from the Rewards column. Snowballs are available until January 31st.
         p.small.muted by Shaner, Lemoness, and SabreCat
-  h5 12/25/2014
+  h5.big_news_header 12/25/2014
     tr
       td
-        h5 December Subscriber Item Set
+        h5.small_news_header December Subscriber Item Set
         .promo_mystery_201412.pull-right
         p The December Subscriber Item has been revealed: the Penguin Item Set! All December subscribers will receive the Penguin Hat and the Penguin Suit. You still have six days to <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribe</a>) and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         p.small.muted by Lemoness
     tr
       td
-        h5 Seasonal Shop: Seasonal Outfits and Quests
+        h5.small_news_header Seasonal Shop: Seasonal Outfits and Quests
         .seasonalshop_winter2015.pull-right
         p The <a href='https://habitrpg.com/#/options/inventory/seasonalshop'>Seasonal Shop</a> has opened! The Seasonal Sorceress is stocking the seasonal edition versions of last year's winter outfits, now available for Gems instead of Gold, and the two winter quests, Trapper Santa and Find the Cub. The Seasonal Shop will only be open until January 31st, so don't wait!
         p.small.muted by SabreCat and Lemoness
     tr
       td
-        h5 Flagging Posts
+        h5.small_news_header Flagging Posts
         p You can now report inappropriate posts to moderators simply by clicking the new flag button next to the post. You should only report posts that violate the Community Guidelines and/or Terms of Service. Thanks for helping us to keep Habitica safe and pleasant for everybody!
         p.small.muted by Alys, Blade, and Matteo
     tr
       td
-        h5 Winter Plot-Line Continues
+        h5.small_news_header Winter Plot-Line Continues
         p SabreCat's news is dire. "Most of my sabertooth friends have been impossible to reach, but one thing is clear: the prides have been disappearing from the Steppes. There are also reports that something drove the mammoths to early migration and disturbed the hibernation of the terrible lizards."
         p He wraps his cloak around himself as another blast of frigid wind roars through the streets. An icy winter gale has been blowing from the north, rattling the window panes and setting the pets and mounts to trembling and howling.
         p "I've never seen anything like it!" says Matt the Beast Master. "Something is terrifying all my animals - even the cacti, who are normally so mighty and brave! For something to frighten a cactus..." He shakes his head.
         p The stress level in Habitica is mounting.
         p.small.muted Missed the previous Winter Plot-line? Catch up on the story <a href='http://habitrpg.wikia.com/wiki/Winter_Wonderland#Winter_Mystery_Plot' target='_blank'>here</a>!
         p.small.muted by Lemoness
-  h5 12/21/2014 - Winter Wonderland Begins, Winter Class Outfits, Wintery Hair Colors, and NPC Decorations!
+  h5.big_news_header 12/21/2014 - Winter Wonderland Begins, Winter Class Outfits, Wintery Hair Colors, and NPC Decorations!
     tr
       td
-        h5 Winter Wonderland Begins!
+        h5.small_news_header Winter Wonderland Begins!
         p Winter has arrived, and the snow is gently drifting down over Habit City. Come celebrate with us!
     tr
       td
-        h5 Winter Class Outfits
+        h5.small_news_header Winter Class Outfits
         .promo_winterclasses2015.pull-right
         p From now until January 31st, limited edition outfits are available in the Rewards column. Depending on your class, you can be a Soothing Skater, Mage of the North, Gingerbread Warrior, or Icicle Drake! You'd better get productive to earn enough gold before they disappear. Good luck!
         p.small.muted by Lemoness
     tr
       td
-        h5 Wintery Hair Colors
+        h5.small_news_header Wintery Hair Colors
         .promo_winteryhair.pull-right
         p The Seasonal Edition Wintery Hair Colors are now available for purchase in the avatar customizations page! Now you can dye your avatar's hair Holly Green, Winter Star, Snowy, Peppermint, Aurora, or Festive.
         p Seasonal Edition items recur unchanged every year, but they are only available to purchase during a short period of time. This is different from Limited Edition Items, which only recur if something is changed, such as the art or the price. These hair colors may remind some of you of the Holiday Hair Colors that were available last winter. The Holiday Hair Colors have been Retired in favor of the similar Seasonal Edition Wintery Hair Colors. Read more about the difference between Seasonal and Limited Edition items <a href='http://habitrpg.wikia.com/wiki/Item_Availability'>here</a>!
         p.small.muted by Lemoness, crystalphoenix, and mariahm
     tr
       td
-        h5 NPC Decorations
+        h5.small_news_header NPC Decorations
         .npc_alex.pull-right
         p Looks like the NPCs are really getting in to the cheery winter mood around the site. Who wouldn't? After all, there's plenty more to come!
         p.small.muted by Lemoness
-  h5 12/17/2014 - Android App Update, Seasonal Shop, and Winter Plot-Line Continues
+  h5.big_news_header 12/17/2014 - Android App Update, Seasonal Shop, and Winter Plot-Line Continues
     tr
       td
-        h5 Android App Update: December Art and Buying Gems!
+        h5.small_news_header Android App Update: December Art and Buying Gems!
         p The December backgrounds and penguin pet quest are now visible in the Android mobile app! Also, we’ve made it possible to buy gems directly from the app. Now you don’t have to switch to the website to stock up!
         p You can get the Android app <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg&hl=en' target='_blank'>here</a>! We will announce when the iOS app is available as well.
         p.small.muted by negue
     tr
       td
-        h5 Seasonal Shop Tab
+        h5.small_news_header Seasonal Shop Tab
         .seasonalshop_closed.pull-right
         p Looks like a new tab has appeared under Inventory - the <a href='https://habitrpg.com/#/options/inventory/seasonalshop'>Seasonal Shop</a>! It's still closed, but I've heard a rumor that it will open soon...
         p.small.muted by SabreCat and Lemoness
     tr
       td
-        h5 Winter Plot-Line Continues
+        h5.small_news_header Winter Plot-Line Continues
         p Lemoness bursts into the Tavern, shaking icicles off her hat. "The Stoïkalm Steppes are completely abandoned!" she says, gulping the cup of tea that Daniel the Barkeep offers her. "No people milling about, no mounts and pets playing in the snow - and when I tried to fly closer, my dragon spooked and refused to land!"
         p A cloaked figure in the corner steps into the fire light - SabreCat, a powerful adventurer from the north. "The Stoïkalm Steppes are the last home of many animals that have long since gone extinct elsewhere," he says. "The stoic Stoïkalmers would never flee their lands unless something was threatening their pets and mounts!"
         p He turns to Lemoness. "I can speak the language of the northern beasts. I'll try to contact the roaming sabertooth prides to see if they know what happened." As he lopes off into the distance, a cold wind begins to blow.
         p.muted Missed the first part of the Winter Plot-Line? Read it <a href='http://habitrpg.wikia.com/wiki/Whats_new'>here</a>.
-  h5 12/9/2014 - Penguin Pet Quest and Winter Plot-Line
+  h5.big_news_header 12/9/2014 - Penguin Pet Quest and Winter Plot-Line
     tr
       td
-        h5 Penguin Pet Quest
+        h5.small_news_header Penguin Pet Quest
         .quest_penguin.pull-right
         p Habiticans wanted to go ice-skating, but instead, a giant penguin is freezing everything in sight! All we wanted was to go ice-skating... Can you get this penguin to chill out? If so, you'll be rewarded with some penguins of your own!
         p.small.muted by Melynnrose, Breadstrings, Rattify, Painter de Cluster, Daniel the Bard, and Leephon
     tr
       td
-        h5 Winter Plot-Line
+        h5.small_news_header Winter Plot-Line
         p Lemoness enters the Tavern with worrying news from the far north of Habitica. "Nobody's heard from the Stoïkalm Steppes for over a week," she says. "It's hard to imagine anything troubling the citizens there, since it's such a placid part of the continent... But just in case, maybe I should pay a visit." Sounds like a good plan to us!
 
-  h5 12/3/2014 - Gifting Subscriptions And Gems, New Subscription Benefits, Mysterious Time Travelers, Steampunk Item Sets, And Block Subscriptions!
+  h5.big_news_header 12/3/2014 - Gifting Subscriptions And Gems, New Subscription Benefits, Mysterious Time Travelers, Steampunk Item Sets, And Block Subscriptions!
   table.table.table-striped
     tr
       td
-        h5 Gifting Subscriptions And Gems
+        h5.small_news_header Gifting Subscriptions And Gems
         p You can now gift subscriptions and gems to other people (bottom-left in a user's profile window)! If you need holiday present ideas for the awesome Habiticans in your life, or just want to do something nice for someone, consider getting them a subscription to our fair site or tossing a few gems their way. They'll thank you, and so will we <3
         p.small.muted by Lefnire
     tr
       td
-        h5 New Subscription Benefits!
+        h5.small_news_header New Subscription Benefits!
         p We've added new benefits for long-term subscribers! Now for every 3 months that you are subscribed consecutively, your monthly gold-to-gem conversion cap will increase by 5, up to a total of 50 gems per month! Plus, for each three months of consecutive subscription, you will receive 1 Mystic Hourglass. What does that do? Read on!
         p.small.muted by Lefnire
     tr
       td
-        h5 Mysterious Time Travelers
+        h5.small_news_header Mysterious Time Travelers
         .npc_timetravelers.pull-right
         p If you've received a Mystic Hourglass for being subscribed for 3 consecutive months, you can now summon the <a href='/#/options/inventory/timetravelers' target='_blank'>Mysterious Time Travelers</a> to get you one Mystery Item Set from the past! Being subscribed for multiple consecutive months is the only way to get these past items if you missed them. They will never be available to non-subscribers.
         p.small.muted by Lemoness, Megan, Lefnire
     tr
       td
-        h5 Steampunk Item Sets
+        h5.small_news_header Steampunk Item Sets
         .promo_mystery_3014.pull-right
         p The Mysterious Time Travelers are also offering two brand-new Item Sets - the Steampunk Standard Item Set and the Steampunk Accessory Item Set! These Item Sets can only be obtained if you have a Mystic Hourglass.
         p.small.muted by Megan
     tr
       td
-        h5 Block Subscriptions
+        h5.small_news_header Block Subscriptions
         p Don't want to wait for your consecutive months to stack up? You can now subscribe in a fixed block period of 1 month, 3 months, 6 months, or 1 year! If you subscribe for a block period of 1 year, you get a 20% discount. PLUS, you'll instantly get all the benefits of consecutive subscription for that time period (e.g. getting a block subscription for 6 months will instantly raise your monthly gold-to-gem cap by 10)!
         p.small.muted by Lefnire
 
-  h5 12/1/2014 - SITE OUTAGE EXPLANATION, DECEMBER BACKGROUNDS, AND DECEMBER MYSTERY ITEM SET
+  h5.big_news_header 12/1/2014 - SITE OUTAGE EXPLANATION, DECEMBER BACKGROUNDS, AND DECEMBER MYSTERY ITEM SET
   table.table.table-striped
     tr
       td
-        h5 Site Outage Explanation
+        h5.small_news_header Site Outage Explanation
         p Many of you may have noticed that you could not access HabitRPG for a large portion of December 1st. This wasn't a problem on our end - it was due to an outage by DNSimple, the service that provides us with our domain. We're very sorry about any frustration that this caused! If you lost any stats, you can restore them using Settings > Site > Fix Character Values. For future reference, if you ever have trouble accessing HabitRPG, be sure to follow our official Twitter, @HabitRPG, for updates! Thank you for all of your supportive messages <3
     tr
       td
-        h5 December Backgrounds
+        h5.small_news_header December Backgrounds
         p There are three new avatar backgrounds in the <a href=https://habitrpg.com/#/options/profile/backgrounds>Background Shop</a>! Now your avatar can explore the South Pole, drift on an Iceberg, or admire the Winter Party Lights!
         p.small.muted by McCoyly, RosieSully, and Holseties
     tr
       td
-        h5 December Mystery Item Set
+        h5.small_news_header December Mystery Item Set
         p Hmmm! What could it be? All Habiticans who are subscribed during the month of December will receive the December Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
         p.small.muted by Lemoness
 
-  h5 11/26/2014 - Happy Thanksgiving!
+  h5.big_news_header 11/26/2014 - Happy Thanksgiving!
   table.table.table-striped
     tr
       td
-        h5 Happy Thanksgiving!
+        h5.small_news_header Happy Thanksgiving!
         p It's Thanksgiving in Habitica! On this day Habiticans celebrate by spending time with loved ones, giving thanks, and riding their glorious turkeys into the magnificent sunset. Some of the NPCs are celebrating the occasion!
         p.small.muted by Lemoness
     tr
       td
-        h5 Turkey Pet and Mount!
+        h5.small_news_header Turkey Pet and Mount!
         p Those of you who weren't around last Thanksgiving have received an adorable Turkey Pet, and those of you who got a Turkey Pet last year have received a handsome Turkey Mount! Thank you for using HabitRPG - we really love you guys <3
         p.small.muted by Lemoness
 
-  h5 11/25/2014
+  h5.big_news_header 11/25/2014
   table.table.table-striped
     tr
       td
-        h5 November Item Set Revealed
+        h5.small_news_header November Item Set Revealed
         p The November Subscriber Item has been revealed: the Feast and Fun Set! All November subscribers will receive the Pitchfork of Feasting and the Steel Helm of Sporting. You still have five days to subscribe and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         p.small.muted by Lemoness
     tr
       td
-        h5 Private Messaging Version 1.0
+        h5.small_news_header Private Messaging Version 1.0
         p We're excited to announce a new feature: Private Messaging! Now you can send someone a PM by clicking the envelope icon in the bottom-left of their profile window . You can check your messages under Social > Inbox! This is a very rudimentary feature so far, only containing the ability to send messages, block people, and opt out. To read about some of the planned features for the future and make suggestions, check out <a href='https://trello.com/c/hHpIzMc5/459-private-messaging-v-2' target='_blank'>this Trello card</a>!
         p.small.muted by Lefnire
 
-  h5 11/18/2014
+  h5.big_news_header 11/18/2014
   table.table.table-striped
     tr
       td
-        h5 New Pet Quest: The Night-Owl!
+        h5.small_news_header New Pet Quest: The Night-Owl!
         p Habiticans are in the dark when a giant Night-Owl blots out the Tavern light! Can you drive it away in time to finish your all-nighter? If so, you may find some cute pet owls in the morning...
         p.small.muted by Twitching, Lemoness, and Arcosine
 
-  h5 11/13/2014 - Share Avatar To Social Media, Email Invites, First Mini Quest, And Data Tab
+  h5.big_news_header 11/13/2014 - Share Avatar To Social Media, Email Invites, First Mini Quest, And Data Tab
   table.table.table-striped
     tr
       td
-        h5 Share Avatar To Social Media
+        h5.small_news_header Share Avatar To Social Media
         p You can now automatically share your avatar and public profile to social media! Just hover over the picture and click the "Share" button in the right-hand corner. Show off your outfit, your achievements, and your profile picture! Note that your tasks, as always, remain 100% private.
         p.small.muted by Lefnire
     tr
       td
-        h5 Invite Friends To Party Via Email
+        h5.small_news_header Invite Friends To Party Via Email
         p Do you want to invite friends to join your party without inputting their User ID? Now you can send them an email directly from the party page - even if they don't have an account yet!
         p.small.muted by Lefnire
     tr
       td
-        h5 Mini Quest: The Basi-List!
+        h5.small_news_header Mini Quest: The Basi-List!
         p Now when someone accepts your party invitation and joins your party, you will be given a Mini Quest: The Basi-List! Battle the Basi-List with your friends for an XP and GP reward.
         p.small.muted by Arcosine and Redphoenix
     tr
       td
-        h5 Data Tab
+        h5.small_news_header Data Tab
         p Now you can access the Data Display Tool and Export Data from the toolbar!
         p.small.muted by ShilohT
 
-  h5 11/12/2014
+  h5.big_news_header 11/12/2014
   table.table.table-striped
     tr
       td
-        h5 New Equipment Quest Line: The Golden Knight!
+        h5.small_news_header New Equipment Quest Line: The Golden Knight!
         p The Golden Knight believes that she is the perfect Habitican, and that anyone who slips up in their quest for self-improvement is a lazy failure. Can you talk some sense into her - or will it come to blows? If you complete the entire quest line, you'll be rewarded with a legendary weapon...
         p The first scroll in this quest line, "A Stern Talking-to," drops automatically at Level 40! If you're already over Level 40, you will automatically be awarded this quest - just check off a task and then check your inventory.
 
-  h5 11/09/2014 - Facebook Login Fixed For Mobile And Community Guidelines To Chat
+  h5.big_news_header 11/09/2014 - Facebook Login Fixed For Mobile And Community Guidelines To Chat
   table.table.table-striped
     tr
       td
-        h5 Facebook Login Fixed For Mobile!
+        h5.small_news_header Facebook Login Fixed For Mobile!
         p Great news! If you use Facebook to log in to the mobile app, we've released an update so you no longer have to type in your UUID/API manually, misspelling things on your tiny keyboard and bemoaning your fate. Thank goodness! The Android update is out now, and the iOS update has been submitted and should be out soon.
     tr
       td
-        h5 Community Guidelines To Chat
+        h5.small_news_header Community Guidelines To Chat
         p Before you can use any of the public chat features, you now have to agree to our Community Guidelines. We know they're long, but they're important, so please do read them if you haven't already. Plus, we worked hard to make them entertaining, and they were illustrated by many of our excellent artisans!
 
-  h5 11/06/2014
+  h5.big_news_header 11/06/2014
   table.table.table-striped
     tr
       td
-        h5 Bailey: Costume Challenge Badges Awarded!
+        h5.small_news_header Bailey: Costume Challenge Badges Awarded!
         p The HabitRPG Costume Challenge Badges have been awarded! Thanks for your patience while we went through all the entries individually. You can see some of the entries <a href='http://blog.habitrpg.com/tagged/cosplay' target='_blank'>on the HabitRPG blog</a> already, and more will be added every week.
         p IMPORTANT: some of the links that people provided did not work. If you entered the Challenge but even after refreshing the page you still don't have your badge, email leslie@habitrpg.com with the link to your costume and your avatar. (The costume and avatar must have been posted prior to November 1st to count.)
         p Thanks to all our amazing participants!
 
-  h5 11/05/2014- November Backgrounds And Beeminder Integration
+  h5.big_news_header 11/05/2014- November Backgrounds And Beeminder Integration
   table.table.table-striped
     tr
       td
-        h5 November Backgrounds
+        h5.small_news_header November Backgrounds
         p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can enjoy a Harvest Feast, admire a Sunset Meadow, or gaze at the Starry Skies!
         p.small.muted by Kiwibot, Holsety1, and Draayder
     tr
       td
-        h5 Beeminder Integration
+        h5.small_news_header Beeminder Integration
         p We've integrated with Beeminder! Now you can beemind your To-Dos automatically :) <a href='https://www.beeminder.com/habitrpg' target='_blank'>Check it out</a>!
         p If you've never heard of Beeminder or want to learn more about what we've integrated so far, check out our <a href='http://blog.habitrpg.com/post/101773418876/beeminder-integration' target='_blank'>blog post about it</a>. Enjoy!
         p.small.muted by Alys and Alice Monday
 
-  h5 11/01/2014
+  h5.big_news_header 11/01/2014
   table.table.table-striped
     tr
       td
-        h5 November Mystery Item Set
+        h5.small_news_header November Mystery Item Set
         .pull-right.inventory_present
         p Cool! What could it be? All Habiticans who are subscribed during the month of November will receive the November Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
 
-  h5 10/31/2014 - Monster Npcs, Last Day For Fall Festival Items, Last Day Of Community Costume Challenge, Last Day For Winged Goblin Item Set
+  h5.big_news_header 10/31/2014 - Monster Npcs, Last Day For Fall Festival Items, Last Day Of Community Costume Challenge, Last Day For Winged Goblin Item Set
   table.table.table-striped
     tr
       td
-        h5 Last Day For Fall Festival Items
+        h5.small_news_header Last Day For Fall Festival Items
         p Tomorrow everything will be back to normal in Habitica, so if you still have any remaining Fall Festival Items that you want to buy, you'd better do it now! The Seasonal Edition items won't be back until next fall, and if the Limited Edition items return they will have increased prices or changed art, so strike while the iron is hot!
     tr
       td
-        h5 Last Day For Winged Goblin Item Set
+        h5.small_news_header Last Day For Winged Goblin Item Set
         p Reminder: this is the final day to subscribe and receive the Winged Goblin Item Set! If you want the Goblin Wings or the Goblin Gear, now's the time! Thanks so much for your support <3
     tr
       td
-        h5 Last Day Of Community Costume Challenge
+        h5.small_news_header Last Day Of Community Costume Challenge
         p It's the last day to post your pictures of yourself dressed up as your HabitRPG avatar if you want to get the Costume Challenge Badge! You can join the Challenge <a href='https://habitrpg.com/#/options/groups/challenges/39f7e9b4-1fbf-4b01-baee-221fd9b9ef43' target='_blank'>here</a>.
     tr
       td
-        h5 Monster Npcs
+        h5.small_news_header Monster Npcs
         p The NPCs have dressed up in their Halloween costumes! Be sure to stop by and check them all out.
 
-  h5 10/27/2014 - Increased Gems For Contributors And Community Guidelines
+  h5.big_news_header 10/27/2014 - Increased Gems For Contributors And Community Guidelines
   table.table.table-striped
     tr
       td
-        h5 Community Guidelines
+        h5.small_news_header Community Guidelines
         p Our community has grown and evolved over this past year and a half, and we realized that none of the community expectations had been codified anywhere. This has now changed with the implementation of the <a href='/static/community-guidelines' target='_blank'>Community Guidelines</a>. The Guidelines have been written by the staff and mods and illustrated by many of our talented artisans. We know they're long, but they contain all the expectations for participating in the public social side of HabitRPG, so please do read them carefully! Soon you'll have to agree to them to participate in any of the Public Chat.
         p.small.muted by <strong>Alys</strong>, Lemoness, lefnire, redphoenix, SabreCat, paglias, Bailey, Ryan, Breadstrings, Megan, Daniel the Bard, Draayder, Kiwibot, Leephon, Luciferian, Revcleo, Shaner, Starsystemic, UncommonCriminal
     tr
       td
-        h5 Increased Gems For Contributors
+        h5.small_news_header Increased Gems For Contributors
         p When we first started rewarding contributors, we decided to give them 2 gems per contributor tier. Since then, however, we've introduced many more things to buy, so we've decided to increase this number. All contributors now receive 3 gems/tier for tiers 1-3, and then 4 gems/tier for tiers 4-7, bringing the total number of gems you can earn by contributing to the site to 25.
         p If you've already contributed, you've been given the gems that you're owed according to the new system. (For example, if you are a tier 3 contributor, you received 6 gems in the past and would receive 9 gems under the new system, so you've been awarded 3 gems to account for the difference.)
         p Enjoy!
         p.small.muted by Alys
 
-  h5 10/25/2014 - October Item Set Revealed And Community Costume Challenge Reminder
+  h5.big_news_header 10/25/2014 - October Item Set Revealed And Community Costume Challenge Reminder
   table.table.table-striped
     tr
       td
-        h5 October Item Set Revealed
+        h5.small_news_header October Item Set Revealed
         .promo_mystery_201410.pull-right
         The October Subscriber Item has been revealed: the Winged Goblin Item Set! All October subscribers will receive the Goblin Gear and the Goblin Wings. You still have six days to subscribe and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         by Lemoness
-        h5 Community Costume Challenge Reminder
+        h5.small_news_header Community Costume Challenge Reminder
         .achievement-costumeContest.pull-right
         p Don't forget about the <a href='https://habitrpg.com/#/options/groups/challenges/39f7e9b4-1fbf-4b01-baee-221fd9b9ef43' target='_blank'>Community Costume Challenge</a>! We've had some really amazing entries so far, and we're looking forward to seeing more over the next six days! All participants will receive the 2014 Costume Challenge Badge.
         p You can view some of the awesome costumes <a href='http://blog.habitrpg.com/tagged/cosplay' target='_blank'>here</a>!
 
-  h5 10/23/2014
+  h5.big_news_header 10/23/2014
   table.table.table-striped
     tr
       td
-        h5 Level 60 Equipment Quest: Recidivate Quest Line!
+        h5.small_news_header Level 60 Equipment Quest: Recidivate Quest Line!
         p All over Habitica, Bad Habits thought long-dead are rising up again - it must be the work of Recidivate, the wicked Necromancer! Can you complete your Dailies and fight down your Bad Habits to lay her to rest once more? If so, you'll reap some fine spoils... including some legendary armor!
         p This quest line contains the hardest Boss Battle that we've released to date, so the first quest scroll drops for free at Level 60. If you're already Level 60 or over, you can unlock it for free, too - just check off any task and it will drop for you :) Good luck! You'll need it.
         p.small.muted by Lemoness, Tru_, aurakami, Inventrix, and Baconsaur
 
-  h5 10/15/2014 - Spider Pet Quest, Mobile App Update, Hide Grey Dailies, And Sortable Checklists!
+  h5.big_news_header 10/15/2014 - Spider Pet Quest, Mobile App Update, Hide Grey Dailies, And Sortable Checklists!
   table.table.tables-striped
     tr
       td
-        h5 New Pet Quest: The Icy Arachnid!
+        h5.small_news_header New Pet Quest: The Icy Arachnid!
         p Yikes, what's leaving these icy webs all over Habitica? It must be the Frost Spider from the newest Pet Quest: The Icy Arachnid! You can buy this quest in the <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>Market</a>. Don't worry, it will be around even after the Fall Festival ends :)
         p.small.muted by Arcosine
     tr
       td
-        h5 Mobile App Update!
+        h5.small_news_header Mobile App Update!
         p The newest mobile app update is available on iOS and Android! Now when you're on your phone you can see Fall Festival items, get drop notifications, and view the pixel art of the bosses that you're battling!
         p.small.muted By lefnire, negue, huarui, and paglias
     tr
       td
-        h5 Hide Grey Dailies
+        h5.small_news_header Hide Grey Dailies
         p You can now hide grey Dailies to de-clutter your list! There are tabs at the bottom of the Dailies column that you can toggle to see only which Dailies are still active.
         p.small.muted by Gaelan, and Alys
     tr
       td
-        h5 Sortable Checklists
+        h5.small_news_header Sortable Checklists
         p Have you ever wanted to rearrange checklist order? Now you can! Simply drag and drop to sort your checklist points.
         p.small.muted By gjoyner
 
-  h5 10/7/2014 - Back-To-School Advice Challenge Winners And Jack-O-Lantern Pet!
+  h5.big_news_header 10/7/2014 - Back-To-School Advice Challenge Winners And Jack-O-Lantern Pet!
   table.table.table-striped
     tr
       td
-        h5 Back-To-School Advice Challenge Winners
+        h5.small_news_header Back-To-School Advice Challenge Winners
         p We had a ton of participants in our Back-To-School Advice Challenge, and we've finally sorted through and chosen the winners! Congratulations to
         p DJ Ringis, The Writer, San Condor, Tavi Wright, Stepharuka, Clyc, samaeldreams, LitNerdy, Tritlo, Shansie, Han Solo, FrauleinNinja, Nortya, itsallaboutfalling, TomFrankly, [TGL] Dogg, Amanda, InfH, Evan950, and Mizuokami! You've all received your gems :)
         p Thanks so much for participating! If you had fun, don't forget that the Community Costume Challenge is happening all October :)
     tr
       td
-        h5 Jack-O-Lantern Pet
+        h5.small_news_header Jack-O-Lantern Pet
         p Habiticans have been carving lots of pumpkins recently - and it looks like one has followed you home! Everyone has received a pet Jack-O-Lantern! You can find it in the Stables :)
         p.small.muted by Lemoness
 
-  h5 10/3/2014- Spooky Sparkles, New Backgrounds, And Memory Leaks Almost Fixed!
+  h5.big_news_header 10/3/2014- Spooky Sparkles, New Backgrounds, And Memory Leaks Almost Fixed!
   table.table.table-striped
     tr
       td
-        h5 Spooky Sparkles
+        h5.small_news_header Spooky Sparkles
         .pull-right
           .inventory_special_spookDust
           .achievement-spookDust
@@ -1382,209 +1382,209 @@ mixin oldNews
         p.small.muted by Lemoness, lefnire
     tr
       td
-        h5 New Backgrounds Revealed: Haunted House, Graveyard, And Pumpkin Patch
+        h5.small_news_header New Backgrounds Revealed: Haunted House, Graveyard, And Pumpkin Patch
         p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can sneak through a Haunted House, visit a creepy Graveyard, or carve jack-o-lanterns in a Pumpkin Patch!
         p.small.muted by cecilyperez, Kiwibot, and Sooz
     tr
       td
-        h5 Memory Leaks Almost Fixed
+        h5.small_news_header Memory Leaks Almost Fixed
         p It took a ton of effort, but Tyler has fixed the largest memory leak that was crashing our servers! There are a few smaller ones that he’s still conquering one by one, but the fiercest monster has been slain. Ten thousand cheers for Tyler! You can read the technical description of how we’re fixing the leaks <a href='https://github.com/HabitRPG/habitrpg/issues/4079' target='_blank'>here</a>, and for any JavaScript developers out there: we'd love your help! We’ll let you all know when we’ve fixed the problem for once and for all.
         p.small.muted by lefnire
 
-  h5 10/1/2014 - Seasonal Edition Skins, Seasonal Edition Hair Colors, Community Costume Challenge, Release Pets, and October Mystery Item!
+  h5.big_news_header 10/1/2014 - Seasonal Edition Skins, Seasonal Edition Hair Colors, Community Costume Challenge, Release Pets, and October Mystery Item!
   table.table.table-striped
     tr
       td
-        h5 Seasonal Edition Hair
+        h5.small_news_header Seasonal Edition Hair
         p The Seasonal Edition Haunted Hair Colors are now available for purchase in the avatar customizations page! Now you can dye your avatar's hair Pumpkin, Midnight, Candy Corn, Ghost White, Zombie, or Halloween.
         p Seasonal Edition items recur unchanged every year, but they are only available to purchase during a short period of time. This is different from Limited Edition Items, which only recur if something is changed, such as the art or the price. Read more about the difference between Seasonal and Limited Edition items <a href='http://habitrpg.wikia.com/wiki/Item_Availability' target='_blank'>here</a>!
         p.small.muted by Lemoness, mariahm, and crystal phoenix
     tr
       td
-        h5 Seasonal Edition Skins
+        h5.small_news_header Seasonal Edition Skins
         p The Supernatural Skin Set is here! Now your avatar can become an Ogre, Skeleton, Pumpkin, Candy Corn, Reptile, or Dread Shade. You can buy them from now until October 31st!
         p These skins may remind some of you of the Spooky Skin set that was available briefly last fall. This is because we've received many requests for these Limited Edition skins from more recent players who were unable to purchase those skins. As a compromise, we have decided to Retire the Spooky Skin Set and release some similar but unique skins as part of the Supernatural Skin Set. That way, anyone who wants their avatar to be a pumpkin can have their way, but the original owners of the skin sets still have the unique items that they were promised. You can read more about the new Item Availability categories <a href='http://habitrpg.wikia.com/wiki/Item_Availability' target='_blank'>here</a>.
         p.small.muted by Lemoness
     tr
       td
-        h5 Community Costume Challenge
+        h5.small_news_header Community Costume Challenge
         p The Community Costume Challenge has begun! Between now and October 31st, dress up as your avatar in real life and post a photo on social media to get the coveted Costume Challenge badge! Read the full rules on the Challenge page <a href='https://habitrpg.com/#/options/groups/challenges/39f7e9b4-1fbf-4b01-baee-221fd9b9ef43' target='_blank'>here</a>.
         p.small.muted by Lemoness
     tr
       td
-        h5 Release Pets and Mounts
+        h5.small_news_header Release Pets and Mounts
         p If you find collecting pets highly motivating and want to start over from zero, you're in luck! You can now release all your pets and mounts so that you can collect them again - and stack your Beastmaster achievement!
         p.small.muted By Ryan
     tr
       td
-        h5 October Mystery Item
+        h5.small_news_header October Mystery Item
         p Spooky! What could it be? All Habiticans who are subscribed during the month of October will receive the October Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
         p.small.muted by Lemoness
 
-  h5 9/25/2014
+  h5.big_news_header 9/25/2014
   table.table.table-striped
     tr
       td
-        h5 Update: Diagnosing Server Problems
+        h5.small_news_header Update: Diagnosing Server Problems
         p Our servers have been under a massive strain recently, and so we've created a <a href='https://github.com/HabitRPG/habitrpg/issues/4079' target='_blank'>Github ticket</a> that you can follow for updates on the things we're doing to fix the problem. We've also written a <a href='http://blog.habitrpg.com/post/98367930371/update-diagnosing-server-problems' target='_blank'>blog post</a>. We'll keep you updated with new developments as we strive to solve this problem.
         p If you've lost any of your stats during this time, you can restore them using Settings > Site > Fix Character Values. Thank you so much for your patience and encouragement as we work to fight this fearsome foe!
         p.small.muted by lefnire, Lemoness
     tr
       td
-        h5 September Item Set Revealed
+        h5.small_news_header September Item Set Revealed
         .promo_mystery_201409.pull-right
         p In happier news, the September Subscriber Item has been revealed: the Autumn Strider Item Set. All people who are subscribed before the end of September will receive the Autumn Antlers and the Strider Vest. Thank you so much for your support - it means a lot to us, especially right now.
         p.small.muted by Lemoness
 
-  h5 9/22/2014 - Fall Festival! Limited-Edition Outfits, Candy Food Drops, And Npc Dress-Up
+  h5.big_news_header 9/22/2014 - Fall Festival! Limited-Edition Outfits, Candy Food Drops, And Npc Dress-Up
   p Autumn is upon us! The air is crisp, the leaves are red, and Habitica is feeling spooky. Come celebrate the Fall Festival with us... if you dare!
   table.table.table-striped
     tr
       td
-        h5 Limited Edition Class Outfits
+        h5.small_news_header Limited Edition Class Outfits
         p Habiticans everywhere are dressing up. From now until October 31st, limited edition outfits are available in the Rewards column. Depending on your class, you can be a Witchy Wizard, Monster of Science, Vampire Smiter, or Mummy Medic! You'd better get productive to earn enough gold before your time runs out...
     tr
       td
-        h5 Candy Food Drops!
+        h5.small_news_header Candy Food Drops!
         p You've received some Candy in your inventory in honor of the Fall Festival! Plus, for the duration of the Event, Habiticans may randomly find candy drops when they complete their tasks. These candies function just like normal food drops - can you guess which flavor your pet will like best?
     tr
       td
-        h5 NPC Dress-Up
+        h5.small_news_header NPC Dress-Up
         p Looks like the NPCs are really getting in to the spooky autumnal mood around the site. Who wouldn't?
 
-  h5 9/17/2014 - Rooster Pets, Party Sorting, And Back-To-School Challenge
+  h5.big_news_header 9/17/2014 - Rooster Pets, Party Sorting, And Back-To-School Challenge
   table.table.table-striped
     tr
       td
-        h5 New Pet Quest: Rooster Rampage!
+        h5.small_news_header New Pet Quest: Rooster Rampage!
         p There's a new pet quest in <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>the Market</a>! This monstrous rooster can't be quieted, and Habiticans are unable to sleep. Can you and your Party calm down this foul fowl? You'll be rewarded with Rooster eggs if you do!
         p.small.muted by LordDarkly, Pandoro, EmeraldOx, extrajordanary, and playgroundgiraffe
     tr
       td
-        h5 Party Sorting!
+        h5.small_news_header Party Sorting!
         p We've improved the preexisting party sort feature. Now you can sort your party members' avatars by level, backgrounds, and more! Simply go to Social > Party > Members and select from the drop-down menu.
         p.small.muted by Alys and Viirus
     tr
       td
-        h5 Back-To-School Challenge!
+        h5.small_news_header Back-To-School Challenge!
         p Don't forget that the 2nd Official HabitRPG Challenge is running right now - the <a href='https://habitrpg.com/#/options/groups/challenges/a367eb40-8514-46fd-805e-b9b7f89bad7f' target='_blank'>Back-To-School Advice Challenge</a>! Post your best tips for using HabitRPG during the Back-To-School season on social media for a chance at winning 60 gems. If you want to share it with the maximum number of people, you can use the #habitrpg and #backtoschool tags. You only have thirteen more days to enter. Good luck!
 
-  h5 9/12/2014 - Official Back-To-School Challenge, Markdown In Checklists, And Help Tab
+  h5.big_news_header 9/12/2014 - Official Back-To-School Challenge, Markdown In Checklists, And Help Tab
   table.table.table-striped
     tr
       td
-        h5 Official Back-To-School Challenge
+        h5.small_news_header Official Back-To-School Challenge
         p We've launched our 2nd Official HabitRPG Challenge: the Back-To-School Advice Challenge! Use social media to tell us how you use HabitRPG to improve study habits, share stories of scholarly success with the app, or just give us your advice on using HabitRPG to be the best you can be.
         p The contest ends on September 30th, and the 20 winners will each get 60 Gems! For the full rules, <a href='https://habitrpg.com/#/options/groups/challenges/a367eb40-8514-46fd-805e-b9b7f89bad7f' target='_blank'>check out the challenge here</a>.
-        h5 Markdown In Checklists
+        h5.small_news_header Markdown In Checklists
         p Previously, you've been able to use <a href='http://habitrpg.wikia.com/wiki/Markdown_Cheat_Sheet' target='_blank'>markdown</a> in your task names and in chat. Now you can also use it in checklists! Fill every aspect of your tasks with emoji, bolding, italics, or links. NOTE: If your checklists look strange, it's probably because they're accidentally using markdown now, so just edit them accordingly! Check out <a href='http://habitrpg.wikia.com/wiki/Markdown_Cheat_Sheet' target='_blank'>this Cheat Sheet</a> for an explanation of how to use markdown.
         p.small.muted By @negue
-        h5 Help Tab
+        h5.small_news_header Help Tab
         p There's a new tab on the top bar that contains some helpful links. If you're confused about something, want to request a feature, or wonder if your question was asked before, you can now use the Help Tab's drop down menu!
         p.small.muted By @Alys
 
-  h5 9/10/2014
+  h5.big_news_header 9/10/2014
   table.table.table-striped
     tr
       td
-        h5 Get Ready For The Community Costume Challenge!
+        h5.small_news_header Get Ready For The Community Costume Challenge!
         p We've got an exciting event coming up this October - the first-ever Community Costume Challenge! In the spirit of the season, Habiticans who dress up in real-life versions of their avatar's armor (or in any HabitRPG costume) will receive a special badge. (No, just wearing a colored shirt doesn't count. Where's the fun in that?)
         p The Community Costume Challenge will start on October 1st, but we're announcing it early so that people have time to get their costumes together.
         p Instructions on how to participate in the CCC will be posted on October 1st. We can't wait to see your costumes!
 
-  h5 9/3/2014
+  h5.big_news_header 9/3/2014
   table.table.table-striped
     tr
       td
-        h5 New Backgrounds Revealed: Thunderstorm, Autumn Forest, Harvest Fields
+        h5.small_news_header New Backgrounds Revealed: Thunderstorm, Autumn Forest, Harvest Fields
         p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop!</a> Now your avatar can conduct lightning in a Thunderstorm, stroll through an Autumn Forest, or cultivate their Harvest Fields!
         p.small.muted by krajzega and Uncommon Criminal
 
-  h5 9/1/2014
+  h5.big_news_header 9/1/2014
   table.table.table-striped
     tr
       td
-        h5 September Mystery Item
+        h5.small_news_header September Mystery Item
         p Hmm, intriguing... All Habiticans who are subscribed during the month of September will receive the September Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
 
-  h5 8/31/2014
+  h5.big_news_header 8/31/2014
   table.table.table-striped
     tr
       td
-        h5 Last Day For Sun Sorcerer Item Set
+        h5.small_news_header Last Day For Sun Sorcerer Item Set
         p Reminder: this is the final day to subscribe and receive the Sun Sorcerer Item Set! If you want the Sun Crown or the Sun Robes, now's the time! Thanks so much for your support <3
 
-  h5 8/26/2014 - August Mystery Item, Sortable Tags, Push To Top
+  h5.big_news_header 8/26/2014 - August Mystery Item, Sortable Tags, Push To Top
   table.table.table-striped
     tr
       td
-        h5 August Item Set Revealed!
+        h5.small_news_header August Item Set Revealed!
         .promo_mystery_201408.pull-right
         p The August Subscriber Item has been revealed: the Sun Sorcerer Item Set! All August subscribers will receive the Sun Crown and the Sun Robes. You still have five days to subscribe and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         p.small.muted by Lemoness
     tr
       td
-        h5 Sortable Tags
+        h5.small_news_header Sortable Tags
         p You can now sort your tags. Drag left-to-right and drop them into place.
         p.small.muted by Fandekasp, lefnire
     tr
       td
-        h5 Push to Top
+        h5.small_news_header Push to Top
         p We've added a small button in your tasks' one-click actions: Push to Top. This will help easily you sort your day's priorities, which may change from day-to-day.
         p.small.muted by negue
 
-  h5 8/19/2014 - Parrot Quest, Audio, And Mobile App Update!
+  h5.big_news_header 8/19/2014 - Parrot Quest, Audio, And Mobile App Update!
   table.table.table-striped
     tr
       td
-        h5 New Pet Quest: Help! Harpy!
+        h5.small_news_header New Pet Quest: Help! Harpy!
         p There's a new Pet Quest available in the <a href='https://habitrpg.com/#/options/inventory/drops'>Market</a>! @UncommonCriminal is being held hostage by a Parrot-like Harpy. If you can find a way to help, you'll definitely get your hands on some coveted Parrot Eggs....
         p After you've purchased the scroll, battle the Boss by completing Habits and To-Dos. Be careful - every Daily that you skip will cause the Boss to attack your party!
         p.small.muted by Uncommon Criminal and Token
     tr
       td
-        h5 Audio
+        h5.small_news_header Audio
         p You can now enable sound effects for various website actions. Click the volume icon (<span class='glyphicon glyphicon-volume-off'></span>) and choose an "Audio Theme". For now, the only theme available is "Daniel The Bard" (@DanielTheBard designed this set); however, we'll release more themes over time (<a href='http://habitrpg.wikia.com/wiki/Guidance_for_Bards' target='_blank'>get involved here</a>). We'll also add more sound effects, and possibly music, to the current set.
         p.small.muted by DanielTheBard, Fandekasp
 
     tr
       td
-        h5 New Mobile Update: Backgrounds and Guilds!
+        h5.small_news_header New Mobile Update: Backgrounds and Guilds!
         p We've updated the mobile app to include Backgrounds and Guilds! Now you can use the mobile app to join common interest groups, chat with like-minded people, and swap your avatar’s background. The iOS app is <a href='https://itunes.apple.com/us/app/habitrpg/id689569235?mt=8' target='_blank'>here</a>, and the Android app is <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg&hl=en' target='_blank'>here</a>. If you enjoy the direction that we’ve been taking the app, we would really appreciate it if you would leave us a review <3 Thank you!
         p.small.muted by huarui, paglias
 
-  h5 8/12/2014
+  h5.big_news_header 8/12/2014
   table.table.table-striped
     tr
       td
-        h5 New Equipment Quest: Attack Of The Mundane!
+        h5.small_news_header New Equipment Quest: Attack Of The Mundane!
         p There's a new Quest that will drop automatically for all users level 15 and up: the Dish Disaster, first quest in the Attack of the Mundane Questline! Scrub enchanted dirty dishes, battle the SnackLess Monster, and face off against the Evil Laundromancer. You might just be rewarded with a new piece of armor...
         p As you complete each quest in this questline, you will be awarded with the quest scroll for the next part. There are three parts in total. Good luck!
         small.muted by Arcosine, Kiwibot, Lemoness, Daniel the Bard, itokro
 
-  h5 8/6/2014
+  h5.big_news_header 8/6/2014
   table.table.table-striped
     tr
       td
-        h5 New Backgrounds Revealed: Volcano, Dusty Canyon, Clouds
+        h5.small_news_header New Backgrounds Revealed: Volcano, Dusty Canyon, Clouds
         p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can heat up inside a Volcano, wander through a Dusty Canyon, or soar through the Clouds!
 
-  h5 8/4/2014
+  h5.big_news_header 8/4/2014
   table.table.table-striped
     tr
       td
-        h5 New Mobile Update: Checklist Editing And Bug Fixes!
+        h5.small_news_header New Mobile Update: Checklist Editing And Bug Fixes!
         p In case you missed it, we’ve released a new mobile update! You can edit checklists from the mobile app now. We also fixed some bugs, including the image problems on iOS! The Android app is <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg&hl=en' target='_blank'>here</a> and the iOS app is <a href='https://itunes.apple.com/us/app/habitrpg/id689569235?mt=8' target='_blank'>here</a>.
         p You may have noticed that we've been releasing lots of updates recently. This is greatly due to two awesome members of our team!
         p The first is superstar contributor Matteo, aka <a href='https://github.com/paglias' target='_blank'>paglias</a>. In addition to the mobile app, he contributes tons of code to the site, runs translations, and fixes bugs without blinking. We are so thankful to have him on the team!
         p We also have another new mobile app contributor who has rocketed to Level 7 in record time: <a href='https://github.com/huaruiwu' target='_blank'>huarui</a>! Huarui has been an absolute whirlwind with mobile app improvements.
         p Give them both a giant round of applause!
 
-  h5 8/2/2014
+  h5.big_news_header 8/2/2014
   table.table.table-striped
     tr
       td
-        h5 Dread Drag'on Defeated! Prizes: Mantis Shrimp Pet, Mantis Shrimp Mount, Food, and Badge
+        h5.small_news_header Dread Drag'on Defeated! Prizes: Mantis Shrimp Pet, Mantis Shrimp Mount, Food, and Badge
         p We've done it!
         p With a final last roar, the Dread Drag'on collapses and swims far, far away. Crowds of cheering Habiticans line the shores! We've helped Daniel rebuild his Tavern.
         p But what's this?
@@ -1594,54 +1594,54 @@ mixin oldNews
         p "As a thank you," says his friend @Ottl, "Please accept this Mantis Shrimp pet and Mantis Shrimp mount, this feast, and our eternal gratitude!"
     tr
       td
-        h5 August Mystery Item
+        h5.small_news_header August Mystery Item
         p Ooh, mysterious! All Habiticans who are subscribed during the month of August will receive the August Mystery Item Set! It will be revealed on the 26th, so keep your eyes peeled. Thanks for supporting the site <3
 
-  h5 7/31/2014
+  h5.big_news_header 7/31/2014
   table.table.table-striped
     tr
       td
-        h5 Last Day for July Subscriber Set
+        h5.small_news_header Last Day for July Subscriber Set
         .promo_mystery_201407.pull-right
         p Reminder: this is the final day to subscribe and receive the Undersea Explorer Item Set! If you want the Undersea Explorer Helm or the Undersea Explorer Suit, now's the time! Thank you so much for your support <3
     tr
       td
-        h5 Final Day for Limited Edition Summer Outfits
+        h5.small_news_header Final Day for Limited Edition Summer Outfits
         p Today is the last day of the Summer Splash Event, so it is the last day to buy the Limited Edition Outfits and the Rainbow Warrior Armor from the Rewards store. Get productive and spend that gold!
 
   hr
-  h5 7/25/2014
+  h5.big_news_header 7/25/2014
   table.table.table-striped
     tr
       td
-        h5 July Subscriber Item
+        h5.small_news_header July Subscriber Item
         .promo_mystery_201407.pull-right
         p The July Subscriber Item has been revealed: the Undersea Explorer Item Set! All July subscribers will receive the Undersea Explorer Helm and the Undersea Explorer Suit. You still have six days to subscribe and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
 
   hr
-  h5 7/16/2014
+  h5.big_news_header 7/16/2014
   table.table.table-striped
     tr
       td
-        h5 Mobile App Update
+        h5.small_news_header Mobile App Update
         p We’ve released another update to the mobile app! Now you can feed and select pets from the app. Carry your cute pets with you everywhere you go! The app is available for <a href='https://itunes.apple.com/us/app/habitrpg/id689569235?mt=8' target='_blank'>iOS here</a>, and <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg' target='_blank'>Android here</a>. We’re continuing to release updates on a regular basis, so if you like the direction that we’ve been taking the app, please do consider leaving us a review. Thank you!
     tr
       td
-        h5 Neglect Strike: Tavern Art Swap
+        h5.small_news_header Neglect Strike: Tavern Art Swap
         p The Dread Drag'on's Rage Bar has filled, and it has unleashed its Neglect Strike, leading to a new look for the Tavern! As a reminder, the Drag'on's rage will NEVER hurt any users or interfere with their ability to be productive, so the chat and inn are still functional. Even so... poor Daniel!
         p All users are automatically damaging the Drag'on with their tasks. There is nothing bad that can happen to you or your account by being in this fight!
     tr
       td
-        h5 Dread Drag'on Prize Change: Food Reward!
+        h5.small_news_header Dread Drag'on Prize Change: Food Reward!
         p We've received a lot of feedback due to the weekend's confusion, and it seems that awarding GP and XP for defeating the world boss significantly unbalanced the game for newer players. Based on your feedback, XP and GP will no longer be awarded. Instead, players will receive an assortment of food! The Mantis Shrimps will still be awarded.
         p If you were looking forward to receiving the 900XP and 90 GP upon completion of the battle, feel free to award it to yourself using Settings > Site > Fix Character Values when the battle is done!
         p Thank you for bearing with us through the confusion. We love you guys.
   hr
-  h5 7/12/2014
+  h5.big_news_header 7/12/2014
   table.table.table-striped
     tr
       td
-        h5 Wow, What'S Going On?!
+        h5.small_news_header Wow, What'S Going On?!
         p You may have noticed some strange things happening - extra gold? Drag'on defeated? No quest damage?
         br
         p Turns out the Dread Drag'on of Dilatory was harder to handle than we expected, and wreaked havoc on us last night by unexpectedly completing due to a glitch, throwing off party quest damage, and granting all of its rewards early! *shakes fist at terrible beast*
@@ -1660,61 +1660,61 @@ mixin oldNews
   table.table.table-striped
     tr
       td
-        h5 July 11th: GaymerX reminder
+        h5.small_news_header July 11th: GaymerX reminder
         p Reminder: Vicky (aka redphoenix) is at GaymerX at the InterContinental in San Francisco this weekend! She will have lots of promo codes for the Unconventional Armor Set. Our champion moderator Ryan will be there, too, and would love to meet you guys! Vicky will be wearing a dinosaur hoodie and a red shirt, and Ryan has a partially-shaved head and is in a wheelchair.
         br
         p There will be an official HabitRPG meet-up on <strong>Saturday 3:15-4:30</strong> outside GX Panel Room A (Grand Ballroom AB (3F)). Come get your promo codes there! If you can't make it at that time, contact Vicky via email (vicky@habitrpg.com) or Twitter (@caffeinatedvee) to coordinate an alternative time and place to meet up at the convention!
   small.muted 7/11/2014
   hr
 
-  h5 7/9/2014
+  h5.big_news_header 7/9/2014
   table.table.table-striped
     tr
       td
-        h5 Happy Derby Day!
+        h5.small_news_header Happy Derby Day!
         p In celebration of Derby Day, all Habiticans have received a seahorse egg! On this day, the worst of Habitica's ancient bugs were defeated, and so every year we celebrate. Let's ride through Dilatory on this fun day.
-        h5 New Pet Quest: Seahorse!
+        h5.small_news_header New Pet Quest: Seahorse!
         p But oh, no - it looks like a wild Sea Stallion is disrupting the races! Quickly, battle the Sea Stallion to calm him down, and you might just get your hands on some additional seahorse eggs...
         p.small.muted - by Kiwibot and Lemoness
-        h5 Updated Stats Bars
+        h5.small_news_header Updated Stats Bars
         p Based on your feedback, we’ve updated the design of the new status bars with an 8-bit style and improved accessibility.
         p.small.muted - by BenManley
 
   hr
-  h5 7/3/2014
+  h5.big_news_header 7/3/2014
   table.table.table-striped
     tr
       td
-        h5 New backgrounds available: Coral Reef, Open Waters, Seafarer Ship
+        h5.small_news_header New backgrounds available: Coral Reef, Open Waters, Seafarer Ship
         p Three new avatar backgrounds are available in the Background Shop! Now your avatar can swim in a <strong>coral reef</strong>, enjoy the <strong>open waters</strong>, or sail aboard a <strong>Seafarer Ship</strong>. Thanks so much for supporting the site!
     tr
       td
-        h5 Next Convention: GaymerX!
+        h5.small_news_header Next Convention: GaymerX!
         p HabitRPG's own Vicky Hsu will be at GaymerX, a game convention celebrating LGBTQ and gaming which is open to everyone, at the InterContinental in downtown San Francisco on July 11-13. (For more information, check out gaymerx.com!) Vicky will be giving away promo codes for the UnConventional Armor Set, so if you want to meet up with her (and snag some awesome capes), send a message to vicky@habitrpg.com or @caffeinatedvee on Twitter!
     tr
       td
-        h5 Rainbow Warrior Set!
+        h5.small_news_header Rainbow Warrior Set!
         p Even if you can't make it to the convention, you can still enjoy the two new armor pieces available for free in the Rewards Store: the Rainbow Warrior Helm and the Rainbow Warrior Armor! They were designed by our GaymerX friends and they look awesome. They'll be available until the end of the month, so enjoy!
 
   hr
-  h5 7/1/2014
+  h5.big_news_header 7/1/2014
   table.table.table-striped
     tr
       td
-        h5 WORLD BOSS: The Dread Drag'on of Dilatory!
+        h5.small_news_header WORLD BOSS: The Dread Drag'on of Dilatory!
         p We should have heeded the warnings.
         p Dark shining eyes. Ancient scales. Massive jaws, and flashing teeth. We've awoken something horrifying from the crevasse: **the Dread Drag'on of Dilatory!** Screaming Habiticans fled in all directions when it reared out of the sea, its terrifyingly long neck extending hundreds of feet out of the water as it shattered windows with its searing roar.
         p "This must be what dragged Dilatory down!" yells Lemoness. "It wasn't the weight of the neglected tasks - the Dark Red Dailies just attracted its attention!"
         p "It's surging with magical energy!" @Baconsaur cries. "To have lived this long, it must be able to heal itself! How can we defeat it?"
         p Why, the same way we defeat all beasts - with productivity! Quickly, Habitica, band together and strike through your tasks, and all of us will battle this monster together. (There's no need to abandon previous quests -  we believe in your ability to double-strike!) It won't attack us individually, but the more Dailies we skip, the closer we get to triggering its Neglect Strike - and I don't like the way it's eyeing the Tavern....
   hr
-  h5 6/30/2014
+  h5.big_news_header 6/30/2014
   table.table.table-striped
     tr
       td
-        h5 Last day for June Item Set!
+        h5.small_news_header Last day for June Item Set!
         p Reminder: this is the final day to subscribe and receive the Octomage Item Set! If you want the Octopus Robe or the Tentacle Helm, now's the time! Thanks so much for your support <3
-        h5 Dilatory Update
+        h5.small_news_header Dilatory Update
         p PLEASE! Habiticans, stop  exploring the dark crevasse!!! Lemoness is really getting worried. There have been.... reports.
         p Reports of something big.
         p Reports of something terrifying.
@@ -1722,45 +1722,45 @@ mixin oldNews
         p Besides, exploring the dark and dangerous crevasse has become a source of procrastination. Let's get back to work, people!
 
   hr
-  h5 6/25/2014
+  h5.big_news_header 6/25/2014
   table.table.table-striped
     tr
       td
-        h5 June Subscriber Item
+        h5.small_news_header June Subscriber Item
         .pull-right.promo_mystery_201406.png
         p The June Subscriber Item has been revealed: the Octomage Item Set!  All June subscribers will receive the Octopus Robe and the Crown of Tentacles. You still have six days to subscribe and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
-        h5 Mobile App Update
+        h5.small_news_header Mobile App Update
         p There's a new mobile app update available! In addition to bug fixes, there are many improvements, including a new button-based menu, tap-and-hold to edit tasks, and the return of stats and in-app avatar customization! Working on the mobile app is our biggest To-Do this summer, so expect more in the coming months. If you feel that the app is improving, we'd love it if you would take the time to give us a review and let us know what you think!
-        h5 Dilatory Update
+        h5.small_news_header Dilatory Update
         p It's great to see Habiticans having fun exploring the ruins! There's just one small thing Lemoness wants us to avoid. She's noticed a lot of Habiticans trying to explore the fallen palace of the other side of the dark crevasse. She really doesn't feel that the crevasse is safe, so please don't swim so close. Other than that, enjoy your explorations!
 
   hr
-  h5 6/21/2014
+  h5.big_news_header 6/21/2014
   table.table.table-striped
     tr
       td
-        h5 Summer Mystery Update
+        h5.small_news_header Summer Mystery Update
         p Lady Lemoness has returned at last! She startled beach-goers by charging up out of the waves and onto the shore, shouting "I found it!!! I found it!!! Oh, I just KNEW that citing it as impossible would make it a narrative probability!"
         p Wait - found what?
-        h5 Summer Splash Event: The Lost City Of Dilatory!
+        h5.small_news_header Summer Splash Event: The Lost City Of Dilatory!
         p Dilatory was a lovely island city of ancient Habitica. It was a prosperous place, but as the wealth of the city grew, the inHabitants grew lazy and procrastinated on their Dailies and To-Dos... until the combined weight of their dark red tasks triggered a massive earthquake that sunk the city. Legends say that all of the inHabitants were transformed into sea creatures.
         p The location of this city was lost to time... until now!
-        h5 Limited Edition Outfits!
+        h5.small_news_header Limited Edition Outfits!
         p What's the fun of an underwater city if you can't explore it? Luckily, from now until July 31st, special Limited Edition Outfits are available for gold in the Rewards store! Spellcasters can transform themselves into <strong>Emerald Mermages</strong> and <strong>Reef Seahealers</strong> to swim among the ruins, while fighters may prefer to dress as <strong>Roguish Pirates</strong> and <strong>Daring Swashbucklers</strong>, riding above the city on magnificent ships. Work hard, and you can join them!
-        h5 NPC Dress-up
+        h5.small_news_header NPC Dress-up
         p The NPCs got so excited about the discovery of Dilatory that they've moved over there for the summer! Daniel the Innkeeper has opened a beachside tavern, and Alex is also selling by the shore! Meanwhile, Justin the Guide is giving tours aboard boats, Ian is dispensing quest wisdom from the deep ocean, Matt has opened stables for aquatic pets, and I am swimming about keeping everyone informed!
-        h5 But what caused the Earthquake?
+        h5.small_news_header But what caused the Earthquake?
         p Only one piece of the mystery remains unsolved - what caused the second earthquake that unearthed the ancient Dailies? After all, the earthquake that destroyed Dilatory was caused by a build up of undone Dailies and To-Dos, wasn't it?
         p But *we've* all been doing our tasks...
 
   hr
-  h5 6/14/2014
+  h5.big_news_header 6/14/2014
   table.table.table-striped
     tr
       td
-        h5 New Feature: Backgrounds!
+        h5.small_news_header New Feature: Backgrounds!
         p We're debuting a brand-new feature - backgrounds for your avatar! Stroll through a Summer Forest, lounge upon a warm Beach, or dance in a Fairy Ring. You can buy the backgrounds in the new Background tab, under User. Have fun!
-        h5 Summer Mystery Update
+        h5.small_news_header Summer Mystery Update
         p It's been a while since we've seen Lemoness around - she's been a bit scarce since she started trying to decipher those ancient Dailies. We just stopped by her hut to check on her and found her..... missing?
         br
         p It looked like she'd taken her armor-enchanting crochet hook, but little else. There was a single scrawled note on the table: "I think I've translated it!!!! If I'm right, this is going to be QUITE the summer. Verifying claims - be back soon!!!"
@@ -1769,33 +1769,33 @@ mixin oldNews
   small.muted 6/14/2014
 
   hr
-  h5 6/10/2014
+  h5.big_news_header 6/10/2014
   table.table.table-striped
     tr
       td
-        h5 New Pet Quest: The Call Of Octothulu!
+        h5.small_news_header New Pet Quest: The Call Of Octothulu!
         p There's a new pet in town! The dreaded Octothulu, sticky spawn of the stars, has emerged from a whirlpool in a dark cave by the sea. It's up to you and your party to banish the foul beast by being extra-productive! If you manage to defeat it, you might just find some octopus eggs...
-        h5 Earthquake Update
+        h5.small_news_header Earthquake Update
         p Remember the strange earthquake we had recently? Well, this probably isn't related in any way, but Habiticans have recently noticed some mysterious black Dailies strewn along the beaches. Lemoness happily reports that they are scrawled upon with an ancient language, and that she is hard at work deciphering the script. More news as this develops!
 
   hr
-  h5 6/5/2014
+  h5.big_news_header 6/5/2014
   table.table.table-striped
     tr
       td
-        h5 June Mystery Item
+        h5.small_news_header June Mystery Item
         p Wow, what could it be? All Habiticans who are subscribed during the month of June will receive the June Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
     tr
       td
-        h5 What Was That?
+        h5.small_news_header What Was That?
         p Yikes! A mysterious earthquake has rocked Habitica! Luckily, nobody was hurt and there was no real damage, but our scholars are baffled. "We're not even IN a seismic zone," Lady Lemoness was heard muttering as she paged through an enormous tome. "There hasn't been an earthquake since.... but no, that's impossible." Well, if Lemoness says so, it must be true! Seems like it was just a false alarm.
 
   hr
-  h5 5/23/2014
+  h5.big_news_header 5/23/2014
   table.table.table-striped
     tr
       td
-        h5 May Mystery Outfit Revealed!
+        h5.small_news_header May Mystery Outfit Revealed!
         .pull-right.promo_mystery_201405.png
         p The May Mystery Item Set has been revealed for all subscribers... <strong>Flame Wielder Item Set</strong>! All people who are subscribed this May will receive two items:
         ul
@@ -1805,25 +1805,25 @@ mixin oldNews
 
 
   hr
-  h5 5/14/2014
+  h5.big_news_header 5/14/2014
   table.table.table-striped
     tr
       td
-        h5 The Rat King
+        h5.small_news_header The Rat King
         p Habitica's streets are filled with the skittering of little paws... looks like there's a new Pet Quest available in the Market! Can you and your party defeat the Rat King? If so, there will be some eggs to reward you...
         small.muted By: Pandah and Token
     tr
       td
-        h5 Level Cap Lifted
+        h5.small_news_header Level Cap Lifted
         p You can now level up beyond 100, the 100-cap has been lifted!
         small.muted By: Ryan
 
   hr
-  h5 5/5/2014
+  h5.big_news_header 5/5/2014
   table.table.table-striped
     tr
       td
-        h5 Mobile Update
+        h5.small_news_header Mobile Update
         p The new iOS update is live! <a href='https://itunes.apple.com/us/app/habitrpg/id689569235?mt=8' target='_blank'>You can download it here</a>. If you have Android, <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg' target='_blank'>the update is available here.</a>
         br
         p Note: to edit a task or view checklists, swipe left on the task. We're <a href='https://github.com/HabitRPG/habitrpg-mobile/issues/199' target='_blank'>working on click-to-view</a>, we'd love some developer help!
@@ -1831,48 +1831,48 @@ mixin oldNews
         p If you think the new app is an improvement, please consider rating us - many of our old reviews were (justifiably!) pretty low, especially on Apple, but we feel that this update is the first in a line of major improvements. Thanks for sticking with us!
     tr
       td
-        h5 The HabitRPG Chrome Extension
+        h5.small_news_header The HabitRPG Chrome Extension
         p Great news - we've fixed our Chrome Extension! Many thanks to new contributor <a href='https://github.com/HabitRPG/habitrpg-chrome/pull/88' target='_blank'>@GoldBattle<a/>. Now you can set the times and dates you want to only browse productive sites. If you're procrastinating, it will automatically start docking your character's health; if you're hard at work, it will reward you with GP and XP! <a href='https://chrome.google.com/webstore/detail/habitrpg/pidkmpibnnnhneohdgjclfdjpijggmjj' target='_blank'>Read more about it here.</a>
     tr
       td
         p Also, a quick change - May's mystery item will now be revealed on the 23rd, instead of the 25th. Rejoice, impatient Habiticans!
 
   hr
-  h5 4/30/2014
+  h5.big_news_header 4/30/2014
   table.table.table-striped
     tr
       td
-        h5 May Mystery Item
+        h5.small_news_header May Mystery Item
         p Ooh, how mysterious! All Habiticans who are subscribed during the month of May will receive the May Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
   hr
-  h5 4/30/2014
+  h5.big_news_header 4/30/2014
   table.table.table-striped
     tr
       td
-        h5 Mobile Update
+        h5.small_news_header Mobile Update
         p Great news! We've just released a big upgrade to our mobile app. One of our biggest priorities right now is improving the HabitRPG mobile experience, so this is an important first step. We've upgraded the framework to Ionic, which means a cleaner look and smoother feel, and best of all, it is now easier for the developers to add new updates and features! <a href='http://blog.habitrpg.com/post/84100207996/habitrpg-mobile-on-ionic' target='_blank'>Read more about the upgrade here.</a>
         p The Android App is <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg' target='_blank'>available here</a>! The iOS app was submitted to the App Store, but Apple always takes a while to process things, so it may be a few more days. Let's hope they're quick this time around! We'll let you know when it goes through.
         p Have a productive day!
     tr
       td
-        h5 Spread the Word Challenge
+        h5.small_news_header Spread the Word Challenge
         p Also, at long last the staff has finished sorting through the 1.5K+ participants in the Spread The World Challenge, and we are pleased (and so, so relieved) to finally announce a winner!
         p Congratulations to ALEX KRALIE, the winner of the Spread The Word Challenge! 47K+ notes is truly momentous.
         p A warm congratulation is also due to the runner-ups: sarahtyler, HannahAR, Raiyna, thefandomsarecool, Chickenfox, Anrisa Ryn, frabajulous, galdrasdottir, Judith Meyer, jazzmoth, RavenclawKiba, daraxlaine, Phiso, Billieboo, Victor Fonic, nikoftime, Aedra, amBarthes, and thaichicken! You guys are great <3 Thanks for helping to get the word out about HabitRPG!
     tr
       td
 
-        h5 Spring Fling
+        h5.small_news_header Spring Fling
         p Reminder that today, 4/30, is the LAST DAY of the Spring Fling event! After today, you will no longer be able to purchase the Pastel Hair Set or the Limited-Edition class items. Additionally, the Egg Hunt scroll will no longer be available in the Market, although if you have started the quest, it will NOT disappear and you will be able to complete it at your leisure.
         p It is also the last day to get the Twilight Butterfly Item Set before it disappears forever! If you want the Twilight Butterfly Wings or the Twilight Butterfly head accessory, this is your last chance to subscribe and get them.
         p Happy Spring!
 
   hr
-  h5 4/25/2014
+  h5.big_news_header 4/25/2014
   table.table.table-striped
     tr
       td
-        h5 April Mystery Outfit Revealed!
+        h5.small_news_header April Mystery Outfit Revealed!
         //-img.pull-right(src='/marketing/promos/April14SAMPLE2.png')
         p The April Mystery Item Set has been revealed for all subscribers... <strong>Twilight Butterfly Armor Set</strong>! All people who are subscribed this April will receive two items:
         ul
@@ -1881,31 +1881,31 @@ mixin oldNews
         p You still have five more days to subscribe and get the item set. Thank you all for supporting us! We love you <3
 
   hr
-  h5 4/6/2014
+  h5.big_news_header 4/6/2014
   table.table.table-striped
     tr
       td
-        h5 The Great Egg Hunt
+        h5.small_news_header The Great Egg Hunt
         p A new quest is available in the Market between now and April 30th. Anyone who signed up before April 7th has one in their inventory free!
 
   hr
-  h5 4/3/2014
+  h5.big_news_header 4/3/2014
   table.table.table-striped
     tr
       td
-        h5 Limited Edition Pastel Hair Color Set
+        h5.small_news_header Limited Edition Pastel Hair Color Set
         p A new set of hair colors has been released: the Pastel Set! Now your avatar can have flowing locks in Pastel Blue, Pastel Pink, Pastel Purple, Pastel Orange, Pastel Green, or Pastel Yellow! You will only be able to purchase these hair colors until April 30th, so don't miss out!
 
   hr
-  h5 4/2/2014
+  h5.big_news_header 4/2/2014
   table.table.table-striped
     tr
       td
-        h5 April Mystery Item
+        h5.small_news_header April Mystery Item
         p  What could it be? All people who are subscribed during the month of April will receive the April Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled.
 
   hr
-  h5 April F... irst
+  h5.big_news_header April F... irst
   table.table.table-striped
     tr
       td
@@ -1915,7 +1915,7 @@ mixin oldNews
         small.muted By @lemoness and @baconsaur
 
   hr
-  h5 03/31/2014
+  h5.big_news_header 03/31/2014
   table.table.table-striped
     tr
       td
@@ -1923,11 +1923,11 @@ mixin oldNews
 
 
   hr
-  h5 03/25/2014
+  h5.big_news_header 03/25/2014
   table.table.table-striped
     tr
       td
-        h5 March Mystery Item Set
+        h5.small_news_header March Mystery Item Set
         //-img.pull-right(src='/marketing/promos/201403_Forest_Walker.png')
         p The March Mystery Item Set has been revealed for all subscribers... The Forest Walker Set! All people who are subscribed this March will receive two items: <strong>Forest Walker Armor</strong> and <strong>Forest Walker Antlers</strong>!
         br
@@ -1936,70 +1936,70 @@ mixin oldNews
         p You still have five more days to subscribe and get the item set. Thank you all for supporting us! We love you <3
     tr
       td
-        h5 PayPal Subscriptions
+        h5.small_news_header PayPal Subscriptions
         p We've added PayPal as a payment method for subscriptions. We still recommend the <strong>Card</strong> method, as <a href='https://stripe.com/' target='_blank'>Stripe</a> (the processor we use) has a more stable API and better account management tools. However, we realize not everyone owns a credit/debit card, so there's PayPal for ya!
 
   hr
-  h5 03/22/2014
+  h5.big_news_header 03/22/2014
   table.table.table-striped
     tr
       td
-        h5 Spring Fling Event
+        h5.small_news_header Spring Fling Event
         p Spring has come to Habitica, and flowers have sprouted everywhere: in the Stables, in the Marketplace... and even in your character customization pages!
     tr
       td
-        h5 Head Accessories
+        h5.small_news_header Head Accessories
         p That's right - we've introduced Head Accessories! Your avatar can now bedeck their helms with colorful flowers. And that's not the only place to get head accessories….
     tr
       td
-        h5 Limited Edition Class Outfits
+        h5.small_news_header Limited Edition Class Outfits
         p The Spring 2014 Limited Edition Class Outfits have been released!
         p From now until April 30th, you will be able to use your gold to buy your current class' armor set from the Rewards store! You can be a Stealthy Kitty, a Mighty Bunny, a Magic Mouse, or a Loving Pup. If you switch classes (system unlocked at level 10), you will gain access to your new classes' armor set. Make sure to collect yours first, though!
         p What are you waiting for? Go be productive and earn some gold!
     tr
       td
-        h5 New Un-Equip Mechanic
+        h5.small_news_header New Un-Equip Mechanic
         p Now to un-equip your gear, click the same item that you have currently equipped. We removed the "Base Equipment" tier for consistency with how un-equipping pets & mounts is handled, and to easily support adding new gear types.
     tr
       td
-        h5 Pet Quest: The Ghost Stag
+        h5.small_news_header Pet Quest: The Ghost Stag
         p The meadows of Habitica are bursting with flowers, sunshine, and.... ominous mist? Looks like a ghost stag is keeping winter alive! Defeat him, and maybe you'll get an egg or three....
     tr
       td
-        h5 And More To Come...
+        h5.small_news_header And More To Come...
         p This is only the beginning of all the treats that we've got in store for you. Stay tuned - and happy Spring Fling!
 
   hr
-  h5 03/18/2014
+  h5.big_news_header 03/18/2014
   table.table.table-striped
     tr
       td
-        h5 New Pet Quest Mechanics
+        h5.small_news_header New Pet Quest Mechanics
         p Great news - now it is easier to complete the Quest Pet sets! Pet Quest  Bosses will now drop 3 eggs instead of 2. Additionally, after you have defeated a Pet Quest Boss two times, those eggs will be gem-purchasable in the market like all other eggs, so that your party doesn't have to replay the same quest over and over :)
     tr
       td
-        h5 WonderCon
+        h5.small_news_header WonderCon
         p HabitRPG will be attending WonderCon from April 18th-20th! Come say hi to Tyler, Leslie, and Vicky, and chat about productivity and games. Tickets are available <a href='http://www.comic-con.org/wca/2014/badge-sale' target='_blank'>here</a>.
         p All the users who visit our booth will receive the <a href='http://goo.gl/2urFUt' target='_blank'>Unconventional Armor Accessory Set</a>! (It will also be available if we attend other cons in the future.)
     tr
       td
-        h5 LifeHacker Poll
+        h5.small_news_header LifeHacker Poll
         p HabitRPG is in the running to be Lifehacker's #1 To-Do list manager! We've got some tough competition, so if you like our site, please help us out <a href='http://lifehacker.com/5924093/five-best-to-do-list-managers' target='_blank'>by voting for us here</a> <3
 
   hr
-  h5 03/02/2014
+  h5.big_news_header 03/02/2014
   table.table.table-striped
     tr
       td
-        h5 March Mystery Item
+        h5.small_news_header March Mystery Item
         p Happy March! The awesome people who subscribe to HabitRPG will now receive the limited-edition March mystery item! The mystery item set will contain a stats-free costume piece that will <strong>only</strong> be available to the people who are subscribers this March. The set will be revealed on the 25th to everyone, but all people who are subscribers during the month of March will receive it. Get excited - and thank you so much for helping to support HabitRPG! We love you.
     tr
       td
-        h5 Hedgehog Quest
+        h5.small_news_header Hedgehog Quest
         p A new pet has been introduced, the Hedgehog. You can find some eggs by battling the Hedgebeast Boss, a quest scroll available in the market.
 
   hr
-  h5 02/22/2014
+  h5.big_news_header 02/22/2014
   table.table.table-striped
     tr
       td
@@ -2016,68 +2016,68 @@ mixin oldNews
 
 
   hr
-  h5 02/18/2014
+  h5.big_news_header 02/18/2014
   table.table.table-striped
     tr
       td
-        h5 Translations
+        h5.small_news_header Translations
         p Translations are well underway! Many of you should already be seeing HabitRPG in your own languages. If not, head <a href='https://trello.com/c/SvTsLdRF/12-translations' target='_blank'>here</a> to see your language's progress or to help translate.
         p
           small.muted by @paglias, @Sinza-, @Luveluen, and more.
     tr
       td
-        h5 BountySource
+        h5.small_news_header BountySource
         p We’ve started using BountySource, a service which lets users post bounties on bug fixes and feature requests. Any features or bugs in HabitRPG you’ve been dying to see resolved? <a href='https://www.bountysource.com/teams/habitrpg/issues' target='_blank'>Post a bounty</a> to attract contributor attention. <a href='http://blog.habitrpg.com/post/76898655192/bountysource' target='_blank'>Read more here</a>.
         p
           small.muted by @Cole, @lefnire, @Ryan
 
   hr
-  h5 02/13/2014
+  h5.big_news_header 02/13/2014
   table.table.table-striped
     tr
       td
-        h5 Happy Valentine's Day!
+        h5.small_news_header Happy Valentine's Day!
         p Help motivate all of the lovely people in your life by sending them a caring valentine. Valentines can be purchased for 10 gold from the Item Store. For spreading love and joy throughout the community, both the giver AND the receiver get a coveted "adoring friends" badge. Hooray!
         p
           small.muted By Lemoness and zoebeagle
 
 
   hr
-  h5 02/12/2014
+  h5.big_news_header 02/12/2014
   table.table.table-striped
     tr
       td
-        h5 Chat & Invite Notifications
+        h5.small_news_header Chat & Invite Notifications
         p Chat & group-invitation notifications are back! Miss them? They currently work for all chat updates in parties & guilds. Any devs willing to jump into @tagging in Tavern, <a href='http://goo.gl/uhcjkg' target='_blank'>see here</a>.
     tr
       td
-        h5 Toolbar
+        h5.small_news_header Toolbar
         p In order to make room for these notifs, we added a toolbar above the header. You can collapse the toolbar (far-right icon), but take care as Bailey notifs are inside the toolbar!
   hr
-  h5 02/07/2014
+  h5.big_news_header 02/07/2014
   table.table.table-striped
     tr
       td
-        h5 February Mystery Item
+        h5.small_news_header February Mystery Item
         p
           .pull-right.inventory_present
           | We're excited to announce a new feature a s a big thank-you to the awesome people who <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribe</a> to HabitRPG! Every month, all subscribers will now receive a limited-edition mystery item! The mystery item will be a stats-free costume piece (like the Absurd Party Robes) that will <strong>only</strong> be available to the people who are subscribers each month. The February 2014 item will be revealed on the 23rd to everyone, but all people who are subscribers during the month of February will receive it. <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>Subscribe now</a>, get excited, and thank you so much for helping to support HabitRPG! We love you.
     tr
       td
-        h5 Critical Hammer Of Bug-Crushing
+        h5.small_news_header Critical Hammer Of Bug-Crushing
         p
           .pull-right.weapon_special_critical
           | Some of you may have noticed that we periodically have some bugs that are nastier than the norm - the dreaded critical bugs. These monstrous apparitions have been snapping at the heels of many a player. For updates on what we're currently working on to improve site stability, read <a href='https://github.com/HabitRPG/habitrpg/issues/milestones' target='_blank'>this link</a> - and then jump in to help!  Not only will programming assistance reward you with the usual contributor levels, but if you actually manage to fix a bug marked <a href='http://goo.gl/v4DnzB' target='_blank'>"critical,"</a> you will now receive the <em>Critical Hammer of Bug-Crushing</em> as your reward!
     tr
       td
 
-        h5 Rainbow Hair Colors
+        h5.small_news_header Rainbow Hair Colors
         p
           .pull-right.customize-option.hair_bangs_1_rainbow
           | Want to spruce up your avatar? Rainbow hair colors are now available! Dye your luscious locks purple, green, or even rainbow-striped, and passersby will look at you with envy.
     tr
       td
-        h5 Stability Update
+        h5.small_news_header Stability Update
         p We've stabilized the site a lot (we're still working out kinks, but we're way better now). Follow the <a href='https://github.com/HabitRPG/habitrpg/issues/milestones' target='_blank'>progress here</a>, but here are some workarounds for now:
         ul
           li Click slower. <a href='https://github.com/HabitRPG/habitrpg/issues/2301#issuecomment-34398206' target='_blank'>VersionError</a> is caused by clicking things off too fast (we're working on a fix).
@@ -2087,37 +2087,37 @@ mixin oldNews
     small.muted By Lemoness, mariahm, crystalphoenix, aiseant, zoebeagle, cole, lefnire
 
   hr
-  h5 02/01/2014
+  h5.big_news_header 02/01/2014
   table.table.table-striped
     tr
       td
-        h5 Vice
+        h5.small_news_header Vice
         p You awaken after the Winter Wonderland festivities and birthday celebrations with a smile. It's been a snowy, cheerful couple months, and the NPCs have finally returned to their normal attire. But today something is very wrong. Shadowy whisps cover the ground of Habitica, the sky has darkened. At the tavern you hear @DanielTheBard struming dark tales on his lute, and @Baconsaur peering into a mug, grumbling about her mounts swallowed in the shadows. They speak of the same thing: <strong>Vice</strong>, a dark an terrible foe. This new boss arc is a 3-part quest that requires level 30 to begin. Bring your strongest party members, and don't miss your dailies - there's a powerful weapon at the end!
         p
           small.muted by @baconsaur & @DanielTheBard
 
   hr
-  h5 01/30/2014
+  h5.big_news_header 01/30/2014
   table.table.table-striped
     tr
       td
-        h5 Happy Birthday, HabitRPG!
+        h5.small_news_header Happy Birthday, HabitRPG!
         p The fair land of Habitica is two years old on January 31st! The NPCs are celebrating in style, and it looks like some of the staff is, too! Won't you join in?
     tr
       td
-        h5 Absurd Party Robtes
+        h5.small_news_header Absurd Party Robtes
         p As part of the festivities, Absurd Party Robes are available free of charge in the Item Store! Swath yourself in those silly garbs and don your matching hats to celebrate this momentous day.
     tr
       td
-        h5 Delicious Cake
+        h5.small_news_header Delicious Cake
         p What would a birthday be without birthday cake in a myriad of flavors? Of course, pets are very picky, but luckily Lemoness and her team of bakers have plenty of slices to go around. Mmm, delicious!
     tr
       td
-        h5 Last Day of Winter Wonderland Event
+        h5.small_news_header Last Day of Winter Wonderland Event
         p Also, just a reminder - January 31st is the final day of the Winter Wonderland event, so it's your last day to get the Limited Edition Winter Hair Colors, the Winter Outfits, the snowballs, and the Trapper Santa and Find the Cub quest scrolls. Remember that mid-progress Trapper Santa and Find the Cub quests will not abort, nor will you lose your scrolls - they will simply be removed from Alexander's marketplace. We hope that you've had a wonderful winter!
     tr
       td
-        h5 Birthday Bash Badge
+        h5.small_news_header Birthday Bash Badge
         p Finally, to commemorate the fun, all party participants receive a birthday badge! Polish it frequently and wear it fondly.
 
   p Thanks so much for being a part of the HabitRPG community. We love you guys, and we can't wait to have you at our sides in the upcoming year! Stay productive, Habiteers, and have an awesome day.
@@ -2125,31 +2125,31 @@ mixin oldNews
   p.muted By @lemoness
 
   hr
-  h5 01/28/2014
+  h5.big_news_header 01/28/2014
   table.table.table-striped
     tr
       td
-        h5 Group Plans
+        h5.small_news_header Group Plans
         p We've begun adding <a href='/static/plans' targte='_blank'>plans for groups</a> (parents, teachers, health & wellness administrators, etc). These plans will provide group leaders with more control, privacy, security, and support. Currently only the Organization Plan (top tier) is available (due to tech limitations believe it or not), and we'll be releasing the Family & Group plans later. <a href='/static/plans' targte='_blank'>Click the "Contact Us" buttons</a> if you're interested, and we'll keep you updated!
     tr
       td
-        h5 Individual Plan
+        h5.small_news_header Individual Plan
         p We've introduced a $5/mo basic subscription plan. It comes with a number of perks, which <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>you can see here</a>. We'll likely add more benefits over time, follow <a href='https://trello.com/c/euDUHPpn/371-basic-plan-subscription' target='_blank'>the conversation here</a>.
     tr
       td
-        h5 Perfect Day Achievement
+        h5.small_news_header Perfect Day Achievement
         p Now when you complete all your dailies, you stack this badge, plus and additional perk: you get a +(level/2) buff to all stats!
     tr
       td
-        h5 <a href='/#/options/groups/challenges/95533e05-1ff9-4e46-970b-d77219f199e9' target='_blank'>Spread The Word Challenge</a> Update
+        h5.small_news_header <a href='/#/options/groups/challenges/95533e05-1ff9-4e46-970b-d77219f199e9' target='_blank'>Spread The Word Challenge</a> Update
         p We have 1k+ submissions, holy cow! Great job everyone! Now, we need to go through these manually, so it will take a few days to a couple weeks to process. The challenge will stay open until we're done choosing our winners, but be sure to edit the To-Do with your submission URL before 1/31, as that's the cut-off date for processing. We'll send a Tweet out when the winner has been selected, so follow <a href='https://twitter.com/habitrpg' target='_blank'>@habitrpg</a> and stay tuned.
 
   hr
-  h5 01/25/2014
+  h5.big_news_header 01/25/2014
   table
     tr
       td
-        h5 Gryphon Quest
+        h5.small_news_header Gryphon Quest
         p A new pet has been introduced, the Gryphon. You can find some eggs by battling the Fiery Gryphon Boss, a quest scroll available in the market.
         p
           small.muted Note: we'll be fixing the beast-master achievement to work from the original 90 in coming days. Fear not current beast-masters, you'll get sorted soon!
@@ -2158,69 +2158,69 @@ mixin oldNews
 
 
   hr
-  h5 01/16/2014
+  h5.big_news_header 01/16/2014
   table.table.table-striped
     tr
       td
-        h5 "Spread The Word" Challenge Updates
+        h5.small_news_header "Spread The Word" Challenge Updates
         p If you're not yet participating, check out the <a target='_blank' href='/#/options/groups/challenges/95533e05-1ff9-4e46-970b-d77219f199e9'>Spread The Word Challenge</a>, which has a large prize and many winners. We've made some updates: upped the prize to 80 Gems for the top 20 posts, 100 Gems for the winner. Note: some people are listing their submission as a Tumblr reblog of someone else's post, often with added commentary. Though reblogs are greatly appreciated, we can only count original submissions. Read more <a target='_blank' href='/#/options/groups/challenges/95533e05-1ff9-4e46-970b-d77219f199e9'>challenge guidelines here</a>.
     tr
       td
-        h5 Quest Deadlines
+        h5.small_news_header Quest Deadlines
         p To clear some confusion, you have until Jan 31, 2014 to <strong>purchase</strong> your quest scrolls, after 1/31 Alexander no longer sells them. You can still begin / finish your quests any time after. Thanks to @Cole, you're now allowed to purchase the Cub quest even if you haven't finished Trapper. Stock up!
 
   hr
-  h5 01/06/2014
+  h5.big_news_header 01/06/2014
   h4 <a tooltip='Winter Wonderland Event' href='http://habitrpg.wikia.com/wiki/Winter_Wonderland' target='_blank'>WWE</a> Part 4: Winter Classes
   table.table.table-striped
     tr
       td
-        h5 Limited-Edition Winter Class Outfits
+        h5.small_news_header Limited-Edition Winter Class Outfits
         p Happy winter! Instead of a boring pair of earmuffs, why not use the gold that you earned with all your hard work to buy a Limited Edition class outfit?
         p From now until January 31st, you will be able to use your gold to buy your current class' armor set from the Rewards store! You can be a Yeti Tamer, a Ski-Sassin, a Candy Cane Mage, or a Snowflake Healer. If you switch classes (system unlocked at level 10), you will gain access to your new classes' armor set. Make sure to collect yours first, though!
         p What are you waiting for? Go be productive and earn some gold!
         small.muted by @lemoness
     tr
       td
-        h5 Chat +1
+        h5.small_news_header Chat +1
         p You can now +1 chat messages in Tavern, Guilds, & Parties
     tr
       td
-        h5 Halls
+        h5.small_news_header Halls
         p We've added the "Hall of Heroes" and "Hall of Patrons" <a href='https://habitrpg.com/#/options/groups/hall/heroes' target='_blank'>here</a>, which list our project contributors and Kickstarter backers. Want be amongst those immortalized in the Hall of Heroes? <a href='http://habitrpg.wikia.com/wiki/Contributor_Rewards' target='_blank'>Lend us your sword!</a>
 
   hr
-  h5 12/31/2013
+  h5.big_news_header 12/31/2013
   h4 Winter Wonderland Event Part 3: Party!
   table.table.table-striped
     tr
       td
-        h5 Happy New Year!
+        h5.small_news_header Happy New Year!
         p Happy New Year! Join the NPCs and Staff in showing off your new Absurd party hat.... and have a great night!
         small.muted by @lemoness
     tr
       td
-        h5 Rebirth
+        h5.small_news_header Rebirth
         p Nothing says New Year like a fresh start. Now when you reach level 50, Ultimate Gear, or BeastMaster, you can begin anew with the most prestigious of achievements: Rebirth. <a href='https://trello.com/c/SLiq4enr/333-rebirth-new-game' target='_blank'>Read more here</a>. But take heed! Scouts have reported <a href='https://github.com/HabitRPG/habitrpg/issues/945#issuecomment-31355229' target='_blank'>monster sightings</a>, harbinged by Trapper Santa. You may need all the strength you can muster come late January, Rebirth is for the hard-core.
         small.muted by @SabreCat
     tr
       td
-        h5 Checklists
+        h5.small_news_header Checklists
         p <a href='https://trello.com/c/PJ1iJ413/65-checklists' target='_blank'>Checklists</a> are here! You can break your Dailies and To-Dos down into bite-size chunks. Their game mechanic takes some learning, so <a href='http://habitrpg.wikia.com/wiki/Checklist' target='_blank'>read more here</a>.
         small.muted by @lefnire
     tr
       td
-        h5 Task Icons & Markdown
+        h5.small_news_header Task Icons & Markdown
         p Task titles now support Markdown and Emoji, so you can create something <a href='http://gyazo.com/f2021674925a79a1dec22101ef74a63c' target='_blank'>like this</a>. Read more <a href='https://trello.com/c/FCVdjdUd/102-task-reward-icons' target='_blank'>here</a>.
         small.muted by @lefnire
 
   hr
-  h5 12/25/2013
+  h5.big_news_header 12/25/2013
   h4 Winter Wonderland Event Part 2: Rescue the Bears
   table.table.table-striped
     tr
       td
-        h5 Quests & Bosses!
+        h5.small_news_header Quests & Bosses!
         p A beast is roaring in the distant mountains, mysterious tracks have appeared in the snow. A new feature has been unlocked, <a href='https://trello.com/c/VPPjVRlF/212-quests-bosses' target='_blank'>Quests & Bosses</a>. As a holiday present, HabitRPG gives you your first quest: "Trapper Santa". Check your inventory, you have until Jan 31 to complete it!
 
   p By @lefnire, @pandoro, @Shaners
@@ -2228,29 +2228,29 @@ mixin oldNews
   hr
 
 
-  h5 12/20/2013
+  h5.big_news_header 12/20/2013
   h4 Winter Wonderland Event Part 1: The Great Snowball Fight
   p It's time for HabitRPG's biggest event yet - Winter Wonderland! The fun starts today, on the first day of winter, and ends on January 31st - HabitRPG's birthday.
   p Get prepared to build new habits, earn fun drops, hold your party members accountable for their tasks, and decorate your avatar. Various features will be rolling out over the course of the event, so expect many updates! For starters...
   table.table.table-striped
     tr
       td
-        h5 NPC Decorations
+        h5.small_news_header NPC Decorations
         p Looks like everyone is really getting into the winter spirit! Check out the new NPC sprites. (And I heard a rumor that the final NPC might show up, just in time for the new year...)
     tr
       td
         .customize-option.hair_bangs_1_winternight.pull-right
-        h5 Limited-Edition Holiday Hair-Colors
+        h5.small_news_header Limited-Edition Holiday Hair-Colors
         p Now your avatar can dye their hair Candy Cane, Frost, Winter Sky, or Holly! You'll only be able to purchase these hair colors until January 31st, when they will be retired.
     tr
       td
         .shop_snowball.pull-right
-        h5 The Great HabitRPG Snowball Fight
+        h5.small_news_header The Great HabitRPG Snowball Fight
         p Yes, you can now buy snowballs and hurl them at all your friends... to, uh, help them improve their habits. How? Weeeeellll, let's just say that after getting walloped, they might find themselves needing some extra gold to escape their predicament...
           //-span.shop_head_special_candycane.item-img.shop-sprite
     tr
       td
-        h5 More to Come
+        h5.small_news_header More to Come
         p A beast is roaring in the distant mountains, mysterious tracks have appeared in the snow, and Lemoness is furiously crocheting something sparkly.
         p It's going to be a wild winter.
 
@@ -2258,7 +2258,7 @@ mixin oldNews
 
   hr
 
-  h5 12/16/2013
+  h5.big_news_header 12/16/2013
   p Good gracious, where do I start...
   br
   table.table.table-striped
@@ -2285,7 +2285,7 @@ mixin oldNews
   hr
   p By @lemoness @sabrecat @danielthebard @fuzzytrees @crystalphoenix @rosemonkeyct @fandekasp, and many more. (Who am I missing? We'll put up a CONTRIBUTORS.md soon)
 
-  h5 12/7/20132
+  h5.big_news_header 12/7/20132
   table.table.table-striped
     tr
       td
@@ -2296,7 +2296,7 @@ mixin oldNews
         p.
          By <a target='_blank' href='https://github.com/lemoness'>@lemoness</a> <a target='_blank' href='https://github.com/Shaners'>@Shaners</a> <a target='_blank' href='https://github.com/baconsaur'>@baconsaur</a> <a target='_blank' href='https://github.com/RandallStanhope'>@RandallStanhope</a> <a target='_blank' href='https://github.com/ashjolliffe'>@ashjolliffe</a> <a target='_blank' href='https://github.com/fuzzytrees'>@fuzzytrees</a>
 
-  h5 11/27/2013
+  h5.big_news_header 11/27/2013
   table.table.table-striped
     tr
       td
@@ -2318,13 +2318,13 @@ mixin oldNews
         p.
          The <a href='http://habitrpg.wikia.com/wiki/HabitRPG_Wiki' target='_blank'>HabitRPG wiki</a> is being speedily updated. If you’re confused about anything, go check it out - it’s a treasure trove.
 
-  h5 11/08/2013
+  h5.big_news_header 11/08/2013
   table.table.table-striped
     tr
       td.
         Contrib Gear. You can now unlock new a top-tier gear set and pet by contributing (code, art, docs, etc) to HabitRPG. <a href='http://habitrpg.wikia.com/wiki/Contributor_Rewards' target='_blank'>Read more</a>
 
-  h5 11/01/2013
+  h5.big_news_header 11/01/2013
   table.table.table-striped
     tr
       td.
@@ -2332,7 +2332,7 @@ mixin oldNews
     tr
       td Backend overhaul, including bookmark-able paths throughout the application. Will pave the way towards improved performance.
 
-  h5 10/22/2013
+  h5.big_news_header 10/22/2013
   table.table.table-striped
     tr
       td TRICK OR TREAT! It's Habit Halloween! Some of the NPCs have decorated for the occasion. Can you spot us?
@@ -2341,14 +2341,14 @@ mixin oldNews
     tr
       td Do note, skins won't work on mobile until the app is updated. We'll update Android ASAP, iPhone usually takes ~1wk to approve.
 
-  h5 10/19/2013
+  h5.big_news_header 10/19/2013
   table.table.table-striped
     tr
       td New custom skin colors are now available! Go check them out in the Profile section. Also, the new mobile update, 0.0.10, is now available to download! It includes the new skin tones and the ability to hide or show your helm, among other things.
     tr
       td You can now sell un-wanted drops to Alex the Merchant. Trade those troves of eggs for gold!
 
-  h5 09/01/2013
+  h5.big_news_header 09/01/2013
   table.table.table-striped
     tr
       td.
@@ -2357,7 +2357,7 @@ mixin oldNews
         Both apps and the website are open source, and we desparately need your help porting the rest of the features, and polishing off the bugs. <a target='_blank' href='http://habitrpg.wikia.com/wiki/Contributing_to_HabitRPG'>Read this guide</a> to getting started.
         We're working on a system of Contributor Gear to reward the awesome people who help out, so stay tuned!
 
-  h5 The Rewrite! (Mid August)
+  h5.big_news_header The Rewrite! (Mid August)
   table.table.table-striped
     tr
       td.
@@ -2376,7 +2376,7 @@ mixin oldNews
          We desparately need your help porting <a href='http://goo.gl/jYWTwl' target='_blank'>the rest of the features</a>, and polishing off the bugs. <a target='_blank' href='http://habitrpg.wikia.com/wiki/Contributing_to_HabitRPG'>Read this guide</a> to getting started.
          Thanks everyone for all your support and patience!
 
-  h5 8/20/2013
+  h5.big_news_header 8/20/2013
   table.table.table-striped
     tr
       td.
@@ -2385,7 +2385,7 @@ mixin oldNews
       td.
         API developers, the above means that <strong>cron</strong> is automatically run for your users! Weee, they no longer have to log into the website to reset their dailies!
 
-  h5 8/18/2013
+  h5.big_news_header 8/18/2013
   table.table.table-striped
     tr
       td.
@@ -2397,14 +2397,14 @@ mixin oldNews
         | of what we're currently working on! This weekend, we are working hard to fix the "Not Enough GP" bug, a cruel and greedy monster that has wrapped itself around the rewards box and is refusing to let anyone purchase anything. Rest assured that our heroic Tyler will slay this beast soon! Then it wiil be full steam ahead on the new site upgrade process.
         a(target='_blank', href='http://habitrpg.tumblr.com/post/57627483715/news-about-upgrade-and-app') Read more about how that will work in this post here
 
-  h5 6/03/2013
+  h5.big_news_header 6/03/2013
   table.table.table-striped
     tr
       td
         a(target='_blank', href='https://trello.com/card/groups-guilds/50e5d3684fe3a7266b0036d6/84') Guilds!
         | You can now belong to multiple groups, not just your party. There are public and private guilds, think "Subreddits" v "multiple friend groups".
 
-  h5 5/27/2013
+  h5.big_news_header 5/27/2013
   table.table.table-striped
     tr
       td
@@ -2415,7 +2415,7 @@ mixin oldNews
         a(href='http://habitrpg.tumblr.com/post/51476277225/upcoming-features-bugs-update-user-survey', target='_blank') New blog post
         | about upcoming Guilds & Challenges features, & huge bug-fixes on the horizon.
 
-  h5 5/25/2013
+  h5.big_news_header 5/25/2013
   table.table.table-striped
     tr
       td
@@ -2427,11 +2427,11 @@ mixin oldNews
         a(href='http://community.habitrpg.com/content/submitting-bugs', target='_blank') report a problem
         | if you experience any issues, (2) this is going to allow for much less buggy code (read previous link for reasoning).
 
-  h5 5/12/2013
+  h5.big_news_header 5/12/2013
   table.table.table-striped
     tr
       td Renamed "Tokens" to "Gems". Tokens caused confusion.
-  h5 5/10/2013
+  h5.big_news_header 5/10/2013
   table.table.table-striped
     tr
       td
@@ -2441,7 +2441,7 @@ mixin oldNews
     tr
       td Chat messages: can delete your own message, fix the duplicate messages issue.
 
-  h5 5/9/2013
+  h5.big_news_header 5/9/2013
   table.table.table-striped
     tr
       td
@@ -2450,28 +2450,28 @@ mixin oldNews
         a(href='https://trello.com/card/backer-items-availability-mechanic/50e5d3684fe3a7266b0036d6/188', target='_blank') here
         | , and if you're top-gear but not seeing backer stuff, message me from your KS profile.
 
-  h5 5/7/2013
+  h5.big_news_header 5/7/2013
   table.table.table-striped
     tr
       td
         a(_target='blank', href='https://trello.com/card/tags-categories/50e5d3684fe3a7266b0036d6/43') Tags
         | . You can now categorize your tasks, eg "Work", "Home", "Morning", "Taxes", etc.
 
-  h5 5/4/2013
+  h5.big_news_header 5/4/2013
   table.table.table-striped
     tr
       td
         a(_target='blank', href='https://trello.com/card/streaks-consecutive-bonus/50e5d3684fe3a7266b0036d6/182') Streaks
         | . You get a GP & drop-% increase the longer you hold daily streaks (they stack). You also get a stacking badge for each 21-day streak.
 
-  h5 5/3/2013
+  h5.big_news_header 5/3/2013
   table.table.table-striped
     tr
       td
         | Two new achievements: Beast Master & Ultimate Gear. Got ideas for more achievements?
         a(target='_blank', href='https://trello.com/card/awards-badges/50e5d3684fe3a7266b0036d6/19') chime in here
 
-  h5 5/2/2013
+  h5.big_news_header 5/2/2013
   table.table.table-striped
     tr
       td
@@ -2489,7 +2489,7 @@ mixin oldNews
         a(href='https://github.com/lefnire/habitrpg/issues/828') New "Game Options" layout
         | (click your avatar to see)
 
-  h5 3/27/2013
+  h5.big_news_header 3/27/2013
   table.table.table-striped
     tr
       td
@@ -2499,13 +2499,13 @@ mixin oldNews
         a(href='https://trello.com/card/pets/50e5d3684fe3a7266b0036d6/166') Trello Card
         | )
 
-  h5 3/21/2013
+  h5.big_news_header 3/21/2013
   table.table.table-striped
     tr
       td
         a(href='https://github.com/lefnire/habitrpg/issues/585') More design tweaks to header & avatars
 
-  h5 3/20/2013
+  h5.big_news_header 3/20/2013
   table.table.table-striped
     tr
       td
@@ -2523,7 +2523,7 @@ mixin oldNews
       td
         a(href='https://trello.com/card/undo-button/50e5d3684fe3a7266b0036d6/20') Undo Button
 
-  h5 3/3/2013
+  h5.big_news_header 3/3/2013
   table.table.table-striped
     tr
       td

--- a/website/views/shared/new-stuff.jade
+++ b/website/views/shared/new-stuff.jade
@@ -1,14 +1,14 @@
-h4 NEW ITEMS IN THE ENCHANTED ARMOIRE AND SEPTEMBER BACKGROUNDS!
+h2 NEW ITEMS IN THE ENCHANTED ARMOIRE AND SEPTEMBER BACKGROUNDS!
   hr
   tr
     td
       .background_tavern.pull-right
-      h5 September Backgrounds Revealed
+      h3 September Backgrounds Revealed
       p There are three new avatar backgrounds in the <a href='/#/options/profile/backgrounds'>Background Shop</a>! Now your avatar can visit the Habitica Tavern, shop in the Habitica Market, or ride mounts in the Habitica Stable! 
   tr
     td
       .promo_enchanted_armoire_201509.pull-right
-      h5 New Items in the Enchanted Armoire!
+      h3 New Items in the Enchanted Armoire!
       p There is new equipment in the Enchanted Armoire, a 100 GP Reward in the Rewards Column which unlocks after you've attained Ultimate Gear! 
       br
       p Click on the Enchanted Armoire for a random chance at special Equipment, including the Yellow Hairbow, Red Floppy Hat, Gold Winged Staff, and the Plague Doctor Item Set! It may also give you random XP or food items. We'll be adding new equipment to it during the first week of each month, but even when you've exhausted the current supply, you can keep clicking for a chance at food and XP.
@@ -22,50 +22,50 @@ h4 NEW ITEMS IN THE ENCHANTED ARMOIRE AND SEPTEMBER BACKGROUNDS!
   a(href='/static/old-news', target='_blank') Read older news
 
 mixin oldNews
-  h4 LAST CHANCE FOR CHEETAH COSTUME! COSTUME CHALLENGE ANNOUNCED!
+  h2 LAST CHANCE FOR CHEETAH COSTUME! COSTUME CHALLENGE ANNOUNCED!
     hr
     tr
       td
         .promo_mystery_201508.pull-right
-        h5 Last Chance for Cheetah Costume Set
+        h3 Last Chance for Cheetah Costume Set
         p Reminder: this is the final day to <a href='/#/options/settings/subscription'>subscribe</a> and receive the Cheetah Costume Item Set! If you want the Cheetah Hat or the Cheetah Costume, now's the time. Thanks so much for your support - it's your generosity that keeps Habitica alive.
     tr
       td
-        h5 Get Ready for the Community Costume Challenge!
+        h3 Get Ready for the Community Costume Challenge!
         p On October 1st, we will launch the second annual Community Costume Challenge! Dress up in real-life versions of your avatar's armor to receive a special badge. (No, just wearing a colored shirt doesn't count. Where's the fun in that?)
         br
         p We're announcing the Challenge early so that people will have time to prepare costumes. You can see some of the excellent costumes from last year <a href='http://blog.habitrpg.com/tagged/cosplay' target='_blank'>here</a>.
         br
         p Instructions on how to take part in the CCC will be posted on October 1st. We can't wait to see your costumes!
 
-  h4 8/27/2015 - OFFICIAL BACK TO SCHOOL ADVICE CHALLENGE
+  h2 8/27/2015 - OFFICIAL BACK TO SCHOOL ADVICE CHALLENGE
     hr
     tr
       td
         .promo_backtoschool.pull-right
-        h5 Official Back to School Advice Challenge!
+        h3 Official Back to School Advice Challenge!
         p We've launched another Official Challenge: the Back To School Advice Challenge! Use social media to tell us how you use Habitica to improve study habits, share stories of scholarly success with the app, or just give us your advice on using Habitica to be the best you can be.
         br
         p The contest ends on September 27th, and the 10 winners will each get 30 Gems! For the full rules, <a href='/#/options/groups/challenges/533cac3f-f431-424f-9eaa-4d509f015a75'>check out the challenge here</a>.
-  h4 8/24/2015 - AUGUST SUBSCRIBER ITEM SET: CHEETAH COSTUME!
+  h2 8/24/2015 - AUGUST SUBSCRIBER ITEM SET: CHEETAH COSTUME!
     hr
     tr
       td
         .promo_mystery_201508.pull-right
-        h5 August Subscriber Item Set: Cheetah Costume!
+        h3 August Subscriber Item Set: Cheetah Costume!
         p The August Subscriber Items have been revealed: the Cheetah Costume Item Set! All August subscribers will receive the Cheetah Costume and the Cheetah Hat. You still have six days to <a href='/#/options/settings/subscription'>subscribe</a> and receive the item set! Thank you so much for your support - we really do rely on you to keep Habitica free to use and running smoothly.
         p.small.muted by Lemoness
-  h4 8/19/2015 - CHEETAH PET QUEST, iPAD APP, and GRYPHON CONTEST WINNER!
+  h2 8/19/2015 - CHEETAH PET QUEST, iPAD APP, and GRYPHON CONTEST WINNER!
     hr
     tr
       td
         .Pet-Cheetah-Base.pull-right
-        h5 Cheetah Pet Quest
+        h3 Cheetah Pet Quest
         p A new pet quest is available in the <a href='/#/options/inventory/quests'>Quests Page</a>: Such a Cheetah! A Cheetah is speeding past incomplete tasks and burning them up before people can complete them. Can you put on the brakes? If so, you’ll be awarded with some cheetah eggs!
         p.small.muted by PainterProphet, tivaquinn, Unruly Hyena, Crawford, janetmango, Lemoness, and SabreCat
     tr
       td
-        h5 iOS Update and iPad App
+        h3 iOS Update and iPad App
         p There’s a new iOS update! One of our awesome open-source contributors, Shadallark, has made our Habitica iOS app Universal so that it natively supports iPads. Enjoy all the new space for your tasks! We've also fixed several bugs, and excellent contributor kylefox has added a search bar.
         br
         p If you like the direction that we’ve been taking the app, please consider leaving us a review. It means a lot to us :) Questions? Concerns? Don't hesitate to email <a href='mailto:mobile@habitica.com' target='_blank'>mobile@habitica.com</a> and we will happily help you!
@@ -78,37 +78,37 @@ mixin oldNews
       td
         span.Mount_Body_Gryphon-RoyalPurple.pull-right
           span.Mount_Head_Gryphon-RoyalPurple.pull-right(style='margin:0')
-        h5 Gryphon Contest Winner
+        h3 Gryphon Contest Winner
         p After sorting through over 1600 entries, we finally have a name for our Royal Purple Gryphon: MELIOR! "Melior" is Latin for "better," because Habitica is a place where everyone is striving to become better at their goals in their quest to improve their lives.
         br
         p The name "Melior" was submitted by awesome user NobleTheSecond, who has received their prize. Congratulations! A secondary prize has also been awarded to TangyDragonBBQ, who independently submitted a slightly different variant of that name. 
         br
         p Thank you so much to everyone who submitted names! They were very well-thought-out and very entertaining, and it was extremely difficult for the staff to make a decision. We hope you will join with us in welcoming Melior into the Habitica family!
 
-  h4 8/13/2015 - GOLD-PURCHASABLE CARDS
+  h2 8/13/2015 - GOLD-PURCHASABLE CARDS
     hr
     tr
       td
         .inventory_special_greeting.pull-right
         .inventory_special_thankyou.pull-right
-        h5 Gold-Purchasable Cards
+        h3 Gold-Purchasable Cards
         p There are two new types of Card available in the <a href='/#/options/inventory/drops'>Market</a> that you can send to the people in your Party: Greeting Cards and Thank-You Cards! Both cost 10 Gold, and will be available year-round. Sending or receiving these cards will give you some fun achievements!
         br
         p Enjoy!
         p.small.muted by PainterProphet, Teto Is Great, Lemoness, and SabreCat
 
-  h4 8/4/2015 - NEW ITEMS IN THE ENCHANTED ARMOIRE AND AUGUST BACKGROUNDS
+  h2 8/4/2015 - NEW ITEMS IN THE ENCHANTED ARMOIRE AND AUGUST BACKGROUNDS
     hr
     tr
       td
         .background_pyramids.pull-right
-        h5 August Backgrounds Revealed
+        h3 August Backgrounds Revealed
         p There are three new avatar backgrounds in the <a href='/#/options/profile/backgrounds'>Background Shop</a>! Now your avatar can admire the Pyramids, stalk across the Sunset Savannah, or dance under Twinkly Party Lights!
         p.small.muted by (in order): minac1, Bambin, and rosiesully
     tr
       td
         .promo_enchanted_armoire_201508.pull-right
-        h5 New Items in the Enchanted Armoire!
+        h3 New Items in the Enchanted Armoire!
         p There is new equipment in Enchanted Armoire, a 100 GP Reward in the Rewards Column which unlocks after you've attained Ultimate Gear!
         br
         p Click on the Enchanted Armoire for a random chance at special Equipment, including the Golden Toga Item Set and the Horned Iron Item Set.! It may also give you random XP or food items. We'll be adding new equipment to it during the first week of each month, but even when you've exhausted the current supply, you can keep clicking for a chance at food and XP.
@@ -117,19 +117,19 @@ mixin oldNews
         br
         p.small.muted by Lemoness and SabreCat
         p.small.muted Art by Kiwibot, Starsystemic, Podcod, and UncommonCriminal
-  h4 8/2/2015 - AUGUST MYSTERY BOX!
+  h2 8/2/2015 - AUGUST MYSTERY BOX!
     hr
     tr
       td
         .inventory_present_08.pull-right
-        h5 August Mystery Box
+        h3 August Mystery Box
         p How curious! All Habiticans who are <a href='/#/options/settings/subscription'>subscribed</a> during the month of August will receive the August Mystery Item Set, as well as the ability to buy Gems with Gold! The August Item Set will be revealed on the 24th, so keep your eyes peeled. Thanks for supporting the site <3
-  h4 7/31/2015 - HABITICA NAMING DAY AND LAST CHANCE FOR SUMMER SPLASH
+  h2 7/31/2015 - HABITICA NAMING DAY AND LAST CHANCE FOR SUMMER SPLASH
     hr
     tr
       td
         .achievement_habiticaDay.pull-right
-        h5 Habitica Naming Day!
+        h3 Habitica Naming Day!
         p It's finally here! HabitRPG has become Habitica. Your accounts should still stay exactly the same and work normally, just with some of the names and references changed. (For example, habitrpg.com now redirects to habitica.com.)
         br
         p In honor of the first annual Habitica Naming Day, we've given everyone an achievement, as well as some awesome treats...
@@ -138,7 +138,7 @@ mixin oldNews
       td
         span.Mount_Body_Gryphon-RoyalPurple.pull-right
           span.Mount_Head_Gryphon-RoyalPurple.pull-right(style='margin:0')
-        h5 Habitica Gryphon Mount and Contest
+        h3 Habitica Gryphon Mount and Contest
         p Our new logo features a Gryphon, and now, so does your stable! We've given everyone a Royal Purple Gryphon Mount, under <a href='/#/options/inventory/mounts'>Inventory &gt; Mounts.</a>
         br
         p Furthermore, we need your help to give our Gryphon a name! Check out the Official Name the Gryphon Challenge <a href='/#/options/groups/challenges/a4898d49-9ed4-4029-974a-ff702f5b8b14'>here</a>. If we choose your name for the Gryphon in our logo, you'll win 30 Gems. You have until August 10th to submit a name.
@@ -146,30 +146,30 @@ mixin oldNews
     tr
       td
         .promo_veteran_pets.pull-right
-        h5 Veteran Pets
+        h3 Veteran Pets
         p Since you are all veterans who have weathered the name change to Habitica, we've awarded everyone a Veteran Pet! If this is your first Veteran Pet, you've received the Veteran Wolf; if you already had the Wolf, you got the Veteran Tiger. You can find it under <a href='/#/options/inventory/pets'>Inventory &gt; Pets</a>, in the Rare Pets section.
         p.small.muted by Lemoness and Shaner
     tr
       td
         .promo_summer_classes_2015.pull-right
-        h5 Last Chance for Summer Splash Outfits, Hair and Skins, and Seafoam!
+        h3 Last Chance for Summer Splash Outfits, Hair and Skins, and Seafoam!
         p Today is the final day of the Summer Splash Festival, so if you still have any remaining Summer Splash Items that you want to buy, you'd better do it now! The <a href='/#/tasks'>Seasonal Edition items</a>, <a href='/#/options/profile/avatar'>Skins</a>, and <a href='/#/options/profile/avatar'>Hair Colors</a> won't be back until next June, and if the Limited Edition items return they will have increased prices or changed art, so strike while the iron is hot!
     tr
       td
         .promo_mystery_201507.pull-right
-        h5 Last Chance for Rad Surfer Item Set
+        h3 Last Chance for Rad Surfer Item Set
         p Reminder: this is the final day to <a href='/#/options/settings/subscription'>subscribe</a> and receive the Rad Surfer Item Set! If you want the Rad Surfboard or the Rad Sunglasses, now's the time! Thanks so much for your support <3
-  h4 7/29/2015 - HABITICA NAMING DAY ON JULY 31ST!
+  h2 7/29/2015 - HABITICA NAMING DAY ON JULY 31ST!
     hr
     tr
       td
-        h5 Habitica Naming Day is July 31st!
+        h3 Habitica Naming Day is July 31st!
         p We are pleased to announce that the final day of the Summer Splash Festival, July 31st, will be the inaugural Habitica Naming Day! On this day, HabitRPG will officially become Habitica. Our old name was unfortunately very confusing to people ("HabitZPR? HabitGRG?"), so we've decided to name our app and website after the land of Habitica, where all these adventures take place.
         br
         p We will be celebrating with some fun surprises, so get excited!
     tr
       td
-        h5 What will change?
+        h3 What will change?
         p In almost all cases, your accounts will still stay exactly the same and work normally! Only some of the names and references will be different. Here is a list of the changes:
         br
         ul
@@ -180,38 +180,38 @@ mixin oldNews
           li We don't anticipate any issues with third-party tools, but we will be actively working with developers to help them make any necessary updates. You can help us by reporting broken third-party tools at <a href='https://github.com/HabitRPG/habitrpg/issues/2760' target='_blank'>Help -&gt; Report a Bug</a>.
     tr
       td
-        h5 When will it change?
+        h3 When will it change?
         p Changing our name is a pretty enormous task, so it won't all happen in an instant! Some changes may start switching over slightly before the 31st, and some may take slightly longer, but the majority of the changes and all of the celebration will take place on July 31st. Thank you for being patient with us!
     tr
       td
-        h5 More questions?
+        h3 More questions?
         p If you have any more questions, drop by <a href='/#/options/groups/guilds/5481ccf3-5d2d-48a9-a871-70a7380cee5a'>the Newbies Guild</a> and we'll be happy to answer them!
-  h4 7/24/2015 - JULY SUBSCRIBER ITEM SET: RAD SURFER!
+  h2 7/24/2015 - JULY SUBSCRIBER ITEM SET: RAD SURFER!
     hr
     tr
       td
         .promo_mystery_201507.pull-right
-        h5 July Subscriber Items Revealed!
+        h3 July Subscriber Items Revealed!
         p The July Subscriber Items have been revealed: the Rad Surfer Item Set! All July subscribers will receive the Rad Surfboard and the Rad Sunglasses. You still have six days to <a href='/#/options/settings/subscription'>subscribe</a> and receive the item set, along with the ability to buy Gems with Gold! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         p.small.muted by Lemoness
-  h4 7/22/2015 - NEW iOS UPDATE, INCLUDING FACEBOOK LOGIN!
+  h2 7/22/2015 - NEW iOS UPDATE, INCLUDING FACEBOOK LOGIN!
     hr
     tr
       td
         .promo_habitica.pull-right
-        h5 Habitica App Update with Facebook Login
+        h3 Habitica App Update with Facebook Login
         p We've released a new update to our iOS Habitica app, including Facebook Login, Accessories, and much more. <a href='https://itunes.apple.com/us/app/habitica/id994882113?mt=8' target='_blank'>Check it out now!</a>
         br
         p If you like what we've been doing with the app, please consider leaving us a review. It means so much to us, and really helps us out. Thanks for being awesome! If you have any feedback or concerns, feel free to email us at <a href='mailto:mobile@habitrpg.com' target='_blank'>mobile@habitrpg.com</a>, or use the in-app Report a Bug feature under Menu > About.
         br
         p We're still hard at work on the native Android app, don't worry! Our Blacksmiths are toiling away. Stay tuned for further information!
         p.small.muted by Viirus
-  h4 7/14/2015 - GOLD-PURCHASABLE QUESTS, NEW EQUIPMENT IN THE ENCHANTED ARMOIRE, AND TRIVIAL TASK DIFFICULTY SETTING!
+  h2 7/14/2015 - GOLD-PURCHASABLE QUESTS, NEW EQUIPMENT IN THE ENCHANTED ARMOIRE, AND TRIVIAL TASK DIFFICULTY SETTING!
     hr
     tr
       td
         .promo_dilatoryDistress.pull-right
-        h5 Gold-Purchasable Quest Line: Dilatory Distress
+        h3 Gold-Purchasable Quest Line: Dilatory Distress
         p We've moved the quests to <a href='/#/options/inventory/quests'>their own separate page</a>, and added a new category: GOLD PURCHASABLE QUESTS!
         br
         p Now you can use Gold to purchase the Dilatory Distress Quest Line! King Manta's daughter has disappeared, and monsters are laying siege to the underwater city of Dilatory. Can you intervene to save them all? If so, you'll earn the exclusive Oceanic Armor Set.
@@ -223,7 +223,7 @@ mixin oldNews
     tr
       td
         .promo_enchanted_armoire_201507.pull-right
-        h5 New Equipment in the Enchanted Armoire
+        h3 New Equipment in the Enchanted Armoire
         p There is new equipment in Enchanted Armoire, a 100 GP Reward in the Rewards Column which unlocks after you've attained Ultimate Gear!
         br
         p Click on the Enchanted Armoire for a random chance at special Equipment, including the Rancher Robes, Rancher Lasso, Blue Hairbow, and Royal Crown! It may also give you random XP or food items. We'll be adding new equipment to it during the first week of each month, but even when you've exhausted the current supply, you can keep clicking for a chance at food and XP.
@@ -233,34 +233,34 @@ mixin oldNews
         p.small.muted Art by podcod, Kiwibot, and Megan
     tr
       td
-        h5 Trivial Task Difficulty
+        h3 Trivial Task Difficulty
         p There's a new difficulty for Tasks available under task edit: Trivial! Trivial tasks reward you or damage you at the rate of one tenth of the amount that Easy tasks would. Likewise, Trivial tasks cause much less damage during boss battles!
         p.small.muted by efim
-  h4 7/9/2015 - DERBY DAY! FREE ORCA MOUNT AND WHALE QUEST
+  h2 7/9/2015 - DERBY DAY! FREE ORCA MOUNT AND WHALE QUEST
     hr
     tr
       td
-        h5 Derby Day!
+        h3 Derby Day!
         p On this day, Habitica defeated the worst of its ancient bugs! We celebrate with the Dilatory Derby, which means that Habiticans get aquatic mounts to ride!
     tr
       td
         .promo_orca.pull-right
-        h5 Free Orca Mount
+        h3 Free Orca Mount
         p Everyone has received a rare Orca Mount in honor of the Dilatory Derby! Now you can race through the waves on the back of your Orca, which is found under <a href='/#/options/inventory/mounts'>Mounts</a>.
         p.small.muted by Uncommon Criminal
     tr
       td
         .quest_whale.pull-right
-        h5 New Pet Quest: Whales!
+        h3 New Pet Quest: Whales!
         p Want more whales? Check out the The Wail of the Whale, a new pet quest in the <a href='/#/options/inventory/drops'>Market</a>! On your way to the Dilatory Derby, you encounter a whale in distress. Can you calm her down? If so, you may gain some whale eggs...
         p.small.muted Art by krazjega, zoebeagle, and Uncommon Criminal
         p.small.muted Writing by Calae
-  h4 7/7/2015 - NEW iOS APP: HABITICA!
+  h2 7/7/2015 - NEW iOS APP: HABITICA!
     hr
     tr
       td
         .promo_habitica.pull-right
-        h5 New iOS App: Habitica!
+        h3 New iOS App: Habitica!
         p We are proud to announce the beta release of our new native iOS app: <a href='https://itunes.apple.com/us/app/habitica/id994882113?ls=1&mt=8' target='_blank'>Habitica</a>! It features an all-new interface, smoother performance, reminders to complete Dailies, and tons of features including skills and better party chat! <a href='https://itunes.apple.com/us/app/habitica/id994882113?ls=1&mt=8' target='_blank'>Click here to download it</a> - it's a new app, not an upgrade of the clunky old one.
         br
         p This is a beta release, so please report any issues using the in-app Send Feedback and Report a Bug buttons, under Menu > About. <a href='https://github.com/HabitRPG/habitrpg-ios/' target='_blank'>The repository is open source</a>, so anyone can jump in and help out.
@@ -269,141 +269,141 @@ mixin oldNews
         p.small.muted by Viirus
     tr
       td
-        h5 What about Android?
+        h3 What about Android?
         p We are hard at work on the native Android app as we speak! It's coming along very well. We will announce as soon as it is ready to download, never fear.
     tr
       td
-        h5 Why Habitica?
+        h3 Why Habitica?
         p Habitica is the land where HabitRPG takes place - a land where players ride dragons and slay Dailies. Plus, it's now the name of the mobile app. Soon, it will also be the name of the site!
         br
         p The decision to switch from HabitRPG to Habitica is a big one, and we've been talking it over for a long time. We've gotten feedback since the beginning that it was confusing, especially for the many people who aren't familiar with the acronym. ("HabitPGR? HabitRZG? What was your name again?") We feel that "Habitica" keeps the fantasy flair without the confusing abbreviation, so it's the best of both realms.
         br
         p So far, habitica.com redirects to habitrpg.com, and it's the name of the native mobile apps. Look forward to an upcoming announcement of the switchover date, when we will be ringing in the name change with our inaugural Habitica Day celebration!
-  h4 7/1/2015 - SEAFOAM TRANSFORMATION ITEM , JULY BACKGROUNDS REVEALED, SUBSCRIBE WITH AMAZON PAYMENTS AND JULY SUBSCRIBER BOX
+  h2 7/1/2015 - SEAFOAM TRANSFORMATION ITEM , JULY BACKGROUNDS REVEALED, SUBSCRIBE WITH AMAZON PAYMENTS AND JULY SUBSCRIBER BOX
     hr
     tr
       td
         .inventory_special_seafoam.pull-right
-        h5 Seafoam Transformation Item
+        h3 Seafoam Transformation Item
         p Splash some Seafoam on your friends and they will undergo a mysterious transformation until their next cron! You can buy the Seafoam in the <a href='/#/options/inventory/seasonalshop'>Seasonal Shop</a> for Gold. Don't want to be transformed? Just buy some Sand from the <a href='/#/tasks'>Rewards Store</a> to reverse it.
         p.small.muted by Lemoness
     tr
       td
         .background_giant_wave.pull-right
-        h5 July Backgrounds Revealed
+        h3 July Backgrounds Revealed
         p There are three new avatar backgrounds in the <a href='/#/options/profile/backgrounds'>Background Shop</a>! Now your avatar can surf on a Giant Wave, explore a Sunken Ship, or dive to the Ruins of Dilatory!
         p.small.muted by (in order): minac1, Mimi Alves, and Twitching
     tr
       td
         .inventory_present_07.pull-left
-        h5 Subscribe with Amazon Payments
+        h3 Subscribe with Amazon Payments
         p Want to subscribe to get the July Mystery Item and the ability to buy Gems with Gold? Now you have a new way to pay for a subscription: Amazon Payments! The July Subscriber Item Set will be revealed on the 24th, so keep your eyes peeled.
         br
         p Right now, we only support Amazon Payments for subscriptions, but in the future, we will make it possible to use Amazon Payments to buy Gems as well. Thanks for supporting the site <3
-  h4 6/30/2015 - LAST CHANCE FOR NEON SNORKELER, CLONE CHALLENGES, AND CHALLENGER CONTRIBUTOR TITLE
+  h2 6/30/2015 - LAST CHANCE FOR NEON SNORKELER, CLONE CHALLENGES, AND CHALLENGER CONTRIBUTOR TITLE
     hr
     tr
       td
         .promo_mystery_201506.pull-right
-        h5 Last Chance for Neon Snorkeler Item Set
+        h3 Last Chance for Neon Snorkeler Item Set
         p Reminder: this is the final day to <a href='/#/options/settings/subscription'>subscribe</a> and receive the Neon Snorkeler Item Set! If you want the Snorkeler Suit or the Neon Snorkel, now's the time! Thanks so much for your support <3
         p.small.muted by Lemoness
     tr
       td
-        h5 Clone Challenges
+        h3 Clone Challenges
         p It's now easier than ever to create a recurring Challenge! Just go to a previously created challenge and click the clone button. This creates a new Challenge with all the same information (name, description, prize, tasks) pre-populated, so the challenge creator can adjust only as needed. We hope this saves you time!
         p.small.muted by TheHollidayInn and Blade
     tr
       td
-        h5 Challenger Contributor Title
+        h3 Challenger Contributor Title
         p Speaking of recurring Challenges, we've decided to create a new Contributor title, "Challenger", to honor the Habiticans who have been working to improve the community by consistently creating many valuable Challenges. The Challenger title is awarded at the discretion of the staff and mods. Many thanks to our creative and dedicated Challengers!
-  h4 6/25/2015 - JUNE SUBSCRIBER ITEM SET, SPLASHY SKIN SET, AND NEW SOUND EFFECTS
+  h2 6/25/2015 - JUNE SUBSCRIBER ITEM SET, SPLASHY SKIN SET, AND NEW SOUND EFFECTS
     hr
     tr
       td
         .promo_mystery_201506.pull-right
-        h5 June Subscriber Item Set!
+        h3 June Subscriber Item Set!
         p The June Subscriber Item has been revealed: the Neon Snorkeler Item Set! All June subscribers will receive the Neon Snorkel and the Snorkel Suit. You still have five days to <a href='https://habitrpg-staging.herokuapp.com/#/options/settings/subscription'>subscribe</a> and receive the item set, along with the ability to buy Gems with Gold! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         p.small.muted by Lemoness
     tr
       td
         .promo_splashyskins.pull-right
-        h5 Splashy Skin Set
+        h3 Splashy Skin Set
         p There's a new set of Seasonal Edition Skins available in the <a href='/#/options/profile/avatar'>Avatar Customization page</a> until July 31st! Get them while you can, or they won't be available until next year.
         p.small.muted by UncommonCriminal
     tr
       td
-        h5 New Sound Effects
+        h3 New Sound Effects
         p There's a new Sound Effects theme on the site: Gokul Theme! You can enable it by clicking on the megaphone in the upper right hand corner and selecting "Gokul Theme" from the dropdown list.
         p.small.muted by NomindTR
-  h4 6/20/2015 - SUMMER SPLASH EVENT: LIMITED EDITION OUTFITS, SEASONAL SHOP OPENS, AND SUMMER NPCS!
+  h2 6/20/2015 - SUMMER SPLASH EVENT: LIMITED EDITION OUTFITS, SEASONAL SHOP OPENS, AND SUMMER NPCS!
     hr
     tr
       td
-        h5 Summer Splash Begins!
+        h3 Summer Splash Begins!
         p The Summer Splash festival has arrived, and Habitica has moved to the undersea city of Dilatory for the summer! From today until July 31st, join us for fun in the sun.
     tr
       td
         .promo_summer_classes_2015.pull-right
-        h5 Limited Edition Class Outfits
+        h3 Limited Edition Class Outfits
         p From now until July 31st, limited edition outfits are available in the Rewards column. Depending on your class, you can be a Reef Renegade, Sunfish Warrior, Strapping Sailor, or Ship Soothsayer! You'd better get productive to earn enough gold before they disappear. Good luck!
         p.small.muted by Lemoness
     tr
       td
         .promo_summer_classes_2014.pull-right
-        h5 Seasonal Shop Opens
+        h3 Seasonal Shop Opens
         p The <a href='/#/options/inventory/seasonalshop'>Seasonal Shop</a> has opened! It's stocking summertime Seasonal Edition goodies at the moment, including last year's summer outfits. Everything there will be available to purchase during the Summer Splash event each year, but it's only open until July 31st, so be sure to stock up now, or you'll have to wait a year to buy these items again.
         p.small.muted by Lemoness
     tr
       td
         .seasonalshop_summer2015.pull-right
-        h5 Summer NPCs
+        h3 Summer NPCs
         p Looks like the NPCs are really getting in to the summer spirit. Ian, Bailey, Matt, and the Seasonal Sorceress are having fun under the sea in the sunken city of Dilatory, and Alex and Daniel have moved down to the beach. Even the Time Travelers are getting into the fun, although... oh dear... they seem to have overshot the season...
         p.small.muted by Lemoness
-  h4 6/17/2015 - CUTTLEFISH PET QUEST AND QUEST DISPLAY IMPROVEMENTS
+  h2 6/17/2015 - CUTTLEFISH PET QUEST AND QUEST DISPLAY IMPROVEMENTS
     hr
     tr
       td
         .quest_kraken.pull-right
-        h5 Cuttlefish Pet Quest
+        h3 Cuttlefish Pet Quest
         p A new pet quest is available in the <a href='/#/options/inventory/drops' target='_blank'>Market</a>: The Kraken of Inkomplete! A pleasant day sailing is ruined when a Kraken attacks. Can you strike down the tasks and tentacles that keep cropping up? If so, you'll be awarded with some cuttlefish eggs!
         p.small.muted art by Lemoness and Wolvenhalo
         p.small.muted writing by Lemoness
     tr
       td
-        h5 Quest Display Improvements
+        h3 Quest Display Improvements
         p Now you can see the details of a pending quest on the Party Page by clicking the new "Quest Details" tab above the quest invitations. We hope this helps you decide whether or not you want to accept the quest!
         p.small.muted by hairlessbear
-  h4 6/16/2015 - SEARCH BAR, CHALLENGES FILTER, INTERMITTENT REFRESH, AND VISUAL TWEAKS
+  h2 6/16/2015 - SEARCH BAR, CHALLENGES FILTER, INTERMITTENT REFRESH, AND VISUAL TWEAKS
     hr
     tr
       td
-        h5 Search Bar
+        h3 Search Bar
         p You can now easily search for a specific task by using the handy search bar on the upper right of the task page!
         p.small.muted by Jiří Chára
     tr
       td
-        h5 New Challenges Filter
+        h3 New Challenges Filter
         p Now you can filter Challenges based on whether or not you own the Challenge! Easily see all the Challenges that you've created with a single click.
         p.small.muted by theHollidayInn
     tr
       td
-        h5 Intermittent Refresh
+        h3 Intermittent Refresh
         p To improve performance, HabitRPG now refreshes automatically after 6 hours of inactivity to combat bugs and make sure that you have the most up-to-date code. You're always welcome to refresh more frequently, of course.
         p.small.muted by cheerskevin
     tr
       td
-        h5 Visual Tweaks
+        h3 Visual Tweaks
         p We now have a highlighted Help button, to remind people about those resources, and a denser task edit style!
         p.small.muted by excentris and nthomsn
-  h4 6/11/2015 - REPEATING TASKS, START DATE, AND MOBILE APP UPDATES!
+  h2 6/11/2015 - REPEATING TASKS, START DATE, AND MOBILE APP UPDATES!
     p
     br
     p.small.muted by Blade and fallenpanda
     hr
     tr
       td
-        h5 New Repeat Option for Dailies
+        h3 New Repeat Option for Dailies
         p Dailies now have a new Advanced Option: Repeat Every X Days. You've wanted this feature for a long time, and it's finally here!
         br
         p First, please note that this new option is OPT-IN only. We won't make any changes to your preexisting Dailies without you knowing it. We wouldn't do that!
@@ -411,30 +411,30 @@ mixin oldNews
         p That being said, here are the new features:
     tr
       td
-        h5 Repeating Tasks
+        h3 Repeating Tasks
         p Use the "Every X Days" function under Dailies Advanced Options to create tasks that repeat after a certain number of days have passed, whether every 2 days, every 15 days, every 30 days... You choose the number that works for you!
         br
         p These Dailies are only due on those given dates. Need to pay your rent every 30 days? Take medicine every other day? Water your plants every 4 days? No longer a problem.
     tr
       td
-        h5 Start Date
+        h3 Start Date
         p Dailies now have a Start Date. They will not be due before this date. This means that if you want to add a new Daily while you're thinking about it, but not have it be due until later, you can achieve that by setting a future Start Date!
     tr
       td
-        h5 Mobile App Updates
+        h3 Mobile App Updates
         p New <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg' target='_blank'>Android</a> and <a href='https://itunes.apple.com/us/app/habitrpg/id689569235?mt=8' target='_blank'>iOS</a> updates are available to support this feature. Please, update your apps before using it, or the new repeating Dailies will not display normally on the mobile apps!
     tr
       td
-        h5 Other Notes
+        h3 Other Notes
         p For a short period of time, the <a href='http://data.habitrpg.com' target='_blank'>Data Display Tool</a> will not be able to calculate damage correctly for Repeat Every X Dailies. We'll get that updated very soon so that it will be accurate again!
         br
         p If you still have questions about Repeat Every X Dailies, don't hesitate to ask in <a href='/#/options/groups/guilds/5481ccf3-5d2d-48a9-a871-70a7380cee5a' target='_blank'>the Newbies Guild</a>!
-  h4 6/1/2015 - NEW EQUIPMENT: THE ENCHANTED ARMOIRE, JUNE BACKGROUNDS, AND NEW MOUNT POSITIONING!
+  h2 6/1/2015 - NEW EQUIPMENT: THE ENCHANTED ARMOIRE, JUNE BACKGROUNDS, AND NEW MOUNT POSITIONING!
     hr
     tr
       td
         .promo_enchanted_armoire.pull-right
-        h5 New Equipment: The Enchanted Armoire!
+        h3 New Equipment: The Enchanted Armoire!
         p Now after you achieve Ultimate Gear, you'll unlock a new Reward: THE ENCHANTED ARMOIRE!
         br
         p Click on the Enchanted Armoire, a 100 GP Reward in the Rewards Column, for a random chance at special Equipment! It may also give you random XP or food items. We'll be adding new equipment to it every month, but even when you've exhausted the current supply, you can keep clicking for a chance at food and XP.
@@ -445,62 +445,62 @@ mixin oldNews
     tr
       td
         .background_island_waterfalls.pull-right
-        h5 June Backgrounds Revealed
+        h3 June Backgrounds Revealed
         p There are three new avatar backgrounds in the <a href='/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can paddle a Drifting Raft, float through a sea of Shimmery Bubbles, or picnic near Island Waterfalls!
         p.small.muted by (in order): Teto is Great, beffymaroo, and UncommonCriminal
     tr
       td
-        h5 New Mount Positioning!
+        h3 New Mount Positioning!
         p The mount positioning has been fixed for all the base mounts where it looked like the avatar was riding extreme sidesaddle. Now avatars sit properly, no longer clinging to the sides of their mounts for dear life.
         p.small.muted by Kiwibot, Lemoness, and SabreCat
-  h4 6/1/2015 - JUNE MYSTERY ITEM!
+  h2 6/1/2015 - JUNE MYSTERY ITEM!
     hr
     tr
       td
         .inventory_present_06.pull-right
-        h5 June Mystery Item!
+        h3 June Mystery Item!
         p Ooh, how mysterious! All Habiticans who are <a href='/#/options/settings/subscription' target='_blank'>subscribed</a> during the month of June will receive the June Mystery Item Set, as well as the ability to buy Gems with Gold! The June Item Set will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
-  h4 5/31/2015 - PUSH NOTIFICATIONS FOR ANDROID, AND LAST CHANCE FOR GREEN KNIGHT SUBSCRIBER ITEMS!
+  h2 5/31/2015 - PUSH NOTIFICATIONS FOR ANDROID, AND LAST CHANCE FOR GREEN KNIGHT SUBSCRIBER ITEMS!
     hr
     tr
       td
         .promo_mystery_201505.pull-right
-        h5 Last Chance for Green Knight Item Set
+        h3 Last Chance for Green Knight Item Set
         p Reminder: this is the final day to <a href='/#/options/settings/subscription' target='_blank'>subscribe</a> and receive the Green Knight Item Set! If you want the Green Knight Helm or the Green Knight Lance, now's the time! Thanks so much for your support <3
         p.small.muted by Lemoness
     tr
       td
-        h5 Push Notifications for Android
+        h3 Push Notifications for Android
         p We've released an update to the Android app that includes new types of push notification! Now it's easier than ever to remember to stay productive. Get the Android update <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg' target='_blank'>here</a>!
         p.small.muted by Negue
-  h4 5/25/2015 - MAY SUBSCRIBER ITEM SET: GREEN KNIGHT!
+  h2 5/25/2015 - MAY SUBSCRIBER ITEM SET: GREEN KNIGHT!
     hr
     tr
       td
         .promo_mystery_201505.pull-right
-        h5 May Subscriber Item Set Revealed: Green Knight!
+        h3 May Subscriber Item Set Revealed: Green Knight!
         p The May Subscriber Item has been revealed: the Green Knight Item Set! All May subscribers will receive the Green Knight Helm and the Green Knight Lance. You still have six days to <a href='/#/options/settings/subscription' target='_blank'>subscribe</a> and receive the item set, along with the ability to buy Gems with Gold! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         p.small.muted by Lemoness
-  h4 5/20/2015 - NEW PET QUEST: SHEEP!
+  h2 5/20/2015 - NEW PET QUEST: SHEEP!
     hr
     tr
       td
         .quest_sheep.pull-right
-        h5 New Pet Quest: Sheep!
+        h3 New Pet Quest: Sheep!
         p It looks like there's some ba-a-a-ad weather in the Taskan countryside! Can you and your party be diligent enough to defeat the Thunder Ram? If so, you may find yourself with some wooly sheep pets...
         p.small.muted art by Starsystemic and Misceo
         p.small.muted writing by Salambander, Leephon, and Lemoness
-  h4 5/13/2015 - NEW ANIMAL SKINS AND ACCESSORIES, INN IMPROVEMENTS, COPY CHAT TO TO-DO, AND EXTRA INFO
+  h2 5/13/2015 - NEW ANIMAL SKINS AND ACCESSORIES, INN IMPROVEMENTS, COPY CHAT TO TO-DO, AND EXTRA INFO
     hr
     tr
       td
         .promo_pet_skins.pull-right
-        h5 New Animal Skins and Accessories Available!
+        h3 New Animal Skins and Accessories Available!
         p They say that owners resemble their pets, and now that's truer than ever for Habiticans! The Animal Skin Set and Animal Accessory Set are now available in the <a href='/#/options/profile/avatar' target='_blank'>Customization shop</a>. Time to let your avatar walk on the wild side.
         p.small.muted by Painter de Cluster and SabreCat
     tr
       td
-        h5 Inn Improvements
+        h3 Inn Improvements
         p Now even when you Rest in the Inn, your Dailies will refresh each day. <strong>Important note: your Dailies still do NOT hurt you while you're in the Inn.</strong> We wouldn't do that to you!
         br
         p It used to be that the Resting in the Inn froze all your Dailies so that they wouldn't refresh the next day - even for important Dailies like "take medicine" or "feed pets." This was very frustrating to a lot of users who relied on these features, even during periods of time when they needed to rest in the Inn for finals, illness, vacation, etc.
@@ -511,125 +511,125 @@ mixin oldNews
         p.small.muted by hairlessbear and Blade
     tr
       td
-        h5 Copy Chat to To-Do
+        h3 Copy Chat to To-Do
         p Now you can copy any chat message into your To-Do list! If your roommate posted in party chat and asked you to grab groceries, or your friend reminded you about the history quiz tomorrow, you can save it right into your To-Do list. Awesome! 
         p.small.muted by Negue and Redphoenix
     tr
       td
-        h5 Extra Info
+        h3 Extra Info
         p We know that HabitRPG can be confusing, so now you can easily double-check what each task type does by clicking the question mark next to its name.
         p.small.muted by Lemoness, lefnire, and SabreCat
-  h4 5/06/2015 - MAY BACKGROUNDS REVEALED
+  h2 5/06/2015 - MAY BACKGROUNDS REVEALED
     hr
     tr
       td
         .background_mountain_lake.pull-right
-        h5 May Backgrounds Revealed
+        h3 May Backgrounds Revealed
         p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can climb to the top of Pagodas, pose in front of a Marble Temple, or dip toes in a Mountain Lake!
         p.small.muted by (in order) Teto is Great, Painter de Cluster, and Hazel40
 
-  h4 5/01/2015 - Skills Rebalancing
+  h2 5/01/2015 - Skills Rebalancing
     hr
     tr
       td
         p After over a year's worth of complaints on Trello and countless bug reports on Github, and after almost five months of dedicated debating, coding, and testing, we have finally rolled out an overhaul of the skills and mana system. Thank you so much to everyone who contributed opinions, time, and effort! Here's what happened:
     tr
       td
-        h5 HABITS DAMAGE BOSSES
+        h3 HABITS DAMAGE BOSSES
         p Now it's even easier to damage a Boss without skills! It was definitely high time that HabitRPG counted Habits towards battles. We were not living up to our name.
     tr
       td
-        h5 MANA DIRECTLY LINKED TO PROGRESS
+        h3 MANA DIRECTLY LINKED TO PROGRESS
         p Mana was pretty broken: you gained it overnight no matter what you'd done the day before, and it was only linked to To-Dos. This meant that using skills was pretty detached from how well you were doing in your real life, which defeated the purpose of the game!
         p Now you can gain Mana from Dailies and positive Habits as well as To-Dos! You still gain Mana overnight, but how much you gain depends on how many of your Dailies you did.
         p You can also lose Mana by hitting negative Habits. Yikes! Better not indulge...
     tr
       td
-        h5 SKILLS STRENGTHENED AND WEAKENED
+        h3 SKILLS STRENGTHENED AND WEAKENED
         p Some notoriously overpowered skills have been weakened, like Backstab (which often granted over 1000GP per cast), Burst of Flames (which allowed you to 1-hit KO most bosses regardless of how much or how little you'd done that day), and Valorous Presence (which caused the notorious "I checked off one Daily and gained 997 levels" bug reports).
         p Some painfully UNDERpowered skills have been strengthened, such as Tools of the Trade and Searing Brightness. We think you'll like these much better now!
         p For a full description of what changed, <a href='http://habitrpg.wikia.com/wiki/User_blog:LadyAlys/Skills_Rebalancing_and_Other_Changes' target='_blank'>check out this blog post</a>.
     tr
       td
-        h5 GIVING FEEDBACK
+        h3 GIVING FEEDBACK
         p We understand that these changes may be disruptive to some of you. We're sorry! We hope that with time, you will find them to be a drastic improvement. We will be waiting two weeks (so that everyone can get used to the new system), and then on May 15th will open up a new Trello card for comments and feedback.
         p For those of you who want to reallocate stats now that you have the new system, please post your User ID in this <a href='https://github.com/HabitRPG/habitrpg/issues/5082' target='_blank'>Github ticket</a>. (Your UUID is found under Settings > API; do NOT post your API Token.) That ticket is also being used to debate a possibility to make it so that reallocating stats does not cost gems. If that's a feature you would like (or would hate), definitely drop by that ticket and let us know!
         p.small.muted by Alys, Verabird, brandonjreid, ShilohT, betaveros, SabreCat, chimericdream, and everyone who commented with feedback on Trello and Github. You all are great!
 
-  h4 4/30/2015 - LAST CHANCE FOR BUSY BEE AND SPRING FLING ITEMS, AND SOON-TO-APPEAR NEW EQUIPMENT!
+  h2 4/30/2015 - LAST CHANCE FOR BUSY BEE AND SPRING FLING ITEMS, AND SOON-TO-APPEAR NEW EQUIPMENT!
     hr
     tr
       td
         .promo_shimmer_hair.pull-right
-        h5 Last Chance for Spring Fling Outfits, Hair Colors, and Shiny Seeds!
+        h3 Last Chance for Spring Fling Outfits, Hair Colors, and Shiny Seeds!
         p Tomorrow everything will be back to normal in Habitica, so if you still have any remaining Spring Fling Items that you want to buy, you'd better do it now! The <a href='https://habitrpg.com/#/options/inventory/seasonalshop' target='_blank'>Seasonal Edition items</a> and <a href='https://habitrpg.com/#/options/profile/avatar' target='_blank'>Hair Colors</a> won't be back until next March, and if the Limited Edition items return they will have increased prices or changed art, so strike while the iron is hot!
     tr
       td
         .promo_mystery_201504.pull-right
-        h5 Last Chance for Busy Bee Item Set
+        h3 Last Chance for Busy Bee Item Set
         p Reminder: this is the final day to <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribe</a> and receive the Busy Bee Item Set! If you want the Busy Bee Robe or the Busy Bee Robes, now's the time! Thanks so much for your support <3
     tr
       td
-        h5 New Equipment Soon
+        h3 New Equipment Soon
         p If you're sad to see the extra gold-purchasable equipment disappear, don't worry! We have something fun in the works...
 
-  h4 4/24/2015 - APRIL SUBSCRIBER ITEM SET AND NEW LANGUAGES
+  h2 4/24/2015 - APRIL SUBSCRIBER ITEM SET AND NEW LANGUAGES
     hr
     tr
       td
         .promo_mystery_201504.pull-right
-        h5 April Subscriber Item Set: Busy Bee!
+        h3 April Subscriber Item Set: Busy Bee!
         p The April Subscriber Item has been revealed: the Busy Bee Item Set! All April subscribers will receive the Busy Bee Robe and the Busy Bee Wings. You still have six days to <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribe</a> and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         p.small.muted by Lemoness
     tr
       td
-        h5 New Languages
+        h3 New Languages
         p We've added three new languages to the site: Japanese, Serbian and Chinese (Traditional)!
         p.small.muted by Paglias, the <a href='https://www.transifex.com/projects/p/habitrpg/language/ja/' target='_blank'>Japanese Translation Team</a>, the <a href='https://www.transifex.com/projects/p/habitrpg/language/sr/' target='_blank'>Serbian Translation Team</a>, and the <a href='https://www.transifex.com/projects/p/habitrpg/language/zh_TW/' target='_blank'>Chinese (Traditional) Translation Team</a>
 
-  h4 4/15/2015 - MARSHMALLOW SLIMES, KEY TO THE KENNELS CHANGE, AND CHALLENGE IMPROVEMENTS
+  h2 4/15/2015 - MARSHMALLOW SLIMES, KEY TO THE KENNELS CHANGE, AND CHALLENGE IMPROVEMENTS
     hr
     tr
       td
         .Pet-Slime-Base.pull-right
-        h5 Marshmallow Slime Pet Quest!
+        h3 Marshmallow Slime Pet Quest!
         p There is a new Pet Quest available in the <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>Market</a>: The Jelly Regent! Gooey slime is gumming up the works, and Habiticans are having a tough time finishing their tasks. Can you mop the floor with the Jelly Regent? If so, you'll get some adorable Marshmallow Slime pets!
         p.small.muted art by Starsystemic, Leephon, LordDarkly, Overomega, and Shaner
         p.small.muted writing by Bethany Woll and Theothermeme
     tr
       td
-        h5 Key to the Kennels Free with Triad Bingo
+        h3 Key to the Kennels Free with Triad Bingo
         .pet_key.pull-right
         p The Key to the Kennels is now free if you have the Triad Bingo achievement and if you choose to release your pets and mounts together! Rejoice, collectors! Note that the Key will not be free if you release only pets or only mounts.
         p.small.muted by gisikw
     tr
       td
-        h5 Challenge Improvements
+        h3 Challenge Improvements
         p Now Challenge links take you directly to that Challenge, instead of the top of the list, and when you edit a Challenge, the name is automatically updated!
         p.small.muted by gisikw, chrisdotcode, and TheHollidayInn
-  h4 4/7/2015 - APRIL BACKGROUNDS REVEALED
+  h2 4/7/2015 - APRIL BACKGROUNDS REVEALED
     hr
     tr
       td
         .background_cherry_trees.pull-right
-        h5 April Backgrounds
+        h3 April Backgrounds
         p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can picnic in a Flowering Meadow, nibble the scenery of Gumdrop Land, or admire the Cherry Trees!
         p.small.muted by Rattify, Painter de Cluster, and kmcallah
-  h4 4/2/2015 - MARCH AND APRIL ITEM SETS; SHINY SEEDS; MESSAGE CHALLENGE CREATORS; ITEM DROP ICONS
+  h2 4/2/2015 - MARCH AND APRIL ITEM SETS; SHINY SEEDS; MESSAGE CHALLENGE CREATORS; ITEM DROP ICONS
     hr
     tr
       td
-        h5 Last Chance for March Item Set
+        h3 Last Chance for March Item Set
         p Reminder: this is the final day to <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribe</a> and receive the Aquamarine Item Set! If you want the Aquamarine Eyewear or the Aquamarine Armor, now's the time! Thanks so much for your support <3
     tr
       td
-        h5 April Mystery Box
+        h3 April Mystery Box
         .inventory_present.pull-right
         p Cool! What could it be? All Habiticans who are subscribed during the month of April will receive the April Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
         p.small.muted by Lemoness
     tr
       td
-        h5 Shiny Seeds
+        h3 Shiny Seeds
         .inventory_special_shinySeed.pull-right
         p Phew! It was tough, but we overthrew the flowers that had taken over the site. However, they've left behind some of their Shiny Seeds!
         br
@@ -639,64 +639,64 @@ mixin oldNews
         p.small.muted by Lemoness and SabreCat
     tr
       td
-        h5 Message Challenge Creators
+        h3 Message Challenge Creators
         p Now on the Challenges page, you can to click on the challenge creator's name to view their profile, message them, or to see how long ago they last logged in if you are curious about whether the challenge might still be active.
         p.small.muted by TheHollidayInn
     tr
       td
         .promo_item_notif.pull-right
-        h5 Icons in Notifications
+        h3 Icons in Notifications
         p Now, when you find an item from scoring a task, an image of the item appears in the drop notification. Instant gratification when that egg or potion you've been hunting for finally appears!
         p.small.muted by TheHollidayInn
-  h4 4/1/2015 - HOSTILE FLOWER TAKEOVER OF JOY AND DOOM
+  h2 4/1/2015 - HOSTILE FLOWER TAKEOVER OF JOY AND DOOM
     hr
     tr
       td
-        h5 Joy and Doom to All!
+        h3 Joy and Doom to All!
         p THE SPRING FLING HAS FLUNG TOO FAR! Run while you can, Habiticans! The floral theme has come to life and is taking over Habitica with horrifying cheer, repeat, the flowers are taking over HMMMPH MMPH MMMHPPPH....
         .avatar_floral_wizard
         p CELEBRATE FLOWER POWER.
         br
         p RESISTANCE IS SILLY.
         p.small.muted by Lemoness and Baconsaur
-  h4 3/29/2015 - PASTEL SKIN, SHIMMER HAIR COLORS, SURVEY BADGES AWARDED, AND PARTY SORT ORDER
+  h2 3/29/2015 - PASTEL SKIN, SHIMMER HAIR COLORS, SURVEY BADGES AWARDED, AND PARTY SORT ORDER
     hr
     tr
       td
         .promo_pastel_skin.pull-right
-        h5 Pastel Skin
+        h3 Pastel Skin
         p The Seasonal Edition Pastel Skin Set is now available for purchase in the <a href='https://habitrpg.com/#/options/profile/avatar' target='_blank'>avatar customizations page</a>! This skin set will only be available until April 30th, and then it will disappear until next Spring Fling.
         p.small.muted by McCoyly
     tr
       td
         .promo_shimmer_hair.pull-right
-        h5 Shimmer Hair Colors
+        h3 Shimmer Hair Colors
         p The Seasonal Edition Shimmer Hair Colors are now available for purchase in the <a href='https://habitrpg.com/#/options/profile/avatar' target='_blank'>avatar customizations page</a>! Now you can dye your avatar's hair Shimmer Pink, Shimmer Purple, Shimmer Blue, Shimmer Green, Shimmer Orange, or Shimmer Yellow.
         br
         p Seasonal Edition items recur unchanged every year, but they are only available to purchase during a short period of time. This is different from Limited Edition Items, which only recur if something is changed, such as the art or the price. These hair colors may remind some of you of the Pastel Hair Colors that were available last spring. The Pastel Hair Colors have been retired in favor of the similar Seasonal Edition Shimmer Hair Colors. Read more about the difference between Seasonal and Limited Edition items <a href='http://habitrpg.wikia.com/wiki/Item_Availability' target='_blank'>here</a>!
         p.small.muted by Lemoness, crystalphoenix, and mariahm
     tr
       td
-        h5 Survey Badges Awarded
+        h3 Survey Badges Awarded
         p The Survey badges have been awarded to everyone who took the survey and provided their user ID! Unfortunately, some people did not include their User ID with the survey. As a result, we have no way of linking the survey with their accounts, and could not give them the "Helped Habit Grow" badge. If you have any questions, please email <a href='mailto:leslie@habitrpg.com'>Leslie</a>.
         p.small.muted by Sugarfiend and Alys
     tr
       td
-        h5 Party Sort Order
+        h3 Party Sort Order
         p Now when you change the sort order for your party, it takes effect immediately. You can change the sort order under Social > Party.
         p.small.muted by ChokesMcGee
-  h4 3/25/2015 - MARCH SUBSCRIBER ITEM, FREE EGG HUNT QUEST, EGG MOUNTS, AND NEW MODERATOR!
+  h2 3/25/2015 - MARCH SUBSCRIBER ITEM, FREE EGG HUNT QUEST, EGG MOUNTS, AND NEW MODERATOR!
     hr
     tr
       td
         .promo_mystery_201503.pull-right
-        h5 March Subscriber Item
+        h3 March Subscriber Item
         p The March Subscriber Item has been revealed: the Aquamarine Item Set! All March subscribers will receive the Aquamarine Eyewear and the Aquamarine Armor. You still have six days to <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribe</a> and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         p.small.muted by Lemoness
     tr
       td
         .Pet-Egg-CottonCandyPink.pull-right
-        h5 Egg Hunt Quest and Egg Mounts
+        h3 Egg Hunt Quest and Egg Mounts
         p In celebration of the season, everyone has received a free Egg Hunt collection quest scroll! You can find it in the <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>Inventory</a>. Collect eggs by completing your tasks, and you'll be rewarded with some egg pets.
         br
         p Furthermore, the Egg Pets can now be fed... and grow into some glorious Egg Mounts!
@@ -705,109 +705,109 @@ mixin oldNews
         p.small.muted by Beffymaroo and Megan
     tr
       td
-        h5 New Moderator
+        h3 New Moderator
         p Finally, we have a new moderator on the site: @Beffymaroo! Hooray! Be sure to say hello to her in the Tavern.
-  h4 3/20/2015 - SPRING FLING EVENT! LIMITED EDITION OUTFITS, SEASONAL SHOP OPENS, AND SPRING NPCS
+  h2 3/20/2015 - SPRING FLING EVENT! LIMITED EDITION OUTFITS, SEASONAL SHOP OPENS, AND SPRING NPCS
     hr
     tr
       td
-        h5 Spring Fling!
+        h3 Spring Fling!
         p The Spring Fling is here! From today until April 30th, join Habitica in its sweet celebration.
     tr
       td
         .promo_springclasses2015.pull-right
-        h5 Limited Edition Class Outfits
+        h3 Limited Edition Class Outfits
         p From now until April 30th, limited edition outfits are available in the Rewards column. Depending on your class, you can be a Beware Dog, Magician's Bunny, Sneaky Squeaker, or Comforting Kitty! You'd better get productive to earn enough gold before they disappear. Good luck!
         p.small.muted by Lemoness
     tr
       td
         .promo_springclasses2014.pull-right
-        h5 Seasonal Shop Opens
+        h3 Seasonal Shop Opens
         p The <a href='https://habitrpg.com/#/options/inventory/seasonalshop' target='_blank'>Seasonal Shop</a> has opened! It's stocking springtime Seasonal Edition goodies at the moment, including last year's spring outfits. Everything there will be available to purchase during the Spring Fling event each year, but it's only open until April 30th, so be sure to stock up now, or you'll have to wait a year to buy these items again.
         p.small.muted by Lemoness
     tr
       td
         .seasonalshop_spring2015.pull-left
-        h5 Spring NPCs
+        h3 Spring NPCs
         p Looks like the NPCs are really getting in to the springtime fun around the site. Who wouldn't? After all, there's plenty more to come!
         p.small.muted by Lemoness and Shaner
-  h4 3/17/2015 - BUNNY PET QUEST, EGG PURCHASING CHANGE, LAST DAY FOR SURVEY AND ACHIEVEMENT, AND UNEQUIP BUTTONS
+  h2 3/17/2015 - BUNNY PET QUEST, EGG PURCHASING CHANGE, LAST DAY FOR SURVEY AND ACHIEVEMENT, AND UNEQUIP BUTTONS
     hr
     tr
       td
-        h5 New Pet Quest: Killer Bunny
+        h3 New Pet Quest: Killer Bunny
         p There's a new quest scroll in the <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>Market</a>! Deep within Mount Procrastination lies a once-sweet beast grown horrifying with neglect. Can you rally your strength to defeat the Killer Bunny? If so, you'll get some bunny eggs!
         p.small.muted by Draayder, Gully, and TetoIsGreat
     tr
       td
-        h5 Egg Purchasing Change
+        h3 Egg Purchasing Change
         p You can now purchase quest eggs from the <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>Market</a> after defeating the corresponding boss at least once! Previously, you had to defeat the boss at least twice before being able to purchase the eggs.
         p.small.muted by Blade
     tr
       td
-        h5 Last Day for Survey and Achievement
+        h3 Last Day for Survey and Achievement
         p March 18th is the final day to complete <a href='https://www.surveymonkey.com/s/62RXRF3' target='_blank'>this survey</a> to receive or stack the Helped Habit Grow survey! After it is closed, it will take us several days to award the badges. Thanks so much for sharing your feedback with us!
         p.small.muted by sugarfiend and SabreCat
     tr
       td
-        h5 Unequip Buttons
+        h3 Unequip Buttons
         p It’s now easier to switch your avatar’s costume! You can now unequip all your battle gear, costume pieces, and/or pets from the Equipment page using the new Unequip buttons.
         p.small.muted by TheHolidayInn
-  h4 3/10/2015 - SURVEY, TESTIMONIALS GUILD, AND CHAT EXTENSION
+  h2 3/10/2015 - SURVEY, TESTIMONIALS GUILD, AND CHAT EXTENSION
     hr
     tr
       td
-        h5 Survey and Achievement
+        h3 Survey and Achievement
         .achievement.achievement-tree.pull-right
         p We're giving out the rare Helped Habit Grow achievement to all users who help us out by completing <a href='https://www.surveymonkey.com/s/62RXRF3' target='_blank'>this 10-question survey</a>! If you already received this badge, taking this new survey will stack your achievement. Thanks for sparing a minute to let us know what you think about HabitRPG!
         p.small.muted by sugarfiend and SabreCat
     tr
       td
-        h5 Testimonials Guild
+        h3 Testimonials Guild
         p We're collecting testimonials from users to display on the front page along with pictures of their avatars. If HabitRPG has been helpful to you and you feel comfortable leaving a short testimonial for us, you can post it <a href='https://habitrpg.com/#/options/groups/guilds/ae985ab0-fcc3-410d-bdb3-ae4defe712bb' target='_blank'>here</a>. Thanks for all your help! <3
     tr
       td
-        h5 Chat Extension
+        h3 Chat Extension
         p Horacious Moreau has made a <a href='https://chrome.google.com/webstore/detail/habitrpg-chat-client/hidkdfgonpoaiannijofifhjidbnilbb' target='_blank'>chat extension</a> for HabitRPG! It creates a chat box for Tavern, parties, and Guilds. :)
         br
         p The Chat Client is also open-source! You can check out the project <a href='https://github.com/Horacious/HabitRPG-Chat-Extension' target='_blank'>here</a>.
         p.small.muted by Horacious Moreau
-  h4 3/3/2015 - MARCH BACKGROUNDS, ANDROID APP NOTIFICATIONS, AND MARCH MYSTERY BOX
+  h2 3/3/2015 - MARCH BACKGROUNDS, ANDROID APP NOTIFICATIONS, AND MARCH MYSTERY BOX
     hr
     tr
       td
-        h5 March Backgrounds Revealed
+        h3 March Backgrounds Revealed
         p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can dance in the Spring Rain, admire some Stained Glass, or frolic through the Rolling Hills!
         p.small.muted by (in order) Sunstroke, Kiwibot, and Uncommon Criminal
     tr
       td
-        h5 Android App Notifications
+        h3 Android App Notifications
         p The <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg' target='_blank'>Android app</a> can now remind you to log in! Simply go to Settings and select the time that you want the reminder.
         p.small.muted by Negue
     tr
       td
         .inventory_present.pull-right
-        h5 March Mystery Box
+        h3 March Mystery Box
         p Wow! What could it be? All Habiticans who are <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribed</a> during the month of March will receive the March Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
         p.small.muted by Lemoness
-  h4 2/24/2015 - FEBRUARY SUBSCRIBER ITEM AND ADD MULTIPLE TASKS!
+  h2 2/24/2015 - FEBRUARY SUBSCRIBER ITEM AND ADD MULTIPLE TASKS!
     hr
     tr
       td
         .promo_mystery_201502.pull-right
-        h5 February Subscriber Item
+        h3 February Subscriber Item
         p The February Subscriber Item has been revealed: the Winged Enchanter Item Set! All February subscribers will receive the Wings of Thought and the Shimmery Winged Staff of Love and Also Truth. You still have four days to <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribe</a> and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         p.small.muted by Lemoness
     tr
       td
-        h5 Add Multiple Tasks
+        h3 Add Multiple Tasks
         p Got a bunch of tasks you need to add all at once? No problem! Now you can add a batch of tasks all at once by clicking "Add Multiple" under the task entry bar. We hope that this will save you time!
         p.small.muted by ChimericDream
-  h4 2/24/2015 - SITE DOWNTIME EXPLANATION (AND SLEEPING AVATARS)
+  h2 2/24/2015 - SITE DOWNTIME EXPLANATION (AND SLEEPING AVATARS)
     hr
     tr
       td
-        h5
+        h3
         p As most of you probably noticed, the site was down yesterday. We got a surge of new users from Imgur who absolutely flattened the servers by registering all at once, and it proved very difficult to start up again. You can read the technical details <a href="https://github.com/HabitRPG/habitrpg/issues/4737" target="_blank">in this Github ticket</a>. We're sorry about all of the frustration!
         br
         p At about midnight PST we checked all active users into the inn, "freezing" their accounts so that their incomplete Dailies would not hurt them, in hopes that this would prevent most of the undeserved deaths due to server troubles. That's why your avatar is sleeping! To check yourself out of the inn, go to Social > Tavern > Check out of inn.
@@ -819,17 +819,17 @@ mixin oldNews
         p And welcome, Imgurians! Sorry your introduction was so rocky, but we can't wait to get to know you. There is a <a href="https://habitrpg.com/#/options/groups/guilds/4709ba62-2ba0-43ff-a5a5-494c774236ec">Camp Imgur Guild</a> that you might enjoy.
         br
         p Now, back to productivity!
-  h4 2/17/2015 - NEW PET QUEST AND COMMUNITY GUIDELINE UPDATES
+  h2 2/17/2015 - NEW PET QUEST AND COMMUNITY GUIDELINE UPDATES
     hr
     tr
       td
         .quest_rock.pull-right
-        h5 New Pet Quest: Rocks!
+        h3 New Pet Quest: Rocks!
         p It seemed like a simple hike... until we discovered that the cave was alive! You can get the newest Pet Quest, "Escape the Cave Creature," in the <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>Market</a>. If you defeat it, you'll get some cuddly pet rocks!
         p.small.muted by itokro, Pfeffernusse, Painter de Cluster, and intone
     tr
       td
-        h5 Community Guideline Updates
+        h3 Community Guideline Updates
         p We've updated the <a href='https://habitrpg.com/static/community-guidelines' target='_blank'>Community Guidelines</a> to include the following:
         ul
           li Blade, a new mod, is listed!
@@ -838,131 +838,131 @@ mixin oldNews
           li Sexism has been added to the list of unacceptable behaviors.
           li Making duplicate accounts to circumvent consequences is now expressly forbidden.
 
-  h4 2/12/2015
+  h2 2/12/2015
     hr
     tr
       td
-        h5 Happy Valentine's Day!
+        h3 Happy Valentine's Day!
         p Help motivate all of the lovely people in your life by sending them a caring valentine. Valentines can be purchased for 10 gold from the Market. For spreading love and joy throughout the community, both the giver AND the receiver get a coveted "adoring friends" badge. Hooray!
         p.small.muted by Lemoness and SabreCat
     tr
       td
-        h5 New Hairstyles!
+        h3 New Hairstyles!
         .promo_updos.pull-right
         p There are a new set of updo hairstyles available in the <a href='https://habitrpg.com/#/options/profile/avatar' target='_blank'>Avatar Customization page</a>! Have fun customizing your characters.
         p.small.muted by Crystalphoenix, Mariahm, Painter de Cluster, Leephon, Beffymaroo, Sungabraverday, Lemoness, and Bailey
-  h4 2/8/2015
+  h2 2/8/2015
     hr
     tr
       td
-        h5 Email Notifications
+        h3 Email Notifications
         p We've implemented email notifications for a variety of events, including receiving a Private Message, being invited to a Party, Guild, or Quest, and receiving a gift of Gems or a Subscription! We've got some more coming up, too, including the much-requested check-in reminders.
         p Don't want to receive a certain type of notification? No problem! Just go to <a href='https://habitrpg.com/#/options/settings/notifications' target='_blank'>Notification Settings</a> to tell us exactly which ones you do and do not want to receive. Our messenger dragons will be happy to comply!
         p.small.muted by paglias and Lemoness
     tr
       td
-        h5 Login Type Switching
+        h3 Login Type Switching
         p Want to change your email address, or switch from Facebook login to email login? Good news! Now you can switch it yourself, under <a href='https://habitrpg.com/#/options/settings/settings' target='_blank'>Settings</a>!
         p.small.muted by Lefnire
-  h4 2/3/2015
+  h2 2/3/2015
     hr
     tr
       td
-        h5 February Backgrounds Revealed
+        h3 February Backgrounds Revealed
         .background_distant_castle.pull-right
         p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can survey a Distant Castle, toil in the Blacksmithy, or explore a Crystal Cave!
         p.small.muted by Holseties, Hanztan, and Twitching
-  h4 2/2/2015
+  h2 2/2/2015
     hr
     tr
       td
-        h5 February Mystery Box
+        h3 February Mystery Box
         .inventory_present.pull-right
         p Ooh... What could it be? All Habiticans who are subscribed during the month of February will receive the February Mystery Item Set! It will be revealed on the 24th, so keep your eyes peeled. Thanks for supporting the site <3
         p.small.muted by Lemoness
     tr
       td
-        h5 New Quest Descriptions
+        h3 New Quest Descriptions
         p We've updated quest descriptions so that when you hover over them, you can now see the Boss or Collection stats and the Rewards that you will gain when you complete the quest!
         p.small.muted by Blade
     tr
       td
-        h5 Spread the Word Challenge Has Ended
+        h3 Spread the Word Challenge Has Ended
         p The Spread the Word Challenge has ended! Thank you to all the participants. It will be some time before the winners are announced because we have to go over all the entries ourselves. Thanks for your patience!
-  h4 1/30/2015
+  h2 1/30/2015
     hr
     tr
       td
         .npc_alex.pull-left
-        h5 HabitRPG Birthday Bash
+        h3 HabitRPG Birthday Bash
         p January 31st is HabitRPG's Birthday! All of the NPCs are celebrating, and we've awarded you a bunch of cake for your pets and mounts!
     tr
       td
-        h5 Party Robes
+        h3 Party Robes
         .shop_armor_special_birthday.pull-right
         .shop_armor_special_birthday2015.pull-right
         p Until February 1st only, there are Party Robes available for free in the Rewards store! If this is your first Birthday bash with us, you can find some Absurd Party Robes; if you already got some last year, then you will find the Silly Party Robes.
     tr
       td
         .promo_mystery_201501.pull-left
-        h5 Last Chance for Starry Knight Item Set
+        h3 Last Chance for Starry Knight Item Set
         p Reminder: this is the final day to <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribe</a> and receive the Starry Knight Item Set! If you want the Starry Helm or the Starry Armor, now's the time! Thanks so much for your support <3
     tr
       td
-        h5 Last Chance for Winter Wonderland Outfits + Hair Colors
+        h3 Last Chance for Winter Wonderland Outfits + Hair Colors
         .promo_winterclasses2015.pull-right
         p Tomorrow everything will be back to normal in Habitica, so if you still have any remaining Winter Wonderland Items that you want to buy, you'd better do it now! The <a href='https://habitrpg.com/#/options/inventory/seasonalshop' target='_blank'>Seasonal Edition items</a> and <a href='https://habitrpg.com/#/options/profile/avatar' target='_blank'>Hair Colors</a> won't be back until next December, and if the Limited Edition items return they will have increased prices or changed art, so strike while the iron is hot!
-  h4 1/26/2015
+  h2 1/26/2015
     hr
     tr
       td
-        h5 Subscriber Outfit Revealed
+        h3 Subscriber Outfit Revealed
         .promo_mystery_201501.pull-right
         p The January Subscriber Item has been revealed: the Starry Knight Item Set! All January subscribers will receive the Starry Helm and the Starry Armor. You still have five days to <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribe</a> and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         p.small.muted by Lemoness
     tr
       td
-        h5 New Audio Theme
+        h3 New Audio Theme
         p A new audio theme is available: Watts' Theme! You can toggle between Watts' Theme and Daniel the Bard's Theme by selecting the megaphone in the upper right-hand corner. Watts' Theme was created by Harry Pepe. You can visit his <a href='https://www.linkedin.com/in/hpepe4' target='_blank'>LinkedIn page here</a>.
         p.small.muted by Hpepe4 and Blade
     tr
       td
-        h5 Quest Scroll Redesign
+        h3 Quest Scroll Redesign
         p We've redesigned the quest scrolls so that they are visually unique! Quest type and difficulty is determined by the scroll lining (Easy Boss = Green, Medium Boss = Yellow, Hard Boss = Red, Collection Quest = Blue, Rage Bar Boss = Purple speckles), and an icon symbolizing the quest is located in the lower left.
         p.small.muted by UncommonCriminal and Rattify
     tr
       td
-        h5 Spread the Word Challenge Ending Soon
+        h3 Spread the Word Challenge Ending Soon
         p Reminder: January 31st is the last day to enter the <a href='https://habitrpg.com/#/options/groups/challenges/e1ad6d92-587d-4137-848e-4a1f643603ba' target='_blank'>Spread the Word Challenge</a> for your chance at winning 100 gems! We will stop accepting new applications on February 1st, but it will be some time before the winners are announced because we have to go over all the entries ourselves. Good luck!
-  h4 1/23/2015
+  h2 1/23/2015
     hr
     tr
       td
-        h5 The Abominable Stressbeast is DEFEATED!
+        h3 The Abominable Stressbeast is DEFEATED!
         p We've done it! With a final bellow, the Abominable Stressbeast dissipates into a cloud of snow. The flakes twinkle down through the air as cheering Habiticans embrace their pets and mounts. Our animals and our NPCs are safe once more!
     tr
       td
-        h5 Stoïkalm is Saved!
+        h3 Stoïkalm is Saved!
         p SabreCat speaks gently to a small sabertooth. "Please find the citizens of the Stoïkalm Steppes and bring them to us," he says. Several hours later, the sabertooth returns, with a herd of mammoth riders following slowly behind. You recognize the head rider as Lady Glaciate, the leader of Stoïkalm.
         p "Mighty Habiticans," she says, "My citizens and I owe you the deepest thanks, and the deepest apologies. In an effort to protect our Steppes from turmoil, we began to secretly banish all of our stress into the icy mountains. We had no idea that it would build up over generations into the Stressbeast that you saw! When it broke loose, it trapped all of us in the mountains in its stead and went on a rampage against our beloved animals." Her sad gaze follows the falling snow. "We put everyone at risk with our foolishness. Rest assured that in the future, we will come to you with our problems before our problems come to you."
         .Pet-Mammoth-Base.pull-right
         p She turns to where @Baconsaur is snuggling with some of the baby mammoths. "We have brought your animals an offering of food to apologize for frightening them, and as a symbol of trust, we will leave some of our pets and mounts with you. We know that you will all take care good care of them."
         p.small.muted by everyone who completed a Daily or a To-Do during the battle!
-  h4 1/21/2015
+  h2 1/21/2015
     hr
     tr
       td
-        h5 THIRD STRESS STRIKE!
+        h3 THIRD STRESS STRIKE!
         .npc_justin_broken.pull-right
         p The World Boss in the <a href='https://habitrpg.com/#/options/groups/tavern' target='_blank'>Tavern</a> has used a third Stress Strike!
         p Justin the Guide is trying to distract the Stressbeast by running around its ankles, yelling productivity tips! The Abominable Stressbeast is stomping madly, but it seems like we're really wearing this beast down. I doubt it has enough energy for another strike. Don't give up... we're so close to finishing it off!
         p Complete Dailies and To-Dos to damage the World Boss! A World Boss will never damage individual players or accounts in any way. Only active accounts who are not resting in the inn will have their incomplete Dailies tallied.
         p.small.muted by Lemoness, Kiwibot, and SabreCat
-  h4 1/20/2015
+  h2 1/20/2015
     hr
     tr
       td
-        h5 Mount Master and Triad Bingo Achievements
+        h3 Mount Master and Triad Bingo Achievements
         .achievement.achievement-wolf
         .achievement.achievement-triadbingo
         p There are two new achievements you can earn: Mount Master and Triad Bingo! Mount Master is awarded to users who have collected all 90 standard mounts, and Triad Bingo is for those who have collected all 90 standard pets, grown all 90 into mounts, and then rehatched 90 more standard pets. Wow!
@@ -971,64 +971,64 @@ mixin oldNews
         p.small.muted by Taldin, Blade, Lorian, Aiseant, and Hanztan
     tr
       td
-        h5 Party Sorting Options
+        h3 Party Sorting Options
         p In the <a href="/#/options/groups/party">Party Page</a> you can now sort your friends' avatars in ascending or descending order! To make the change take effect, you'll have to refresh the page.
 
         p.small.muted by Blade and Viirus
     tr
       td
-        h5 Dated To-Dos
+        h3 Dated To-Dos
         p Now you can use To-Do tabs to sort and see your dated To-Dos! Simply click the "Dated" tab and only To-Dos with a due date will be displayed. They are not currently sorted by date, but we will be implementing that feature in the future.
 
         p.small.muted by Alys
     tr
       td
-        h5 Stressbeast Desperation Triggered
+        h3 Stressbeast Desperation Triggered
 
         p We're almost there, Habiticans! With diligence and Dailies, we've whittled the Stressbeast's health down to only 500K! The creature roars and flails in desperation, rage building faster than ever. The monster is --- AHHH! --- swinging me and Matt around at a terrifying pace, raising a blinding snowstorm that makes it harder to hit.
         p We'll have to redouble our efforts, but take heart - this is a sign that the Stressbeast knows it is about to be defeated. Don't give up now! Please?
 
         p The Stressbeast raises its Rage and Defense! Complete Dailies and To-Dos to damage the World Boss. A World Boss will never damage individual players or accounts in any way. Only active accounts who are not resting in the inn will have their incomplete Dailies tallied.
         p.small.muted by Lemoness, Kiwibot, and SabreCat
-  h4 1/19/2015
+  h2 1/19/2015
     hr
     tr
       td
-        h5 WORLD BOSS: SECOND STRESS STRIKE!
+        h3 WORLD BOSS: SECOND STRESS STRIKE!
         p AHHHHHHHH!!!!! IT'S GOT ME!!!!! Oh, Habiticans, why didn't you do your Dailies?!
         p The World Boss in the <a href='https://habitrpg.com/#/options/groups/tavern' target='_blank'>Tavern</a> has used another Stress Strike, and this time it's attacked me, Bailey the Town Crier! To save me and the other NPCs, complete Dailies and To-Dos to damage the World Boss! Incomplete Dailies fill the Stress Strike Bar. When the Stress Strike bar is full, the World Boss will attack an NPC and regain some health. A World Boss will never damage individual players or accounts in any way. Only active accounts who are not resting in the inn will have their incomplete Dailies tallied.
         p.small.muted by Lemoness, Kiwibot, and SabreCat
 
-  h4 1/15/2015
+  h2 1/15/2015
     hr
     tr
       td
-        h5 Tyrannosaur Pet Quest
+        h3 Tyrannosaur Pet Quest
         p In the <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>Market</a> there are now two new pet quests: King of the Dinosaurs and The Dinosaur Unearthed! They both give out the same rewards, including pet Tyrannosaur eggs. The difference is that "King of the Dinosaurs" is a normal pet quest, like all the others, whereas "The Dinosaur Unearthed" has less HP - but also a Rage bar (a la World Bosses) that allows it to heal if you skip too many of your Dailies. Both bosses still attack your party based on how many Dailies are incomplete. Users will be able to buy Tyrannosaur eggs after defeating either boss twice or both bosses once.
         p Have fun!
         p.small.muted by Baconsaur, Urse, Lemoness, and SabreCat
     tr
       td
-        h5 Spread the Word Challenge Reminder
+        h3 Spread the Word Challenge Reminder
         p In case you missed it, we're running our second Spread the Word Challenge! The rules are simple: make a post some time between December 31st 2014 and January 31st 2015 on some form of blog or social media that tells people about HabitRPG. The top post will be awarded 100 GEMS, and the next nineteen top posts will be awarded 80 GEMS each. Learn more and join in <a href='https://habitrpg.com/#/options/groups/challenges/e1ad6d92-587d-4137-848e-4a1f643603ba' target='_blank'>here</a>!
     tr
       td
-        h5 World Boss: First Stress Strike!
+        h3 World Boss: First Stress Strike!
         p The World Boss in the <a href='https://habitrpg.com/#/options/groups/tavern' target='_blank'>Tavern</a> has used its first Stress Strike!
         p Despite our best efforts, we've let some Dailies get away from us, and their dark-red color has infuriated the Abominable Stressbeast and caused it to regain some of its health! The horrible creature lunges for the Stables, but Matt the Beast Master heroically leaps into the fray to protect the pets and mounts. The Stressbeast has seized Matt in its vicious grip, but at least it's distracted for the moment.
         p Complete Dailies and To-Dos to damage the World Boss! Incomplete Dailies fill the Stress Strike Bar. When the Stress Strike bar is full, the World Boss will attack an NPC. A World Boss will never damage individual players or accounts in any way. Only active accounts who are not resting in the inn will have their incomplete Dailies tallied.
         p.small.muted by Lemoness, Kiwibot, and SabreCat
-  h4 1/8/2015
+  h2 1/8/2015
     hr
     tr
       td
-        h5 World Boss: The Abominable Stressbeast!
+        h3 World Boss: The Abominable Stressbeast!
         .quest_stressbeast.pull-right
         p A new World Boss has appeared in the <a href='https://habitrpg.com/#/options/groups/tavern' target='_blank'>Tavern</a>! All of the completed Dailies and To-Dos of Habiticans damage the World Boss. Incomplete Dailies fill the Stress Strike Bar. When the Stress Strike bar is full, the World Boss will attack an NPC.
         p A World Boss will never damage individual players or accounts in any way. Only active accounts who are not resting in the inn will have their incomplete Dailies tallied. Read on for the details!
     tr
       td
-        h5 Winter Plot-Line: The Abominable Stressbeast Attacks!
+        h3 Winter Plot-Line: The Abominable Stressbeast Attacks!
         p The first thing we hear are the footsteps, slower and more thundering than the stampede. One by one, Habiticans look outside their doors, and words fail us.
         p We've all seen Stressbeasts before, of course - tiny vicious creatures that attack during difficult times. But this? This towers taller than the buildings, with paws that could crush a dragon with ease. Frost swings from its stinking fur, and as it roars, the icy blast rips the roofs off our houses. A monster of this magnitude has never been mentioned outside of distant legend.
         p "Beware, Habiticans!" SabreCat cries. "Barricade yourselves indoors - this is the Abominable Stressbeast itself!"
@@ -1036,400 +1036,400 @@ mixin oldNews
         p "The Stoïkalm Steppes," Lemoness says, face grim. "All this time, we thought they were placid and untroubled, but they must have been secretly hiding their stress somewhere. Over generations, it grew into this, and now it's broken free and attacked them - and us!"
         p There's only one way to drive away a Stressbeast, Abominable or otherwise, and that's to attack it with completed Dailies and To-Dos! Let's all band together and fight off this fearsome foe - but be sure not to slack on your tasks, or our undone Dailies may enrage it so much that it lashes out...
         p.small.muted by Lemoness, Kiwibot, and SabreCat
-  h4 1/5/2015
+  h2 1/5/2015
     hr
     tr
       td
-        h5 January Backgrounds
+        h3 January Backgrounds
         p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can summit a Frigid Peak, shiver in an Ice Cave, or wander through the Snowy Pines!
         p.small.muted by Kiwibot, Sunstroke, and Rattify
     tr
       td
-        h5 Testing Fix for Cron Bug
+        h3 Testing Fix for Cron Bug
         p Today we will be testing a possible fix for a bug that sometimes causes Dailies to not reset correctly on the following day. It's a big change, so we will be keeping a close watch on the site to make sure that it doesn't break anything. If you experience any problems with day start or Dailies reseting in the next few days, please let us know immediately on <a href='https://github.com/HabitRPG/habitrpg/issues/1057' target='_blank'>GitHub</a>. Thanks!
     tr
       td
-        h5 Date Format Adjustment
+        h3 Date Format Adjustment
         p There's a new option under <a href='https://habitrpg.com/#/options/settings/settings' target='_blank'>Settings</a> that lets you adjust the date format. Now you can list dates as MM/DD/YYYY, DD/MM/YYYY, or YYYY/MM/DD.
         p.small.muted by Verabird
-  h4 1/3/2015
+  h2 1/3/2015
     hr
     tr
       td
-        h5 January Mystery Item Set
+        h3 January Mystery Item Set
         .inventory_present.pull-right
         p Sparkly! What could it be? All Habiticans who are subscribed during the month of January will receive the January Mystery Item Set! It will be revealed on the 26th, so keep your eyes peeled. Thanks for supporting the site <3
         p.small.muted by Lemoness
     tr
       td
-        h5 Spread the Word Challenge
+        h3 Spread the Word Challenge
         p In honor of the season of New Year's resolutions, we're running our second Spread the Word Challenge! The rules are simple: make a post some time between December 31st 2014 and January 31st 2015 on some form of blog or social media that tells people about HabitRPG. The top post will be awarded 100 GEMS, and the next nineteen top posts will be awarded 80 GEMS each. Learn more and join in <a href='https://habitrpg.com/#/options/groups/challenges/e1ad6d92-587d-4137-848e-4a1f643603ba' target='_blank'>here</a>!
     tr
       td
-        h5 Winter Plot-Line Continues
+        h3 Winter Plot-Line Continues
         p After a fun-filled New Year's Eve, Habiticans wake to a rumbling that shakes them out of their Absurd Party Hats. Running to their windows reveals.... a stampede?
         p A thundering herd of mammoths charges past, sabertooths roar, and dinosaurs both feathery and scaly slither by at top speed. Habiticans stare open-mouthed, but before anyone can react, the stampede has swept through Habit City and is gone into the distance, leaving only pawprints in the snow, the howling wind, and some trampled New Year's cards.
         p Habiticans are advised to keep calm and not give in to stress during this confusing and difficult time. We've sent SabreCat after the frightened animals from the Stoïkalm Steppes, and he is working to calm them down so that we can bring them back to the safety of the Stables. We hope to have an explanation for this strangeness soon. In the meantime, keep all of your own pets and mounts indoors.
         p.small.muted Read the previous installments of the Winter Plot-Line <a href='http://habitrpg.wikia.com/wiki/Winter_Wonderland#Winter_Mystery_Plot' target='_blank'>here</a>!
-  h4 12/31/2014
+  h2 12/31/2014
     hr
     tr
       td
-        h5 Party Hats
+        h3 Party Hats
         .promo_partyhats.pull-right
         p In honor of the new year, some free Party Hats are available in the Rewards store! New users get the ever-handsome Absurd Party Hat, and users who already received one last year get the Silly Party Hat. These hats will be available to purchase until January 31st, but once you've bought them, you'll have them forever. Enjoy!
         p.small.muted by Lemoness and SabreCat
     tr
       td
-        h5 New Year's Cards (Until Jan 1st Only!)
+        h3 New Year's Cards (Until Jan 1st Only!)
         .inventory_special_nye.pull-right
         p Until January 1st only, the <a href='https://habitrpg.com/#/options/inventory/seasonalshop' target='_blank'>Seasonal Shop</a> is stocking New Year's Cards! Now you can send cards to your friends (and yourself) to wish them a Happy Habit New Year. All senders and recipients will receive the Auld Acquaintance badge! When you receive a card, it will appear in your <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>Inventory</a>. Click it to receive a seasonal message!
         p.small.muted by Lemoness and SabreCat
     tr
       td
-        h5 Snowballs
+        h3 Snowballs
         .inventory_special_snowball.pull-right
         p The <a href='https://habitrpg.com/#/options/inventory/seasonalshop' target='_blank'>Seasonal Shop</a> is also stocking Snowballs for gold! Throw them at your friends to have an exciting effect. Anyone hit with a snowball earns the Annoying Friends badge. The results of being hit with a Snowball will last until the end of your day, but you can also reverse them early by buying Salt from the Rewards column. Snowballs are available until January 31st.
         p.small.muted by Shaner, Lemoness, and SabreCat
-  h4 12/25/2014
+  h2 12/25/2014
     hr
     tr
       td
-        h5 December Subscriber Item Set
+        h3 December Subscriber Item Set
         .promo_mystery_201412.pull-right
         p The December Subscriber Item has been revealed: the Penguin Item Set! All December subscribers will receive the Penguin Hat and the Penguin Suit. You still have six days to <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribe</a>) and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         p.small.muted by Lemoness
     tr
       td
-        h5 Seasonal Shop: Seasonal Outfits and Quests
+        h3 Seasonal Shop: Seasonal Outfits and Quests
         .seasonalshop_winter2015.pull-right
         p The <a href='https://habitrpg.com/#/options/inventory/seasonalshop'>Seasonal Shop</a> has opened! The Seasonal Sorceress is stocking the seasonal edition versions of last year's winter outfits, now available for Gems instead of Gold, and the two winter quests, Trapper Santa and Find the Cub. The Seasonal Shop will only be open until January 31st, so don't wait!
         p.small.muted by SabreCat and Lemoness
     tr
       td
-        h5 Flagging Posts
+        h3 Flagging Posts
         p You can now report inappropriate posts to moderators simply by clicking the new flag button next to the post. You should only report posts that violate the Community Guidelines and/or Terms of Service. Thanks for helping us to keep Habitica safe and pleasant for everybody!
         p.small.muted by Alys, Blade, and Matteo
     tr
       td
-        h5 Winter Plot-Line Continues
+        h3 Winter Plot-Line Continues
         p SabreCat's news is dire. "Most of my sabertooth friends have been impossible to reach, but one thing is clear: the prides have been disappearing from the Steppes. There are also reports that something drove the mammoths to early migration and disturbed the hibernation of the terrible lizards."
         p He wraps his cloak around himself as another blast of frigid wind roars through the streets. An icy winter gale has been blowing from the north, rattling the window panes and setting the pets and mounts to trembling and howling.
         p "I've never seen anything like it!" says Matt the Beast Master. "Something is terrifying all my animals - even the cacti, who are normally so mighty and brave! For something to frighten a cactus..." He shakes his head.
         p The stress level in Habitica is mounting.
         p.small.muted Missed the previous Winter Plot-line? Catch up on the story <a href='http://habitrpg.wikia.com/wiki/Winter_Wonderland#Winter_Mystery_Plot' target='_blank'>here</a>!
         p.small.muted by Lemoness
-  h4 12/21/2014 - Winter Wonderland Begins, Winter Class Outfits, Wintery Hair Colors, and NPC Decorations!
+  h2 12/21/2014 - Winter Wonderland Begins, Winter Class Outfits, Wintery Hair Colors, and NPC Decorations!
     hr
     tr
       td
-        h5 Winter Wonderland Begins!
+        h3 Winter Wonderland Begins!
         p Winter has arrived, and the snow is gently drifting down over Habit City. Come celebrate with us!
     tr
       td
-        h5 Winter Class Outfits
+        h3 Winter Class Outfits
         .promo_winterclasses2015.pull-right
         p From now until January 31st, limited edition outfits are available in the Rewards column. Depending on your class, you can be a Soothing Skater, Mage of the North, Gingerbread Warrior, or Icicle Drake! You'd better get productive to earn enough gold before they disappear. Good luck!
         p.small.muted by Lemoness
     tr
       td
-        h5 Wintery Hair Colors
+        h3 Wintery Hair Colors
         .promo_winteryhair.pull-right
         p The Seasonal Edition Wintery Hair Colors are now available for purchase in the avatar customizations page! Now you can dye your avatar's hair Holly Green, Winter Star, Snowy, Peppermint, Aurora, or Festive.
         p Seasonal Edition items recur unchanged every year, but they are only available to purchase during a short period of time. This is different from Limited Edition Items, which only recur if something is changed, such as the art or the price. These hair colors may remind some of you of the Holiday Hair Colors that were available last winter. The Holiday Hair Colors have been Retired in favor of the similar Seasonal Edition Wintery Hair Colors. Read more about the difference between Seasonal and Limited Edition items <a href='http://habitrpg.wikia.com/wiki/Item_Availability'>here</a>!
         p.small.muted by Lemoness, crystalphoenix, and mariahm
     tr
       td
-        h5 NPC Decorations
+        h3 NPC Decorations
         .npc_alex.pull-right
         p Looks like the NPCs are really getting in to the cheery winter mood around the site. Who wouldn't? After all, there's plenty more to come!
         p.small.muted by Lemoness
-  h4 12/17/2014 - Android App Update, Seasonal Shop, and Winter Plot-Line Continues
+  h2 12/17/2014 - Android App Update, Seasonal Shop, and Winter Plot-Line Continues
     hr
     tr
       td
-        h5 Android App Update: December Art and Buying Gems!
+        h3 Android App Update: December Art and Buying Gems!
         p The December backgrounds and penguin pet quest are now visible in the Android mobile app! Also, we’ve made it possible to buy gems directly from the app. Now you don’t have to switch to the website to stock up!
         p You can get the Android app <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg&hl=en' target='_blank'>here</a>! We will announce when the iOS app is available as well.
         p.small.muted by negue
     tr
       td
-        h5 Seasonal Shop Tab
+        h3 Seasonal Shop Tab
         .seasonalshop_closed.pull-right
         p Looks like a new tab has appeared under Inventory - the <a href='https://habitrpg.com/#/options/inventory/seasonalshop'>Seasonal Shop</a>! It's still closed, but I've heard a rumor that it will open soon...
         p.small.muted by SabreCat and Lemoness
     tr
       td
-        h5 Winter Plot-Line Continues
+        h3 Winter Plot-Line Continues
         p Lemoness bursts into the Tavern, shaking icicles off her hat. "The Stoïkalm Steppes are completely abandoned!" she says, gulping the cup of tea that Daniel the Barkeep offers her. "No people milling about, no mounts and pets playing in the snow - and when I tried to fly closer, my dragon spooked and refused to land!"
         p A cloaked figure in the corner steps into the fire light - SabreCat, a powerful adventurer from the north. "The Stoïkalm Steppes are the last home of many animals that have long since gone extinct elsewhere," he says. "The stoic Stoïkalmers would never flee their lands unless something was threatening their pets and mounts!"
         p He turns to Lemoness. "I can speak the language of the northern beasts. I'll try to contact the roaming sabertooth prides to see if they know what happened." As he lopes off into the distance, a cold wind begins to blow.
         p.muted Missed the first part of the Winter Plot-Line? Read it <a href='http://habitrpg.wikia.com/wiki/Whats_new'>here</a>.
-  h4 12/9/2014 - Penguin Pet Quest and Winter Plot-Line
+  h2 12/9/2014 - Penguin Pet Quest and Winter Plot-Line
     hr
     tr
       td
-        h5 Penguin Pet Quest
+        h3 Penguin Pet Quest
         .quest_penguin.pull-right
         p Habiticans wanted to go ice-skating, but instead, a giant penguin is freezing everything in sight! All we wanted was to go ice-skating... Can you get this penguin to chill out? If so, you'll be rewarded with some penguins of your own!
         p.small.muted by Melynnrose, Breadstrings, Rattify, Painter de Cluster, Daniel the Bard, and Leephon
     tr
       td
-        h5 Winter Plot-Line
+        h3 Winter Plot-Line
         p Lemoness enters the Tavern with worrying news from the far north of Habitica. "Nobody's heard from the Stoïkalm Steppes for over a week," she says. "It's hard to imagine anything troubling the citizens there, since it's such a placid part of the continent... But just in case, maybe I should pay a visit." Sounds like a good plan to us!
 
-  h4 12/3/2014 - Gifting Subscriptions And Gems, New Subscription Benefits, Mysterious Time Travelers, Steampunk Item Sets, And Block Subscriptions!
+  h2 12/3/2014 - Gifting Subscriptions And Gems, New Subscription Benefits, Mysterious Time Travelers, Steampunk Item Sets, And Block Subscriptions!
   table.table.table-striped
     tr
       td
-        h5 Gifting Subscriptions And Gems
+        h3 Gifting Subscriptions And Gems
         p You can now gift subscriptions and gems to other people (bottom-left in a user's profile window)! If you need holiday present ideas for the awesome Habiticans in your life, or just want to do something nice for someone, consider getting them a subscription to our fair site or tossing a few gems their way. They'll thank you, and so will we <3
         p.small.muted by Lefnire
     tr
       td
-        h5 New Subscription Benefits!
+        h3 New Subscription Benefits!
         p We've added new benefits for long-term subscribers! Now for every 3 months that you are subscribed consecutively, your monthly gold-to-gem conversion cap will increase by 5, up to a total of 50 gems per month! Plus, for each three months of consecutive subscription, you will receive 1 Mystic Hourglass. What does that do? Read on!
         p.small.muted by Lefnire
     tr
       td
-        h5 Mysterious Time Travelers
+        h3 Mysterious Time Travelers
         .npc_timetravelers.pull-right
         p If you've received a Mystic Hourglass for being subscribed for 3 consecutive months, you can now summon the <a href='/#/options/inventory/timetravelers' target='_blank'>Mysterious Time Travelers</a> to get you one Mystery Item Set from the past! Being subscribed for multiple consecutive months is the only way to get these past items if you missed them. They will never be available to non-subscribers.
         p.small.muted by Lemoness, Megan, Lefnire
     tr
       td
-        h5 Steampunk Item Sets
+        h3 Steampunk Item Sets
         .promo_mystery_3014.pull-right
         p The Mysterious Time Travelers are also offering two brand-new Item Sets - the Steampunk Standard Item Set and the Steampunk Accessory Item Set! These Item Sets can only be obtained if you have a Mystic Hourglass.
         p.small.muted by Megan
     tr
       td
-        h5 Block Subscriptions
+        h3 Block Subscriptions
         p Don't want to wait for your consecutive months to stack up? You can now subscribe in a fixed block period of 1 month, 3 months, 6 months, or 1 year! If you subscribe for a block period of 1 year, you get a 20% discount. PLUS, you'll instantly get all the benefits of consecutive subscription for that time period (e.g. getting a block subscription for 6 months will instantly raise your monthly gold-to-gem cap by 10)!
         p.small.muted by Lefnire
 
-  h4 12/1/2014 - SITE OUTAGE EXPLANATION, DECEMBER BACKGROUNDS, AND DECEMBER MYSTERY ITEM SET
+  h2 12/1/2014 - SITE OUTAGE EXPLANATION, DECEMBER BACKGROUNDS, AND DECEMBER MYSTERY ITEM SET
   table.table.table-striped
     tr
       td
-        h5 Site Outage Explanation
+        h3 Site Outage Explanation
         p Many of you may have noticed that you could not access HabitRPG for a large portion of December 1st. This wasn't a problem on our end - it was due to an outage by DNSimple, the service that provides us with our domain. We're very sorry about any frustration that this caused! If you lost any stats, you can restore them using Settings > Site > Fix Character Values. For future reference, if you ever have trouble accessing HabitRPG, be sure to follow our official Twitter, @HabitRPG, for updates! Thank you for all of your supportive messages <3
     tr
       td
-        h5 December Backgrounds
+        h3 December Backgrounds
         p There are three new avatar backgrounds in the <a href=https://habitrpg.com/#/options/profile/backgrounds>Background Shop</a>! Now your avatar can explore the South Pole, drift on an Iceberg, or admire the Winter Party Lights!
         p.small.muted by McCoyly, RosieSully, and Holseties
     tr
       td
-        h5 December Mystery Item Set
+        h3 December Mystery Item Set
         p Hmmm! What could it be? All Habiticans who are subscribed during the month of December will receive the December Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
         p.small.muted by Lemoness
 
-  h4 11/26/2014 - Happy Thanksgiving!
+  h2 11/26/2014 - Happy Thanksgiving!
   table.table.table-striped
     tr
       td
-        h5 Happy Thanksgiving!
+        h3 Happy Thanksgiving!
         p It's Thanksgiving in Habitica! On this day Habiticans celebrate by spending time with loved ones, giving thanks, and riding their glorious turkeys into the magnificent sunset. Some of the NPCs are celebrating the occasion!
         p.small.muted by Lemoness
     tr
       td
-        h5 Turkey Pet and Mount!
+        h3 Turkey Pet and Mount!
         p Those of you who weren't around last Thanksgiving have received an adorable Turkey Pet, and those of you who got a Turkey Pet last year have received a handsome Turkey Mount! Thank you for using HabitRPG - we really love you guys <3
         p.small.muted by Lemoness
 
-  h4 11/25/2014
+  h2 11/25/2014
   table.table.table-striped
     tr
       td
-        h5 November Item Set Revealed
+        h3 November Item Set Revealed
         p The November Subscriber Item has been revealed: the Feast and Fun Set! All November subscribers will receive the Pitchfork of Feasting and the Steel Helm of Sporting. You still have five days to subscribe and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         p.small.muted by Lemoness
     tr
       td
-        h5 Private Messaging Version 1.0
+        h3 Private Messaging Version 1.0
         p We're excited to announce a new feature: Private Messaging! Now you can send someone a PM by clicking the envelope icon in the bottom-left of their profile window . You can check your messages under Social > Inbox! This is a very rudimentary feature so far, only containing the ability to send messages, block people, and opt out. To read about some of the planned features for the future and make suggestions, check out <a href='https://trello.com/c/hHpIzMc5/459-private-messaging-v-2' target='_blank'>this Trello card</a>!
         p.small.muted by Lefnire
 
-  h4 11/18/2014
+  h2 11/18/2014
   table.table.table-striped
     tr
       td
-        h5 New Pet Quest: The Night-Owl!
+        h3 New Pet Quest: The Night-Owl!
         p Habiticans are in the dark when a giant Night-Owl blots out the Tavern light! Can you drive it away in time to finish your all-nighter? If so, you may find some cute pet owls in the morning...
         p.small.muted by Twitching, Lemoness, and Arcosine
 
-  h4 11/13/2014 - Share Avatar To Social Media, Email Invites, First Mini Quest, And Data Tab
+  h2 11/13/2014 - Share Avatar To Social Media, Email Invites, First Mini Quest, And Data Tab
   table.table.table-striped
     tr
       td
-        h5 Share Avatar To Social Media
+        h3 Share Avatar To Social Media
         p You can now automatically share your avatar and public profile to social media! Just hover over the picture and click the "Share" button in the right-hand corner. Show off your outfit, your achievements, and your profile picture! Note that your tasks, as always, remain 100% private.
         p.small.muted by Lefnire
     tr
       td
-        h5 Invite Friends To Party Via Email
+        h3 Invite Friends To Party Via Email
         p Do you want to invite friends to join your party without inputting their User ID? Now you can send them an email directly from the party page - even if they don't have an account yet!
         p.small.muted by Lefnire
     tr
       td
-        h5 Mini Quest: The Basi-List!
+        h3 Mini Quest: The Basi-List!
         p Now when someone accepts your party invitation and joins your party, you will be given a Mini Quest: The Basi-List! Battle the Basi-List with your friends for an XP and GP reward.
         p.small.muted by Arcosine and Redphoenix
     tr
       td
-        h5 Data Tab
+        h3 Data Tab
         p Now you can access the Data Display Tool and Export Data from the toolbar!
         p.small.muted by ShilohT
 
-  h4 11/12/2014
+  h2 11/12/2014
   table.table.table-striped
     tr
       td
-        h5 New Equipment Quest Line: The Golden Knight!
+        h3 New Equipment Quest Line: The Golden Knight!
         p The Golden Knight believes that she is the perfect Habitican, and that anyone who slips up in their quest for self-improvement is a lazy failure. Can you talk some sense into her - or will it come to blows? If you complete the entire quest line, you'll be rewarded with a legendary weapon...
         p The first scroll in this quest line, "A Stern Talking-to," drops automatically at Level 40! If you're already over Level 40, you will automatically be awarded this quest - just check off a task and then check your inventory.
 
-  h4 11/09/2014 - Facebook Login Fixed For Mobile And Community Guidelines To Chat
+  h2 11/09/2014 - Facebook Login Fixed For Mobile And Community Guidelines To Chat
   table.table.table-striped
     tr
       td
-        h5 Facebook Login Fixed For Mobile!
+        h3 Facebook Login Fixed For Mobile!
         p Great news! If you use Facebook to log in to the mobile app, we've released an update so you no longer have to type in your UUID/API manually, misspelling things on your tiny keyboard and bemoaning your fate. Thank goodness! The Android update is out now, and the iOS update has been submitted and should be out soon.
     tr
       td
-        h5 Community Guidelines To Chat
+        h3 Community Guidelines To Chat
         p Before you can use any of the public chat features, you now have to agree to our Community Guidelines. We know they're long, but they're important, so please do read them if you haven't already. Plus, we worked hard to make them entertaining, and they were illustrated by many of our excellent artisans!
 
-  h4 11/06/2014
+  h2 11/06/2014
   table.table.table-striped
     tr
       td
-        h5 Bailey: Costume Challenge Badges Awarded!
+        h3 Bailey: Costume Challenge Badges Awarded!
         p The HabitRPG Costume Challenge Badges have been awarded! Thanks for your patience while we went through all the entries individually. You can see some of the entries <a href='http://blog.habitrpg.com/tagged/cosplay' target='_blank'>on the HabitRPG blog</a> already, and more will be added every week.
         p IMPORTANT: some of the links that people provided did not work. If you entered the Challenge but even after refreshing the page you still don't have your badge, email leslie@habitrpg.com with the link to your costume and your avatar. (The costume and avatar must have been posted prior to November 1st to count.)
         p Thanks to all our amazing participants!
 
-  h4 11/05/2014- November Backgrounds And Beeminder Integration
+  h2 11/05/2014- November Backgrounds And Beeminder Integration
   table.table.table-striped
     tr
       td
-        h5 November Backgrounds
+        h3 November Backgrounds
         p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can enjoy a Harvest Feast, admire a Sunset Meadow, or gaze at the Starry Skies!
         p.small.muted by Kiwibot, Holsety1, and Draayder
     tr
       td
-        h5 Beeminder Integration
+        h3 Beeminder Integration
         p We've integrated with Beeminder! Now you can beemind your To-Dos automatically :) <a href='https://www.beeminder.com/habitrpg' target='_blank'>Check it out</a>!
         p If you've never heard of Beeminder or want to learn more about what we've integrated so far, check out our <a href='http://blog.habitrpg.com/post/101773418876/beeminder-integration' target='_blank'>blog post about it</a>. Enjoy!
         p.small.muted by Alys and Alice Monday
 
-  h4 11/01/2014
+  h2 11/01/2014
   table.table.table-striped
     tr
       td
-        h5 November Mystery Item Set
+        h3 November Mystery Item Set
         .pull-right.inventory_present
         p Cool! What could it be? All Habiticans who are subscribed during the month of November will receive the November Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
 
-  h4 10/31/2014 - Monster Npcs, Last Day For Fall Festival Items, Last Day Of Community Costume Challenge, Last Day For Winged Goblin Item Set
+  h2 10/31/2014 - Monster Npcs, Last Day For Fall Festival Items, Last Day Of Community Costume Challenge, Last Day For Winged Goblin Item Set
   table.table.table-striped
     tr
       td
-        h5 Last Day For Fall Festival Items
+        h3 Last Day For Fall Festival Items
         p Tomorrow everything will be back to normal in Habitica, so if you still have any remaining Fall Festival Items that you want to buy, you'd better do it now! The Seasonal Edition items won't be back until next fall, and if the Limited Edition items return they will have increased prices or changed art, so strike while the iron is hot!
     tr
       td
-        h5 Last Day For Winged Goblin Item Set
+        h3 Last Day For Winged Goblin Item Set
         p Reminder: this is the final day to subscribe and receive the Winged Goblin Item Set! If you want the Goblin Wings or the Goblin Gear, now's the time! Thanks so much for your support <3
     tr
       td
-        h5 Last Day Of Community Costume Challenge
+        h3 Last Day Of Community Costume Challenge
         p It's the last day to post your pictures of yourself dressed up as your HabitRPG avatar if you want to get the Costume Challenge Badge! You can join the Challenge <a href='https://habitrpg.com/#/options/groups/challenges/39f7e9b4-1fbf-4b01-baee-221fd9b9ef43' target='_blank'>here</a>.
     tr
       td
-        h5 Monster Npcs
+        h3 Monster Npcs
         p The NPCs have dressed up in their Halloween costumes! Be sure to stop by and check them all out.
 
-  h4 10/27/2014 - Increased Gems For Contributors And Community Guidelines
+  h2 10/27/2014 - Increased Gems For Contributors And Community Guidelines
   table.table.table-striped
     tr
       td
-        h5 Community Guidelines
+        h3 Community Guidelines
         p Our community has grown and evolved over this past year and a half, and we realized that none of the community expectations had been codified anywhere. This has now changed with the implementation of the <a href='/static/community-guidelines' target='_blank'>Community Guidelines</a>. The Guidelines have been written by the staff and mods and illustrated by many of our talented artisans. We know they're long, but they contain all the expectations for participating in the public social side of HabitRPG, so please do read them carefully! Soon you'll have to agree to them to participate in any of the Public Chat.
         p.small.muted by <strong>Alys</strong>, Lemoness, lefnire, redphoenix, SabreCat, paglias, Bailey, Ryan, Breadstrings, Megan, Daniel the Bard, Draayder, Kiwibot, Leephon, Luciferian, Revcleo, Shaner, Starsystemic, UncommonCriminal
     tr
       td
-        h5 Increased Gems For Contributors
+        h3 Increased Gems For Contributors
         p When we first started rewarding contributors, we decided to give them 2 gems per contributor tier. Since then, however, we've introduced many more things to buy, so we've decided to increase this number. All contributors now receive 3 gems/tier for tiers 1-3, and then 4 gems/tier for tiers 4-7, bringing the total number of gems you can earn by contributing to the site to 25.
         p If you've already contributed, you've been given the gems that you're owed according to the new system. (For example, if you are a tier 3 contributor, you received 6 gems in the past and would receive 9 gems under the new system, so you've been awarded 3 gems to account for the difference.)
         p Enjoy!
         p.small.muted by Alys
 
-  h4 10/25/2014 - October Item Set Revealed And Community Costume Challenge Reminder
+  h2 10/25/2014 - October Item Set Revealed And Community Costume Challenge Reminder
   table.table.table-striped
     tr
       td
-        h5 October Item Set Revealed
+        h3 October Item Set Revealed
         .promo_mystery_201410.pull-right
         The October Subscriber Item has been revealed: the Winged Goblin Item Set! All October subscribers will receive the Goblin Gear and the Goblin Wings. You still have six days to subscribe and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         by Lemoness
-        h5 Community Costume Challenge Reminder
+        h3 Community Costume Challenge Reminder
         .achievement-costumeContest.pull-right
         p Don't forget about the <a href='https://habitrpg.com/#/options/groups/challenges/39f7e9b4-1fbf-4b01-baee-221fd9b9ef43' target='_blank'>Community Costume Challenge</a>! We've had some really amazing entries so far, and we're looking forward to seeing more over the next six days! All participants will receive the 2014 Costume Challenge Badge.
         p You can view some of the awesome costumes <a href='http://blog.habitrpg.com/tagged/cosplay' target='_blank'>here</a>!
 
-  h4 10/23/2014
+  h2 10/23/2014
   table.table.table-striped
     tr
       td
-        h5 Level 60 Equipment Quest: Recidivate Quest Line!
+        h3 Level 60 Equipment Quest: Recidivate Quest Line!
         p All over Habitica, Bad Habits thought long-dead are rising up again - it must be the work of Recidivate, the wicked Necromancer! Can you complete your Dailies and fight down your Bad Habits to lay her to rest once more? If so, you'll reap some fine spoils... including some legendary armor!
         p This quest line contains the hardest Boss Battle that we've released to date, so the first quest scroll drops for free at Level 60. If you're already Level 60 or over, you can unlock it for free, too - just check off any task and it will drop for you :) Good luck! You'll need it.
         p.small.muted by Lemoness, Tru_, aurakami, Inventrix, and Baconsaur
 
-  h4 10/15/2014 - Spider Pet Quest, Mobile App Update, Hide Grey Dailies, And Sortable Checklists!
+  h2 10/15/2014 - Spider Pet Quest, Mobile App Update, Hide Grey Dailies, And Sortable Checklists!
   table.table.tables-striped
     tr
       td
-        h5 New Pet Quest: The Icy Arachnid!
+        h3 New Pet Quest: The Icy Arachnid!
         p Yikes, what's leaving these icy webs all over Habitica? It must be the Frost Spider from the newest Pet Quest: The Icy Arachnid! You can buy this quest in the <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>Market</a>. Don't worry, it will be around even after the Fall Festival ends :)
         p.small.muted by Arcosine
     tr
       td
-        h5 Mobile App Update!
+        h3 Mobile App Update!
         p The newest mobile app update is available on iOS and Android! Now when you're on your phone you can see Fall Festival items, get drop notifications, and view the pixel art of the bosses that you're battling!
         p.small.muted By lefnire, negue, huarui, and paglias
     tr
       td
-        h5 Hide Grey Dailies
+        h3 Hide Grey Dailies
         p You can now hide grey Dailies to de-clutter your list! There are tabs at the bottom of the Dailies column that you can toggle to see only which Dailies are still active.
         p.small.muted by Gaelan, and Alys
     tr
       td
-        h5 Sortable Checklists
+        h3 Sortable Checklists
         p Have you ever wanted to rearrange checklist order? Now you can! Simply drag and drop to sort your checklist points.
         p.small.muted By gjoyner
 
-  h4 10/7/2014 - Back-To-School Advice Challenge Winners And Jack-O-Lantern Pet!
+  h2 10/7/2014 - Back-To-School Advice Challenge Winners And Jack-O-Lantern Pet!
   table.table.table-striped
     tr
       td
-        h5 Back-To-School Advice Challenge Winners
+        h3 Back-To-School Advice Challenge Winners
         p We had a ton of participants in our Back-To-School Advice Challenge, and we've finally sorted through and chosen the winners! Congratulations to
         p DJ Ringis, The Writer, San Condor, Tavi Wright, Stepharuka, Clyc, samaeldreams, LitNerdy, Tritlo, Shansie, Han Solo, FrauleinNinja, Nortya, itsallaboutfalling, TomFrankly, [TGL] Dogg, Amanda, InfH, Evan950, and Mizuokami! You've all received your gems :)
         p Thanks so much for participating! If you had fun, don't forget that the Community Costume Challenge is happening all October :)
     tr
       td
-        h5 Jack-O-Lantern Pet
+        h3 Jack-O-Lantern Pet
         p Habiticans have been carving lots of pumpkins recently - and it looks like one has followed you home! Everyone has received a pet Jack-O-Lantern! You can find it in the Stables :)
         p.small.muted by Lemoness
 
-  h4 10/3/2014- Spooky Sparkles, New Backgrounds, And Memory Leaks Almost Fixed!
+  h2 10/3/2014- Spooky Sparkles, New Backgrounds, And Memory Leaks Almost Fixed!
   table.table.table-striped
     tr
       td
-        h5 Spooky Sparkles
+        h3 Spooky Sparkles
         .pull-right
           .inventory_special_spookDust
           .achievement-spookDust
@@ -1442,209 +1442,209 @@ mixin oldNews
         p.small.muted by Lemoness, lefnire
     tr
       td
-        h5 New Backgrounds Revealed: Haunted House, Graveyard, And Pumpkin Patch
+        h3 New Backgrounds Revealed: Haunted House, Graveyard, And Pumpkin Patch
         p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can sneak through a Haunted House, visit a creepy Graveyard, or carve jack-o-lanterns in a Pumpkin Patch!
         p.small.muted by cecilyperez, Kiwibot, and Sooz
     tr
       td
-        h5 Memory Leaks Almost Fixed
+        h3 Memory Leaks Almost Fixed
         p It took a ton of effort, but Tyler has fixed the largest memory leak that was crashing our servers! There are a few smaller ones that he’s still conquering one by one, but the fiercest monster has been slain. Ten thousand cheers for Tyler! You can read the technical description of how we’re fixing the leaks <a href='https://github.com/HabitRPG/habitrpg/issues/4079' target='_blank'>here</a>, and for any JavaScript developers out there: we'd love your help! We’ll let you all know when we’ve fixed the problem for once and for all.
         p.small.muted by lefnire
 
-  h4 10/1/2014 - Seasonal Edition Skins, Seasonal Edition Hair Colors, Community Costume Challenge, Release Pets, and October Mystery Item!
+  h2 10/1/2014 - Seasonal Edition Skins, Seasonal Edition Hair Colors, Community Costume Challenge, Release Pets, and October Mystery Item!
   table.table.table-striped
     tr
       td
-        h5 Seasonal Edition Hair
+        h3 Seasonal Edition Hair
         p The Seasonal Edition Haunted Hair Colors are now available for purchase in the avatar customizations page! Now you can dye your avatar's hair Pumpkin, Midnight, Candy Corn, Ghost White, Zombie, or Halloween.
         p Seasonal Edition items recur unchanged every year, but they are only available to purchase during a short period of time. This is different from Limited Edition Items, which only recur if something is changed, such as the art or the price. Read more about the difference between Seasonal and Limited Edition items <a href='http://habitrpg.wikia.com/wiki/Item_Availability' target='_blank'>here</a>!
         p.small.muted by Lemoness, mariahm, and crystal phoenix
     tr
       td
-        h5 Seasonal Edition Skins
+        h3 Seasonal Edition Skins
         p The Supernatural Skin Set is here! Now your avatar can become an Ogre, Skeleton, Pumpkin, Candy Corn, Reptile, or Dread Shade. You can buy them from now until October 31st!
         p These skins may remind some of you of the Spooky Skin set that was available briefly last fall. This is because we've received many requests for these Limited Edition skins from more recent players who were unable to purchase those skins. As a compromise, we have decided to Retire the Spooky Skin Set and release some similar but unique skins as part of the Supernatural Skin Set. That way, anyone who wants their avatar to be a pumpkin can have their way, but the original owners of the skin sets still have the unique items that they were promised. You can read more about the new Item Availability categories <a href='http://habitrpg.wikia.com/wiki/Item_Availability' target='_blank'>here</a>.
         p.small.muted by Lemoness
     tr
       td
-        h5 Community Costume Challenge
+        h3 Community Costume Challenge
         p The Community Costume Challenge has begun! Between now and October 31st, dress up as your avatar in real life and post a photo on social media to get the coveted Costume Challenge badge! Read the full rules on the Challenge page <a href='https://habitrpg.com/#/options/groups/challenges/39f7e9b4-1fbf-4b01-baee-221fd9b9ef43' target='_blank'>here</a>.
         p.small.muted by Lemoness
     tr
       td
-        h5 Release Pets and Mounts
+        h3 Release Pets and Mounts
         p If you find collecting pets highly motivating and want to start over from zero, you're in luck! You can now release all your pets and mounts so that you can collect them again - and stack your Beastmaster achievement!
         p.small.muted By Ryan
     tr
       td
-        h5 October Mystery Item
+        h3 October Mystery Item
         p Spooky! What could it be? All Habiticans who are subscribed during the month of October will receive the October Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
         p.small.muted by Lemoness
 
-  h4 9/25/2014
+  h2 9/25/2014
   table.table.table-striped
     tr
       td
-        h5 Update: Diagnosing Server Problems
+        h3 Update: Diagnosing Server Problems
         p Our servers have been under a massive strain recently, and so we've created a <a href='https://github.com/HabitRPG/habitrpg/issues/4079' target='_blank'>Github ticket</a> that you can follow for updates on the things we're doing to fix the problem. We've also written a <a href='http://blog.habitrpg.com/post/98367930371/update-diagnosing-server-problems' target='_blank'>blog post</a>. We'll keep you updated with new developments as we strive to solve this problem.
         p If you've lost any of your stats during this time, you can restore them using Settings > Site > Fix Character Values. Thank you so much for your patience and encouragement as we work to fight this fearsome foe!
         p.small.muted by lefnire, Lemoness
     tr
       td
-        h5 September Item Set Revealed
+        h3 September Item Set Revealed
         .promo_mystery_201409.pull-right
         p In happier news, the September Subscriber Item has been revealed: the Autumn Strider Item Set. All people who are subscribed before the end of September will receive the Autumn Antlers and the Strider Vest. Thank you so much for your support - it means a lot to us, especially right now.
         p.small.muted by Lemoness
 
-  h4 9/22/2014 - Fall Festival! Limited-Edition Outfits, Candy Food Drops, And Npc Dress-Up
+  h2 9/22/2014 - Fall Festival! Limited-Edition Outfits, Candy Food Drops, And Npc Dress-Up
   p Autumn is upon us! The air is crisp, the leaves are red, and Habitica is feeling spooky. Come celebrate the Fall Festival with us... if you dare!
   table.table.table-striped
     tr
       td
-        h5 Limited Edition Class Outfits
+        h3 Limited Edition Class Outfits
         p Habiticans everywhere are dressing up. From now until October 31st, limited edition outfits are available in the Rewards column. Depending on your class, you can be a Witchy Wizard, Monster of Science, Vampire Smiter, or Mummy Medic! You'd better get productive to earn enough gold before your time runs out...
     tr
       td
-        h5 Candy Food Drops!
+        h3 Candy Food Drops!
         p You've received some Candy in your inventory in honor of the Fall Festival! Plus, for the duration of the Event, Habiticans may randomly find candy drops when they complete their tasks. These candies function just like normal food drops - can you guess which flavor your pet will like best?
     tr
       td
-        h5 NPC Dress-Up
+        h3 NPC Dress-Up
         p Looks like the NPCs are really getting in to the spooky autumnal mood around the site. Who wouldn't?
 
-  h4 9/17/2014 - Rooster Pets, Party Sorting, And Back-To-School Challenge
+  h2 9/17/2014 - Rooster Pets, Party Sorting, And Back-To-School Challenge
   table.table.table-striped
     tr
       td
-        h5 New Pet Quest: Rooster Rampage!
+        h3 New Pet Quest: Rooster Rampage!
         p There's a new pet quest in <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>the Market</a>! This monstrous rooster can't be quieted, and Habiticans are unable to sleep. Can you and your Party calm down this foul fowl? You'll be rewarded with Rooster eggs if you do!
         p.small.muted by LordDarkly, Pandoro, EmeraldOx, extrajordanary, and playgroundgiraffe
     tr
       td
-        h5 Party Sorting!
+        h3 Party Sorting!
         p We've improved the preexisting party sort feature. Now you can sort your party members' avatars by level, backgrounds, and more! Simply go to Social > Party > Members and select from the drop-down menu.
         p.small.muted by Alys and Viirus
     tr
       td
-        h5 Back-To-School Challenge!
+        h3 Back-To-School Challenge!
         p Don't forget that the 2nd Official HabitRPG Challenge is running right now - the <a href='https://habitrpg.com/#/options/groups/challenges/a367eb40-8514-46fd-805e-b9b7f89bad7f' target='_blank'>Back-To-School Advice Challenge</a>! Post your best tips for using HabitRPG during the Back-To-School season on social media for a chance at winning 60 gems. If you want to share it with the maximum number of people, you can use the #habitrpg and #backtoschool tags. You only have thirteen more days to enter. Good luck!
 
-  h4 9/12/2014 - Official Back-To-School Challenge, Markdown In Checklists, And Help Tab
+  h2 9/12/2014 - Official Back-To-School Challenge, Markdown In Checklists, And Help Tab
   table.table.table-striped
     tr
       td
-        h5 Official Back-To-School Challenge
+        h3 Official Back-To-School Challenge
         p We've launched our 2nd Official HabitRPG Challenge: the Back-To-School Advice Challenge! Use social media to tell us how you use HabitRPG to improve study habits, share stories of scholarly success with the app, or just give us your advice on using HabitRPG to be the best you can be.
         p The contest ends on September 30th, and the 20 winners will each get 60 Gems! For the full rules, <a href='https://habitrpg.com/#/options/groups/challenges/a367eb40-8514-46fd-805e-b9b7f89bad7f' target='_blank'>check out the challenge here</a>.
-        h5 Markdown In Checklists
+        h3 Markdown In Checklists
         p Previously, you've been able to use <a href='http://habitrpg.wikia.com/wiki/Markdown_Cheat_Sheet' target='_blank'>markdown</a> in your task names and in chat. Now you can also use it in checklists! Fill every aspect of your tasks with emoji, bolding, italics, or links. NOTE: If your checklists look strange, it's probably because they're accidentally using markdown now, so just edit them accordingly! Check out <a href='http://habitrpg.wikia.com/wiki/Markdown_Cheat_Sheet' target='_blank'>this Cheat Sheet</a> for an explanation of how to use markdown.
         p.small.muted By @negue
-        h5 Help Tab
+        h3 Help Tab
         p There's a new tab on the top bar that contains some helpful links. If you're confused about something, want to request a feature, or wonder if your question was asked before, you can now use the Help Tab's drop down menu!
         p.small.muted By @Alys
 
-  h4 9/10/2014
+  h2 9/10/2014
   table.table.table-striped
     tr
       td
-        h5 Get Ready For The Community Costume Challenge!
+        h3 Get Ready For The Community Costume Challenge!
         p We've got an exciting event coming up this October - the first-ever Community Costume Challenge! In the spirit of the season, Habiticans who dress up in real-life versions of their avatar's armor (or in any HabitRPG costume) will receive a special badge. (No, just wearing a colored shirt doesn't count. Where's the fun in that?)
         p The Community Costume Challenge will start on October 1st, but we're announcing it early so that people have time to get their costumes together.
         p Instructions on how to participate in the CCC will be posted on October 1st. We can't wait to see your costumes!
 
-  h4 9/3/2014
+  h2 9/3/2014
   table.table.table-striped
     tr
       td
-        h5 New Backgrounds Revealed: Thunderstorm, Autumn Forest, Harvest Fields
+        h3 New Backgrounds Revealed: Thunderstorm, Autumn Forest, Harvest Fields
         p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop!</a> Now your avatar can conduct lightning in a Thunderstorm, stroll through an Autumn Forest, or cultivate their Harvest Fields!
         p.small.muted by krajzega and Uncommon Criminal
 
-  h4 9/1/2014
+  h2 9/1/2014
   table.table.table-striped
     tr
       td
-        h5 September Mystery Item
+        h3 September Mystery Item
         p Hmm, intriguing... All Habiticans who are subscribed during the month of September will receive the September Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
 
-  h4 8/31/2014
+  h2 8/31/2014
   table.table.table-striped
     tr
       td
-        h5 Last Day For Sun Sorcerer Item Set
+        h3 Last Day For Sun Sorcerer Item Set
         p Reminder: this is the final day to subscribe and receive the Sun Sorcerer Item Set! If you want the Sun Crown or the Sun Robes, now's the time! Thanks so much for your support <3
 
-  h4 8/26/2014 - August Mystery Item, Sortable Tags, Push To Top
+  h2 8/26/2014 - August Mystery Item, Sortable Tags, Push To Top
   table.table.table-striped
     tr
       td
-        h5 August Item Set Revealed!
+        h3 August Item Set Revealed!
         .promo_mystery_201408.pull-right
         p The August Subscriber Item has been revealed: the Sun Sorcerer Item Set! All August subscribers will receive the Sun Crown and the Sun Robes. You still have five days to subscribe and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         p.small.muted by Lemoness
     tr
       td
-        h5 Sortable Tags
+        h3 Sortable Tags
         p You can now sort your tags. Drag left-to-right and drop them into place.
         p.small.muted by Fandekasp, lefnire
     tr
       td
-        h5 Push to Top
+        h3 Push to Top
         p We've added a small button in your tasks' one-click actions: Push to Top. This will help easily you sort your day's priorities, which may change from day-to-day.
         p.small.muted by negue
 
-  h4 8/19/2014 - Parrot Quest, Audio, And Mobile App Update!
+  h2 8/19/2014 - Parrot Quest, Audio, And Mobile App Update!
   table.table.table-striped
     tr
       td
-        h5 New Pet Quest: Help! Harpy!
+        h3 New Pet Quest: Help! Harpy!
         p There's a new Pet Quest available in the <a href='https://habitrpg.com/#/options/inventory/drops'>Market</a>! @UncommonCriminal is being held hostage by a Parrot-like Harpy. If you can find a way to help, you'll definitely get your hands on some coveted Parrot Eggs....
         p After you've purchased the scroll, battle the Boss by completing Habits and To-Dos. Be careful - every Daily that you skip will cause the Boss to attack your party!
         p.small.muted by Uncommon Criminal and Token
     tr
       td
-        h5 Audio
+        h3 Audio
         p You can now enable sound effects for various website actions. Click the volume icon (<span class='glyphicon glyphicon-volume-off'></span>) and choose an "Audio Theme". For now, the only theme available is "Daniel The Bard" (@DanielTheBard designed this set); however, we'll release more themes over time (<a href='http://habitrpg.wikia.com/wiki/Guidance_for_Bards' target='_blank'>get involved here</a>). We'll also add more sound effects, and possibly music, to the current set.
         p.small.muted by DanielTheBard, Fandekasp
 
     tr
       td
-        h5 New Mobile Update: Backgrounds and Guilds!
+        h3 New Mobile Update: Backgrounds and Guilds!
         p We've updated the mobile app to include Backgrounds and Guilds! Now you can use the mobile app to join common interest groups, chat with like-minded people, and swap your avatar’s background. The iOS app is <a href='https://itunes.apple.com/us/app/habitrpg/id689569235?mt=8' target='_blank'>here</a>, and the Android app is <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg&hl=en' target='_blank'>here</a>. If you enjoy the direction that we’ve been taking the app, we would really appreciate it if you would leave us a review <3 Thank you!
         p.small.muted by huarui, paglias
 
-  h4 8/12/2014
+  h2 8/12/2014
   table.table.table-striped
     tr
       td
-        h5 New Equipment Quest: Attack Of The Mundane!
+        h3 New Equipment Quest: Attack Of The Mundane!
         p There's a new Quest that will drop automatically for all users level 15 and up: the Dish Disaster, first quest in the Attack of the Mundane Questline! Scrub enchanted dirty dishes, battle the SnackLess Monster, and face off against the Evil Laundromancer. You might just be rewarded with a new piece of armor...
         p As you complete each quest in this questline, you will be awarded with the quest scroll for the next part. There are three parts in total. Good luck!
         small.muted by Arcosine, Kiwibot, Lemoness, Daniel the Bard, itokro
 
-  h4 8/6/2014
+  h2 8/6/2014
   table.table.table-striped
     tr
       td
-        h5 New Backgrounds Revealed: Volcano, Dusty Canyon, Clouds
+        h3 New Backgrounds Revealed: Volcano, Dusty Canyon, Clouds
         p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can heat up inside a Volcano, wander through a Dusty Canyon, or soar through the Clouds!
 
-  h4 8/4/2014
+  h2 8/4/2014
   table.table.table-striped
     tr
       td
-        h5 New Mobile Update: Checklist Editing And Bug Fixes!
+        h3 New Mobile Update: Checklist Editing And Bug Fixes!
         p In case you missed it, we’ve released a new mobile update! You can edit checklists from the mobile app now. We also fixed some bugs, including the image problems on iOS! The Android app is <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg&hl=en' target='_blank'>here</a> and the iOS app is <a href='https://itunes.apple.com/us/app/habitrpg/id689569235?mt=8' target='_blank'>here</a>.
         p You may have noticed that we've been releasing lots of updates recently. This is greatly due to two awesome members of our team!
         p The first is superstar contributor Matteo, aka <a href='https://github.com/paglias' target='_blank'>paglias</a>. In addition to the mobile app, he contributes tons of code to the site, runs translations, and fixes bugs without blinking. We are so thankful to have him on the team!
         p We also have another new mobile app contributor who has rocketed to Level 7 in record time: <a href='https://github.com/huaruiwu' target='_blank'>huarui</a>! Huarui has been an absolute whirlwind with mobile app improvements.
         p Give them both a giant round of applause!
 
-  h4 8/2/2014
+  h2 8/2/2014
   table.table.table-striped
     tr
       td
-        h5 Dread Drag'on Defeated! Prizes: Mantis Shrimp Pet, Mantis Shrimp Mount, Food, and Badge
+        h3 Dread Drag'on Defeated! Prizes: Mantis Shrimp Pet, Mantis Shrimp Mount, Food, and Badge
         p We've done it!
         p With a final last roar, the Dread Drag'on collapses and swims far, far away. Crowds of cheering Habiticans line the shores! We've helped Daniel rebuild his Tavern.
         p But what's this?
@@ -1654,54 +1654,54 @@ mixin oldNews
         p "As a thank you," says his friend @Ottl, "Please accept this Mantis Shrimp pet and Mantis Shrimp mount, this feast, and our eternal gratitude!"
     tr
       td
-        h5 August Mystery Item
+        h3 August Mystery Item
         p Ooh, mysterious! All Habiticans who are subscribed during the month of August will receive the August Mystery Item Set! It will be revealed on the 26th, so keep your eyes peeled. Thanks for supporting the site <3
 
-  h4 7/31/2014
+  h2 7/31/2014
   table.table.table-striped
     tr
       td
-        h5 Last Day for July Subscriber Set
+        h3 Last Day for July Subscriber Set
         .promo_mystery_201407.pull-right
         p Reminder: this is the final day to subscribe and receive the Undersea Explorer Item Set! If you want the Undersea Explorer Helm or the Undersea Explorer Suit, now's the time! Thank you so much for your support <3
     tr
       td
-        h5 Final Day for Limited Edition Summer Outfits
+        h3 Final Day for Limited Edition Summer Outfits
         p Today is the last day of the Summer Splash Event, so it is the last day to buy the Limited Edition Outfits and the Rainbow Warrior Armor from the Rewards store. Get productive and spend that gold!
 
   hr
-  h4 7/25/2014
+  h2 7/25/2014
   table.table.table-striped
     tr
       td
-        h5 July Subscriber Item
+        h3 July Subscriber Item
         .promo_mystery_201407.pull-right
         p The July Subscriber Item has been revealed: the Undersea Explorer Item Set! All July subscribers will receive the Undersea Explorer Helm and the Undersea Explorer Suit. You still have six days to subscribe and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
 
   hr
-  h4 7/16/2014
+  h2 7/16/2014
   table.table.table-striped
     tr
       td
-        h5 Mobile App Update
+        h3 Mobile App Update
         p We’ve released another update to the mobile app! Now you can feed and select pets from the app. Carry your cute pets with you everywhere you go! The app is available for <a href='https://itunes.apple.com/us/app/habitrpg/id689569235?mt=8' target='_blank'>iOS here</a>, and <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg' target='_blank'>Android here</a>. We’re continuing to release updates on a regular basis, so if you like the direction that we’ve been taking the app, please do consider leaving us a review. Thank you!
     tr
       td
-        h5 Neglect Strike: Tavern Art Swap
+        h3 Neglect Strike: Tavern Art Swap
         p The Dread Drag'on's Rage Bar has filled, and it has unleashed its Neglect Strike, leading to a new look for the Tavern! As a reminder, the Drag'on's rage will NEVER hurt any users or interfere with their ability to be productive, so the chat and inn are still functional. Even so... poor Daniel!
         p All users are automatically damaging the Drag'on with their tasks. There is nothing bad that can happen to you or your account by being in this fight!
     tr
       td
-        h5 Dread Drag'on Prize Change: Food Reward!
+        h3 Dread Drag'on Prize Change: Food Reward!
         p We've received a lot of feedback due to the weekend's confusion, and it seems that awarding GP and XP for defeating the world boss significantly unbalanced the game for newer players. Based on your feedback, XP and GP will no longer be awarded. Instead, players will receive an assortment of food! The Mantis Shrimps will still be awarded.
         p If you were looking forward to receiving the 900XP and 90 GP upon completion of the battle, feel free to award it to yourself using Settings > Site > Fix Character Values when the battle is done!
         p Thank you for bearing with us through the confusion. We love you guys.
   hr
-  h4 7/12/2014
+  h2 7/12/2014
   table.table.table-striped
     tr
       td
-        h5 Wow, What'S Going On?!
+        h3 Wow, What'S Going On?!
         p You may have noticed some strange things happening - extra gold? Drag'on defeated? No quest damage?
         br
         p Turns out the Dread Drag'on of Dilatory was harder to handle than we expected, and wreaked havoc on us last night by unexpectedly completing due to a glitch, throwing off party quest damage, and granting all of its rewards early! *shakes fist at terrible beast*
@@ -1720,61 +1720,61 @@ mixin oldNews
   table.table.table-striped
     tr
       td
-        h5 July 11th: GaymerX reminder
+        h3 July 11th: GaymerX reminder
         p Reminder: Vicky (aka redphoenix) is at GaymerX at the InterContinental in San Francisco this weekend! She will have lots of promo codes for the Unconventional Armor Set. Our champion moderator Ryan will be there, too, and would love to meet you guys! Vicky will be wearing a dinosaur hoodie and a red shirt, and Ryan has a partially-shaved head and is in a wheelchair.
         br
         p There will be an official HabitRPG meet-up on <strong>Saturday 3:15-4:30</strong> outside GX Panel Room A (Grand Ballroom AB (3F)). Come get your promo codes there! If you can't make it at that time, contact Vicky via email (vicky@habitrpg.com) or Twitter (@caffeinatedvee) to coordinate an alternative time and place to meet up at the convention!
   small.muted 7/11/2014
   hr
 
-  h4 7/9/2014
+  h2 7/9/2014
   table.table.table-striped
     tr
       td
-        h5 Happy Derby Day!
+        h3 Happy Derby Day!
         p In celebration of Derby Day, all Habiticans have received a seahorse egg! On this day, the worst of Habitica's ancient bugs were defeated, and so every year we celebrate. Let's ride through Dilatory on this fun day.
-        h5 New Pet Quest: Seahorse!
+        h3 New Pet Quest: Seahorse!
         p But oh, no - it looks like a wild Sea Stallion is disrupting the races! Quickly, battle the Sea Stallion to calm him down, and you might just get your hands on some additional seahorse eggs...
         p.small.muted - by Kiwibot and Lemoness
-        h5 Updated Stats Bars
+        h3 Updated Stats Bars
         p Based on your feedback, we’ve updated the design of the new status bars with an 8-bit style and improved accessibility.
         p.small.muted - by BenManley
 
   hr
-  h4 7/3/2014
+  h2 7/3/2014
   table.table.table-striped
     tr
       td
-        h5 New backgrounds available: Coral Reef, Open Waters, Seafarer Ship
+        h3 New backgrounds available: Coral Reef, Open Waters, Seafarer Ship
         p Three new avatar backgrounds are available in the Background Shop! Now your avatar can swim in a <strong>coral reef</strong>, enjoy the <strong>open waters</strong>, or sail aboard a <strong>Seafarer Ship</strong>. Thanks so much for supporting the site!
     tr
       td
-        h5 Next Convention: GaymerX!
+        h3 Next Convention: GaymerX!
         p HabitRPG's own Vicky Hsu will be at GaymerX, a game convention celebrating LGBTQ and gaming which is open to everyone, at the InterContinental in downtown San Francisco on July 11-13. (For more information, check out gaymerx.com!) Vicky will be giving away promo codes for the UnConventional Armor Set, so if you want to meet up with her (and snag some awesome capes), send a message to vicky@habitrpg.com or @caffeinatedvee on Twitter!
     tr
       td
-        h5 Rainbow Warrior Set!
+        h3 Rainbow Warrior Set!
         p Even if you can't make it to the convention, you can still enjoy the two new armor pieces available for free in the Rewards Store: the Rainbow Warrior Helm and the Rainbow Warrior Armor! They were designed by our GaymerX friends and they look awesome. They'll be available until the end of the month, so enjoy!
 
   hr
-  h4 7/1/2014
+  h2 7/1/2014
   table.table.table-striped
     tr
       td
-        h5 WORLD BOSS: The Dread Drag'on of Dilatory!
+        h3 WORLD BOSS: The Dread Drag'on of Dilatory!
         p We should have heeded the warnings.
         p Dark shining eyes. Ancient scales. Massive jaws, and flashing teeth. We've awoken something horrifying from the crevasse: **the Dread Drag'on of Dilatory!** Screaming Habiticans fled in all directions when it reared out of the sea, its terrifyingly long neck extending hundreds of feet out of the water as it shattered windows with its searing roar.
         p "This must be what dragged Dilatory down!" yells Lemoness. "It wasn't the weight of the neglected tasks - the Dark Red Dailies just attracted its attention!"
         p "It's surging with magical energy!" @Baconsaur cries. "To have lived this long, it must be able to heal itself! How can we defeat it?"
         p Why, the same way we defeat all beasts - with productivity! Quickly, Habitica, band together and strike through your tasks, and all of us will battle this monster together. (There's no need to abandon previous quests -  we believe in your ability to double-strike!) It won't attack us individually, but the more Dailies we skip, the closer we get to triggering its Neglect Strike - and I don't like the way it's eyeing the Tavern....
   hr
-  h4 6/30/2014
+  h2 6/30/2014
   table.table.table-striped
     tr
       td
-        h5 Last day for June Item Set!
+        h3 Last day for June Item Set!
         p Reminder: this is the final day to subscribe and receive the Octomage Item Set! If you want the Octopus Robe or the Tentacle Helm, now's the time! Thanks so much for your support <3
-        h5 Dilatory Update
+        h3 Dilatory Update
         p PLEASE! Habiticans, stop  exploring the dark crevasse!!! Lemoness is really getting worried. There have been.... reports.
         p Reports of something big.
         p Reports of something terrifying.
@@ -1782,45 +1782,45 @@ mixin oldNews
         p Besides, exploring the dark and dangerous crevasse has become a source of procrastination. Let's get back to work, people!
 
   hr
-  h4 6/25/2014
+  h2 6/25/2014
   table.table.table-striped
     tr
       td
-        h5 June Subscriber Item
+        h3 June Subscriber Item
         .pull-right.promo_mystery_201406.png
         p The June Subscriber Item has been revealed: the Octomage Item Set!  All June subscribers will receive the Octopus Robe and the Crown of Tentacles. You still have six days to subscribe and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
-        h5 Mobile App Update
+        h3 Mobile App Update
         p There's a new mobile app update available! In addition to bug fixes, there are many improvements, including a new button-based menu, tap-and-hold to edit tasks, and the return of stats and in-app avatar customization! Working on the mobile app is our biggest To-Do this summer, so expect more in the coming months. If you feel that the app is improving, we'd love it if you would take the time to give us a review and let us know what you think!
-        h5 Dilatory Update
+        h3 Dilatory Update
         p It's great to see Habiticans having fun exploring the ruins! There's just one small thing Lemoness wants us to avoid. She's noticed a lot of Habiticans trying to explore the fallen palace of the other side of the dark crevasse. She really doesn't feel that the crevasse is safe, so please don't swim so close. Other than that, enjoy your explorations!
 
   hr
-  h4 6/21/2014
+  h2 6/21/2014
   table.table.table-striped
     tr
       td
-        h5 Summer Mystery Update
+        h3 Summer Mystery Update
         p Lady Lemoness has returned at last! She startled beach-goers by charging up out of the waves and onto the shore, shouting "I found it!!! I found it!!! Oh, I just KNEW that citing it as impossible would make it a narrative probability!"
         p Wait - found what?
-        h5 Summer Splash Event: The Lost City Of Dilatory!
+        h3 Summer Splash Event: The Lost City Of Dilatory!
         p Dilatory was a lovely island city of ancient Habitica. It was a prosperous place, but as the wealth of the city grew, the inHabitants grew lazy and procrastinated on their Dailies and To-Dos... until the combined weight of their dark red tasks triggered a massive earthquake that sunk the city. Legends say that all of the inHabitants were transformed into sea creatures.
         p The location of this city was lost to time... until now!
-        h5 Limited Edition Outfits!
+        h3 Limited Edition Outfits!
         p What's the fun of an underwater city if you can't explore it? Luckily, from now until July 31st, special Limited Edition Outfits are available for gold in the Rewards store! Spellcasters can transform themselves into <strong>Emerald Mermages</strong> and <strong>Reef Seahealers</strong> to swim among the ruins, while fighters may prefer to dress as <strong>Roguish Pirates</strong> and <strong>Daring Swashbucklers</strong>, riding above the city on magnificent ships. Work hard, and you can join them!
-        h5 NPC Dress-up
+        h3 NPC Dress-up
         p The NPCs got so excited about the discovery of Dilatory that they've moved over there for the summer! Daniel the Innkeeper has opened a beachside tavern, and Alex is also selling by the shore! Meanwhile, Justin the Guide is giving tours aboard boats, Ian is dispensing quest wisdom from the deep ocean, Matt has opened stables for aquatic pets, and I am swimming about keeping everyone informed!
-        h5 But what caused the Earthquake?
+        h3 But what caused the Earthquake?
         p Only one piece of the mystery remains unsolved - what caused the second earthquake that unearthed the ancient Dailies? After all, the earthquake that destroyed Dilatory was caused by a build up of undone Dailies and To-Dos, wasn't it?
         p But *we've* all been doing our tasks...
 
   hr
-  h4 6/14/2014
+  h2 6/14/2014
   table.table.table-striped
     tr
       td
-        h5 New Feature: Backgrounds!
+        h3 New Feature: Backgrounds!
         p We're debuting a brand-new feature - backgrounds for your avatar! Stroll through a Summer Forest, lounge upon a warm Beach, or dance in a Fairy Ring. You can buy the backgrounds in the new Background tab, under User. Have fun!
-        h5 Summer Mystery Update
+        h3 Summer Mystery Update
         p It's been a while since we've seen Lemoness around - she's been a bit scarce since she started trying to decipher those ancient Dailies. We just stopped by her hut to check on her and found her..... missing?
         br
         p It looked like she'd taken her armor-enchanting crochet hook, but little else. There was a single scrawled note on the table: "I think I've translated it!!!! If I'm right, this is going to be QUITE the summer. Verifying claims - be back soon!!!"
@@ -1829,33 +1829,33 @@ mixin oldNews
   small.muted 6/14/2014
 
   hr
-  h4 6/10/2014
+  h2 6/10/2014
   table.table.table-striped
     tr
       td
-        h5 New Pet Quest: The Call Of Octothulu!
+        h3 New Pet Quest: The Call Of Octothulu!
         p There's a new pet in town! The dreaded Octothulu, sticky spawn of the stars, has emerged from a whirlpool in a dark cave by the sea. It's up to you and your party to banish the foul beast by being extra-productive! If you manage to defeat it, you might just find some octopus eggs...
-        h5 Earthquake Update
+        h3 Earthquake Update
         p Remember the strange earthquake we had recently? Well, this probably isn't related in any way, but Habiticans have recently noticed some mysterious black Dailies strewn along the beaches. Lemoness happily reports that they are scrawled upon with an ancient language, and that she is hard at work deciphering the script. More news as this develops!
 
   hr
-  h4 6/5/2014
+  h2 6/5/2014
   table.table.table-striped
     tr
       td
-        h5 June Mystery Item
+        h3 June Mystery Item
         p Wow, what could it be? All Habiticans who are subscribed during the month of June will receive the June Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
     tr
       td
-        h5 What Was That?
+        h3 What Was That?
         p Yikes! A mysterious earthquake has rocked Habitica! Luckily, nobody was hurt and there was no real damage, but our scholars are baffled. "We're not even IN a seismic zone," Lady Lemoness was heard muttering as she paged through an enormous tome. "There hasn't been an earthquake since.... but no, that's impossible." Well, if Lemoness says so, it must be true! Seems like it was just a false alarm.
 
   hr
-  h4 5/23/2014
+  h2 5/23/2014
   table.table.table-striped
     tr
       td
-        h5 May Mystery Outfit Revealed!
+        h3 May Mystery Outfit Revealed!
         .pull-right.promo_mystery_201405.png
         p The May Mystery Item Set has been revealed for all subscribers... <strong>Flame Wielder Item Set</strong>! All people who are subscribed this May will receive two items:
         ul
@@ -1865,25 +1865,25 @@ mixin oldNews
 
 
   hr
-  h4 5/14/2014
+  h2 5/14/2014
   table.table.table-striped
     tr
       td
-        h5 The Rat King
+        h3 The Rat King
         p Habitica's streets are filled with the skittering of little paws... looks like there's a new Pet Quest available in the Market! Can you and your party defeat the Rat King? If so, there will be some eggs to reward you...
         small.muted By: Pandah and Token
     tr
       td
-        h5 Level Cap Lifted
+        h3 Level Cap Lifted
         p You can now level up beyond 100, the 100-cap has been lifted!
         small.muted By: Ryan
 
   hr
-  h4 5/5/2014
+  h2 5/5/2014
   table.table.table-striped
     tr
       td
-        h5 Mobile Update
+        h3 Mobile Update
         p The new iOS update is live! <a href='https://itunes.apple.com/us/app/habitrpg/id689569235?mt=8' target='_blank'>You can download it here</a>. If you have Android, <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg' target='_blank'>the update is available here.</a>
         br
         p Note: to edit a task or view checklists, swipe left on the task. We're <a href='https://github.com/HabitRPG/habitrpg-mobile/issues/199' target='_blank'>working on click-to-view</a>, we'd love some developer help!
@@ -1891,48 +1891,48 @@ mixin oldNews
         p If you think the new app is an improvement, please consider rating us - many of our old reviews were (justifiably!) pretty low, especially on Apple, but we feel that this update is the first in a line of major improvements. Thanks for sticking with us!
     tr
       td
-        h5 The HabitRPG Chrome Extension
+        h3 The HabitRPG Chrome Extension
         p Great news - we've fixed our Chrome Extension! Many thanks to new contributor <a href='https://github.com/HabitRPG/habitrpg-chrome/pull/88' target='_blank'>@GoldBattle<a/>. Now you can set the times and dates you want to only browse productive sites. If you're procrastinating, it will automatically start docking your character's health; if you're hard at work, it will reward you with GP and XP! <a href='https://chrome.google.com/webstore/detail/habitrpg/pidkmpibnnnhneohdgjclfdjpijggmjj' target='_blank'>Read more about it here.</a>
     tr
       td
         p Also, a quick change - May's mystery item will now be revealed on the 23rd, instead of the 25th. Rejoice, impatient Habiticans!
 
   hr
-  h4 4/30/2014
+  h2 4/30/2014
   table.table.table-striped
     tr
       td
-        h5 May Mystery Item
+        h3 May Mystery Item
         p Ooh, how mysterious! All Habiticans who are subscribed during the month of May will receive the May Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
   hr
-  h4 4/30/2014
+  h2 4/30/2014
   table.table.table-striped
     tr
       td
-        h5 Mobile Update
+        h3 Mobile Update
         p Great news! We've just released a big upgrade to our mobile app. One of our biggest priorities right now is improving the HabitRPG mobile experience, so this is an important first step. We've upgraded the framework to Ionic, which means a cleaner look and smoother feel, and best of all, it is now easier for the developers to add new updates and features! <a href='http://blog.habitrpg.com/post/84100207996/habitrpg-mobile-on-ionic' target='_blank'>Read more about the upgrade here.</a>
         p The Android App is <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg' target='_blank'>available here</a>! The iOS app was submitted to the App Store, but Apple always takes a while to process things, so it may be a few more days. Let's hope they're quick this time around! We'll let you know when it goes through.
         p Have a productive day!
     tr
       td
-        h5 Spread the Word Challenge
+        h3 Spread the Word Challenge
         p Also, at long last the staff has finished sorting through the 1.5K+ participants in the Spread The World Challenge, and we are pleased (and so, so relieved) to finally announce a winner!
         p Congratulations to ALEX KRALIE, the winner of the Spread The Word Challenge! 47K+ notes is truly momentous.
         p A warm congratulation is also due to the runner-ups: sarahtyler, HannahAR, Raiyna, thefandomsarecool, Chickenfox, Anrisa Ryn, frabajulous, galdrasdottir, Judith Meyer, jazzmoth, RavenclawKiba, daraxlaine, Phiso, Billieboo, Victor Fonic, nikoftime, Aedra, amBarthes, and thaichicken! You guys are great <3 Thanks for helping to get the word out about HabitRPG!
     tr
       td
 
-        h5 Spring Fling
+        h3 Spring Fling
         p Reminder that today, 4/30, is the LAST DAY of the Spring Fling event! After today, you will no longer be able to purchase the Pastel Hair Set or the Limited-Edition class items. Additionally, the Egg Hunt scroll will no longer be available in the Market, although if you have started the quest, it will NOT disappear and you will be able to complete it at your leisure.
         p It is also the last day to get the Twilight Butterfly Item Set before it disappears forever! If you want the Twilight Butterfly Wings or the Twilight Butterfly head accessory, this is your last chance to subscribe and get them.
         p Happy Spring!
 
   hr
-  h4 4/25/2014
+  h2 4/25/2014
   table.table.table-striped
     tr
       td
-        h5 April Mystery Outfit Revealed!
+        h3 April Mystery Outfit Revealed!
         //-img.pull-right(src='/marketing/promos/April14SAMPLE2.png')
         p The April Mystery Item Set has been revealed for all subscribers... <strong>Twilight Butterfly Armor Set</strong>! All people who are subscribed this April will receive two items:
         ul
@@ -1941,31 +1941,31 @@ mixin oldNews
         p You still have five more days to subscribe and get the item set. Thank you all for supporting us! We love you <3
 
   hr
-  h4 4/6/2014
+  h2 4/6/2014
   table.table.table-striped
     tr
       td
-        h5 The Great Egg Hunt
+        h3 The Great Egg Hunt
         p A new quest is available in the Market between now and April 30th. Anyone who signed up before April 7th has one in their inventory free!
 
   hr
-  h4 4/3/2014
+  h2 4/3/2014
   table.table.table-striped
     tr
       td
-        h5 Limited Edition Pastel Hair Color Set
+        h3 Limited Edition Pastel Hair Color Set
         p A new set of hair colors has been released: the Pastel Set! Now your avatar can have flowing locks in Pastel Blue, Pastel Pink, Pastel Purple, Pastel Orange, Pastel Green, or Pastel Yellow! You will only be able to purchase these hair colors until April 30th, so don't miss out!
 
   hr
-  h4 4/2/2014
+  h2 4/2/2014
   table.table.table-striped
     tr
       td
-        h5 April Mystery Item
+        h3 April Mystery Item
         p  What could it be? All people who are subscribed during the month of April will receive the April Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled.
 
   hr
-  h4 April F... irst
+  h2 April F... irst
   table.table.table-striped
     tr
       td
@@ -1975,7 +1975,7 @@ mixin oldNews
         small.muted By @lemoness and @baconsaur
 
   hr
-  h4 03/31/2014
+  h2 03/31/2014
   table.table.table-striped
     tr
       td
@@ -1983,11 +1983,11 @@ mixin oldNews
 
 
   hr
-  h4 03/25/2014
+  h2 03/25/2014
   table.table.table-striped
     tr
       td
-        h5 March Mystery Item Set
+        h3 March Mystery Item Set
         //-img.pull-right(src='/marketing/promos/201403_Forest_Walker.png')
         p The March Mystery Item Set has been revealed for all subscribers... The Forest Walker Set! All people who are subscribed this March will receive two items: <strong>Forest Walker Armor</strong> and <strong>Forest Walker Antlers</strong>!
         br
@@ -1996,70 +1996,70 @@ mixin oldNews
         p You still have five more days to subscribe and get the item set. Thank you all for supporting us! We love you <3
     tr
       td
-        h5 PayPal Subscriptions
+        h3 PayPal Subscriptions
         p We've added PayPal as a payment method for subscriptions. We still recommend the <strong>Card</strong> method, as <a href='https://stripe.com/' target='_blank'>Stripe</a> (the processor we use) has a more stable API and better account management tools. However, we realize not everyone owns a credit/debit card, so there's PayPal for ya!
 
   hr
-  h4 03/22/2014
+  h2 03/22/2014
   table.table.table-striped
     tr
       td
-        h5 Spring Fling Event
+        h3 Spring Fling Event
         p Spring has come to Habitica, and flowers have sprouted everywhere: in the Stables, in the Marketplace... and even in your character customization pages!
     tr
       td
-        h5 Head Accessories
+        h3 Head Accessories
         p That's right - we've introduced Head Accessories! Your avatar can now bedeck their helms with colorful flowers. And that's not the only place to get head accessories….
     tr
       td
-        h5 Limited Edition Class Outfits
+        h3 Limited Edition Class Outfits
         p The Spring 2014 Limited Edition Class Outfits have been released!
         p From now until April 30th, you will be able to use your gold to buy your current class' armor set from the Rewards store! You can be a Stealthy Kitty, a Mighty Bunny, a Magic Mouse, or a Loving Pup. If you switch classes (system unlocked at level 10), you will gain access to your new classes' armor set. Make sure to collect yours first, though!
         p What are you waiting for? Go be productive and earn some gold!
     tr
       td
-        h5 New Un-Equip Mechanic
+        h3 New Un-Equip Mechanic
         p Now to un-equip your gear, click the same item that you have currently equipped. We removed the "Base Equipment" tier for consistency with how un-equipping pets & mounts is handled, and to easily support adding new gear types.
     tr
       td
-        h5 Pet Quest: The Ghost Stag
+        h3 Pet Quest: The Ghost Stag
         p The meadows of Habitica are bursting with flowers, sunshine, and.... ominous mist? Looks like a ghost stag is keeping winter alive! Defeat him, and maybe you'll get an egg or three....
     tr
       td
-        h5 And More To Come...
+        h3 And More To Come...
         p This is only the beginning of all the treats that we've got in store for you. Stay tuned - and happy Spring Fling!
 
   hr
-  h4 03/18/2014
+  h2 03/18/2014
   table.table.table-striped
     tr
       td
-        h5 New Pet Quest Mechanics
+        h3 New Pet Quest Mechanics
         p Great news - now it is easier to complete the Quest Pet sets! Pet Quest  Bosses will now drop 3 eggs instead of 2. Additionally, after you have defeated a Pet Quest Boss two times, those eggs will be gem-purchasable in the market like all other eggs, so that your party doesn't have to replay the same quest over and over :)
     tr
       td
-        h5 WonderCon
+        h3 WonderCon
         p HabitRPG will be attending WonderCon from April 18th-20th! Come say hi to Tyler, Leslie, and Vicky, and chat about productivity and games. Tickets are available <a href='http://www.comic-con.org/wca/2014/badge-sale' target='_blank'>here</a>.
         p All the users who visit our booth will receive the <a href='http://goo.gl/2urFUt' target='_blank'>Unconventional Armor Accessory Set</a>! (It will also be available if we attend other cons in the future.)
     tr
       td
-        h5 LifeHacker Poll
+        h3 LifeHacker Poll
         p HabitRPG is in the running to be Lifehacker's #1 To-Do list manager! We've got some tough competition, so if you like our site, please help us out <a href='http://lifehacker.com/5924093/five-best-to-do-list-managers' target='_blank'>by voting for us here</a> <3
 
   hr
-  h4 03/02/2014
+  h2 03/02/2014
   table.table.table-striped
     tr
       td
-        h5 March Mystery Item
+        h3 March Mystery Item
         p Happy March! The awesome people who subscribe to HabitRPG will now receive the limited-edition March mystery item! The mystery item set will contain a stats-free costume piece that will <strong>only</strong> be available to the people who are subscribers this March. The set will be revealed on the 25th to everyone, but all people who are subscribers during the month of March will receive it. Get excited - and thank you so much for helping to support HabitRPG! We love you.
     tr
       td
-        h5 Hedgehog Quest
+        h3 Hedgehog Quest
         p A new pet has been introduced, the Hedgehog. You can find some eggs by battling the Hedgebeast Boss, a quest scroll available in the market.
 
   hr
-  h4 02/22/2014
+  h2 02/22/2014
   table.table.table-striped
     tr
       td
@@ -2076,68 +2076,68 @@ mixin oldNews
 
 
   hr
-  h4 02/18/2014
+  h2 02/18/2014
   table.table.table-striped
     tr
       td
-        h5 Translations
+        h3 Translations
         p Translations are well underway! Many of you should already be seeing HabitRPG in your own languages. If not, head <a href='https://trello.com/c/SvTsLdRF/12-translations' target='_blank'>here</a> to see your language's progress or to help translate.
         p
           small.muted by @paglias, @Sinza-, @Luveluen, and more.
     tr
       td
-        h5 BountySource
+        h3 BountySource
         p We’ve started using BountySource, a service which lets users post bounties on bug fixes and feature requests. Any features or bugs in HabitRPG you’ve been dying to see resolved? <a href='https://www.bountysource.com/teams/habitrpg/issues' target='_blank'>Post a bounty</a> to attract contributor attention. <a href='http://blog.habitrpg.com/post/76898655192/bountysource' target='_blank'>Read more here</a>.
         p
           small.muted by @Cole, @lefnire, @Ryan
 
   hr
-  h4 02/13/2014
+  h2 02/13/2014
   table.table.table-striped
     tr
       td
-        h5 Happy Valentine's Day!
+        h3 Happy Valentine's Day!
         p Help motivate all of the lovely people in your life by sending them a caring valentine. Valentines can be purchased for 10 gold from the Item Store. For spreading love and joy throughout the community, both the giver AND the receiver get a coveted "adoring friends" badge. Hooray!
         p
           small.muted By Lemoness and zoebeagle
 
 
   hr
-  h4 02/12/2014
+  h2 02/12/2014
   table.table.table-striped
     tr
       td
-        h5 Chat & Invite Notifications
+        h3 Chat & Invite Notifications
         p Chat & group-invitation notifications are back! Miss them? They currently work for all chat updates in parties & guilds. Any devs willing to jump into @tagging in Tavern, <a href='http://goo.gl/uhcjkg' target='_blank'>see here</a>.
     tr
       td
-        h5 Toolbar
+        h3 Toolbar
         p In order to make room for these notifs, we added a toolbar above the header. You can collapse the toolbar (far-right icon), but take care as Bailey notifs are inside the toolbar!
   hr
-  h4 02/07/2014
+  h2 02/07/2014
   table.table.table-striped
     tr
       td
-        h5 February Mystery Item
+        h3 February Mystery Item
         p
           .pull-right.inventory_present
           | We're excited to announce a new feature a s a big thank-you to the awesome people who <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribe</a> to HabitRPG! Every month, all subscribers will now receive a limited-edition mystery item! The mystery item will be a stats-free costume piece (like the Absurd Party Robes) that will <strong>only</strong> be available to the people who are subscribers each month. The February 2014 item will be revealed on the 23rd to everyone, but all people who are subscribers during the month of February will receive it. <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>Subscribe now</a>, get excited, and thank you so much for helping to support HabitRPG! We love you.
     tr
       td
-        h5 Critical Hammer Of Bug-Crushing
+        h3 Critical Hammer Of Bug-Crushing
         p
           .pull-right.weapon_special_critical
           | Some of you may have noticed that we periodically have some bugs that are nastier than the norm - the dreaded critical bugs. These monstrous apparitions have been snapping at the heels of many a player. For updates on what we're currently working on to improve site stability, read <a href='https://github.com/HabitRPG/habitrpg/issues/milestones' target='_blank'>this link</a> - and then jump in to help!  Not only will programming assistance reward you with the usual contributor levels, but if you actually manage to fix a bug marked <a href='http://goo.gl/v4DnzB' target='_blank'>"critical,"</a> you will now receive the <em>Critical Hammer of Bug-Crushing</em> as your reward!
     tr
       td
 
-        h5 Rainbow Hair Colors
+        h3 Rainbow Hair Colors
         p
           .pull-right.customize-option.hair_bangs_1_rainbow
           | Want to spruce up your avatar? Rainbow hair colors are now available! Dye your luscious locks purple, green, or even rainbow-striped, and passersby will look at you with envy.
     tr
       td
-        h5 Stability Update
+        h3 Stability Update
         p We've stabilized the site a lot (we're still working out kinks, but we're way better now). Follow the <a href='https://github.com/HabitRPG/habitrpg/issues/milestones' target='_blank'>progress here</a>, but here are some workarounds for now:
         ul
           li Click slower. <a href='https://github.com/HabitRPG/habitrpg/issues/2301#issuecomment-34398206' target='_blank'>VersionError</a> is caused by clicking things off too fast (we're working on a fix).
@@ -2147,37 +2147,37 @@ mixin oldNews
     small.muted By Lemoness, mariahm, crystalphoenix, aiseant, zoebeagle, cole, lefnire
 
   hr
-  h4 02/01/2014
+  h2 02/01/2014
   table.table.table-striped
     tr
       td
-        h5 Vice
+        h3 Vice
         p You awaken after the Winter Wonderland festivities and birthday celebrations with a smile. It's been a snowy, cheerful couple months, and the NPCs have finally returned to their normal attire. But today something is very wrong. Shadowy whisps cover the ground of Habitica, the sky has darkened. At the tavern you hear @DanielTheBard struming dark tales on his lute, and @Baconsaur peering into a mug, grumbling about her mounts swallowed in the shadows. They speak of the same thing: <strong>Vice</strong>, a dark an terrible foe. This new boss arc is a 3-part quest that requires level 30 to begin. Bring your strongest party members, and don't miss your dailies - there's a powerful weapon at the end!
         p
           small.muted by @baconsaur & @DanielTheBard
 
   hr
-  h4 01/30/2014
+  h2 01/30/2014
   table.table.table-striped
     tr
       td
-        h5 Happy Birthday, HabitRPG!
+        h3 Happy Birthday, HabitRPG!
         p The fair land of Habitica is two years old on January 31st! The NPCs are celebrating in style, and it looks like some of the staff is, too! Won't you join in?
     tr
       td
-        h5 Absurd Party Robtes
+        h3 Absurd Party Robtes
         p As part of the festivities, Absurd Party Robes are available free of charge in the Item Store! Swath yourself in those silly garbs and don your matching hats to celebrate this momentous day.
     tr
       td
-        h5 Delicious Cake
+        h3 Delicious Cake
         p What would a birthday be without birthday cake in a myriad of flavors? Of course, pets are very picky, but luckily Lemoness and her team of bakers have plenty of slices to go around. Mmm, delicious!
     tr
       td
-        h5 Last Day of Winter Wonderland Event
+        h3 Last Day of Winter Wonderland Event
         p Also, just a reminder - January 31st is the final day of the Winter Wonderland event, so it's your last day to get the Limited Edition Winter Hair Colors, the Winter Outfits, the snowballs, and the Trapper Santa and Find the Cub quest scrolls. Remember that mid-progress Trapper Santa and Find the Cub quests will not abort, nor will you lose your scrolls - they will simply be removed from Alexander's marketplace. We hope that you've had a wonderful winter!
     tr
       td
-        h5 Birthday Bash Badge
+        h3 Birthday Bash Badge
         p Finally, to commemorate the fun, all party participants receive a birthday badge! Polish it frequently and wear it fondly.
 
   p Thanks so much for being a part of the HabitRPG community. We love you guys, and we can't wait to have you at our sides in the upcoming year! Stay productive, Habiteers, and have an awesome day.
@@ -2185,31 +2185,31 @@ mixin oldNews
   p.muted By @lemoness
 
   hr
-  h4 01/28/2014
+  h2 01/28/2014
   table.table.table-striped
     tr
       td
-        h5 Group Plans
+        h3 Group Plans
         p We've begun adding <a href='/static/plans' targte='_blank'>plans for groups</a> (parents, teachers, health & wellness administrators, etc). These plans will provide group leaders with more control, privacy, security, and support. Currently only the Organization Plan (top tier) is available (due to tech limitations believe it or not), and we'll be releasing the Family & Group plans later. <a href='/static/plans' targte='_blank'>Click the "Contact Us" buttons</a> if you're interested, and we'll keep you updated!
     tr
       td
-        h5 Individual Plan
+        h3 Individual Plan
         p We've introduced a $5/mo basic subscription plan. It comes with a number of perks, which <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>you can see here</a>. We'll likely add more benefits over time, follow <a href='https://trello.com/c/euDUHPpn/371-basic-plan-subscription' target='_blank'>the conversation here</a>.
     tr
       td
-        h5 Perfect Day Achievement
+        h3 Perfect Day Achievement
         p Now when you complete all your dailies, you stack this badge, plus and additional perk: you get a +(level/2) buff to all stats!
     tr
       td
-        h5 <a href='/#/options/groups/challenges/95533e05-1ff9-4e46-970b-d77219f199e9' target='_blank'>Spread The Word Challenge</a> Update
+        h3 <a href='/#/options/groups/challenges/95533e05-1ff9-4e46-970b-d77219f199e9' target='_blank'>Spread The Word Challenge</a> Update
         p We have 1k+ submissions, holy cow! Great job everyone! Now, we need to go through these manually, so it will take a few days to a couple weeks to process. The challenge will stay open until we're done choosing our winners, but be sure to edit the To-Do with your submission URL before 1/31, as that's the cut-off date for processing. We'll send a Tweet out when the winner has been selected, so follow <a href='https://twitter.com/habitrpg' target='_blank'>@habitrpg</a> and stay tuned.
 
   hr
-  h4 01/25/2014
+  h2 01/25/2014
   table
     tr
       td
-        h5 Gryphon Quest
+        h3 Gryphon Quest
         p A new pet has been introduced, the Gryphon. You can find some eggs by battling the Fiery Gryphon Boss, a quest scroll available in the market.
         p
           small.muted Note: we'll be fixing the beast-master achievement to work from the original 90 in coming days. Fear not current beast-masters, you'll get sorted soon!
@@ -2218,69 +2218,69 @@ mixin oldNews
 
 
   hr
-  h4 01/16/2014
+  h2 01/16/2014
   table.table.table-striped
     tr
       td
-        h5 "Spread The Word" Challenge Updates
+        h3 "Spread The Word" Challenge Updates
         p If you're not yet participating, check out the <a target='_blank' href='/#/options/groups/challenges/95533e05-1ff9-4e46-970b-d77219f199e9'>Spread The Word Challenge</a>, which has a large prize and many winners. We've made some updates: upped the prize to 80 Gems for the top 20 posts, 100 Gems for the winner. Note: some people are listing their submission as a Tumblr reblog of someone else's post, often with added commentary. Though reblogs are greatly appreciated, we can only count original submissions. Read more <a target='_blank' href='/#/options/groups/challenges/95533e05-1ff9-4e46-970b-d77219f199e9'>challenge guidelines here</a>.
     tr
       td
-        h5 Quest Deadlines
+        h3 Quest Deadlines
         p To clear some confusion, you have until Jan 31, 2014 to <strong>purchase</strong> your quest scrolls, after 1/31 Alexander no longer sells them. You can still begin / finish your quests any time after. Thanks to @Cole, you're now allowed to purchase the Cub quest even if you haven't finished Trapper. Stock up!
 
   hr
-  h4 01/06/2014
-  h4 <a tooltip='Winter Wonderland Event' href='http://habitrpg.wikia.com/wiki/Winter_Wonderland' target='_blank'>WWE</a> Part 4: Winter Classes
+  h2 01/06/2014
+  h2 <a tooltip='Winter Wonderland Event' href='http://habitrpg.wikia.com/wiki/Winter_Wonderland' target='_blank'>WWE</a> Part 4: Winter Classes
   table.table.table-striped
     tr
       td
-        h5 Limited-Edition Winter Class Outfits
+        h3 Limited-Edition Winter Class Outfits
         p Happy winter! Instead of a boring pair of earmuffs, why not use the gold that you earned with all your hard work to buy a Limited Edition class outfit?
         p From now until January 31st, you will be able to use your gold to buy your current class' armor set from the Rewards store! You can be a Yeti Tamer, a Ski-Sassin, a Candy Cane Mage, or a Snowflake Healer. If you switch classes (system unlocked at level 10), you will gain access to your new classes' armor set. Make sure to collect yours first, though!
         p What are you waiting for? Go be productive and earn some gold!
         small.muted by @lemoness
     tr
       td
-        h5 Chat +1
+        h3 Chat +1
         p You can now +1 chat messages in Tavern, Guilds, & Parties
     tr
       td
-        h5 Halls
+        h3 Halls
         p We've added the "Hall of Heroes" and "Hall of Patrons" <a href='https://habitrpg.com/#/options/groups/hall/heroes' target='_blank'>here</a>, which list our project contributors and Kickstarter backers. Want be amongst those immortalized in the Hall of Heroes? <a href='http://habitrpg.wikia.com/wiki/Contributor_Rewards' target='_blank'>Lend us your sword!</a>
 
   hr
-  h4 12/31/2013
-  h4 Winter Wonderland Event Part 3: Party!
+  h2 12/31/2013
+  h2 Winter Wonderland Event Part 3: Party!
   table.table.table-striped
     tr
       td
-        h5 Happy New Year!
+        h3 Happy New Year!
         p Happy New Year! Join the NPCs and Staff in showing off your new Absurd party hat.... and have a great night!
         small.muted by @lemoness
     tr
       td
-        h5 Rebirth
+        h3 Rebirth
         p Nothing says New Year like a fresh start. Now when you reach level 50, Ultimate Gear, or BeastMaster, you can begin anew with the most prestigious of achievements: Rebirth. <a href='https://trello.com/c/SLiq4enr/333-rebirth-new-game' target='_blank'>Read more here</a>. But take heed! Scouts have reported <a href='https://github.com/HabitRPG/habitrpg/issues/945#issuecomment-31355229' target='_blank'>monster sightings</a>, harbinged by Trapper Santa. You may need all the strength you can muster come late January, Rebirth is for the hard-core.
         small.muted by @SabreCat
     tr
       td
-        h5 Checklists
+        h3 Checklists
         p <a href='https://trello.com/c/PJ1iJ413/65-checklists' target='_blank'>Checklists</a> are here! You can break your Dailies and To-Dos down into bite-size chunks. Their game mechanic takes some learning, so <a href='http://habitrpg.wikia.com/wiki/Checklist' target='_blank'>read more here</a>.
         small.muted by @lefnire
     tr
       td
-        h5 Task Icons & Markdown
+        h3 Task Icons & Markdown
         p Task titles now support Markdown and Emoji, so you can create something <a href='http://gyazo.com/f2021674925a79a1dec22101ef74a63c' target='_blank'>like this</a>. Read more <a href='https://trello.com/c/FCVdjdUd/102-task-reward-icons' target='_blank'>here</a>.
         small.muted by @lefnire
 
   hr
-  h4 12/25/2013
-  h4 Winter Wonderland Event Part 2: Rescue the Bears
+  h2 12/25/2013
+  h2 Winter Wonderland Event Part 2: Rescue the Bears
   table.table.table-striped
     tr
       td
-        h5 Quests & Bosses!
+        h3 Quests & Bosses!
         p A beast is roaring in the distant mountains, mysterious tracks have appeared in the snow. A new feature has been unlocked, <a href='https://trello.com/c/VPPjVRlF/212-quests-bosses' target='_blank'>Quests & Bosses</a>. As a holiday present, HabitRPG gives you your first quest: "Trapper Santa". Check your inventory, you have until Jan 31 to complete it!
 
   p By @lefnire, @pandoro, @Shaners
@@ -2288,29 +2288,29 @@ mixin oldNews
   hr
 
 
-  h4 12/20/2013
-  h4 Winter Wonderland Event Part 1: The Great Snowball Fight
+  h2 12/20/2013
+  h2 Winter Wonderland Event Part 1: The Great Snowball Fight
   p It's time for HabitRPG's biggest event yet - Winter Wonderland! The fun starts today, on the first day of winter, and ends on January 31st - HabitRPG's birthday.
   p Get prepared to build new habits, earn fun drops, hold your party members accountable for their tasks, and decorate your avatar. Various features will be rolling out over the course of the event, so expect many updates! For starters...
   table.table.table-striped
     tr
       td
-        h5 NPC Decorations
+        h3 NPC Decorations
         p Looks like everyone is really getting into the winter spirit! Check out the new NPC sprites. (And I heard a rumor that the final NPC might show up, just in time for the new year...)
     tr
       td
         .customize-option.hair_bangs_1_winternight.pull-right
-        h5 Limited-Edition Holiday Hair-Colors
+        h3 Limited-Edition Holiday Hair-Colors
         p Now your avatar can dye their hair Candy Cane, Frost, Winter Sky, or Holly! You'll only be able to purchase these hair colors until January 31st, when they will be retired.
     tr
       td
         .shop_snowball.pull-right
-        h5 The Great HabitRPG Snowball Fight
+        h3 The Great HabitRPG Snowball Fight
         p Yes, you can now buy snowballs and hurl them at all your friends... to, uh, help them improve their habits. How? Weeeeellll, let's just say that after getting walloped, they might find themselves needing some extra gold to escape their predicament...
           //-span.shop_head_special_candycane.item-img.shop-sprite
     tr
       td
-        h5 More to Come
+        h3 More to Come
         p A beast is roaring in the distant mountains, mysterious tracks have appeared in the snow, and Lemoness is furiously crocheting something sparkly.
         p It's going to be a wild winter.
 
@@ -2318,73 +2318,73 @@ mixin oldNews
 
   hr
 
-  h4 12/16/2013
+  h2 12/16/2013
   p Good gracious, where do I start...
   br
   table.table.table-striped
     tr
       td
-        h4 Classes
+        h2 Classes
         p You can now be a Warrior, Rogue, Wizard, or Healer. <a href='http://habitrpg.wikia.com/wiki/Class_System' target='_blank'>See details here.</a>
     tr
       td
-        h4 Armory & Costumes
+        h2 Armory & Costumes
         p Once you select your new class, you're now equipped with your new class's apprentice gear. Fear not, your old gear is still available in your inventory! You can switch gear at any time, and wear a different costume than your equipment. See <a href='https://trello.com/c/83M5RqQB/299-armory' target='_blank'>Armory</a> & <a href='https://trello.com/c/iY6A7nlX/336-costumes-armory-v2' target='_blank'>Costumes</a>
     tr
       td
-        h4 New Customizations
+        h2 New Customizations
         p We now have a much wider selection of hair, shirt, facial-hair, body-size, etc. customizations. See <a href='https://trello.com/c/YKXmHNjY/306-customization-redo' target='_blank'>Customizations v2</a>
     tr
       td
-        h4 300 Tier Gear
+        h2 300 Tier Gear
         p All you $300 backers who have been waiting patiently, your gear is now in! Currently, only available to $300+ backers, but we'll add them as drops to the Boss system once that's released. See <a href='https://trello.com/c/sb6f9w5r/217-custom-items-300-tier' target='_blank'>300-tier</a>
     tr
       td
-        h4 API v2
+        h2 API v2
         p The API has been completely overhauled, and v2 comes with many more routes for a *full featured* API. v1 is no longer supported, take heed ye 3rd-party-ists! For the time being, basic routes are supported (such as up/down -scoring). v2 will be documented soon, and I'll ping you when. see <a href='https://trello.com/c/L4pYimQM/343-api-v2' target='_blank'>APIv2</a>
   hr
   p By @lemoness @sabrecat @danielthebard @fuzzytrees @crystalphoenix @rosemonkeyct @fandekasp, and many more. (Who am I missing? We'll put up a CONTRIBUTORS.md soon)
 
-  h4 12/7/20132
+  h2 12/7/20132
   table.table.table-striped
     tr
       td
-        h4 Mounts!
+        h2 Mounts!
         p You can now feed your pets and they'll grow into trusty steeds. Obtain food as new random drops, or you can hasten the process buy buying a saddle from Alexander.
         // We may want to use their twitter handles, or something they prefer instead
         hr
         p.
          By <a target='_blank' href='https://github.com/lemoness'>@lemoness</a> <a target='_blank' href='https://github.com/Shaners'>@Shaners</a> <a target='_blank' href='https://github.com/baconsaur'>@baconsaur</a> <a target='_blank' href='https://github.com/RandallStanhope'>@RandallStanhope</a> <a target='_blank' href='https://github.com/ashjolliffe'>@ashjolliffe</a> <a target='_blank' href='https://github.com/fuzzytrees'>@fuzzytrees</a>
 
-  h4 11/27/2013
+  h2 11/27/2013
   table.table.table-striped
     tr
       td
-        h4 Turkey Event (by @lemoness)
+        h2 Turkey Event (by @lemoness)
         p Say hi to our NPCs, dressed to impressed for Turkey day! Also - check your stable, you'll find a fun new pet.
     tr
       td
-        h4 Chat Enhancements (by @Nick Gordon)
+        h2 Chat Enhancements (by @Nick Gordon)
         p.
           Chat can now use markdown, Emoji, and @-tagging. Some pointers on using markdown & Emoji at <a href="http://habitrpg.wikia.com/wiki/Markdown_Cheat_Sheet" target="_blank">here</a>. To use @-tagging, simply type '@' in chat.
     tr
       td
-        h4 Party Sorting (by @Fandekasp)
+        h2 Party Sorting (by @Fandekasp)
         p.
           You can now adjust the way you view your party members in the top bar. They can be sorted by level, number of pets, the date they joined the party, or just randomly. Also, level colors now reflect your contributor status.
     tr
       td
-        h4 Wiki Updates (by @bobbyroberts99)
+        h2 Wiki Updates (by @bobbyroberts99)
         p.
          The <a href='http://habitrpg.wikia.com/wiki/HabitRPG_Wiki' target='_blank'>HabitRPG wiki</a> is being speedily updated. If you’re confused about anything, go check it out - it’s a treasure trove.
 
-  h4 11/08/2013
+  h2 11/08/2013
   table.table.table-striped
     tr
       td.
         Contrib Gear. You can now unlock new a top-tier gear set and pet by contributing (code, art, docs, etc) to HabitRPG. <a href='http://habitrpg.wikia.com/wiki/Contributor_Rewards' target='_blank'>Read more</a>
 
-  h4 11/01/2013
+  h2 11/01/2013
   table.table.table-striped
     tr
       td.
@@ -2392,7 +2392,7 @@ mixin oldNews
     tr
       td Backend overhaul, including bookmark-able paths throughout the application. Will pave the way towards improved performance.
 
-  h4 10/22/2013
+  h2 10/22/2013
   table.table.table-striped
     tr
       td TRICK OR TREAT! It's Habit Halloween! Some of the NPCs have decorated for the occasion. Can you spot us?
@@ -2401,14 +2401,14 @@ mixin oldNews
     tr
       td Do note, skins won't work on mobile until the app is updated. We'll update Android ASAP, iPhone usually takes ~1wk to approve.
 
-  h4 10/19/2013
+  h2 10/19/2013
   table.table.table-striped
     tr
       td New custom skin colors are now available! Go check them out in the Profile section. Also, the new mobile update, 0.0.10, is now available to download! It includes the new skin tones and the ability to hide or show your helm, among other things.
     tr
       td You can now sell un-wanted drops to Alex the Merchant. Trade those troves of eggs for gold!
 
-  h4 09/01/2013
+  h2 09/01/2013
   table.table.table-striped
     tr
       td.
@@ -2417,7 +2417,7 @@ mixin oldNews
         Both apps and the website are open source, and we desparately need your help porting the rest of the features, and polishing off the bugs. <a target='_blank' href='http://habitrpg.wikia.com/wiki/Contributing_to_HabitRPG'>Read this guide</a> to getting started.
         We're working on a system of Contributor Gear to reward the awesome people who help out, so stay tuned!
 
-  h4 The Rewrite! (Mid August)
+  h2 The Rewrite! (Mid August)
   table.table.table-striped
     tr
       td.
@@ -2436,7 +2436,7 @@ mixin oldNews
          We desparately need your help porting <a href='http://goo.gl/jYWTwl' target='_blank'>the rest of the features</a>, and polishing off the bugs. <a target='_blank' href='http://habitrpg.wikia.com/wiki/Contributing_to_HabitRPG'>Read this guide</a> to getting started.
          Thanks everyone for all your support and patience!
 
-  h4 8/20/2013
+  h2 8/20/2013
   table.table.table-striped
     tr
       td.
@@ -2445,7 +2445,7 @@ mixin oldNews
       td.
         API developers, the above means that <strong>cron</strong> is automatically run for your users! Weee, they no longer have to log into the website to reset their dailies!
 
-  h4 8/18/2013
+  h2 8/18/2013
   table.table.table-striped
     tr
       td.
@@ -2457,14 +2457,14 @@ mixin oldNews
         | of what we're currently working on! This weekend, we are working hard to fix the "Not Enough GP" bug, a cruel and greedy monster that has wrapped itself around the rewards box and is refusing to let anyone purchase anything. Rest assured that our heroic Tyler will slay this beast soon! Then it wiil be full steam ahead on the new site upgrade process.
         a(target='_blank', href='http://habitrpg.tumblr.com/post/57627483715/news-about-upgrade-and-app') Read more about how that will work in this post here
 
-  h4 6/03/2013
+  h2 6/03/2013
   table.table.table-striped
     tr
       td
         a(target='_blank', href='https://trello.com/card/groups-guilds/50e5d3684fe3a7266b0036d6/84') Guilds!
         | You can now belong to multiple groups, not just your party. There are public and private guilds, think "Subreddits" v "multiple friend groups".
 
-  h4 5/27/2013
+  h2 5/27/2013
   table.table.table-striped
     tr
       td
@@ -2475,7 +2475,7 @@ mixin oldNews
         a(href='http://habitrpg.tumblr.com/post/51476277225/upcoming-features-bugs-update-user-survey', target='_blank') New blog post
         | about upcoming Guilds & Challenges features, & huge bug-fixes on the horizon.
 
-  h4 5/25/2013
+  h2 5/25/2013
   table.table.table-striped
     tr
       td
@@ -2487,11 +2487,11 @@ mixin oldNews
         a(href='http://community.habitrpg.com/content/submitting-bugs', target='_blank') report a problem
         | if you experience any issues, (2) this is going to allow for much less buggy code (read previous link for reasoning).
 
-  h4 5/12/2013
+  h2 5/12/2013
   table.table.table-striped
     tr
       td Renamed "Tokens" to "Gems". Tokens caused confusion.
-  h4 5/10/2013
+  h2 5/10/2013
   table.table.table-striped
     tr
       td
@@ -2501,7 +2501,7 @@ mixin oldNews
     tr
       td Chat messages: can delete your own message, fix the duplicate messages issue.
 
-  h4 5/9/2013
+  h2 5/9/2013
   table.table.table-striped
     tr
       td
@@ -2510,28 +2510,28 @@ mixin oldNews
         a(href='https://trello.com/card/backer-items-availability-mechanic/50e5d3684fe3a7266b0036d6/188', target='_blank') here
         | , and if you're top-gear but not seeing backer stuff, message me from your KS profile.
 
-  h4 5/7/2013
+  h2 5/7/2013
   table.table.table-striped
     tr
       td
         a(_target='blank', href='https://trello.com/card/tags-categories/50e5d3684fe3a7266b0036d6/43') Tags
         | . You can now categorize your tasks, eg "Work", "Home", "Morning", "Taxes", etc.
 
-  h4 5/4/2013
+  h2 5/4/2013
   table.table.table-striped
     tr
       td
         a(_target='blank', href='https://trello.com/card/streaks-consecutive-bonus/50e5d3684fe3a7266b0036d6/182') Streaks
         | . You get a GP & drop-% increase the longer you hold daily streaks (they stack). You also get a stacking badge for each 21-day streak.
 
-  h4 5/3/2013
+  h2 5/3/2013
   table.table.table-striped
     tr
       td
         | Two new achievements: Beast Master & Ultimate Gear. Got ideas for more achievements?
         a(target='_blank', href='https://trello.com/card/awards-badges/50e5d3684fe3a7266b0036d6/19') chime in here
 
-  h4 5/2/2013
+  h2 5/2/2013
   table.table.table-striped
     tr
       td
@@ -2549,7 +2549,7 @@ mixin oldNews
         a(href='https://github.com/lefnire/habitrpg/issues/828') New "Game Options" layout
         | (click your avatar to see)
 
-  h4 3/27/2013
+  h2 3/27/2013
   table.table.table-striped
     tr
       td
@@ -2559,13 +2559,13 @@ mixin oldNews
         a(href='https://trello.com/card/pets/50e5d3684fe3a7266b0036d6/166') Trello Card
         | )
 
-  h4 3/21/2013
+  h2 3/21/2013
   table.table.table-striped
     tr
       td
         a(href='https://github.com/lefnire/habitrpg/issues/585') More design tweaks to header & avatars
 
-  h4 3/20/2013
+  h2 3/20/2013
   table.table.table-striped
     tr
       td
@@ -2583,7 +2583,7 @@ mixin oldNews
       td
         a(href='https://trello.com/card/undo-button/50e5d3684fe3a7266b0036d6/20') Undo Button
 
-  h4 3/3/2013
+  h2 3/3/2013
   table.table.table-striped
     tr
       td

--- a/website/views/shared/new-stuff.jade
+++ b/website/views/shared/new-stuff.jade
@@ -17,8 +17,9 @@ h4 NEW ITEMS IN THE ENCHANTED ARMOIRE AND SEPTEMBER BACKGROUNDS!
       p.small.muted by Lemoness and SabreCat
       p.small.muted Art by Starsystemic and Kiwibot
 
-hr.remove-on-static
-a(href='/static/old-news', target='_blank').remove-on-static Read older news
+.remove-on-static
+  hr
+  a(href='/static/old-news', target='_blank') Read older news
 
 mixin oldNews
   h4 LAST CHANCE FOR CHEETAH COSTUME! COSTUME CHALLENGE ANNOUNCED!

--- a/website/views/shared/new-stuff.jade
+++ b/website/views/shared/new-stuff.jade
@@ -1,14 +1,14 @@
-h5.big_news_header NEW ITEMS IN THE ENCHANTED ARMOIRE AND SEPTEMBER BACKGROUNDS!
+h4 NEW ITEMS IN THE ENCHANTED ARMOIRE AND SEPTEMBER BACKGROUNDS!
   hr
   tr
     td
       .background_tavern.pull-right
-      h5.small_news_header September Backgrounds Revealed
+      h5 September Backgrounds Revealed
       p There are three new avatar backgrounds in the <a href='/#/options/profile/backgrounds'>Background Shop</a>! Now your avatar can visit the Habitica Tavern, shop in the Habitica Market, or ride mounts in the Habitica Stable! 
   tr
     td
       .promo_enchanted_armoire_201509.pull-right
-      h5.small_news_header New Items in the Enchanted Armoire!
+      h5 New Items in the Enchanted Armoire!
       p There is new equipment in the Enchanted Armoire, a 100 GP Reward in the Rewards Column which unlocks after you've attained Ultimate Gear! 
       br
       p Click on the Enchanted Armoire for a random chance at special Equipment, including the Yellow Hairbow, Red Floppy Hat, Gold Winged Staff, and the Plague Doctor Item Set! It may also give you random XP or food items. We'll be adding new equipment to it during the first week of each month, but even when you've exhausted the current supply, you can keep clicking for a chance at food and XP.
@@ -17,51 +17,54 @@ h5.big_news_header NEW ITEMS IN THE ENCHANTED ARMOIRE AND SEPTEMBER BACKGROUNDS!
       p.small.muted by Lemoness and SabreCat
       p.small.muted Art by Starsystemic and Kiwibot
 
-hr.remove_on_static
-a(href='/static/old-news', target='_blank').remove_on_static Read older news
+hr.remove-on-static
+a(href='/static/old-news', target='_blank').remove-on-static Read older news
 
 mixin oldNews
-  h5.big_news_header LAST CHANCE FOR CHEETAH COSTUME! COSTUME CHALLENGE ANNOUNCED!
+  h4 LAST CHANCE FOR CHEETAH COSTUME! COSTUME CHALLENGE ANNOUNCED!
+    hr
     tr
       td
         .promo_mystery_201508.pull-right
-        h5.small_news_header Last Chance for Cheetah Costume Set
+        h5 Last Chance for Cheetah Costume Set
         p Reminder: this is the final day to <a href='/#/options/settings/subscription'>subscribe</a> and receive the Cheetah Costume Item Set! If you want the Cheetah Hat or the Cheetah Costume, now's the time. Thanks so much for your support - it's your generosity that keeps Habitica alive.
     tr
       td
-        h5.small_news_header Get Ready for the Community Costume Challenge!
+        h5 Get Ready for the Community Costume Challenge!
         p On October 1st, we will launch the second annual Community Costume Challenge! Dress up in real-life versions of your avatar's armor to receive a special badge. (No, just wearing a colored shirt doesn't count. Where's the fun in that?)
         br
         p We're announcing the Challenge early so that people will have time to prepare costumes. You can see some of the excellent costumes from last year <a href='http://blog.habitrpg.com/tagged/cosplay' target='_blank'>here</a>.
         br
         p Instructions on how to take part in the CCC will be posted on October 1st. We can't wait to see your costumes!
 
-  h5.big_news_header 8/27/2015 - OFFICIAL BACK TO SCHOOL ADVICE CHALLENGE
+  h4 8/27/2015 - OFFICIAL BACK TO SCHOOL ADVICE CHALLENGE
     hr
     tr
       td
         .promo_backtoschool.pull-right
-        h5.small_news_header Official Back to School Advice Challenge!
+        h5 Official Back to School Advice Challenge!
         p We've launched another Official Challenge: the Back To School Advice Challenge! Use social media to tell us how you use Habitica to improve study habits, share stories of scholarly success with the app, or just give us your advice on using Habitica to be the best you can be.
         br
         p The contest ends on September 27th, and the 10 winners will each get 30 Gems! For the full rules, <a href='/#/options/groups/challenges/533cac3f-f431-424f-9eaa-4d509f015a75'>check out the challenge here</a>.
-  h5.big_news_header 8/24/2015 - AUGUST SUBSCRIBER ITEM SET: CHEETAH COSTUME!
+  h4 8/24/2015 - AUGUST SUBSCRIBER ITEM SET: CHEETAH COSTUME!
+    hr
     tr
       td
         .promo_mystery_201508.pull-right
-        h5.small_news_header August Subscriber Item Set: Cheetah Costume!
+        h5 August Subscriber Item Set: Cheetah Costume!
         p The August Subscriber Items have been revealed: the Cheetah Costume Item Set! All August subscribers will receive the Cheetah Costume and the Cheetah Hat. You still have six days to <a href='/#/options/settings/subscription'>subscribe</a> and receive the item set! Thank you so much for your support - we really do rely on you to keep Habitica free to use and running smoothly.
         p.small.muted by Lemoness
-  h5.big_news_header 8/19/2015 - CHEETAH PET QUEST, iPAD APP, and GRYPHON CONTEST WINNER!
+  h4 8/19/2015 - CHEETAH PET QUEST, iPAD APP, and GRYPHON CONTEST WINNER!
+    hr
     tr
       td
         .Pet-Cheetah-Base.pull-right
-        h5.small_news_header Cheetah Pet Quest
+        h5 Cheetah Pet Quest
         p A new pet quest is available in the <a href='/#/options/inventory/quests'>Quests Page</a>: Such a Cheetah! A Cheetah is speeding past incomplete tasks and burning them up before people can complete them. Can you put on the brakes? If so, you’ll be awarded with some cheetah eggs!
         p.small.muted by PainterProphet, tivaquinn, Unruly Hyena, Crawford, janetmango, Lemoness, and SabreCat
     tr
       td
-        h5.small_news_header iOS Update and iPad App
+        h5 iOS Update and iPad App
         p There’s a new iOS update! One of our awesome open-source contributors, Shadallark, has made our Habitica iOS app Universal so that it natively supports iPads. Enjoy all the new space for your tasks! We've also fixed several bugs, and excellent contributor kylefox has added a search bar.
         br
         p If you like the direction that we’ve been taking the app, please consider leaving us a review. It means a lot to us :) Questions? Concerns? Don't hesitate to email <a href='mailto:mobile@habitica.com' target='_blank'>mobile@habitica.com</a> and we will happily help you!
@@ -74,35 +77,37 @@ mixin oldNews
       td
         span.Mount_Body_Gryphon-RoyalPurple.pull-right
           span.Mount_Head_Gryphon-RoyalPurple.pull-right(style='margin:0')
-        h5.small_news_header Gryphon Contest Winner
+        h5 Gryphon Contest Winner
         p After sorting through over 1600 entries, we finally have a name for our Royal Purple Gryphon: MELIOR! "Melior" is Latin for "better," because Habitica is a place where everyone is striving to become better at their goals in their quest to improve their lives.
         br
         p The name "Melior" was submitted by awesome user NobleTheSecond, who has received their prize. Congratulations! A secondary prize has also been awarded to TangyDragonBBQ, who independently submitted a slightly different variant of that name. 
         br
         p Thank you so much to everyone who submitted names! They were very well-thought-out and very entertaining, and it was extremely difficult for the staff to make a decision. We hope you will join with us in welcoming Melior into the Habitica family!
 
-  h5.big_news_header 8/13/2015 - GOLD-PURCHASABLE CARDS
+  h4 8/13/2015 - GOLD-PURCHASABLE CARDS
+    hr
     tr
       td
         .inventory_special_greeting.pull-right
         .inventory_special_thankyou.pull-right
-        h5.small_news_header Gold-Purchasable Cards
+        h5 Gold-Purchasable Cards
         p There are two new types of Card available in the <a href='/#/options/inventory/drops'>Market</a> that you can send to the people in your Party: Greeting Cards and Thank-You Cards! Both cost 10 Gold, and will be available year-round. Sending or receiving these cards will give you some fun achievements!
         br
         p Enjoy!
         p.small.muted by PainterProphet, Teto Is Great, Lemoness, and SabreCat
 
-  h5.big_news_header 8/4/2015 - NEW ITEMS IN THE ENCHANTED ARMOIRE AND AUGUST BACKGROUNDS
+  h4 8/4/2015 - NEW ITEMS IN THE ENCHANTED ARMOIRE AND AUGUST BACKGROUNDS
+    hr
     tr
       td
         .background_pyramids.pull-right
-        h5.small_news_header August Backgrounds Revealed
+        h5 August Backgrounds Revealed
         p There are three new avatar backgrounds in the <a href='/#/options/profile/backgrounds'>Background Shop</a>! Now your avatar can admire the Pyramids, stalk across the Sunset Savannah, or dance under Twinkly Party Lights!
         p.small.muted by (in order): minac1, Bambin, and rosiesully
     tr
       td
         .promo_enchanted_armoire_201508.pull-right
-        h5.small_news_header New Items in the Enchanted Armoire!
+        h5 New Items in the Enchanted Armoire!
         p There is new equipment in Enchanted Armoire, a 100 GP Reward in the Rewards Column which unlocks after you've attained Ultimate Gear!
         br
         p Click on the Enchanted Armoire for a random chance at special Equipment, including the Golden Toga Item Set and the Horned Iron Item Set.! It may also give you random XP or food items. We'll be adding new equipment to it during the first week of each month, but even when you've exhausted the current supply, you can keep clicking for a chance at food and XP.
@@ -111,17 +116,19 @@ mixin oldNews
         br
         p.small.muted by Lemoness and SabreCat
         p.small.muted Art by Kiwibot, Starsystemic, Podcod, and UncommonCriminal
-  h5.big_news_header 8/2/2015 - AUGUST MYSTERY BOX!
+  h4 8/2/2015 - AUGUST MYSTERY BOX!
+    hr
     tr
       td
         .inventory_present_08.pull-right
-        h5.small_news_header August Mystery Box
+        h5 August Mystery Box
         p How curious! All Habiticans who are <a href='/#/options/settings/subscription'>subscribed</a> during the month of August will receive the August Mystery Item Set, as well as the ability to buy Gems with Gold! The August Item Set will be revealed on the 24th, so keep your eyes peeled. Thanks for supporting the site <3
-  h5.big_news_header 7/31/2015 - HABITICA NAMING DAY AND LAST CHANCE FOR SUMMER SPLASH
+  h4 7/31/2015 - HABITICA NAMING DAY AND LAST CHANCE FOR SUMMER SPLASH
+    hr
     tr
       td
         .achievement_habiticaDay.pull-right
-        h5.small_news_header Habitica Naming Day!
+        h5 Habitica Naming Day!
         p It's finally here! HabitRPG has become Habitica. Your accounts should still stay exactly the same and work normally, just with some of the names and references changed. (For example, habitrpg.com now redirects to habitica.com.)
         br
         p In honor of the first annual Habitica Naming Day, we've given everyone an achievement, as well as some awesome treats...
@@ -130,7 +137,7 @@ mixin oldNews
       td
         span.Mount_Body_Gryphon-RoyalPurple.pull-right
           span.Mount_Head_Gryphon-RoyalPurple.pull-right(style='margin:0')
-        h5.small_news_header Habitica Gryphon Mount and Contest
+        h5 Habitica Gryphon Mount and Contest
         p Our new logo features a Gryphon, and now, so does your stable! We've given everyone a Royal Purple Gryphon Mount, under <a href='/#/options/inventory/mounts'>Inventory &gt; Mounts.</a>
         br
         p Furthermore, we need your help to give our Gryphon a name! Check out the Official Name the Gryphon Challenge <a href='/#/options/groups/challenges/a4898d49-9ed4-4029-974a-ff702f5b8b14'>here</a>. If we choose your name for the Gryphon in our logo, you'll win 30 Gems. You have until August 10th to submit a name.
@@ -138,29 +145,30 @@ mixin oldNews
     tr
       td
         .promo_veteran_pets.pull-right
-        h5.small_news_header Veteran Pets
+        h5 Veteran Pets
         p Since you are all veterans who have weathered the name change to Habitica, we've awarded everyone a Veteran Pet! If this is your first Veteran Pet, you've received the Veteran Wolf; if you already had the Wolf, you got the Veteran Tiger. You can find it under <a href='/#/options/inventory/pets'>Inventory &gt; Pets</a>, in the Rare Pets section.
         p.small.muted by Lemoness and Shaner
     tr
       td
         .promo_summer_classes_2015.pull-right
-        h5.small_news_header Last Chance for Summer Splash Outfits, Hair and Skins, and Seafoam!
+        h5 Last Chance for Summer Splash Outfits, Hair and Skins, and Seafoam!
         p Today is the final day of the Summer Splash Festival, so if you still have any remaining Summer Splash Items that you want to buy, you'd better do it now! The <a href='/#/tasks'>Seasonal Edition items</a>, <a href='/#/options/profile/avatar'>Skins</a>, and <a href='/#/options/profile/avatar'>Hair Colors</a> won't be back until next June, and if the Limited Edition items return they will have increased prices or changed art, so strike while the iron is hot!
     tr
       td
         .promo_mystery_201507.pull-right
-        h5.small_news_header Last Chance for Rad Surfer Item Set
+        h5 Last Chance for Rad Surfer Item Set
         p Reminder: this is the final day to <a href='/#/options/settings/subscription'>subscribe</a> and receive the Rad Surfer Item Set! If you want the Rad Surfboard or the Rad Sunglasses, now's the time! Thanks so much for your support <3
-  h5.big_news_header 7/29/2015 - HABITICA NAMING DAY ON JULY 31ST!
+  h4 7/29/2015 - HABITICA NAMING DAY ON JULY 31ST!
+    hr
     tr
       td
-        h5.small_news_header Habitica Naming Day is July 31st!
+        h5 Habitica Naming Day is July 31st!
         p We are pleased to announce that the final day of the Summer Splash Festival, July 31st, will be the inaugural Habitica Naming Day! On this day, HabitRPG will officially become Habitica. Our old name was unfortunately very confusing to people ("HabitZPR? HabitGRG?"), so we've decided to name our app and website after the land of Habitica, where all these adventures take place.
         br
         p We will be celebrating with some fun surprises, so get excited!
     tr
       td
-        h5.small_news_header What will change?
+        h5 What will change?
         p In almost all cases, your accounts will still stay exactly the same and work normally! Only some of the names and references will be different. Here is a list of the changes:
         br
         ul
@@ -171,35 +179,38 @@ mixin oldNews
           li We don't anticipate any issues with third-party tools, but we will be actively working with developers to help them make any necessary updates. You can help us by reporting broken third-party tools at <a href='https://github.com/HabitRPG/habitrpg/issues/2760' target='_blank'>Help -&gt; Report a Bug</a>.
     tr
       td
-        h5.small_news_header When will it change?
+        h5 When will it change?
         p Changing our name is a pretty enormous task, so it won't all happen in an instant! Some changes may start switching over slightly before the 31st, and some may take slightly longer, but the majority of the changes and all of the celebration will take place on July 31st. Thank you for being patient with us!
     tr
       td
-        h5.small_news_header More questions?
+        h5 More questions?
         p If you have any more questions, drop by <a href='/#/options/groups/guilds/5481ccf3-5d2d-48a9-a871-70a7380cee5a'>the Newbies Guild</a> and we'll be happy to answer them!
-  h5.big_news_header 7/24/2015 - JULY SUBSCRIBER ITEM SET: RAD SURFER!
+  h4 7/24/2015 - JULY SUBSCRIBER ITEM SET: RAD SURFER!
+    hr
     tr
       td
         .promo_mystery_201507.pull-right
-        h5.small_news_header July Subscriber Items Revealed!
+        h5 July Subscriber Items Revealed!
         p The July Subscriber Items have been revealed: the Rad Surfer Item Set! All July subscribers will receive the Rad Surfboard and the Rad Sunglasses. You still have six days to <a href='/#/options/settings/subscription'>subscribe</a> and receive the item set, along with the ability to buy Gems with Gold! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         p.small.muted by Lemoness
-  h5.big_news_header 7/22/2015 - NEW iOS UPDATE, INCLUDING FACEBOOK LOGIN!
+  h4 7/22/2015 - NEW iOS UPDATE, INCLUDING FACEBOOK LOGIN!
+    hr
     tr
       td
         .promo_habitica.pull-right
-        h5.small_news_header Habitica App Update with Facebook Login
+        h5 Habitica App Update with Facebook Login
         p We've released a new update to our iOS Habitica app, including Facebook Login, Accessories, and much more. <a href='https://itunes.apple.com/us/app/habitica/id994882113?mt=8' target='_blank'>Check it out now!</a>
         br
         p If you like what we've been doing with the app, please consider leaving us a review. It means so much to us, and really helps us out. Thanks for being awesome! If you have any feedback or concerns, feel free to email us at <a href='mailto:mobile@habitrpg.com' target='_blank'>mobile@habitrpg.com</a>, or use the in-app Report a Bug feature under Menu > About.
         br
         p We're still hard at work on the native Android app, don't worry! Our Blacksmiths are toiling away. Stay tuned for further information!
         p.small.muted by Viirus
-  h5.big_news_header 7/14/2015 - GOLD-PURCHASABLE QUESTS, NEW EQUIPMENT IN THE ENCHANTED ARMOIRE, AND TRIVIAL TASK DIFFICULTY SETTING!
+  h4 7/14/2015 - GOLD-PURCHASABLE QUESTS, NEW EQUIPMENT IN THE ENCHANTED ARMOIRE, AND TRIVIAL TASK DIFFICULTY SETTING!
+    hr
     tr
       td
         .promo_dilatoryDistress.pull-right
-        h5.small_news_header Gold-Purchasable Quest Line: Dilatory Distress
+        h5 Gold-Purchasable Quest Line: Dilatory Distress
         p We've moved the quests to <a href='/#/options/inventory/quests'>their own separate page</a>, and added a new category: GOLD PURCHASABLE QUESTS!
         br
         p Now you can use Gold to purchase the Dilatory Distress Quest Line! King Manta's daughter has disappeared, and monsters are laying siege to the underwater city of Dilatory. Can you intervene to save them all? If so, you'll earn the exclusive Oceanic Armor Set.
@@ -211,7 +222,7 @@ mixin oldNews
     tr
       td
         .promo_enchanted_armoire_201507.pull-right
-        h5.small_news_header New Equipment in the Enchanted Armoire
+        h5 New Equipment in the Enchanted Armoire
         p There is new equipment in Enchanted Armoire, a 100 GP Reward in the Rewards Column which unlocks after you've attained Ultimate Gear!
         br
         p Click on the Enchanted Armoire for a random chance at special Equipment, including the Rancher Robes, Rancher Lasso, Blue Hairbow, and Royal Crown! It may also give you random XP or food items. We'll be adding new equipment to it during the first week of each month, but even when you've exhausted the current supply, you can keep clicking for a chance at food and XP.
@@ -221,32 +232,34 @@ mixin oldNews
         p.small.muted Art by podcod, Kiwibot, and Megan
     tr
       td
-        h5.small_news_header Trivial Task Difficulty
+        h5 Trivial Task Difficulty
         p There's a new difficulty for Tasks available under task edit: Trivial! Trivial tasks reward you or damage you at the rate of one tenth of the amount that Easy tasks would. Likewise, Trivial tasks cause much less damage during boss battles!
         p.small.muted by efim
-  h5.big_news_header 7/9/2015 - DERBY DAY! FREE ORCA MOUNT AND WHALE QUEST
+  h4 7/9/2015 - DERBY DAY! FREE ORCA MOUNT AND WHALE QUEST
+    hr
     tr
       td
-        h5.small_news_header Derby Day!
+        h5 Derby Day!
         p On this day, Habitica defeated the worst of its ancient bugs! We celebrate with the Dilatory Derby, which means that Habiticans get aquatic mounts to ride!
     tr
       td
         .promo_orca.pull-right
-        h5.small_news_header Free Orca Mount
+        h5 Free Orca Mount
         p Everyone has received a rare Orca Mount in honor of the Dilatory Derby! Now you can race through the waves on the back of your Orca, which is found under <a href='/#/options/inventory/mounts'>Mounts</a>.
         p.small.muted by Uncommon Criminal
     tr
       td
         .quest_whale.pull-right
-        h5.small_news_header New Pet Quest: Whales!
+        h5 New Pet Quest: Whales!
         p Want more whales? Check out the The Wail of the Whale, a new pet quest in the <a href='/#/options/inventory/drops'>Market</a>! On your way to the Dilatory Derby, you encounter a whale in distress. Can you calm her down? If so, you may gain some whale eggs...
         p.small.muted Art by krazjega, zoebeagle, and Uncommon Criminal
         p.small.muted Writing by Calae
-  h5.big_news_header 7/7/2015 - NEW iOS APP: HABITICA!
+  h4 7/7/2015 - NEW iOS APP: HABITICA!
+    hr
     tr
       td
         .promo_habitica.pull-right
-        h5.small_news_header New iOS App: Habitica!
+        h5 New iOS App: Habitica!
         p We are proud to announce the beta release of our new native iOS app: <a href='https://itunes.apple.com/us/app/habitica/id994882113?ls=1&mt=8' target='_blank'>Habitica</a>! It features an all-new interface, smoother performance, reminders to complete Dailies, and tons of features including skills and better party chat! <a href='https://itunes.apple.com/us/app/habitica/id994882113?ls=1&mt=8' target='_blank'>Click here to download it</a> - it's a new app, not an upgrade of the clunky old one.
         br
         p This is a beta release, so please report any issues using the in-app Send Feedback and Report a Bug buttons, under Menu > About. <a href='https://github.com/HabitRPG/habitrpg-ios/' target='_blank'>The repository is open source</a>, so anyone can jump in and help out.
@@ -255,135 +268,141 @@ mixin oldNews
         p.small.muted by Viirus
     tr
       td
-        h5.small_news_header What about Android?
+        h5 What about Android?
         p We are hard at work on the native Android app as we speak! It's coming along very well. We will announce as soon as it is ready to download, never fear.
     tr
       td
-        h5.small_news_header Why Habitica?
+        h5 Why Habitica?
         p Habitica is the land where HabitRPG takes place - a land where players ride dragons and slay Dailies. Plus, it's now the name of the mobile app. Soon, it will also be the name of the site!
         br
         p The decision to switch from HabitRPG to Habitica is a big one, and we've been talking it over for a long time. We've gotten feedback since the beginning that it was confusing, especially for the many people who aren't familiar with the acronym. ("HabitPGR? HabitRZG? What was your name again?") We feel that "Habitica" keeps the fantasy flair without the confusing abbreviation, so it's the best of both realms.
         br
         p So far, habitica.com redirects to habitrpg.com, and it's the name of the native mobile apps. Look forward to an upcoming announcement of the switchover date, when we will be ringing in the name change with our inaugural Habitica Day celebration!
-  h5.big_news_header 7/1/2015 - SEAFOAM TRANSFORMATION ITEM , JULY BACKGROUNDS REVEALED, SUBSCRIBE WITH AMAZON PAYMENTS AND JULY SUBSCRIBER BOX
+  h4 7/1/2015 - SEAFOAM TRANSFORMATION ITEM , JULY BACKGROUNDS REVEALED, SUBSCRIBE WITH AMAZON PAYMENTS AND JULY SUBSCRIBER BOX
+    hr
     tr
       td
         .inventory_special_seafoam.pull-right
-        h5.small_news_header Seafoam Transformation Item
+        h5 Seafoam Transformation Item
         p Splash some Seafoam on your friends and they will undergo a mysterious transformation until their next cron! You can buy the Seafoam in the <a href='/#/options/inventory/seasonalshop'>Seasonal Shop</a> for Gold. Don't want to be transformed? Just buy some Sand from the <a href='/#/tasks'>Rewards Store</a> to reverse it.
         p.small.muted by Lemoness
     tr
       td
         .background_giant_wave.pull-right
-        h5.small_news_header July Backgrounds Revealed
+        h5 July Backgrounds Revealed
         p There are three new avatar backgrounds in the <a href='/#/options/profile/backgrounds'>Background Shop</a>! Now your avatar can surf on a Giant Wave, explore a Sunken Ship, or dive to the Ruins of Dilatory!
         p.small.muted by (in order): minac1, Mimi Alves, and Twitching
     tr
       td
         .inventory_present_07.pull-left
-        h5.small_news_header Subscribe with Amazon Payments
+        h5 Subscribe with Amazon Payments
         p Want to subscribe to get the July Mystery Item and the ability to buy Gems with Gold? Now you have a new way to pay for a subscription: Amazon Payments! The July Subscriber Item Set will be revealed on the 24th, so keep your eyes peeled.
         br
         p Right now, we only support Amazon Payments for subscriptions, but in the future, we will make it possible to use Amazon Payments to buy Gems as well. Thanks for supporting the site <3
-  h5.big_news_header 6/30/2015 - LAST CHANCE FOR NEON SNORKELER, CLONE CHALLENGES, AND CHALLENGER CONTRIBUTOR TITLE
+  h4 6/30/2015 - LAST CHANCE FOR NEON SNORKELER, CLONE CHALLENGES, AND CHALLENGER CONTRIBUTOR TITLE
+    hr
     tr
       td
         .promo_mystery_201506.pull-right
-        h5.small_news_header Last Chance for Neon Snorkeler Item Set
+        h5 Last Chance for Neon Snorkeler Item Set
         p Reminder: this is the final day to <a href='/#/options/settings/subscription'>subscribe</a> and receive the Neon Snorkeler Item Set! If you want the Snorkeler Suit or the Neon Snorkel, now's the time! Thanks so much for your support <3
         p.small.muted by Lemoness
     tr
       td
-        h5.small_news_header Clone Challenges
+        h5 Clone Challenges
         p It's now easier than ever to create a recurring Challenge! Just go to a previously created challenge and click the clone button. This creates a new Challenge with all the same information (name, description, prize, tasks) pre-populated, so the challenge creator can adjust only as needed. We hope this saves you time!
         p.small.muted by TheHollidayInn and Blade
     tr
       td
-        h5.small_news_header Challenger Contributor Title
+        h5 Challenger Contributor Title
         p Speaking of recurring Challenges, we've decided to create a new Contributor title, "Challenger", to honor the Habiticans who have been working to improve the community by consistently creating many valuable Challenges. The Challenger title is awarded at the discretion of the staff and mods. Many thanks to our creative and dedicated Challengers!
-  h5.big_news_header 6/25/2015 - JUNE SUBSCRIBER ITEM SET, SPLASHY SKIN SET, AND NEW SOUND EFFECTS
+  h4 6/25/2015 - JUNE SUBSCRIBER ITEM SET, SPLASHY SKIN SET, AND NEW SOUND EFFECTS
+    hr
     tr
       td
         .promo_mystery_201506.pull-right
-        h5.small_news_header June Subscriber Item Set!
+        h5 June Subscriber Item Set!
         p The June Subscriber Item has been revealed: the Neon Snorkeler Item Set! All June subscribers will receive the Neon Snorkel and the Snorkel Suit. You still have five days to <a href='https://habitrpg-staging.herokuapp.com/#/options/settings/subscription'>subscribe</a> and receive the item set, along with the ability to buy Gems with Gold! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         p.small.muted by Lemoness
     tr
       td
         .promo_splashyskins.pull-right
-        h5.small_news_header Splashy Skin Set
+        h5 Splashy Skin Set
         p There's a new set of Seasonal Edition Skins available in the <a href='/#/options/profile/avatar'>Avatar Customization page</a> until July 31st! Get them while you can, or they won't be available until next year.
         p.small.muted by UncommonCriminal
     tr
       td
-        h5.small_news_header New Sound Effects
+        h5 New Sound Effects
         p There's a new Sound Effects theme on the site: Gokul Theme! You can enable it by clicking on the megaphone in the upper right hand corner and selecting "Gokul Theme" from the dropdown list.
         p.small.muted by NomindTR
-  h5.big_news_header 6/20/2015 - SUMMER SPLASH EVENT: LIMITED EDITION OUTFITS, SEASONAL SHOP OPENS, AND SUMMER NPCS!
+  h4 6/20/2015 - SUMMER SPLASH EVENT: LIMITED EDITION OUTFITS, SEASONAL SHOP OPENS, AND SUMMER NPCS!
+    hr
     tr
       td
-        h5.small_news_header Summer Splash Begins!
+        h5 Summer Splash Begins!
         p The Summer Splash festival has arrived, and Habitica has moved to the undersea city of Dilatory for the summer! From today until July 31st, join us for fun in the sun.
     tr
       td
         .promo_summer_classes_2015.pull-right
-        h5.small_news_header Limited Edition Class Outfits
+        h5 Limited Edition Class Outfits
         p From now until July 31st, limited edition outfits are available in the Rewards column. Depending on your class, you can be a Reef Renegade, Sunfish Warrior, Strapping Sailor, or Ship Soothsayer! You'd better get productive to earn enough gold before they disappear. Good luck!
         p.small.muted by Lemoness
     tr
       td
         .promo_summer_classes_2014.pull-right
-        h5.small_news_header Seasonal Shop Opens
+        h5 Seasonal Shop Opens
         p The <a href='/#/options/inventory/seasonalshop'>Seasonal Shop</a> has opened! It's stocking summertime Seasonal Edition goodies at the moment, including last year's summer outfits. Everything there will be available to purchase during the Summer Splash event each year, but it's only open until July 31st, so be sure to stock up now, or you'll have to wait a year to buy these items again.
         p.small.muted by Lemoness
     tr
       td
         .seasonalshop_summer2015.pull-right
-        h5.small_news_header Summer NPCs
+        h5 Summer NPCs
         p Looks like the NPCs are really getting in to the summer spirit. Ian, Bailey, Matt, and the Seasonal Sorceress are having fun under the sea in the sunken city of Dilatory, and Alex and Daniel have moved down to the beach. Even the Time Travelers are getting into the fun, although... oh dear... they seem to have overshot the season...
         p.small.muted by Lemoness
-  h5.big_news_header 6/17/2015 - CUTTLEFISH PET QUEST AND QUEST DISPLAY IMPROVEMENTS
+  h4 6/17/2015 - CUTTLEFISH PET QUEST AND QUEST DISPLAY IMPROVEMENTS
+    hr
     tr
       td
         .quest_kraken.pull-right
-        h5.small_news_header Cuttlefish Pet Quest
+        h5 Cuttlefish Pet Quest
         p A new pet quest is available in the <a href='/#/options/inventory/drops' target='_blank'>Market</a>: The Kraken of Inkomplete! A pleasant day sailing is ruined when a Kraken attacks. Can you strike down the tasks and tentacles that keep cropping up? If so, you'll be awarded with some cuttlefish eggs!
         p.small.muted art by Lemoness and Wolvenhalo
         p.small.muted writing by Lemoness
     tr
       td
-        h5.small_news_header Quest Display Improvements
+        h5 Quest Display Improvements
         p Now you can see the details of a pending quest on the Party Page by clicking the new "Quest Details" tab above the quest invitations. We hope this helps you decide whether or not you want to accept the quest!
         p.small.muted by hairlessbear
-  h5.big_news_header 6/16/2015 - SEARCH BAR, CHALLENGES FILTER, INTERMITTENT REFRESH, AND VISUAL TWEAKS
+  h4 6/16/2015 - SEARCH BAR, CHALLENGES FILTER, INTERMITTENT REFRESH, AND VISUAL TWEAKS
+    hr
     tr
       td
-        h5.small_news_header Search Bar
+        h5 Search Bar
         p You can now easily search for a specific task by using the handy search bar on the upper right of the task page!
         p.small.muted by Jiří Chára
     tr
       td
-        h5.small_news_header New Challenges Filter
+        h5 New Challenges Filter
         p Now you can filter Challenges based on whether or not you own the Challenge! Easily see all the Challenges that you've created with a single click.
         p.small.muted by theHollidayInn
     tr
       td
-        h5.small_news_header Intermittent Refresh
+        h5 Intermittent Refresh
         p To improve performance, HabitRPG now refreshes automatically after 6 hours of inactivity to combat bugs and make sure that you have the most up-to-date code. You're always welcome to refresh more frequently, of course.
         p.small.muted by cheerskevin
     tr
       td
-        h5.small_news_header Visual Tweaks
+        h5 Visual Tweaks
         p We now have a highlighted Help button, to remind people about those resources, and a denser task edit style!
         p.small.muted by excentris and nthomsn
-  h5.big_news_header 6/11/2015 - REPEATING TASKS, START DATE, AND MOBILE APP UPDATES!
+  h4 6/11/2015 - REPEATING TASKS, START DATE, AND MOBILE APP UPDATES!
     p
     br
     p.small.muted by Blade and fallenpanda
     hr
     tr
       td
-        h5.small_news_header New Repeat Option for Dailies
+        h5 New Repeat Option for Dailies
         p Dailies now have a new Advanced Option: Repeat Every X Days. You've wanted this feature for a long time, and it's finally here!
         br
         p First, please note that this new option is OPT-IN only. We won't make any changes to your preexisting Dailies without you knowing it. We wouldn't do that!
@@ -391,29 +410,30 @@ mixin oldNews
         p That being said, here are the new features:
     tr
       td
-        h5.small_news_header Repeating Tasks
+        h5 Repeating Tasks
         p Use the "Every X Days" function under Dailies Advanced Options to create tasks that repeat after a certain number of days have passed, whether every 2 days, every 15 days, every 30 days... You choose the number that works for you!
         br
         p These Dailies are only due on those given dates. Need to pay your rent every 30 days? Take medicine every other day? Water your plants every 4 days? No longer a problem.
     tr
       td
-        h5.small_news_header Start Date
+        h5 Start Date
         p Dailies now have a Start Date. They will not be due before this date. This means that if you want to add a new Daily while you're thinking about it, but not have it be due until later, you can achieve that by setting a future Start Date!
     tr
       td
-        h5.small_news_header Mobile App Updates
+        h5 Mobile App Updates
         p New <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg' target='_blank'>Android</a> and <a href='https://itunes.apple.com/us/app/habitrpg/id689569235?mt=8' target='_blank'>iOS</a> updates are available to support this feature. Please, update your apps before using it, or the new repeating Dailies will not display normally on the mobile apps!
     tr
       td
-        h5.small_news_header Other Notes
+        h5 Other Notes
         p For a short period of time, the <a href='http://data.habitrpg.com' target='_blank'>Data Display Tool</a> will not be able to calculate damage correctly for Repeat Every X Dailies. We'll get that updated very soon so that it will be accurate again!
         br
         p If you still have questions about Repeat Every X Dailies, don't hesitate to ask in <a href='/#/options/groups/guilds/5481ccf3-5d2d-48a9-a871-70a7380cee5a' target='_blank'>the Newbies Guild</a>!
-  h5.big_news_header 6/1/2015 - NEW EQUIPMENT: THE ENCHANTED ARMOIRE, JUNE BACKGROUNDS, AND NEW MOUNT POSITIONING!
+  h4 6/1/2015 - NEW EQUIPMENT: THE ENCHANTED ARMOIRE, JUNE BACKGROUNDS, AND NEW MOUNT POSITIONING!
+    hr
     tr
       td
         .promo_enchanted_armoire.pull-right
-        h5.small_news_header New Equipment: The Enchanted Armoire!
+        h5 New Equipment: The Enchanted Armoire!
         p Now after you achieve Ultimate Gear, you'll unlock a new Reward: THE ENCHANTED ARMOIRE!
         br
         p Click on the Enchanted Armoire, a 100 GP Reward in the Rewards Column, for a random chance at special Equipment! It may also give you random XP or food items. We'll be adding new equipment to it every month, but even when you've exhausted the current supply, you can keep clicking for a chance at food and XP.
@@ -424,57 +444,62 @@ mixin oldNews
     tr
       td
         .background_island_waterfalls.pull-right
-        h5.small_news_header June Backgrounds Revealed
+        h5 June Backgrounds Revealed
         p There are three new avatar backgrounds in the <a href='/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can paddle a Drifting Raft, float through a sea of Shimmery Bubbles, or picnic near Island Waterfalls!
         p.small.muted by (in order): Teto is Great, beffymaroo, and UncommonCriminal
     tr
       td
-        h5.small_news_header New Mount Positioning!
+        h5 New Mount Positioning!
         p The mount positioning has been fixed for all the base mounts where it looked like the avatar was riding extreme sidesaddle. Now avatars sit properly, no longer clinging to the sides of their mounts for dear life.
         p.small.muted by Kiwibot, Lemoness, and SabreCat
-  h5.big_news_header 6/1/2015 - JUNE MYSTERY ITEM!
+  h4 6/1/2015 - JUNE MYSTERY ITEM!
+    hr
     tr
       td
         .inventory_present_06.pull-right
-        h5.small_news_header June Mystery Item!
+        h5 June Mystery Item!
         p Ooh, how mysterious! All Habiticans who are <a href='/#/options/settings/subscription' target='_blank'>subscribed</a> during the month of June will receive the June Mystery Item Set, as well as the ability to buy Gems with Gold! The June Item Set will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
-  h5.big_news_header 5/31/2015 - PUSH NOTIFICATIONS FOR ANDROID, AND LAST CHANCE FOR GREEN KNIGHT SUBSCRIBER ITEMS!
+  h4 5/31/2015 - PUSH NOTIFICATIONS FOR ANDROID, AND LAST CHANCE FOR GREEN KNIGHT SUBSCRIBER ITEMS!
+    hr
     tr
       td
         .promo_mystery_201505.pull-right
-        h5.small_news_header Last Chance for Green Knight Item Set
+        h5 Last Chance for Green Knight Item Set
         p Reminder: this is the final day to <a href='/#/options/settings/subscription' target='_blank'>subscribe</a> and receive the Green Knight Item Set! If you want the Green Knight Helm or the Green Knight Lance, now's the time! Thanks so much for your support <3
         p.small.muted by Lemoness
     tr
       td
-        h5.small_news_header Push Notifications for Android
+        h5 Push Notifications for Android
         p We've released an update to the Android app that includes new types of push notification! Now it's easier than ever to remember to stay productive. Get the Android update <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg' target='_blank'>here</a>!
         p.small.muted by Negue
-  h5.big_news_header 5/25/2015 - MAY SUBSCRIBER ITEM SET: GREEN KNIGHT!
+  h4 5/25/2015 - MAY SUBSCRIBER ITEM SET: GREEN KNIGHT!
+    hr
     tr
       td
         .promo_mystery_201505.pull-right
-        h5.small_news_header May Subscriber Item Set Revealed: Green Knight!
+        h5 May Subscriber Item Set Revealed: Green Knight!
         p The May Subscriber Item has been revealed: the Green Knight Item Set! All May subscribers will receive the Green Knight Helm and the Green Knight Lance. You still have six days to <a href='/#/options/settings/subscription' target='_blank'>subscribe</a> and receive the item set, along with the ability to buy Gems with Gold! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         p.small.muted by Lemoness
-  h5.big_news_header 5/20/2015 - NEW PET QUEST: SHEEP!
+  h4 5/20/2015 - NEW PET QUEST: SHEEP!
+    hr
     tr
       td
         .quest_sheep.pull-right
-        h5.small_news_header New Pet Quest: Sheep!
+        h5 New Pet Quest: Sheep!
         p It looks like there's some ba-a-a-ad weather in the Taskan countryside! Can you and your party be diligent enough to defeat the Thunder Ram? If so, you may find yourself with some wooly sheep pets...
         p.small.muted art by Starsystemic and Misceo
         p.small.muted writing by Salambander, Leephon, and Lemoness
-  h5.big_news_header 5/13/2015 - NEW ANIMAL SKINS AND ACCESSORIES, INN IMPROVEMENTS, COPY CHAT TO TO-DO, AND EXTRA INFO
+  h4 5/13/2015 - NEW ANIMAL SKINS AND ACCESSORIES, INN IMPROVEMENTS, COPY CHAT TO TO-DO, AND EXTRA INFO
+    hr
     tr
       td
         .promo_pet_skins.pull-right
-        h5.small_news_header New Animal Skins and Accessories Available!
+        h5 New Animal Skins and Accessories Available!
         p They say that owners resemble their pets, and now that's truer than ever for Habiticans! The Animal Skin Set and Animal Accessory Set are now available in the <a href='/#/options/profile/avatar' target='_blank'>Customization shop</a>. Time to let your avatar walk on the wild side.
         p.small.muted by Painter de Cluster and SabreCat
     tr
       td
-        h5.small_news_header Inn Improvements
+        h5 Inn Improvements
         p Now even when you Rest in the Inn, your Dailies will refresh each day. <strong>Important note: your Dailies still do NOT hurt you while you're in the Inn.</strong> We wouldn't do that to you!
         br
         p It used to be that the Resting in the Inn froze all your Dailies so that they wouldn't refresh the next day - even for important Dailies like "take medicine" or "feed pets." This was very frustrating to a lot of users who relied on these features, even during periods of time when they needed to rest in the Inn for finals, illness, vacation, etc.
@@ -485,118 +510,125 @@ mixin oldNews
         p.small.muted by hairlessbear and Blade
     tr
       td
-        h5.small_news_header Copy Chat to To-Do
+        h5 Copy Chat to To-Do
         p Now you can copy any chat message into your To-Do list! If your roommate posted in party chat and asked you to grab groceries, or your friend reminded you about the history quiz tomorrow, you can save it right into your To-Do list. Awesome! 
         p.small.muted by Negue and Redphoenix
     tr
       td
-        h5.small_news_header Extra Info
+        h5 Extra Info
         p We know that HabitRPG can be confusing, so now you can easily double-check what each task type does by clicking the question mark next to its name.
         p.small.muted by Lemoness, lefnire, and SabreCat
-  h5.big_news_header 5/06/2015 - MAY BACKGROUNDS REVEALED
+  h4 5/06/2015 - MAY BACKGROUNDS REVEALED
+    hr
     tr
       td
         .background_mountain_lake.pull-right
-        h5.small_news_header May Backgrounds Revealed
+        h5 May Backgrounds Revealed
         p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can climb to the top of Pagodas, pose in front of a Marble Temple, or dip toes in a Mountain Lake!
         p.small.muted by (in order) Teto is Great, Painter de Cluster, and Hazel40
 
-  h5.big_news_header 5/01/2015 - Skills Rebalancing
+  h4 5/01/2015 - Skills Rebalancing
+    hr
     tr
       td
         p After over a year's worth of complaints on Trello and countless bug reports on Github, and after almost five months of dedicated debating, coding, and testing, we have finally rolled out an overhaul of the skills and mana system. Thank you so much to everyone who contributed opinions, time, and effort! Here's what happened:
     tr
       td
-        h5.small_news_header HABITS DAMAGE BOSSES
+        h5 HABITS DAMAGE BOSSES
         p Now it's even easier to damage a Boss without skills! It was definitely high time that HabitRPG counted Habits towards battles. We were not living up to our name.
     tr
       td
-        h5.small_news_header MANA DIRECTLY LINKED TO PROGRESS
+        h5 MANA DIRECTLY LINKED TO PROGRESS
         p Mana was pretty broken: you gained it overnight no matter what you'd done the day before, and it was only linked to To-Dos. This meant that using skills was pretty detached from how well you were doing in your real life, which defeated the purpose of the game!
         p Now you can gain Mana from Dailies and positive Habits as well as To-Dos! You still gain Mana overnight, but how much you gain depends on how many of your Dailies you did.
         p You can also lose Mana by hitting negative Habits. Yikes! Better not indulge...
     tr
       td
-        h5.small_news_header SKILLS STRENGTHENED AND WEAKENED
+        h5 SKILLS STRENGTHENED AND WEAKENED
         p Some notoriously overpowered skills have been weakened, like Backstab (which often granted over 1000GP per cast), Burst of Flames (which allowed you to 1-hit KO most bosses regardless of how much or how little you'd done that day), and Valorous Presence (which caused the notorious "I checked off one Daily and gained 997 levels" bug reports).
         p Some painfully UNDERpowered skills have been strengthened, such as Tools of the Trade and Searing Brightness. We think you'll like these much better now!
         p For a full description of what changed, <a href='http://habitrpg.wikia.com/wiki/User_blog:LadyAlys/Skills_Rebalancing_and_Other_Changes' target='_blank'>check out this blog post</a>.
     tr
       td
-        h5.small_news_header GIVING FEEDBACK
+        h5 GIVING FEEDBACK
         p We understand that these changes may be disruptive to some of you. We're sorry! We hope that with time, you will find them to be a drastic improvement. We will be waiting two weeks (so that everyone can get used to the new system), and then on May 15th will open up a new Trello card for comments and feedback.
         p For those of you who want to reallocate stats now that you have the new system, please post your User ID in this <a href='https://github.com/HabitRPG/habitrpg/issues/5082' target='_blank'>Github ticket</a>. (Your UUID is found under Settings > API; do NOT post your API Token.) That ticket is also being used to debate a possibility to make it so that reallocating stats does not cost gems. If that's a feature you would like (or would hate), definitely drop by that ticket and let us know!
         p.small.muted by Alys, Verabird, brandonjreid, ShilohT, betaveros, SabreCat, chimericdream, and everyone who commented with feedback on Trello and Github. You all are great!
 
-  h5.big_news_header 4/30/2015 - LAST CHANCE FOR BUSY BEE AND SPRING FLING ITEMS, AND SOON-TO-APPEAR NEW EQUIPMENT!
+  h4 4/30/2015 - LAST CHANCE FOR BUSY BEE AND SPRING FLING ITEMS, AND SOON-TO-APPEAR NEW EQUIPMENT!
+    hr
     tr
       td
         .promo_shimmer_hair.pull-right
-        h5.small_news_header Last Chance for Spring Fling Outfits, Hair Colors, and Shiny Seeds!
+        h5 Last Chance for Spring Fling Outfits, Hair Colors, and Shiny Seeds!
         p Tomorrow everything will be back to normal in Habitica, so if you still have any remaining Spring Fling Items that you want to buy, you'd better do it now! The <a href='https://habitrpg.com/#/options/inventory/seasonalshop' target='_blank'>Seasonal Edition items</a> and <a href='https://habitrpg.com/#/options/profile/avatar' target='_blank'>Hair Colors</a> won't be back until next March, and if the Limited Edition items return they will have increased prices or changed art, so strike while the iron is hot!
     tr
       td
         .promo_mystery_201504.pull-right
-        h5.small_news_header Last Chance for Busy Bee Item Set
+        h5 Last Chance for Busy Bee Item Set
         p Reminder: this is the final day to <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribe</a> and receive the Busy Bee Item Set! If you want the Busy Bee Robe or the Busy Bee Robes, now's the time! Thanks so much for your support <3
     tr
       td
-        h5.small_news_header New Equipment Soon
+        h5 New Equipment Soon
         p If you're sad to see the extra gold-purchasable equipment disappear, don't worry! We have something fun in the works...
 
-  h5.big_news_header 4/24/2015 - APRIL SUBSCRIBER ITEM SET AND NEW LANGUAGES
+  h4 4/24/2015 - APRIL SUBSCRIBER ITEM SET AND NEW LANGUAGES
+    hr
     tr
       td
         .promo_mystery_201504.pull-right
-        h5.small_news_header April Subscriber Item Set: Busy Bee!
+        h5 April Subscriber Item Set: Busy Bee!
         p The April Subscriber Item has been revealed: the Busy Bee Item Set! All April subscribers will receive the Busy Bee Robe and the Busy Bee Wings. You still have six days to <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribe</a> and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         p.small.muted by Lemoness
     tr
       td
-        h5.small_news_header New Languages
+        h5 New Languages
         p We've added three new languages to the site: Japanese, Serbian and Chinese (Traditional)!
         p.small.muted by Paglias, the <a href='https://www.transifex.com/projects/p/habitrpg/language/ja/' target='_blank'>Japanese Translation Team</a>, the <a href='https://www.transifex.com/projects/p/habitrpg/language/sr/' target='_blank'>Serbian Translation Team</a>, and the <a href='https://www.transifex.com/projects/p/habitrpg/language/zh_TW/' target='_blank'>Chinese (Traditional) Translation Team</a>
 
-  h5.big_news_header 4/15/2015 - MARSHMALLOW SLIMES, KEY TO THE KENNELS CHANGE, AND CHALLENGE IMPROVEMENTS
+  h4 4/15/2015 - MARSHMALLOW SLIMES, KEY TO THE KENNELS CHANGE, AND CHALLENGE IMPROVEMENTS
+    hr
     tr
       td
         .Pet-Slime-Base.pull-right
-        h5.small_news_header Marshmallow Slime Pet Quest!
+        h5 Marshmallow Slime Pet Quest!
         p There is a new Pet Quest available in the <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>Market</a>: The Jelly Regent! Gooey slime is gumming up the works, and Habiticans are having a tough time finishing their tasks. Can you mop the floor with the Jelly Regent? If so, you'll get some adorable Marshmallow Slime pets!
         p.small.muted art by Starsystemic, Leephon, LordDarkly, Overomega, and Shaner
         p.small.muted writing by Bethany Woll and Theothermeme
     tr
       td
-        h5.small_news_header Key to the Kennels Free with Triad Bingo
+        h5 Key to the Kennels Free with Triad Bingo
         .pet_key.pull-right
         p The Key to the Kennels is now free if you have the Triad Bingo achievement and if you choose to release your pets and mounts together! Rejoice, collectors! Note that the Key will not be free if you release only pets or only mounts.
         p.small.muted by gisikw
     tr
       td
-        h5.small_news_header Challenge Improvements
+        h5 Challenge Improvements
         p Now Challenge links take you directly to that Challenge, instead of the top of the list, and when you edit a Challenge, the name is automatically updated!
         p.small.muted by gisikw, chrisdotcode, and TheHollidayInn
-  h5.big_news_header 4/7/2015 - APRIL BACKGROUNDS REVEALED
+  h4 4/7/2015 - APRIL BACKGROUNDS REVEALED
+    hr
     tr
       td
         .background_cherry_trees.pull-right
-        h5.small_news_header April Backgrounds
+        h5 April Backgrounds
         p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can picnic in a Flowering Meadow, nibble the scenery of Gumdrop Land, or admire the Cherry Trees!
         p.small.muted by Rattify, Painter de Cluster, and kmcallah
-  h5.big_news_header 4/2/2015 - MARCH AND APRIL ITEM SETS; SHINY SEEDS; MESSAGE CHALLENGE CREATORS; ITEM DROP ICONS
+  h4 4/2/2015 - MARCH AND APRIL ITEM SETS; SHINY SEEDS; MESSAGE CHALLENGE CREATORS; ITEM DROP ICONS
+    hr
     tr
       td
-        h5.small_news_header Last Chance for March Item Set
+        h5 Last Chance for March Item Set
         p Reminder: this is the final day to <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribe</a> and receive the Aquamarine Item Set! If you want the Aquamarine Eyewear or the Aquamarine Armor, now's the time! Thanks so much for your support <3
     tr
       td
-        h5.small_news_header April Mystery Box
+        h5 April Mystery Box
         .inventory_present.pull-right
         p Cool! What could it be? All Habiticans who are subscribed during the month of April will receive the April Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
         p.small.muted by Lemoness
     tr
       td
-        h5.small_news_header Shiny Seeds
+        h5 Shiny Seeds
         .inventory_special_shinySeed.pull-right
         p Phew! It was tough, but we overthrew the flowers that had taken over the site. However, they've left behind some of their Shiny Seeds!
         br
@@ -606,61 +638,64 @@ mixin oldNews
         p.small.muted by Lemoness and SabreCat
     tr
       td
-        h5.small_news_header Message Challenge Creators
+        h5 Message Challenge Creators
         p Now on the Challenges page, you can to click on the challenge creator's name to view their profile, message them, or to see how long ago they last logged in if you are curious about whether the challenge might still be active.
         p.small.muted by TheHollidayInn
     tr
       td
         .promo_item_notif.pull-right
-        h5.small_news_header Icons in Notifications
+        h5 Icons in Notifications
         p Now, when you find an item from scoring a task, an image of the item appears in the drop notification. Instant gratification when that egg or potion you've been hunting for finally appears!
         p.small.muted by TheHollidayInn
-  h5.big_news_header 4/1/2015 - HOSTILE FLOWER TAKEOVER OF JOY AND DOOM
+  h4 4/1/2015 - HOSTILE FLOWER TAKEOVER OF JOY AND DOOM
+    hr
     tr
       td
-        h5.small_news_header Joy and Doom to All!
+        h5 Joy and Doom to All!
         p THE SPRING FLING HAS FLUNG TOO FAR! Run while you can, Habiticans! The floral theme has come to life and is taking over Habitica with horrifying cheer, repeat, the flowers are taking over HMMMPH MMPH MMMHPPPH....
         .avatar_floral_wizard
         p CELEBRATE FLOWER POWER.
         br
         p RESISTANCE IS SILLY.
         p.small.muted by Lemoness and Baconsaur
-  h5.big_news_header 3/29/2015 - PASTEL SKIN, SHIMMER HAIR COLORS, SURVEY BADGES AWARDED, AND PARTY SORT ORDER
+  h4 3/29/2015 - PASTEL SKIN, SHIMMER HAIR COLORS, SURVEY BADGES AWARDED, AND PARTY SORT ORDER
+    hr
     tr
       td
         .promo_pastel_skin.pull-right
-        h5.small_news_header Pastel Skin
+        h5 Pastel Skin
         p The Seasonal Edition Pastel Skin Set is now available for purchase in the <a href='https://habitrpg.com/#/options/profile/avatar' target='_blank'>avatar customizations page</a>! This skin set will only be available until April 30th, and then it will disappear until next Spring Fling.
         p.small.muted by McCoyly
     tr
       td
         .promo_shimmer_hair.pull-right
-        h5.small_news_header Shimmer Hair Colors
+        h5 Shimmer Hair Colors
         p The Seasonal Edition Shimmer Hair Colors are now available for purchase in the <a href='https://habitrpg.com/#/options/profile/avatar' target='_blank'>avatar customizations page</a>! Now you can dye your avatar's hair Shimmer Pink, Shimmer Purple, Shimmer Blue, Shimmer Green, Shimmer Orange, or Shimmer Yellow.
         br
         p Seasonal Edition items recur unchanged every year, but they are only available to purchase during a short period of time. This is different from Limited Edition Items, which only recur if something is changed, such as the art or the price. These hair colors may remind some of you of the Pastel Hair Colors that were available last spring. The Pastel Hair Colors have been retired in favor of the similar Seasonal Edition Shimmer Hair Colors. Read more about the difference between Seasonal and Limited Edition items <a href='http://habitrpg.wikia.com/wiki/Item_Availability' target='_blank'>here</a>!
         p.small.muted by Lemoness, crystalphoenix, and mariahm
     tr
       td
-        h5.small_news_header Survey Badges Awarded
+        h5 Survey Badges Awarded
         p The Survey badges have been awarded to everyone who took the survey and provided their user ID! Unfortunately, some people did not include their User ID with the survey. As a result, we have no way of linking the survey with their accounts, and could not give them the "Helped Habit Grow" badge. If you have any questions, please email <a href='mailto:leslie@habitrpg.com'>Leslie</a>.
         p.small.muted by Sugarfiend and Alys
     tr
       td
-        h5.small_news_header Party Sort Order
+        h5 Party Sort Order
         p Now when you change the sort order for your party, it takes effect immediately. You can change the sort order under Social > Party.
         p.small.muted by ChokesMcGee
-  h5.big_news_header 3/25/2015 - MARCH SUBSCRIBER ITEM, FREE EGG HUNT QUEST, EGG MOUNTS, AND NEW MODERATOR!
+  h4 3/25/2015 - MARCH SUBSCRIBER ITEM, FREE EGG HUNT QUEST, EGG MOUNTS, AND NEW MODERATOR!
+    hr
     tr
       td
         .promo_mystery_201503.pull-right
-        h5.small_news_header March Subscriber Item
+        h5 March Subscriber Item
         p The March Subscriber Item has been revealed: the Aquamarine Item Set! All March subscribers will receive the Aquamarine Eyewear and the Aquamarine Armor. You still have six days to <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribe</a> and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         p.small.muted by Lemoness
     tr
       td
         .Pet-Egg-CottonCandyPink.pull-right
-        h5.small_news_header Egg Hunt Quest and Egg Mounts
+        h5 Egg Hunt Quest and Egg Mounts
         p In celebration of the season, everyone has received a free Egg Hunt collection quest scroll! You can find it in the <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>Inventory</a>. Collect eggs by completing your tasks, and you'll be rewarded with some egg pets.
         br
         p Furthermore, the Egg Pets can now be fed... and grow into some glorious Egg Mounts!
@@ -669,104 +704,109 @@ mixin oldNews
         p.small.muted by Beffymaroo and Megan
     tr
       td
-        h5.small_news_header New Moderator
+        h5 New Moderator
         p Finally, we have a new moderator on the site: @Beffymaroo! Hooray! Be sure to say hello to her in the Tavern.
-  h5.big_news_header 3/20/2015 - SPRING FLING EVENT! LIMITED EDITION OUTFITS, SEASONAL SHOP OPENS, AND SPRING NPCS
+  h4 3/20/2015 - SPRING FLING EVENT! LIMITED EDITION OUTFITS, SEASONAL SHOP OPENS, AND SPRING NPCS
+    hr
     tr
       td
-        h5.small_news_header Spring Fling!
+        h5 Spring Fling!
         p The Spring Fling is here! From today until April 30th, join Habitica in its sweet celebration.
     tr
       td
         .promo_springclasses2015.pull-right
-        h5.small_news_header Limited Edition Class Outfits
+        h5 Limited Edition Class Outfits
         p From now until April 30th, limited edition outfits are available in the Rewards column. Depending on your class, you can be a Beware Dog, Magician's Bunny, Sneaky Squeaker, or Comforting Kitty! You'd better get productive to earn enough gold before they disappear. Good luck!
         p.small.muted by Lemoness
     tr
       td
         .promo_springclasses2014.pull-right
-        h5.small_news_header Seasonal Shop Opens
+        h5 Seasonal Shop Opens
         p The <a href='https://habitrpg.com/#/options/inventory/seasonalshop' target='_blank'>Seasonal Shop</a> has opened! It's stocking springtime Seasonal Edition goodies at the moment, including last year's spring outfits. Everything there will be available to purchase during the Spring Fling event each year, but it's only open until April 30th, so be sure to stock up now, or you'll have to wait a year to buy these items again.
         p.small.muted by Lemoness
     tr
       td
         .seasonalshop_spring2015.pull-left
-        h5.small_news_header Spring NPCs
+        h5 Spring NPCs
         p Looks like the NPCs are really getting in to the springtime fun around the site. Who wouldn't? After all, there's plenty more to come!
         p.small.muted by Lemoness and Shaner
-  h5.big_news_header 3/17/2015 - BUNNY PET QUEST, EGG PURCHASING CHANGE, LAST DAY FOR SURVEY AND ACHIEVEMENT, AND UNEQUIP BUTTONS
+  h4 3/17/2015 - BUNNY PET QUEST, EGG PURCHASING CHANGE, LAST DAY FOR SURVEY AND ACHIEVEMENT, AND UNEQUIP BUTTONS
+    hr
     tr
       td
-        h5.small_news_header New Pet Quest: Killer Bunny
+        h5 New Pet Quest: Killer Bunny
         p There's a new quest scroll in the <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>Market</a>! Deep within Mount Procrastination lies a once-sweet beast grown horrifying with neglect. Can you rally your strength to defeat the Killer Bunny? If so, you'll get some bunny eggs!
         p.small.muted by Draayder, Gully, and TetoIsGreat
     tr
       td
-        h5.small_news_header Egg Purchasing Change
+        h5 Egg Purchasing Change
         p You can now purchase quest eggs from the <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>Market</a> after defeating the corresponding boss at least once! Previously, you had to defeat the boss at least twice before being able to purchase the eggs.
         p.small.muted by Blade
     tr
       td
-        h5.small_news_header Last Day for Survey and Achievement
+        h5 Last Day for Survey and Achievement
         p March 18th is the final day to complete <a href='https://www.surveymonkey.com/s/62RXRF3' target='_blank'>this survey</a> to receive or stack the Helped Habit Grow survey! After it is closed, it will take us several days to award the badges. Thanks so much for sharing your feedback with us!
         p.small.muted by sugarfiend and SabreCat
     tr
       td
-        h5.small_news_header Unequip Buttons
+        h5 Unequip Buttons
         p It’s now easier to switch your avatar’s costume! You can now unequip all your battle gear, costume pieces, and/or pets from the Equipment page using the new Unequip buttons.
         p.small.muted by TheHolidayInn
-  h5.big_news_header 3/10/2015 - SURVEY, TESTIMONIALS GUILD, AND CHAT EXTENSION
+  h4 3/10/2015 - SURVEY, TESTIMONIALS GUILD, AND CHAT EXTENSION
     hr
     tr
       td
-        h5.small_news_header Survey and Achievement
+        h5 Survey and Achievement
         .achievement.achievement-tree.pull-right
         p We're giving out the rare Helped Habit Grow achievement to all users who help us out by completing <a href='https://www.surveymonkey.com/s/62RXRF3' target='_blank'>this 10-question survey</a>! If you already received this badge, taking this new survey will stack your achievement. Thanks for sparing a minute to let us know what you think about HabitRPG!
         p.small.muted by sugarfiend and SabreCat
     tr
       td
-        h5.small_news_header Testimonials Guild
+        h5 Testimonials Guild
         p We're collecting testimonials from users to display on the front page along with pictures of their avatars. If HabitRPG has been helpful to you and you feel comfortable leaving a short testimonial for us, you can post it <a href='https://habitrpg.com/#/options/groups/guilds/ae985ab0-fcc3-410d-bdb3-ae4defe712bb' target='_blank'>here</a>. Thanks for all your help! <3
     tr
       td
-        h5.small_news_header Chat Extension
+        h5 Chat Extension
         p Horacious Moreau has made a <a href='https://chrome.google.com/webstore/detail/habitrpg-chat-client/hidkdfgonpoaiannijofifhjidbnilbb' target='_blank'>chat extension</a> for HabitRPG! It creates a chat box for Tavern, parties, and Guilds. :)
         br
         p The Chat Client is also open-source! You can check out the project <a href='https://github.com/Horacious/HabitRPG-Chat-Extension' target='_blank'>here</a>.
         p.small.muted by Horacious Moreau
-  h5.big_news_header 3/3/2015 - MARCH BACKGROUNDS, ANDROID APP NOTIFICATIONS, AND MARCH MYSTERY BOX
+  h4 3/3/2015 - MARCH BACKGROUNDS, ANDROID APP NOTIFICATIONS, AND MARCH MYSTERY BOX
+    hr
     tr
       td
-        h5.small_news_header March Backgrounds Revealed
+        h5 March Backgrounds Revealed
         p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can dance in the Spring Rain, admire some Stained Glass, or frolic through the Rolling Hills!
         p.small.muted by (in order) Sunstroke, Kiwibot, and Uncommon Criminal
     tr
       td
-        h5.small_news_header Android App Notifications
+        h5 Android App Notifications
         p The <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg' target='_blank'>Android app</a> can now remind you to log in! Simply go to Settings and select the time that you want the reminder.
         p.small.muted by Negue
     tr
       td
         .inventory_present.pull-right
-        h5.small_news_header March Mystery Box
+        h5 March Mystery Box
         p Wow! What could it be? All Habiticans who are <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribed</a> during the month of March will receive the March Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
         p.small.muted by Lemoness
-  h5.big_news_header 2/24/2015 - FEBRUARY SUBSCRIBER ITEM AND ADD MULTIPLE TASKS!
+  h4 2/24/2015 - FEBRUARY SUBSCRIBER ITEM AND ADD MULTIPLE TASKS!
+    hr
     tr
       td
         .promo_mystery_201502.pull-right
-        h5.small_news_header February Subscriber Item
+        h5 February Subscriber Item
         p The February Subscriber Item has been revealed: the Winged Enchanter Item Set! All February subscribers will receive the Wings of Thought and the Shimmery Winged Staff of Love and Also Truth. You still have four days to <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribe</a> and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         p.small.muted by Lemoness
     tr
       td
-        h5.small_news_header Add Multiple Tasks
+        h5 Add Multiple Tasks
         p Got a bunch of tasks you need to add all at once? No problem! Now you can add a batch of tasks all at once by clicking "Add Multiple" under the task entry bar. We hope that this will save you time!
         p.small.muted by ChimericDream
-  h5.big_news_header 2/24/2015 - SITE DOWNTIME EXPLANATION (AND SLEEPING AVATARS)
+  h4 2/24/2015 - SITE DOWNTIME EXPLANATION (AND SLEEPING AVATARS)
+    hr
     tr
       td
-        h5.small_news_header
+        h5
         p As most of you probably noticed, the site was down yesterday. We got a surge of new users from Imgur who absolutely flattened the servers by registering all at once, and it proved very difficult to start up again. You can read the technical details <a href="https://github.com/HabitRPG/habitrpg/issues/4737" target="_blank">in this Github ticket</a>. We're sorry about all of the frustration!
         br
         p At about midnight PST we checked all active users into the inn, "freezing" their accounts so that their incomplete Dailies would not hurt them, in hopes that this would prevent most of the undeserved deaths due to server troubles. That's why your avatar is sleeping! To check yourself out of the inn, go to Social > Tavern > Check out of inn.
@@ -778,17 +818,17 @@ mixin oldNews
         p And welcome, Imgurians! Sorry your introduction was so rocky, but we can't wait to get to know you. There is a <a href="https://habitrpg.com/#/options/groups/guilds/4709ba62-2ba0-43ff-a5a5-494c774236ec">Camp Imgur Guild</a> that you might enjoy.
         br
         p Now, back to productivity!
-  h5.big_news_header 2/17/2015 - NEW PET QUEST AND COMMUNITY GUIDELINE UPDATES
+  h4 2/17/2015 - NEW PET QUEST AND COMMUNITY GUIDELINE UPDATES
     hr
     tr
       td
         .quest_rock.pull-right
-        h5.small_news_header New Pet Quest: Rocks!
+        h5 New Pet Quest: Rocks!
         p It seemed like a simple hike... until we discovered that the cave was alive! You can get the newest Pet Quest, "Escape the Cave Creature," in the <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>Market</a>. If you defeat it, you'll get some cuddly pet rocks!
         p.small.muted by itokro, Pfeffernusse, Painter de Cluster, and intone
     tr
       td
-        h5.small_news_header Community Guideline Updates
+        h5 Community Guideline Updates
         p We've updated the <a href='https://habitrpg.com/static/community-guidelines' target='_blank'>Community Guidelines</a> to include the following:
         ul
           li Blade, a new mod, is listed!
@@ -797,122 +837,131 @@ mixin oldNews
           li Sexism has been added to the list of unacceptable behaviors.
           li Making duplicate accounts to circumvent consequences is now expressly forbidden.
 
-  h5.big_news_header 2/12/2015
+  h4 2/12/2015
+    hr
     tr
       td
-        h5.small_news_header Happy Valentine's Day!
+        h5 Happy Valentine's Day!
         p Help motivate all of the lovely people in your life by sending them a caring valentine. Valentines can be purchased for 10 gold from the Market. For spreading love and joy throughout the community, both the giver AND the receiver get a coveted "adoring friends" badge. Hooray!
         p.small.muted by Lemoness and SabreCat
     tr
       td
-        h5.small_news_header New Hairstyles!
+        h5 New Hairstyles!
         .promo_updos.pull-right
         p There are a new set of updo hairstyles available in the <a href='https://habitrpg.com/#/options/profile/avatar' target='_blank'>Avatar Customization page</a>! Have fun customizing your characters.
         p.small.muted by Crystalphoenix, Mariahm, Painter de Cluster, Leephon, Beffymaroo, Sungabraverday, Lemoness, and Bailey
-  h5.big_news_header 2/8/2015
+  h4 2/8/2015
+    hr
     tr
       td
-        h5.small_news_header Email Notifications
+        h5 Email Notifications
         p We've implemented email notifications for a variety of events, including receiving a Private Message, being invited to a Party, Guild, or Quest, and receiving a gift of Gems or a Subscription! We've got some more coming up, too, including the much-requested check-in reminders.
         p Don't want to receive a certain type of notification? No problem! Just go to <a href='https://habitrpg.com/#/options/settings/notifications' target='_blank'>Notification Settings</a> to tell us exactly which ones you do and do not want to receive. Our messenger dragons will be happy to comply!
         p.small.muted by paglias and Lemoness
     tr
       td
-        h5.small_news_header Login Type Switching
+        h5 Login Type Switching
         p Want to change your email address, or switch from Facebook login to email login? Good news! Now you can switch it yourself, under <a href='https://habitrpg.com/#/options/settings/settings' target='_blank'>Settings</a>!
         p.small.muted by Lefnire
-  h5.big_news_header 2/3/2015
+  h4 2/3/2015
+    hr
     tr
       td
-        h5.small_news_header February Backgrounds Revealed
+        h5 February Backgrounds Revealed
         .background_distant_castle.pull-right
         p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can survey a Distant Castle, toil in the Blacksmithy, or explore a Crystal Cave!
         p.small.muted by Holseties, Hanztan, and Twitching
-  h5.big_news_header 2/2/2015
+  h4 2/2/2015
+    hr
     tr
       td
-        h5.small_news_header February Mystery Box
+        h5 February Mystery Box
         .inventory_present.pull-right
         p Ooh... What could it be? All Habiticans who are subscribed during the month of February will receive the February Mystery Item Set! It will be revealed on the 24th, so keep your eyes peeled. Thanks for supporting the site <3
         p.small.muted by Lemoness
     tr
       td
-        h5.small_news_header New Quest Descriptions
+        h5 New Quest Descriptions
         p We've updated quest descriptions so that when you hover over them, you can now see the Boss or Collection stats and the Rewards that you will gain when you complete the quest!
         p.small.muted by Blade
     tr
       td
-        h5.small_news_header Spread the Word Challenge Has Ended
+        h5 Spread the Word Challenge Has Ended
         p The Spread the Word Challenge has ended! Thank you to all the participants. It will be some time before the winners are announced because we have to go over all the entries ourselves. Thanks for your patience!
-  h5.big_news_header 1/30/2015
+  h4 1/30/2015
+    hr
     tr
       td
         .npc_alex.pull-left
-        h5.small_news_header HabitRPG Birthday Bash
+        h5 HabitRPG Birthday Bash
         p January 31st is HabitRPG's Birthday! All of the NPCs are celebrating, and we've awarded you a bunch of cake for your pets and mounts!
     tr
       td
-        h5.small_news_header Party Robes
+        h5 Party Robes
         .shop_armor_special_birthday.pull-right
         .shop_armor_special_birthday2015.pull-right
         p Until February 1st only, there are Party Robes available for free in the Rewards store! If this is your first Birthday bash with us, you can find some Absurd Party Robes; if you already got some last year, then you will find the Silly Party Robes.
     tr
       td
         .promo_mystery_201501.pull-left
-        h5.small_news_header Last Chance for Starry Knight Item Set
+        h5 Last Chance for Starry Knight Item Set
         p Reminder: this is the final day to <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribe</a> and receive the Starry Knight Item Set! If you want the Starry Helm or the Starry Armor, now's the time! Thanks so much for your support <3
     tr
       td
-        h5.small_news_header Last Chance for Winter Wonderland Outfits + Hair Colors
+        h5 Last Chance for Winter Wonderland Outfits + Hair Colors
         .promo_winterclasses2015.pull-right
         p Tomorrow everything will be back to normal in Habitica, so if you still have any remaining Winter Wonderland Items that you want to buy, you'd better do it now! The <a href='https://habitrpg.com/#/options/inventory/seasonalshop' target='_blank'>Seasonal Edition items</a> and <a href='https://habitrpg.com/#/options/profile/avatar' target='_blank'>Hair Colors</a> won't be back until next December, and if the Limited Edition items return they will have increased prices or changed art, so strike while the iron is hot!
-  h5.big_news_header 1/26/2015
+  h4 1/26/2015
+    hr
     tr
       td
-        h5.small_news_header Subscriber Outfit Revealed
+        h5 Subscriber Outfit Revealed
         .promo_mystery_201501.pull-right
         p The January Subscriber Item has been revealed: the Starry Knight Item Set! All January subscribers will receive the Starry Helm and the Starry Armor. You still have five days to <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribe</a> and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         p.small.muted by Lemoness
     tr
       td
-        h5.small_news_header New Audio Theme
+        h5 New Audio Theme
         p A new audio theme is available: Watts' Theme! You can toggle between Watts' Theme and Daniel the Bard's Theme by selecting the megaphone in the upper right-hand corner. Watts' Theme was created by Harry Pepe. You can visit his <a href='https://www.linkedin.com/in/hpepe4' target='_blank'>LinkedIn page here</a>.
         p.small.muted by Hpepe4 and Blade
     tr
       td
-        h5.small_news_header Quest Scroll Redesign
+        h5 Quest Scroll Redesign
         p We've redesigned the quest scrolls so that they are visually unique! Quest type and difficulty is determined by the scroll lining (Easy Boss = Green, Medium Boss = Yellow, Hard Boss = Red, Collection Quest = Blue, Rage Bar Boss = Purple speckles), and an icon symbolizing the quest is located in the lower left.
         p.small.muted by UncommonCriminal and Rattify
     tr
       td
-        h5.small_news_header Spread the Word Challenge Ending Soon
+        h5 Spread the Word Challenge Ending Soon
         p Reminder: January 31st is the last day to enter the <a href='https://habitrpg.com/#/options/groups/challenges/e1ad6d92-587d-4137-848e-4a1f643603ba' target='_blank'>Spread the Word Challenge</a> for your chance at winning 100 gems! We will stop accepting new applications on February 1st, but it will be some time before the winners are announced because we have to go over all the entries ourselves. Good luck!
-  h5.big_news_header 1/23/2015
+  h4 1/23/2015
+    hr
     tr
       td
-        h5.small_news_header The Abominable Stressbeast is DEFEATED!
+        h5 The Abominable Stressbeast is DEFEATED!
         p We've done it! With a final bellow, the Abominable Stressbeast dissipates into a cloud of snow. The flakes twinkle down through the air as cheering Habiticans embrace their pets and mounts. Our animals and our NPCs are safe once more!
     tr
       td
-        h5.small_news_header Stoïkalm is Saved!
+        h5 Stoïkalm is Saved!
         p SabreCat speaks gently to a small sabertooth. "Please find the citizens of the Stoïkalm Steppes and bring them to us," he says. Several hours later, the sabertooth returns, with a herd of mammoth riders following slowly behind. You recognize the head rider as Lady Glaciate, the leader of Stoïkalm.
         p "Mighty Habiticans," she says, "My citizens and I owe you the deepest thanks, and the deepest apologies. In an effort to protect our Steppes from turmoil, we began to secretly banish all of our stress into the icy mountains. We had no idea that it would build up over generations into the Stressbeast that you saw! When it broke loose, it trapped all of us in the mountains in its stead and went on a rampage against our beloved animals." Her sad gaze follows the falling snow. "We put everyone at risk with our foolishness. Rest assured that in the future, we will come to you with our problems before our problems come to you."
         .Pet-Mammoth-Base.pull-right
         p She turns to where @Baconsaur is snuggling with some of the baby mammoths. "We have brought your animals an offering of food to apologize for frightening them, and as a symbol of trust, we will leave some of our pets and mounts with you. We know that you will all take care good care of them."
         p.small.muted by everyone who completed a Daily or a To-Do during the battle!
-  h5.big_news_header 1/21/2015
+  h4 1/21/2015
+    hr
     tr
       td
-        h5.small_news_header THIRD STRESS STRIKE!
+        h5 THIRD STRESS STRIKE!
         .npc_justin_broken.pull-right
         p The World Boss in the <a href='https://habitrpg.com/#/options/groups/tavern' target='_blank'>Tavern</a> has used a third Stress Strike!
         p Justin the Guide is trying to distract the Stressbeast by running around its ankles, yelling productivity tips! The Abominable Stressbeast is stomping madly, but it seems like we're really wearing this beast down. I doubt it has enough energy for another strike. Don't give up... we're so close to finishing it off!
         p Complete Dailies and To-Dos to damage the World Boss! A World Boss will never damage individual players or accounts in any way. Only active accounts who are not resting in the inn will have their incomplete Dailies tallied.
         p.small.muted by Lemoness, Kiwibot, and SabreCat
-  h5.big_news_header 1/20/2015
+  h4 1/20/2015
+    hr
     tr
       td
-        h5.small_news_header Mount Master and Triad Bingo Achievements
+        h5 Mount Master and Triad Bingo Achievements
         .achievement.achievement-wolf
         .achievement.achievement-triadbingo
         p There are two new achievements you can earn: Mount Master and Triad Bingo! Mount Master is awarded to users who have collected all 90 standard mounts, and Triad Bingo is for those who have collected all 90 standard pets, grown all 90 into mounts, and then rehatched 90 more standard pets. Wow!
@@ -921,61 +970,64 @@ mixin oldNews
         p.small.muted by Taldin, Blade, Lorian, Aiseant, and Hanztan
     tr
       td
-        h5.small_news_header Party Sorting Options
+        h5 Party Sorting Options
         p In the <a href="/#/options/groups/party">Party Page</a> you can now sort your friends' avatars in ascending or descending order! To make the change take effect, you'll have to refresh the page.
 
         p.small.muted by Blade and Viirus
     tr
       td
-        h5.small_news_header Dated To-Dos
+        h5 Dated To-Dos
         p Now you can use To-Do tabs to sort and see your dated To-Dos! Simply click the "Dated" tab and only To-Dos with a due date will be displayed. They are not currently sorted by date, but we will be implementing that feature in the future.
 
         p.small.muted by Alys
     tr
       td
-        h5.small_news_header Stressbeast Desperation Triggered
+        h5 Stressbeast Desperation Triggered
 
         p We're almost there, Habiticans! With diligence and Dailies, we've whittled the Stressbeast's health down to only 500K! The creature roars and flails in desperation, rage building faster than ever. The monster is --- AHHH! --- swinging me and Matt around at a terrifying pace, raising a blinding snowstorm that makes it harder to hit.
         p We'll have to redouble our efforts, but take heart - this is a sign that the Stressbeast knows it is about to be defeated. Don't give up now! Please?
 
         p The Stressbeast raises its Rage and Defense! Complete Dailies and To-Dos to damage the World Boss. A World Boss will never damage individual players or accounts in any way. Only active accounts who are not resting in the inn will have their incomplete Dailies tallied.
         p.small.muted by Lemoness, Kiwibot, and SabreCat
-  h5.big_news_header 1/19/2015
+  h4 1/19/2015
+    hr
     tr
       td
-        h5.small_news_header WORLD BOSS: SECOND STRESS STRIKE!
+        h5 WORLD BOSS: SECOND STRESS STRIKE!
         p AHHHHHHHH!!!!! IT'S GOT ME!!!!! Oh, Habiticans, why didn't you do your Dailies?!
         p The World Boss in the <a href='https://habitrpg.com/#/options/groups/tavern' target='_blank'>Tavern</a> has used another Stress Strike, and this time it's attacked me, Bailey the Town Crier! To save me and the other NPCs, complete Dailies and To-Dos to damage the World Boss! Incomplete Dailies fill the Stress Strike Bar. When the Stress Strike bar is full, the World Boss will attack an NPC and regain some health. A World Boss will never damage individual players or accounts in any way. Only active accounts who are not resting in the inn will have their incomplete Dailies tallied.
         p.small.muted by Lemoness, Kiwibot, and SabreCat
 
-  h5.big_news_header 1/15/2015
+  h4 1/15/2015
+    hr
     tr
       td
-        h5.small_news_header Tyrannosaur Pet Quest
+        h5 Tyrannosaur Pet Quest
         p In the <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>Market</a> there are now two new pet quests: King of the Dinosaurs and The Dinosaur Unearthed! They both give out the same rewards, including pet Tyrannosaur eggs. The difference is that "King of the Dinosaurs" is a normal pet quest, like all the others, whereas "The Dinosaur Unearthed" has less HP - but also a Rage bar (a la World Bosses) that allows it to heal if you skip too many of your Dailies. Both bosses still attack your party based on how many Dailies are incomplete. Users will be able to buy Tyrannosaur eggs after defeating either boss twice or both bosses once.
         p Have fun!
         p.small.muted by Baconsaur, Urse, Lemoness, and SabreCat
     tr
       td
-        h5.small_news_header Spread the Word Challenge Reminder
+        h5 Spread the Word Challenge Reminder
         p In case you missed it, we're running our second Spread the Word Challenge! The rules are simple: make a post some time between December 31st 2014 and January 31st 2015 on some form of blog or social media that tells people about HabitRPG. The top post will be awarded 100 GEMS, and the next nineteen top posts will be awarded 80 GEMS each. Learn more and join in <a href='https://habitrpg.com/#/options/groups/challenges/e1ad6d92-587d-4137-848e-4a1f643603ba' target='_blank'>here</a>!
     tr
       td
-        h5.small_news_header World Boss: First Stress Strike!
+        h5 World Boss: First Stress Strike!
         p The World Boss in the <a href='https://habitrpg.com/#/options/groups/tavern' target='_blank'>Tavern</a> has used its first Stress Strike!
         p Despite our best efforts, we've let some Dailies get away from us, and their dark-red color has infuriated the Abominable Stressbeast and caused it to regain some of its health! The horrible creature lunges for the Stables, but Matt the Beast Master heroically leaps into the fray to protect the pets and mounts. The Stressbeast has seized Matt in its vicious grip, but at least it's distracted for the moment.
         p Complete Dailies and To-Dos to damage the World Boss! Incomplete Dailies fill the Stress Strike Bar. When the Stress Strike bar is full, the World Boss will attack an NPC. A World Boss will never damage individual players or accounts in any way. Only active accounts who are not resting in the inn will have their incomplete Dailies tallied.
         p.small.muted by Lemoness, Kiwibot, and SabreCat
-  h5.big_news_header 1/8/2015
+  h4 1/8/2015
+    hr
     tr
       td
-        h5.small_news_header World Boss: The Abominable Stressbeast!
+        h5 World Boss: The Abominable Stressbeast!
         .quest_stressbeast.pull-right
         p A new World Boss has appeared in the <a href='https://habitrpg.com/#/options/groups/tavern' target='_blank'>Tavern</a>! All of the completed Dailies and To-Dos of Habiticans damage the World Boss. Incomplete Dailies fill the Stress Strike Bar. When the Stress Strike bar is full, the World Boss will attack an NPC.
         p A World Boss will never damage individual players or accounts in any way. Only active accounts who are not resting in the inn will have their incomplete Dailies tallied. Read on for the details!
     tr
       td
-        h5.small_news_header Winter Plot-Line: The Abominable Stressbeast Attacks!
+        h5 Winter Plot-Line: The Abominable Stressbeast Attacks!
         p The first thing we hear are the footsteps, slower and more thundering than the stampede. One by one, Habiticans look outside their doors, and words fail us.
         p We've all seen Stressbeasts before, of course - tiny vicious creatures that attack during difficult times. But this? This towers taller than the buildings, with paws that could crush a dragon with ease. Frost swings from its stinking fur, and as it roars, the icy blast rips the roofs off our houses. A monster of this magnitude has never been mentioned outside of distant legend.
         p "Beware, Habiticans!" SabreCat cries. "Barricade yourselves indoors - this is the Abominable Stressbeast itself!"
@@ -983,393 +1035,400 @@ mixin oldNews
         p "The Stoïkalm Steppes," Lemoness says, face grim. "All this time, we thought they were placid and untroubled, but they must have been secretly hiding their stress somewhere. Over generations, it grew into this, and now it's broken free and attacked them - and us!"
         p There's only one way to drive away a Stressbeast, Abominable or otherwise, and that's to attack it with completed Dailies and To-Dos! Let's all band together and fight off this fearsome foe - but be sure not to slack on your tasks, or our undone Dailies may enrage it so much that it lashes out...
         p.small.muted by Lemoness, Kiwibot, and SabreCat
-  h5.big_news_header 1/5/2015
+  h4 1/5/2015
+    hr
     tr
       td
-        h5.small_news_header January Backgrounds
+        h5 January Backgrounds
         p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can summit a Frigid Peak, shiver in an Ice Cave, or wander through the Snowy Pines!
         p.small.muted by Kiwibot, Sunstroke, and Rattify
     tr
       td
-        h5.small_news_header Testing Fix for Cron Bug
+        h5 Testing Fix for Cron Bug
         p Today we will be testing a possible fix for a bug that sometimes causes Dailies to not reset correctly on the following day. It's a big change, so we will be keeping a close watch on the site to make sure that it doesn't break anything. If you experience any problems with day start or Dailies reseting in the next few days, please let us know immediately on <a href='https://github.com/HabitRPG/habitrpg/issues/1057' target='_blank'>GitHub</a>. Thanks!
     tr
       td
-        h5.small_news_header Date Format Adjustment
+        h5 Date Format Adjustment
         p There's a new option under <a href='https://habitrpg.com/#/options/settings/settings' target='_blank'>Settings</a> that lets you adjust the date format. Now you can list dates as MM/DD/YYYY, DD/MM/YYYY, or YYYY/MM/DD.
         p.small.muted by Verabird
-  h5.big_news_header 1/3/2015
+  h4 1/3/2015
+    hr
     tr
       td
-        h5.small_news_header January Mystery Item Set
+        h5 January Mystery Item Set
         .inventory_present.pull-right
         p Sparkly! What could it be? All Habiticans who are subscribed during the month of January will receive the January Mystery Item Set! It will be revealed on the 26th, so keep your eyes peeled. Thanks for supporting the site <3
         p.small.muted by Lemoness
     tr
       td
-        h5.small_news_header Spread the Word Challenge
+        h5 Spread the Word Challenge
         p In honor of the season of New Year's resolutions, we're running our second Spread the Word Challenge! The rules are simple: make a post some time between December 31st 2014 and January 31st 2015 on some form of blog or social media that tells people about HabitRPG. The top post will be awarded 100 GEMS, and the next nineteen top posts will be awarded 80 GEMS each. Learn more and join in <a href='https://habitrpg.com/#/options/groups/challenges/e1ad6d92-587d-4137-848e-4a1f643603ba' target='_blank'>here</a>!
     tr
       td
-        h5.small_news_header Winter Plot-Line Continues
+        h5 Winter Plot-Line Continues
         p After a fun-filled New Year's Eve, Habiticans wake to a rumbling that shakes them out of their Absurd Party Hats. Running to their windows reveals.... a stampede?
         p A thundering herd of mammoths charges past, sabertooths roar, and dinosaurs both feathery and scaly slither by at top speed. Habiticans stare open-mouthed, but before anyone can react, the stampede has swept through Habit City and is gone into the distance, leaving only pawprints in the snow, the howling wind, and some trampled New Year's cards.
         p Habiticans are advised to keep calm and not give in to stress during this confusing and difficult time. We've sent SabreCat after the frightened animals from the Stoïkalm Steppes, and he is working to calm them down so that we can bring them back to the safety of the Stables. We hope to have an explanation for this strangeness soon. In the meantime, keep all of your own pets and mounts indoors.
         p.small.muted Read the previous installments of the Winter Plot-Line <a href='http://habitrpg.wikia.com/wiki/Winter_Wonderland#Winter_Mystery_Plot' target='_blank'>here</a>!
-  h5.big_news_header 12/31/2014
+  h4 12/31/2014
+    hr
     tr
       td
-        h5.small_news_header Party Hats
+        h5 Party Hats
         .promo_partyhats.pull-right
         p In honor of the new year, some free Party Hats are available in the Rewards store! New users get the ever-handsome Absurd Party Hat, and users who already received one last year get the Silly Party Hat. These hats will be available to purchase until January 31st, but once you've bought them, you'll have them forever. Enjoy!
         p.small.muted by Lemoness and SabreCat
     tr
       td
-        h5.small_news_header New Year's Cards (Until Jan 1st Only!)
+        h5 New Year's Cards (Until Jan 1st Only!)
         .inventory_special_nye.pull-right
         p Until January 1st only, the <a href='https://habitrpg.com/#/options/inventory/seasonalshop' target='_blank'>Seasonal Shop</a> is stocking New Year's Cards! Now you can send cards to your friends (and yourself) to wish them a Happy Habit New Year. All senders and recipients will receive the Auld Acquaintance badge! When you receive a card, it will appear in your <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>Inventory</a>. Click it to receive a seasonal message!
         p.small.muted by Lemoness and SabreCat
     tr
       td
-        h5.small_news_header Snowballs
+        h5 Snowballs
         .inventory_special_snowball.pull-right
         p The <a href='https://habitrpg.com/#/options/inventory/seasonalshop' target='_blank'>Seasonal Shop</a> is also stocking Snowballs for gold! Throw them at your friends to have an exciting effect. Anyone hit with a snowball earns the Annoying Friends badge. The results of being hit with a Snowball will last until the end of your day, but you can also reverse them early by buying Salt from the Rewards column. Snowballs are available until January 31st.
         p.small.muted by Shaner, Lemoness, and SabreCat
-  h5.big_news_header 12/25/2014
+  h4 12/25/2014
+    hr
     tr
       td
-        h5.small_news_header December Subscriber Item Set
+        h5 December Subscriber Item Set
         .promo_mystery_201412.pull-right
         p The December Subscriber Item has been revealed: the Penguin Item Set! All December subscribers will receive the Penguin Hat and the Penguin Suit. You still have six days to <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribe</a>) and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         p.small.muted by Lemoness
     tr
       td
-        h5.small_news_header Seasonal Shop: Seasonal Outfits and Quests
+        h5 Seasonal Shop: Seasonal Outfits and Quests
         .seasonalshop_winter2015.pull-right
         p The <a href='https://habitrpg.com/#/options/inventory/seasonalshop'>Seasonal Shop</a> has opened! The Seasonal Sorceress is stocking the seasonal edition versions of last year's winter outfits, now available for Gems instead of Gold, and the two winter quests, Trapper Santa and Find the Cub. The Seasonal Shop will only be open until January 31st, so don't wait!
         p.small.muted by SabreCat and Lemoness
     tr
       td
-        h5.small_news_header Flagging Posts
+        h5 Flagging Posts
         p You can now report inappropriate posts to moderators simply by clicking the new flag button next to the post. You should only report posts that violate the Community Guidelines and/or Terms of Service. Thanks for helping us to keep Habitica safe and pleasant for everybody!
         p.small.muted by Alys, Blade, and Matteo
     tr
       td
-        h5.small_news_header Winter Plot-Line Continues
+        h5 Winter Plot-Line Continues
         p SabreCat's news is dire. "Most of my sabertooth friends have been impossible to reach, but one thing is clear: the prides have been disappearing from the Steppes. There are also reports that something drove the mammoths to early migration and disturbed the hibernation of the terrible lizards."
         p He wraps his cloak around himself as another blast of frigid wind roars through the streets. An icy winter gale has been blowing from the north, rattling the window panes and setting the pets and mounts to trembling and howling.
         p "I've never seen anything like it!" says Matt the Beast Master. "Something is terrifying all my animals - even the cacti, who are normally so mighty and brave! For something to frighten a cactus..." He shakes his head.
         p The stress level in Habitica is mounting.
         p.small.muted Missed the previous Winter Plot-line? Catch up on the story <a href='http://habitrpg.wikia.com/wiki/Winter_Wonderland#Winter_Mystery_Plot' target='_blank'>here</a>!
         p.small.muted by Lemoness
-  h5.big_news_header 12/21/2014 - Winter Wonderland Begins, Winter Class Outfits, Wintery Hair Colors, and NPC Decorations!
+  h4 12/21/2014 - Winter Wonderland Begins, Winter Class Outfits, Wintery Hair Colors, and NPC Decorations!
+    hr
     tr
       td
-        h5.small_news_header Winter Wonderland Begins!
+        h5 Winter Wonderland Begins!
         p Winter has arrived, and the snow is gently drifting down over Habit City. Come celebrate with us!
     tr
       td
-        h5.small_news_header Winter Class Outfits
+        h5 Winter Class Outfits
         .promo_winterclasses2015.pull-right
         p From now until January 31st, limited edition outfits are available in the Rewards column. Depending on your class, you can be a Soothing Skater, Mage of the North, Gingerbread Warrior, or Icicle Drake! You'd better get productive to earn enough gold before they disappear. Good luck!
         p.small.muted by Lemoness
     tr
       td
-        h5.small_news_header Wintery Hair Colors
+        h5 Wintery Hair Colors
         .promo_winteryhair.pull-right
         p The Seasonal Edition Wintery Hair Colors are now available for purchase in the avatar customizations page! Now you can dye your avatar's hair Holly Green, Winter Star, Snowy, Peppermint, Aurora, or Festive.
         p Seasonal Edition items recur unchanged every year, but they are only available to purchase during a short period of time. This is different from Limited Edition Items, which only recur if something is changed, such as the art or the price. These hair colors may remind some of you of the Holiday Hair Colors that were available last winter. The Holiday Hair Colors have been Retired in favor of the similar Seasonal Edition Wintery Hair Colors. Read more about the difference between Seasonal and Limited Edition items <a href='http://habitrpg.wikia.com/wiki/Item_Availability'>here</a>!
         p.small.muted by Lemoness, crystalphoenix, and mariahm
     tr
       td
-        h5.small_news_header NPC Decorations
+        h5 NPC Decorations
         .npc_alex.pull-right
         p Looks like the NPCs are really getting in to the cheery winter mood around the site. Who wouldn't? After all, there's plenty more to come!
         p.small.muted by Lemoness
-  h5.big_news_header 12/17/2014 - Android App Update, Seasonal Shop, and Winter Plot-Line Continues
+  h4 12/17/2014 - Android App Update, Seasonal Shop, and Winter Plot-Line Continues
+    hr
     tr
       td
-        h5.small_news_header Android App Update: December Art and Buying Gems!
+        h5 Android App Update: December Art and Buying Gems!
         p The December backgrounds and penguin pet quest are now visible in the Android mobile app! Also, we’ve made it possible to buy gems directly from the app. Now you don’t have to switch to the website to stock up!
         p You can get the Android app <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg&hl=en' target='_blank'>here</a>! We will announce when the iOS app is available as well.
         p.small.muted by negue
     tr
       td
-        h5.small_news_header Seasonal Shop Tab
+        h5 Seasonal Shop Tab
         .seasonalshop_closed.pull-right
         p Looks like a new tab has appeared under Inventory - the <a href='https://habitrpg.com/#/options/inventory/seasonalshop'>Seasonal Shop</a>! It's still closed, but I've heard a rumor that it will open soon...
         p.small.muted by SabreCat and Lemoness
     tr
       td
-        h5.small_news_header Winter Plot-Line Continues
+        h5 Winter Plot-Line Continues
         p Lemoness bursts into the Tavern, shaking icicles off her hat. "The Stoïkalm Steppes are completely abandoned!" she says, gulping the cup of tea that Daniel the Barkeep offers her. "No people milling about, no mounts and pets playing in the snow - and when I tried to fly closer, my dragon spooked and refused to land!"
         p A cloaked figure in the corner steps into the fire light - SabreCat, a powerful adventurer from the north. "The Stoïkalm Steppes are the last home of many animals that have long since gone extinct elsewhere," he says. "The stoic Stoïkalmers would never flee their lands unless something was threatening their pets and mounts!"
         p He turns to Lemoness. "I can speak the language of the northern beasts. I'll try to contact the roaming sabertooth prides to see if they know what happened." As he lopes off into the distance, a cold wind begins to blow.
         p.muted Missed the first part of the Winter Plot-Line? Read it <a href='http://habitrpg.wikia.com/wiki/Whats_new'>here</a>.
-  h5.big_news_header 12/9/2014 - Penguin Pet Quest and Winter Plot-Line
+  h4 12/9/2014 - Penguin Pet Quest and Winter Plot-Line
+    hr
     tr
       td
-        h5.small_news_header Penguin Pet Quest
+        h5 Penguin Pet Quest
         .quest_penguin.pull-right
         p Habiticans wanted to go ice-skating, but instead, a giant penguin is freezing everything in sight! All we wanted was to go ice-skating... Can you get this penguin to chill out? If so, you'll be rewarded with some penguins of your own!
         p.small.muted by Melynnrose, Breadstrings, Rattify, Painter de Cluster, Daniel the Bard, and Leephon
     tr
       td
-        h5.small_news_header Winter Plot-Line
+        h5 Winter Plot-Line
         p Lemoness enters the Tavern with worrying news from the far north of Habitica. "Nobody's heard from the Stoïkalm Steppes for over a week," she says. "It's hard to imagine anything troubling the citizens there, since it's such a placid part of the continent... But just in case, maybe I should pay a visit." Sounds like a good plan to us!
 
-  h5.big_news_header 12/3/2014 - Gifting Subscriptions And Gems, New Subscription Benefits, Mysterious Time Travelers, Steampunk Item Sets, And Block Subscriptions!
+  h4 12/3/2014 - Gifting Subscriptions And Gems, New Subscription Benefits, Mysterious Time Travelers, Steampunk Item Sets, And Block Subscriptions!
   table.table.table-striped
     tr
       td
-        h5.small_news_header Gifting Subscriptions And Gems
+        h5 Gifting Subscriptions And Gems
         p You can now gift subscriptions and gems to other people (bottom-left in a user's profile window)! If you need holiday present ideas for the awesome Habiticans in your life, or just want to do something nice for someone, consider getting them a subscription to our fair site or tossing a few gems their way. They'll thank you, and so will we <3
         p.small.muted by Lefnire
     tr
       td
-        h5.small_news_header New Subscription Benefits!
+        h5 New Subscription Benefits!
         p We've added new benefits for long-term subscribers! Now for every 3 months that you are subscribed consecutively, your monthly gold-to-gem conversion cap will increase by 5, up to a total of 50 gems per month! Plus, for each three months of consecutive subscription, you will receive 1 Mystic Hourglass. What does that do? Read on!
         p.small.muted by Lefnire
     tr
       td
-        h5.small_news_header Mysterious Time Travelers
+        h5 Mysterious Time Travelers
         .npc_timetravelers.pull-right
         p If you've received a Mystic Hourglass for being subscribed for 3 consecutive months, you can now summon the <a href='/#/options/inventory/timetravelers' target='_blank'>Mysterious Time Travelers</a> to get you one Mystery Item Set from the past! Being subscribed for multiple consecutive months is the only way to get these past items if you missed them. They will never be available to non-subscribers.
         p.small.muted by Lemoness, Megan, Lefnire
     tr
       td
-        h5.small_news_header Steampunk Item Sets
+        h5 Steampunk Item Sets
         .promo_mystery_3014.pull-right
         p The Mysterious Time Travelers are also offering two brand-new Item Sets - the Steampunk Standard Item Set and the Steampunk Accessory Item Set! These Item Sets can only be obtained if you have a Mystic Hourglass.
         p.small.muted by Megan
     tr
       td
-        h5.small_news_header Block Subscriptions
+        h5 Block Subscriptions
         p Don't want to wait for your consecutive months to stack up? You can now subscribe in a fixed block period of 1 month, 3 months, 6 months, or 1 year! If you subscribe for a block period of 1 year, you get a 20% discount. PLUS, you'll instantly get all the benefits of consecutive subscription for that time period (e.g. getting a block subscription for 6 months will instantly raise your monthly gold-to-gem cap by 10)!
         p.small.muted by Lefnire
 
-  h5.big_news_header 12/1/2014 - SITE OUTAGE EXPLANATION, DECEMBER BACKGROUNDS, AND DECEMBER MYSTERY ITEM SET
+  h4 12/1/2014 - SITE OUTAGE EXPLANATION, DECEMBER BACKGROUNDS, AND DECEMBER MYSTERY ITEM SET
   table.table.table-striped
     tr
       td
-        h5.small_news_header Site Outage Explanation
+        h5 Site Outage Explanation
         p Many of you may have noticed that you could not access HabitRPG for a large portion of December 1st. This wasn't a problem on our end - it was due to an outage by DNSimple, the service that provides us with our domain. We're very sorry about any frustration that this caused! If you lost any stats, you can restore them using Settings > Site > Fix Character Values. For future reference, if you ever have trouble accessing HabitRPG, be sure to follow our official Twitter, @HabitRPG, for updates! Thank you for all of your supportive messages <3
     tr
       td
-        h5.small_news_header December Backgrounds
+        h5 December Backgrounds
         p There are three new avatar backgrounds in the <a href=https://habitrpg.com/#/options/profile/backgrounds>Background Shop</a>! Now your avatar can explore the South Pole, drift on an Iceberg, or admire the Winter Party Lights!
         p.small.muted by McCoyly, RosieSully, and Holseties
     tr
       td
-        h5.small_news_header December Mystery Item Set
+        h5 December Mystery Item Set
         p Hmmm! What could it be? All Habiticans who are subscribed during the month of December will receive the December Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
         p.small.muted by Lemoness
 
-  h5.big_news_header 11/26/2014 - Happy Thanksgiving!
+  h4 11/26/2014 - Happy Thanksgiving!
   table.table.table-striped
     tr
       td
-        h5.small_news_header Happy Thanksgiving!
+        h5 Happy Thanksgiving!
         p It's Thanksgiving in Habitica! On this day Habiticans celebrate by spending time with loved ones, giving thanks, and riding their glorious turkeys into the magnificent sunset. Some of the NPCs are celebrating the occasion!
         p.small.muted by Lemoness
     tr
       td
-        h5.small_news_header Turkey Pet and Mount!
+        h5 Turkey Pet and Mount!
         p Those of you who weren't around last Thanksgiving have received an adorable Turkey Pet, and those of you who got a Turkey Pet last year have received a handsome Turkey Mount! Thank you for using HabitRPG - we really love you guys <3
         p.small.muted by Lemoness
 
-  h5.big_news_header 11/25/2014
+  h4 11/25/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header November Item Set Revealed
+        h5 November Item Set Revealed
         p The November Subscriber Item has been revealed: the Feast and Fun Set! All November subscribers will receive the Pitchfork of Feasting and the Steel Helm of Sporting. You still have five days to subscribe and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         p.small.muted by Lemoness
     tr
       td
-        h5.small_news_header Private Messaging Version 1.0
+        h5 Private Messaging Version 1.0
         p We're excited to announce a new feature: Private Messaging! Now you can send someone a PM by clicking the envelope icon in the bottom-left of their profile window . You can check your messages under Social > Inbox! This is a very rudimentary feature so far, only containing the ability to send messages, block people, and opt out. To read about some of the planned features for the future and make suggestions, check out <a href='https://trello.com/c/hHpIzMc5/459-private-messaging-v-2' target='_blank'>this Trello card</a>!
         p.small.muted by Lefnire
 
-  h5.big_news_header 11/18/2014
+  h4 11/18/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header New Pet Quest: The Night-Owl!
+        h5 New Pet Quest: The Night-Owl!
         p Habiticans are in the dark when a giant Night-Owl blots out the Tavern light! Can you drive it away in time to finish your all-nighter? If so, you may find some cute pet owls in the morning...
         p.small.muted by Twitching, Lemoness, and Arcosine
 
-  h5.big_news_header 11/13/2014 - Share Avatar To Social Media, Email Invites, First Mini Quest, And Data Tab
+  h4 11/13/2014 - Share Avatar To Social Media, Email Invites, First Mini Quest, And Data Tab
   table.table.table-striped
     tr
       td
-        h5.small_news_header Share Avatar To Social Media
+        h5 Share Avatar To Social Media
         p You can now automatically share your avatar and public profile to social media! Just hover over the picture and click the "Share" button in the right-hand corner. Show off your outfit, your achievements, and your profile picture! Note that your tasks, as always, remain 100% private.
         p.small.muted by Lefnire
     tr
       td
-        h5.small_news_header Invite Friends To Party Via Email
+        h5 Invite Friends To Party Via Email
         p Do you want to invite friends to join your party without inputting their User ID? Now you can send them an email directly from the party page - even if they don't have an account yet!
         p.small.muted by Lefnire
     tr
       td
-        h5.small_news_header Mini Quest: The Basi-List!
+        h5 Mini Quest: The Basi-List!
         p Now when someone accepts your party invitation and joins your party, you will be given a Mini Quest: The Basi-List! Battle the Basi-List with your friends for an XP and GP reward.
         p.small.muted by Arcosine and Redphoenix
     tr
       td
-        h5.small_news_header Data Tab
+        h5 Data Tab
         p Now you can access the Data Display Tool and Export Data from the toolbar!
         p.small.muted by ShilohT
 
-  h5.big_news_header 11/12/2014
+  h4 11/12/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header New Equipment Quest Line: The Golden Knight!
+        h5 New Equipment Quest Line: The Golden Knight!
         p The Golden Knight believes that she is the perfect Habitican, and that anyone who slips up in their quest for self-improvement is a lazy failure. Can you talk some sense into her - or will it come to blows? If you complete the entire quest line, you'll be rewarded with a legendary weapon...
         p The first scroll in this quest line, "A Stern Talking-to," drops automatically at Level 40! If you're already over Level 40, you will automatically be awarded this quest - just check off a task and then check your inventory.
 
-  h5.big_news_header 11/09/2014 - Facebook Login Fixed For Mobile And Community Guidelines To Chat
+  h4 11/09/2014 - Facebook Login Fixed For Mobile And Community Guidelines To Chat
   table.table.table-striped
     tr
       td
-        h5.small_news_header Facebook Login Fixed For Mobile!
+        h5 Facebook Login Fixed For Mobile!
         p Great news! If you use Facebook to log in to the mobile app, we've released an update so you no longer have to type in your UUID/API manually, misspelling things on your tiny keyboard and bemoaning your fate. Thank goodness! The Android update is out now, and the iOS update has been submitted and should be out soon.
     tr
       td
-        h5.small_news_header Community Guidelines To Chat
+        h5 Community Guidelines To Chat
         p Before you can use any of the public chat features, you now have to agree to our Community Guidelines. We know they're long, but they're important, so please do read them if you haven't already. Plus, we worked hard to make them entertaining, and they were illustrated by many of our excellent artisans!
 
-  h5.big_news_header 11/06/2014
+  h4 11/06/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header Bailey: Costume Challenge Badges Awarded!
+        h5 Bailey: Costume Challenge Badges Awarded!
         p The HabitRPG Costume Challenge Badges have been awarded! Thanks for your patience while we went through all the entries individually. You can see some of the entries <a href='http://blog.habitrpg.com/tagged/cosplay' target='_blank'>on the HabitRPG blog</a> already, and more will be added every week.
         p IMPORTANT: some of the links that people provided did not work. If you entered the Challenge but even after refreshing the page you still don't have your badge, email leslie@habitrpg.com with the link to your costume and your avatar. (The costume and avatar must have been posted prior to November 1st to count.)
         p Thanks to all our amazing participants!
 
-  h5.big_news_header 11/05/2014- November Backgrounds And Beeminder Integration
+  h4 11/05/2014- November Backgrounds And Beeminder Integration
   table.table.table-striped
     tr
       td
-        h5.small_news_header November Backgrounds
+        h5 November Backgrounds
         p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can enjoy a Harvest Feast, admire a Sunset Meadow, or gaze at the Starry Skies!
         p.small.muted by Kiwibot, Holsety1, and Draayder
     tr
       td
-        h5.small_news_header Beeminder Integration
+        h5 Beeminder Integration
         p We've integrated with Beeminder! Now you can beemind your To-Dos automatically :) <a href='https://www.beeminder.com/habitrpg' target='_blank'>Check it out</a>!
         p If you've never heard of Beeminder or want to learn more about what we've integrated so far, check out our <a href='http://blog.habitrpg.com/post/101773418876/beeminder-integration' target='_blank'>blog post about it</a>. Enjoy!
         p.small.muted by Alys and Alice Monday
 
-  h5.big_news_header 11/01/2014
+  h4 11/01/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header November Mystery Item Set
+        h5 November Mystery Item Set
         .pull-right.inventory_present
         p Cool! What could it be? All Habiticans who are subscribed during the month of November will receive the November Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
 
-  h5.big_news_header 10/31/2014 - Monster Npcs, Last Day For Fall Festival Items, Last Day Of Community Costume Challenge, Last Day For Winged Goblin Item Set
+  h4 10/31/2014 - Monster Npcs, Last Day For Fall Festival Items, Last Day Of Community Costume Challenge, Last Day For Winged Goblin Item Set
   table.table.table-striped
     tr
       td
-        h5.small_news_header Last Day For Fall Festival Items
+        h5 Last Day For Fall Festival Items
         p Tomorrow everything will be back to normal in Habitica, so if you still have any remaining Fall Festival Items that you want to buy, you'd better do it now! The Seasonal Edition items won't be back until next fall, and if the Limited Edition items return they will have increased prices or changed art, so strike while the iron is hot!
     tr
       td
-        h5.small_news_header Last Day For Winged Goblin Item Set
+        h5 Last Day For Winged Goblin Item Set
         p Reminder: this is the final day to subscribe and receive the Winged Goblin Item Set! If you want the Goblin Wings or the Goblin Gear, now's the time! Thanks so much for your support <3
     tr
       td
-        h5.small_news_header Last Day Of Community Costume Challenge
+        h5 Last Day Of Community Costume Challenge
         p It's the last day to post your pictures of yourself dressed up as your HabitRPG avatar if you want to get the Costume Challenge Badge! You can join the Challenge <a href='https://habitrpg.com/#/options/groups/challenges/39f7e9b4-1fbf-4b01-baee-221fd9b9ef43' target='_blank'>here</a>.
     tr
       td
-        h5.small_news_header Monster Npcs
+        h5 Monster Npcs
         p The NPCs have dressed up in their Halloween costumes! Be sure to stop by and check them all out.
 
-  h5.big_news_header 10/27/2014 - Increased Gems For Contributors And Community Guidelines
+  h4 10/27/2014 - Increased Gems For Contributors And Community Guidelines
   table.table.table-striped
     tr
       td
-        h5.small_news_header Community Guidelines
+        h5 Community Guidelines
         p Our community has grown and evolved over this past year and a half, and we realized that none of the community expectations had been codified anywhere. This has now changed with the implementation of the <a href='/static/community-guidelines' target='_blank'>Community Guidelines</a>. The Guidelines have been written by the staff and mods and illustrated by many of our talented artisans. We know they're long, but they contain all the expectations for participating in the public social side of HabitRPG, so please do read them carefully! Soon you'll have to agree to them to participate in any of the Public Chat.
         p.small.muted by <strong>Alys</strong>, Lemoness, lefnire, redphoenix, SabreCat, paglias, Bailey, Ryan, Breadstrings, Megan, Daniel the Bard, Draayder, Kiwibot, Leephon, Luciferian, Revcleo, Shaner, Starsystemic, UncommonCriminal
     tr
       td
-        h5.small_news_header Increased Gems For Contributors
+        h5 Increased Gems For Contributors
         p When we first started rewarding contributors, we decided to give them 2 gems per contributor tier. Since then, however, we've introduced many more things to buy, so we've decided to increase this number. All contributors now receive 3 gems/tier for tiers 1-3, and then 4 gems/tier for tiers 4-7, bringing the total number of gems you can earn by contributing to the site to 25.
         p If you've already contributed, you've been given the gems that you're owed according to the new system. (For example, if you are a tier 3 contributor, you received 6 gems in the past and would receive 9 gems under the new system, so you've been awarded 3 gems to account for the difference.)
         p Enjoy!
         p.small.muted by Alys
 
-  h5.big_news_header 10/25/2014 - October Item Set Revealed And Community Costume Challenge Reminder
+  h4 10/25/2014 - October Item Set Revealed And Community Costume Challenge Reminder
   table.table.table-striped
     tr
       td
-        h5.small_news_header October Item Set Revealed
+        h5 October Item Set Revealed
         .promo_mystery_201410.pull-right
         The October Subscriber Item has been revealed: the Winged Goblin Item Set! All October subscribers will receive the Goblin Gear and the Goblin Wings. You still have six days to subscribe and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         by Lemoness
-        h5.small_news_header Community Costume Challenge Reminder
+        h5 Community Costume Challenge Reminder
         .achievement-costumeContest.pull-right
         p Don't forget about the <a href='https://habitrpg.com/#/options/groups/challenges/39f7e9b4-1fbf-4b01-baee-221fd9b9ef43' target='_blank'>Community Costume Challenge</a>! We've had some really amazing entries so far, and we're looking forward to seeing more over the next six days! All participants will receive the 2014 Costume Challenge Badge.
         p You can view some of the awesome costumes <a href='http://blog.habitrpg.com/tagged/cosplay' target='_blank'>here</a>!
 
-  h5.big_news_header 10/23/2014
+  h4 10/23/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header Level 60 Equipment Quest: Recidivate Quest Line!
+        h5 Level 60 Equipment Quest: Recidivate Quest Line!
         p All over Habitica, Bad Habits thought long-dead are rising up again - it must be the work of Recidivate, the wicked Necromancer! Can you complete your Dailies and fight down your Bad Habits to lay her to rest once more? If so, you'll reap some fine spoils... including some legendary armor!
         p This quest line contains the hardest Boss Battle that we've released to date, so the first quest scroll drops for free at Level 60. If you're already Level 60 or over, you can unlock it for free, too - just check off any task and it will drop for you :) Good luck! You'll need it.
         p.small.muted by Lemoness, Tru_, aurakami, Inventrix, and Baconsaur
 
-  h5.big_news_header 10/15/2014 - Spider Pet Quest, Mobile App Update, Hide Grey Dailies, And Sortable Checklists!
+  h4 10/15/2014 - Spider Pet Quest, Mobile App Update, Hide Grey Dailies, And Sortable Checklists!
   table.table.tables-striped
     tr
       td
-        h5.small_news_header New Pet Quest: The Icy Arachnid!
+        h5 New Pet Quest: The Icy Arachnid!
         p Yikes, what's leaving these icy webs all over Habitica? It must be the Frost Spider from the newest Pet Quest: The Icy Arachnid! You can buy this quest in the <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>Market</a>. Don't worry, it will be around even after the Fall Festival ends :)
         p.small.muted by Arcosine
     tr
       td
-        h5.small_news_header Mobile App Update!
+        h5 Mobile App Update!
         p The newest mobile app update is available on iOS and Android! Now when you're on your phone you can see Fall Festival items, get drop notifications, and view the pixel art of the bosses that you're battling!
         p.small.muted By lefnire, negue, huarui, and paglias
     tr
       td
-        h5.small_news_header Hide Grey Dailies
+        h5 Hide Grey Dailies
         p You can now hide grey Dailies to de-clutter your list! There are tabs at the bottom of the Dailies column that you can toggle to see only which Dailies are still active.
         p.small.muted by Gaelan, and Alys
     tr
       td
-        h5.small_news_header Sortable Checklists
+        h5 Sortable Checklists
         p Have you ever wanted to rearrange checklist order? Now you can! Simply drag and drop to sort your checklist points.
         p.small.muted By gjoyner
 
-  h5.big_news_header 10/7/2014 - Back-To-School Advice Challenge Winners And Jack-O-Lantern Pet!
+  h4 10/7/2014 - Back-To-School Advice Challenge Winners And Jack-O-Lantern Pet!
   table.table.table-striped
     tr
       td
-        h5.small_news_header Back-To-School Advice Challenge Winners
+        h5 Back-To-School Advice Challenge Winners
         p We had a ton of participants in our Back-To-School Advice Challenge, and we've finally sorted through and chosen the winners! Congratulations to
         p DJ Ringis, The Writer, San Condor, Tavi Wright, Stepharuka, Clyc, samaeldreams, LitNerdy, Tritlo, Shansie, Han Solo, FrauleinNinja, Nortya, itsallaboutfalling, TomFrankly, [TGL] Dogg, Amanda, InfH, Evan950, and Mizuokami! You've all received your gems :)
         p Thanks so much for participating! If you had fun, don't forget that the Community Costume Challenge is happening all October :)
     tr
       td
-        h5.small_news_header Jack-O-Lantern Pet
+        h5 Jack-O-Lantern Pet
         p Habiticans have been carving lots of pumpkins recently - and it looks like one has followed you home! Everyone has received a pet Jack-O-Lantern! You can find it in the Stables :)
         p.small.muted by Lemoness
 
-  h5.big_news_header 10/3/2014- Spooky Sparkles, New Backgrounds, And Memory Leaks Almost Fixed!
+  h4 10/3/2014- Spooky Sparkles, New Backgrounds, And Memory Leaks Almost Fixed!
   table.table.table-striped
     tr
       td
-        h5.small_news_header Spooky Sparkles
+        h5 Spooky Sparkles
         .pull-right
           .inventory_special_spookDust
           .achievement-spookDust
@@ -1382,209 +1441,209 @@ mixin oldNews
         p.small.muted by Lemoness, lefnire
     tr
       td
-        h5.small_news_header New Backgrounds Revealed: Haunted House, Graveyard, And Pumpkin Patch
+        h5 New Backgrounds Revealed: Haunted House, Graveyard, And Pumpkin Patch
         p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can sneak through a Haunted House, visit a creepy Graveyard, or carve jack-o-lanterns in a Pumpkin Patch!
         p.small.muted by cecilyperez, Kiwibot, and Sooz
     tr
       td
-        h5.small_news_header Memory Leaks Almost Fixed
+        h5 Memory Leaks Almost Fixed
         p It took a ton of effort, but Tyler has fixed the largest memory leak that was crashing our servers! There are a few smaller ones that he’s still conquering one by one, but the fiercest monster has been slain. Ten thousand cheers for Tyler! You can read the technical description of how we’re fixing the leaks <a href='https://github.com/HabitRPG/habitrpg/issues/4079' target='_blank'>here</a>, and for any JavaScript developers out there: we'd love your help! We’ll let you all know when we’ve fixed the problem for once and for all.
         p.small.muted by lefnire
 
-  h5.big_news_header 10/1/2014 - Seasonal Edition Skins, Seasonal Edition Hair Colors, Community Costume Challenge, Release Pets, and October Mystery Item!
+  h4 10/1/2014 - Seasonal Edition Skins, Seasonal Edition Hair Colors, Community Costume Challenge, Release Pets, and October Mystery Item!
   table.table.table-striped
     tr
       td
-        h5.small_news_header Seasonal Edition Hair
+        h5 Seasonal Edition Hair
         p The Seasonal Edition Haunted Hair Colors are now available for purchase in the avatar customizations page! Now you can dye your avatar's hair Pumpkin, Midnight, Candy Corn, Ghost White, Zombie, or Halloween.
         p Seasonal Edition items recur unchanged every year, but they are only available to purchase during a short period of time. This is different from Limited Edition Items, which only recur if something is changed, such as the art or the price. Read more about the difference between Seasonal and Limited Edition items <a href='http://habitrpg.wikia.com/wiki/Item_Availability' target='_blank'>here</a>!
         p.small.muted by Lemoness, mariahm, and crystal phoenix
     tr
       td
-        h5.small_news_header Seasonal Edition Skins
+        h5 Seasonal Edition Skins
         p The Supernatural Skin Set is here! Now your avatar can become an Ogre, Skeleton, Pumpkin, Candy Corn, Reptile, or Dread Shade. You can buy them from now until October 31st!
         p These skins may remind some of you of the Spooky Skin set that was available briefly last fall. This is because we've received many requests for these Limited Edition skins from more recent players who were unable to purchase those skins. As a compromise, we have decided to Retire the Spooky Skin Set and release some similar but unique skins as part of the Supernatural Skin Set. That way, anyone who wants their avatar to be a pumpkin can have their way, but the original owners of the skin sets still have the unique items that they were promised. You can read more about the new Item Availability categories <a href='http://habitrpg.wikia.com/wiki/Item_Availability' target='_blank'>here</a>.
         p.small.muted by Lemoness
     tr
       td
-        h5.small_news_header Community Costume Challenge
+        h5 Community Costume Challenge
         p The Community Costume Challenge has begun! Between now and October 31st, dress up as your avatar in real life and post a photo on social media to get the coveted Costume Challenge badge! Read the full rules on the Challenge page <a href='https://habitrpg.com/#/options/groups/challenges/39f7e9b4-1fbf-4b01-baee-221fd9b9ef43' target='_blank'>here</a>.
         p.small.muted by Lemoness
     tr
       td
-        h5.small_news_header Release Pets and Mounts
+        h5 Release Pets and Mounts
         p If you find collecting pets highly motivating and want to start over from zero, you're in luck! You can now release all your pets and mounts so that you can collect them again - and stack your Beastmaster achievement!
         p.small.muted By Ryan
     tr
       td
-        h5.small_news_header October Mystery Item
+        h5 October Mystery Item
         p Spooky! What could it be? All Habiticans who are subscribed during the month of October will receive the October Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
         p.small.muted by Lemoness
 
-  h5.big_news_header 9/25/2014
+  h4 9/25/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header Update: Diagnosing Server Problems
+        h5 Update: Diagnosing Server Problems
         p Our servers have been under a massive strain recently, and so we've created a <a href='https://github.com/HabitRPG/habitrpg/issues/4079' target='_blank'>Github ticket</a> that you can follow for updates on the things we're doing to fix the problem. We've also written a <a href='http://blog.habitrpg.com/post/98367930371/update-diagnosing-server-problems' target='_blank'>blog post</a>. We'll keep you updated with new developments as we strive to solve this problem.
         p If you've lost any of your stats during this time, you can restore them using Settings > Site > Fix Character Values. Thank you so much for your patience and encouragement as we work to fight this fearsome foe!
         p.small.muted by lefnire, Lemoness
     tr
       td
-        h5.small_news_header September Item Set Revealed
+        h5 September Item Set Revealed
         .promo_mystery_201409.pull-right
         p In happier news, the September Subscriber Item has been revealed: the Autumn Strider Item Set. All people who are subscribed before the end of September will receive the Autumn Antlers and the Strider Vest. Thank you so much for your support - it means a lot to us, especially right now.
         p.small.muted by Lemoness
 
-  h5.big_news_header 9/22/2014 - Fall Festival! Limited-Edition Outfits, Candy Food Drops, And Npc Dress-Up
+  h4 9/22/2014 - Fall Festival! Limited-Edition Outfits, Candy Food Drops, And Npc Dress-Up
   p Autumn is upon us! The air is crisp, the leaves are red, and Habitica is feeling spooky. Come celebrate the Fall Festival with us... if you dare!
   table.table.table-striped
     tr
       td
-        h5.small_news_header Limited Edition Class Outfits
+        h5 Limited Edition Class Outfits
         p Habiticans everywhere are dressing up. From now until October 31st, limited edition outfits are available in the Rewards column. Depending on your class, you can be a Witchy Wizard, Monster of Science, Vampire Smiter, or Mummy Medic! You'd better get productive to earn enough gold before your time runs out...
     tr
       td
-        h5.small_news_header Candy Food Drops!
+        h5 Candy Food Drops!
         p You've received some Candy in your inventory in honor of the Fall Festival! Plus, for the duration of the Event, Habiticans may randomly find candy drops when they complete their tasks. These candies function just like normal food drops - can you guess which flavor your pet will like best?
     tr
       td
-        h5.small_news_header NPC Dress-Up
+        h5 NPC Dress-Up
         p Looks like the NPCs are really getting in to the spooky autumnal mood around the site. Who wouldn't?
 
-  h5.big_news_header 9/17/2014 - Rooster Pets, Party Sorting, And Back-To-School Challenge
+  h4 9/17/2014 - Rooster Pets, Party Sorting, And Back-To-School Challenge
   table.table.table-striped
     tr
       td
-        h5.small_news_header New Pet Quest: Rooster Rampage!
+        h5 New Pet Quest: Rooster Rampage!
         p There's a new pet quest in <a href='https://habitrpg.com/#/options/inventory/drops' target='_blank'>the Market</a>! This monstrous rooster can't be quieted, and Habiticans are unable to sleep. Can you and your Party calm down this foul fowl? You'll be rewarded with Rooster eggs if you do!
         p.small.muted by LordDarkly, Pandoro, EmeraldOx, extrajordanary, and playgroundgiraffe
     tr
       td
-        h5.small_news_header Party Sorting!
+        h5 Party Sorting!
         p We've improved the preexisting party sort feature. Now you can sort your party members' avatars by level, backgrounds, and more! Simply go to Social > Party > Members and select from the drop-down menu.
         p.small.muted by Alys and Viirus
     tr
       td
-        h5.small_news_header Back-To-School Challenge!
+        h5 Back-To-School Challenge!
         p Don't forget that the 2nd Official HabitRPG Challenge is running right now - the <a href='https://habitrpg.com/#/options/groups/challenges/a367eb40-8514-46fd-805e-b9b7f89bad7f' target='_blank'>Back-To-School Advice Challenge</a>! Post your best tips for using HabitRPG during the Back-To-School season on social media for a chance at winning 60 gems. If you want to share it with the maximum number of people, you can use the #habitrpg and #backtoschool tags. You only have thirteen more days to enter. Good luck!
 
-  h5.big_news_header 9/12/2014 - Official Back-To-School Challenge, Markdown In Checklists, And Help Tab
+  h4 9/12/2014 - Official Back-To-School Challenge, Markdown In Checklists, And Help Tab
   table.table.table-striped
     tr
       td
-        h5.small_news_header Official Back-To-School Challenge
+        h5 Official Back-To-School Challenge
         p We've launched our 2nd Official HabitRPG Challenge: the Back-To-School Advice Challenge! Use social media to tell us how you use HabitRPG to improve study habits, share stories of scholarly success with the app, or just give us your advice on using HabitRPG to be the best you can be.
         p The contest ends on September 30th, and the 20 winners will each get 60 Gems! For the full rules, <a href='https://habitrpg.com/#/options/groups/challenges/a367eb40-8514-46fd-805e-b9b7f89bad7f' target='_blank'>check out the challenge here</a>.
-        h5.small_news_header Markdown In Checklists
+        h5 Markdown In Checklists
         p Previously, you've been able to use <a href='http://habitrpg.wikia.com/wiki/Markdown_Cheat_Sheet' target='_blank'>markdown</a> in your task names and in chat. Now you can also use it in checklists! Fill every aspect of your tasks with emoji, bolding, italics, or links. NOTE: If your checklists look strange, it's probably because they're accidentally using markdown now, so just edit them accordingly! Check out <a href='http://habitrpg.wikia.com/wiki/Markdown_Cheat_Sheet' target='_blank'>this Cheat Sheet</a> for an explanation of how to use markdown.
         p.small.muted By @negue
-        h5.small_news_header Help Tab
+        h5 Help Tab
         p There's a new tab on the top bar that contains some helpful links. If you're confused about something, want to request a feature, or wonder if your question was asked before, you can now use the Help Tab's drop down menu!
         p.small.muted By @Alys
 
-  h5.big_news_header 9/10/2014
+  h4 9/10/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header Get Ready For The Community Costume Challenge!
+        h5 Get Ready For The Community Costume Challenge!
         p We've got an exciting event coming up this October - the first-ever Community Costume Challenge! In the spirit of the season, Habiticans who dress up in real-life versions of their avatar's armor (or in any HabitRPG costume) will receive a special badge. (No, just wearing a colored shirt doesn't count. Where's the fun in that?)
         p The Community Costume Challenge will start on October 1st, but we're announcing it early so that people have time to get their costumes together.
         p Instructions on how to participate in the CCC will be posted on October 1st. We can't wait to see your costumes!
 
-  h5.big_news_header 9/3/2014
+  h4 9/3/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header New Backgrounds Revealed: Thunderstorm, Autumn Forest, Harvest Fields
+        h5 New Backgrounds Revealed: Thunderstorm, Autumn Forest, Harvest Fields
         p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop!</a> Now your avatar can conduct lightning in a Thunderstorm, stroll through an Autumn Forest, or cultivate their Harvest Fields!
         p.small.muted by krajzega and Uncommon Criminal
 
-  h5.big_news_header 9/1/2014
+  h4 9/1/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header September Mystery Item
+        h5 September Mystery Item
         p Hmm, intriguing... All Habiticans who are subscribed during the month of September will receive the September Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
 
-  h5.big_news_header 8/31/2014
+  h4 8/31/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header Last Day For Sun Sorcerer Item Set
+        h5 Last Day For Sun Sorcerer Item Set
         p Reminder: this is the final day to subscribe and receive the Sun Sorcerer Item Set! If you want the Sun Crown or the Sun Robes, now's the time! Thanks so much for your support <3
 
-  h5.big_news_header 8/26/2014 - August Mystery Item, Sortable Tags, Push To Top
+  h4 8/26/2014 - August Mystery Item, Sortable Tags, Push To Top
   table.table.table-striped
     tr
       td
-        h5.small_news_header August Item Set Revealed!
+        h5 August Item Set Revealed!
         .promo_mystery_201408.pull-right
         p The August Subscriber Item has been revealed: the Sun Sorcerer Item Set! All August subscribers will receive the Sun Crown and the Sun Robes. You still have five days to subscribe and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
         p.small.muted by Lemoness
     tr
       td
-        h5.small_news_header Sortable Tags
+        h5 Sortable Tags
         p You can now sort your tags. Drag left-to-right and drop them into place.
         p.small.muted by Fandekasp, lefnire
     tr
       td
-        h5.small_news_header Push to Top
+        h5 Push to Top
         p We've added a small button in your tasks' one-click actions: Push to Top. This will help easily you sort your day's priorities, which may change from day-to-day.
         p.small.muted by negue
 
-  h5.big_news_header 8/19/2014 - Parrot Quest, Audio, And Mobile App Update!
+  h4 8/19/2014 - Parrot Quest, Audio, And Mobile App Update!
   table.table.table-striped
     tr
       td
-        h5.small_news_header New Pet Quest: Help! Harpy!
+        h5 New Pet Quest: Help! Harpy!
         p There's a new Pet Quest available in the <a href='https://habitrpg.com/#/options/inventory/drops'>Market</a>! @UncommonCriminal is being held hostage by a Parrot-like Harpy. If you can find a way to help, you'll definitely get your hands on some coveted Parrot Eggs....
         p After you've purchased the scroll, battle the Boss by completing Habits and To-Dos. Be careful - every Daily that you skip will cause the Boss to attack your party!
         p.small.muted by Uncommon Criminal and Token
     tr
       td
-        h5.small_news_header Audio
+        h5 Audio
         p You can now enable sound effects for various website actions. Click the volume icon (<span class='glyphicon glyphicon-volume-off'></span>) and choose an "Audio Theme". For now, the only theme available is "Daniel The Bard" (@DanielTheBard designed this set); however, we'll release more themes over time (<a href='http://habitrpg.wikia.com/wiki/Guidance_for_Bards' target='_blank'>get involved here</a>). We'll also add more sound effects, and possibly music, to the current set.
         p.small.muted by DanielTheBard, Fandekasp
 
     tr
       td
-        h5.small_news_header New Mobile Update: Backgrounds and Guilds!
+        h5 New Mobile Update: Backgrounds and Guilds!
         p We've updated the mobile app to include Backgrounds and Guilds! Now you can use the mobile app to join common interest groups, chat with like-minded people, and swap your avatar’s background. The iOS app is <a href='https://itunes.apple.com/us/app/habitrpg/id689569235?mt=8' target='_blank'>here</a>, and the Android app is <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg&hl=en' target='_blank'>here</a>. If you enjoy the direction that we’ve been taking the app, we would really appreciate it if you would leave us a review <3 Thank you!
         p.small.muted by huarui, paglias
 
-  h5.big_news_header 8/12/2014
+  h4 8/12/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header New Equipment Quest: Attack Of The Mundane!
+        h5 New Equipment Quest: Attack Of The Mundane!
         p There's a new Quest that will drop automatically for all users level 15 and up: the Dish Disaster, first quest in the Attack of the Mundane Questline! Scrub enchanted dirty dishes, battle the SnackLess Monster, and face off against the Evil Laundromancer. You might just be rewarded with a new piece of armor...
         p As you complete each quest in this questline, you will be awarded with the quest scroll for the next part. There are three parts in total. Good luck!
         small.muted by Arcosine, Kiwibot, Lemoness, Daniel the Bard, itokro
 
-  h5.big_news_header 8/6/2014
+  h4 8/6/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header New Backgrounds Revealed: Volcano, Dusty Canyon, Clouds
+        h5 New Backgrounds Revealed: Volcano, Dusty Canyon, Clouds
         p There are three new avatar backgrounds in the <a href='https://habitrpg.com/#/options/profile/backgrounds' target='_blank'>Background Shop</a>! Now your avatar can heat up inside a Volcano, wander through a Dusty Canyon, or soar through the Clouds!
 
-  h5.big_news_header 8/4/2014
+  h4 8/4/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header New Mobile Update: Checklist Editing And Bug Fixes!
+        h5 New Mobile Update: Checklist Editing And Bug Fixes!
         p In case you missed it, we’ve released a new mobile update! You can edit checklists from the mobile app now. We also fixed some bugs, including the image problems on iOS! The Android app is <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg&hl=en' target='_blank'>here</a> and the iOS app is <a href='https://itunes.apple.com/us/app/habitrpg/id689569235?mt=8' target='_blank'>here</a>.
         p You may have noticed that we've been releasing lots of updates recently. This is greatly due to two awesome members of our team!
         p The first is superstar contributor Matteo, aka <a href='https://github.com/paglias' target='_blank'>paglias</a>. In addition to the mobile app, he contributes tons of code to the site, runs translations, and fixes bugs without blinking. We are so thankful to have him on the team!
         p We also have another new mobile app contributor who has rocketed to Level 7 in record time: <a href='https://github.com/huaruiwu' target='_blank'>huarui</a>! Huarui has been an absolute whirlwind with mobile app improvements.
         p Give them both a giant round of applause!
 
-  h5.big_news_header 8/2/2014
+  h4 8/2/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header Dread Drag'on Defeated! Prizes: Mantis Shrimp Pet, Mantis Shrimp Mount, Food, and Badge
+        h5 Dread Drag'on Defeated! Prizes: Mantis Shrimp Pet, Mantis Shrimp Mount, Food, and Badge
         p We've done it!
         p With a final last roar, the Dread Drag'on collapses and swims far, far away. Crowds of cheering Habiticans line the shores! We've helped Daniel rebuild his Tavern.
         p But what's this?
@@ -1594,54 +1653,54 @@ mixin oldNews
         p "As a thank you," says his friend @Ottl, "Please accept this Mantis Shrimp pet and Mantis Shrimp mount, this feast, and our eternal gratitude!"
     tr
       td
-        h5.small_news_header August Mystery Item
+        h5 August Mystery Item
         p Ooh, mysterious! All Habiticans who are subscribed during the month of August will receive the August Mystery Item Set! It will be revealed on the 26th, so keep your eyes peeled. Thanks for supporting the site <3
 
-  h5.big_news_header 7/31/2014
+  h4 7/31/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header Last Day for July Subscriber Set
+        h5 Last Day for July Subscriber Set
         .promo_mystery_201407.pull-right
         p Reminder: this is the final day to subscribe and receive the Undersea Explorer Item Set! If you want the Undersea Explorer Helm or the Undersea Explorer Suit, now's the time! Thank you so much for your support <3
     tr
       td
-        h5.small_news_header Final Day for Limited Edition Summer Outfits
+        h5 Final Day for Limited Edition Summer Outfits
         p Today is the last day of the Summer Splash Event, so it is the last day to buy the Limited Edition Outfits and the Rainbow Warrior Armor from the Rewards store. Get productive and spend that gold!
 
   hr
-  h5.big_news_header 7/25/2014
+  h4 7/25/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header July Subscriber Item
+        h5 July Subscriber Item
         .promo_mystery_201407.pull-right
         p The July Subscriber Item has been revealed: the Undersea Explorer Item Set! All July subscribers will receive the Undersea Explorer Helm and the Undersea Explorer Suit. You still have six days to subscribe and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
 
   hr
-  h5.big_news_header 7/16/2014
+  h4 7/16/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header Mobile App Update
+        h5 Mobile App Update
         p We’ve released another update to the mobile app! Now you can feed and select pets from the app. Carry your cute pets with you everywhere you go! The app is available for <a href='https://itunes.apple.com/us/app/habitrpg/id689569235?mt=8' target='_blank'>iOS here</a>, and <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg' target='_blank'>Android here</a>. We’re continuing to release updates on a regular basis, so if you like the direction that we’ve been taking the app, please do consider leaving us a review. Thank you!
     tr
       td
-        h5.small_news_header Neglect Strike: Tavern Art Swap
+        h5 Neglect Strike: Tavern Art Swap
         p The Dread Drag'on's Rage Bar has filled, and it has unleashed its Neglect Strike, leading to a new look for the Tavern! As a reminder, the Drag'on's rage will NEVER hurt any users or interfere with their ability to be productive, so the chat and inn are still functional. Even so... poor Daniel!
         p All users are automatically damaging the Drag'on with their tasks. There is nothing bad that can happen to you or your account by being in this fight!
     tr
       td
-        h5.small_news_header Dread Drag'on Prize Change: Food Reward!
+        h5 Dread Drag'on Prize Change: Food Reward!
         p We've received a lot of feedback due to the weekend's confusion, and it seems that awarding GP and XP for defeating the world boss significantly unbalanced the game for newer players. Based on your feedback, XP and GP will no longer be awarded. Instead, players will receive an assortment of food! The Mantis Shrimps will still be awarded.
         p If you were looking forward to receiving the 900XP and 90 GP upon completion of the battle, feel free to award it to yourself using Settings > Site > Fix Character Values when the battle is done!
         p Thank you for bearing with us through the confusion. We love you guys.
   hr
-  h5.big_news_header 7/12/2014
+  h4 7/12/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header Wow, What'S Going On?!
+        h5 Wow, What'S Going On?!
         p You may have noticed some strange things happening - extra gold? Drag'on defeated? No quest damage?
         br
         p Turns out the Dread Drag'on of Dilatory was harder to handle than we expected, and wreaked havoc on us last night by unexpectedly completing due to a glitch, throwing off party quest damage, and granting all of its rewards early! *shakes fist at terrible beast*
@@ -1660,61 +1719,61 @@ mixin oldNews
   table.table.table-striped
     tr
       td
-        h5.small_news_header July 11th: GaymerX reminder
+        h5 July 11th: GaymerX reminder
         p Reminder: Vicky (aka redphoenix) is at GaymerX at the InterContinental in San Francisco this weekend! She will have lots of promo codes for the Unconventional Armor Set. Our champion moderator Ryan will be there, too, and would love to meet you guys! Vicky will be wearing a dinosaur hoodie and a red shirt, and Ryan has a partially-shaved head and is in a wheelchair.
         br
         p There will be an official HabitRPG meet-up on <strong>Saturday 3:15-4:30</strong> outside GX Panel Room A (Grand Ballroom AB (3F)). Come get your promo codes there! If you can't make it at that time, contact Vicky via email (vicky@habitrpg.com) or Twitter (@caffeinatedvee) to coordinate an alternative time and place to meet up at the convention!
   small.muted 7/11/2014
   hr
 
-  h5.big_news_header 7/9/2014
+  h4 7/9/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header Happy Derby Day!
+        h5 Happy Derby Day!
         p In celebration of Derby Day, all Habiticans have received a seahorse egg! On this day, the worst of Habitica's ancient bugs were defeated, and so every year we celebrate. Let's ride through Dilatory on this fun day.
-        h5.small_news_header New Pet Quest: Seahorse!
+        h5 New Pet Quest: Seahorse!
         p But oh, no - it looks like a wild Sea Stallion is disrupting the races! Quickly, battle the Sea Stallion to calm him down, and you might just get your hands on some additional seahorse eggs...
         p.small.muted - by Kiwibot and Lemoness
-        h5.small_news_header Updated Stats Bars
+        h5 Updated Stats Bars
         p Based on your feedback, we’ve updated the design of the new status bars with an 8-bit style and improved accessibility.
         p.small.muted - by BenManley
 
   hr
-  h5.big_news_header 7/3/2014
+  h4 7/3/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header New backgrounds available: Coral Reef, Open Waters, Seafarer Ship
+        h5 New backgrounds available: Coral Reef, Open Waters, Seafarer Ship
         p Three new avatar backgrounds are available in the Background Shop! Now your avatar can swim in a <strong>coral reef</strong>, enjoy the <strong>open waters</strong>, or sail aboard a <strong>Seafarer Ship</strong>. Thanks so much for supporting the site!
     tr
       td
-        h5.small_news_header Next Convention: GaymerX!
+        h5 Next Convention: GaymerX!
         p HabitRPG's own Vicky Hsu will be at GaymerX, a game convention celebrating LGBTQ and gaming which is open to everyone, at the InterContinental in downtown San Francisco on July 11-13. (For more information, check out gaymerx.com!) Vicky will be giving away promo codes for the UnConventional Armor Set, so if you want to meet up with her (and snag some awesome capes), send a message to vicky@habitrpg.com or @caffeinatedvee on Twitter!
     tr
       td
-        h5.small_news_header Rainbow Warrior Set!
+        h5 Rainbow Warrior Set!
         p Even if you can't make it to the convention, you can still enjoy the two new armor pieces available for free in the Rewards Store: the Rainbow Warrior Helm and the Rainbow Warrior Armor! They were designed by our GaymerX friends and they look awesome. They'll be available until the end of the month, so enjoy!
 
   hr
-  h5.big_news_header 7/1/2014
+  h4 7/1/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header WORLD BOSS: The Dread Drag'on of Dilatory!
+        h5 WORLD BOSS: The Dread Drag'on of Dilatory!
         p We should have heeded the warnings.
         p Dark shining eyes. Ancient scales. Massive jaws, and flashing teeth. We've awoken something horrifying from the crevasse: **the Dread Drag'on of Dilatory!** Screaming Habiticans fled in all directions when it reared out of the sea, its terrifyingly long neck extending hundreds of feet out of the water as it shattered windows with its searing roar.
         p "This must be what dragged Dilatory down!" yells Lemoness. "It wasn't the weight of the neglected tasks - the Dark Red Dailies just attracted its attention!"
         p "It's surging with magical energy!" @Baconsaur cries. "To have lived this long, it must be able to heal itself! How can we defeat it?"
         p Why, the same way we defeat all beasts - with productivity! Quickly, Habitica, band together and strike through your tasks, and all of us will battle this monster together. (There's no need to abandon previous quests -  we believe in your ability to double-strike!) It won't attack us individually, but the more Dailies we skip, the closer we get to triggering its Neglect Strike - and I don't like the way it's eyeing the Tavern....
   hr
-  h5.big_news_header 6/30/2014
+  h4 6/30/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header Last day for June Item Set!
+        h5 Last day for June Item Set!
         p Reminder: this is the final day to subscribe and receive the Octomage Item Set! If you want the Octopus Robe or the Tentacle Helm, now's the time! Thanks so much for your support <3
-        h5.small_news_header Dilatory Update
+        h5 Dilatory Update
         p PLEASE! Habiticans, stop  exploring the dark crevasse!!! Lemoness is really getting worried. There have been.... reports.
         p Reports of something big.
         p Reports of something terrifying.
@@ -1722,45 +1781,45 @@ mixin oldNews
         p Besides, exploring the dark and dangerous crevasse has become a source of procrastination. Let's get back to work, people!
 
   hr
-  h5.big_news_header 6/25/2014
+  h4 6/25/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header June Subscriber Item
+        h5 June Subscriber Item
         .pull-right.promo_mystery_201406.png
         p The June Subscriber Item has been revealed: the Octomage Item Set!  All June subscribers will receive the Octopus Robe and the Crown of Tentacles. You still have six days to subscribe and receive the item set! Thank you so much for your support - we really do rely on you to keep HabitRPG free to use and running smoothly.
-        h5.small_news_header Mobile App Update
+        h5 Mobile App Update
         p There's a new mobile app update available! In addition to bug fixes, there are many improvements, including a new button-based menu, tap-and-hold to edit tasks, and the return of stats and in-app avatar customization! Working on the mobile app is our biggest To-Do this summer, so expect more in the coming months. If you feel that the app is improving, we'd love it if you would take the time to give us a review and let us know what you think!
-        h5.small_news_header Dilatory Update
+        h5 Dilatory Update
         p It's great to see Habiticans having fun exploring the ruins! There's just one small thing Lemoness wants us to avoid. She's noticed a lot of Habiticans trying to explore the fallen palace of the other side of the dark crevasse. She really doesn't feel that the crevasse is safe, so please don't swim so close. Other than that, enjoy your explorations!
 
   hr
-  h5.big_news_header 6/21/2014
+  h4 6/21/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header Summer Mystery Update
+        h5 Summer Mystery Update
         p Lady Lemoness has returned at last! She startled beach-goers by charging up out of the waves and onto the shore, shouting "I found it!!! I found it!!! Oh, I just KNEW that citing it as impossible would make it a narrative probability!"
         p Wait - found what?
-        h5.small_news_header Summer Splash Event: The Lost City Of Dilatory!
+        h5 Summer Splash Event: The Lost City Of Dilatory!
         p Dilatory was a lovely island city of ancient Habitica. It was a prosperous place, but as the wealth of the city grew, the inHabitants grew lazy and procrastinated on their Dailies and To-Dos... until the combined weight of their dark red tasks triggered a massive earthquake that sunk the city. Legends say that all of the inHabitants were transformed into sea creatures.
         p The location of this city was lost to time... until now!
-        h5.small_news_header Limited Edition Outfits!
+        h5 Limited Edition Outfits!
         p What's the fun of an underwater city if you can't explore it? Luckily, from now until July 31st, special Limited Edition Outfits are available for gold in the Rewards store! Spellcasters can transform themselves into <strong>Emerald Mermages</strong> and <strong>Reef Seahealers</strong> to swim among the ruins, while fighters may prefer to dress as <strong>Roguish Pirates</strong> and <strong>Daring Swashbucklers</strong>, riding above the city on magnificent ships. Work hard, and you can join them!
-        h5.small_news_header NPC Dress-up
+        h5 NPC Dress-up
         p The NPCs got so excited about the discovery of Dilatory that they've moved over there for the summer! Daniel the Innkeeper has opened a beachside tavern, and Alex is also selling by the shore! Meanwhile, Justin the Guide is giving tours aboard boats, Ian is dispensing quest wisdom from the deep ocean, Matt has opened stables for aquatic pets, and I am swimming about keeping everyone informed!
-        h5.small_news_header But what caused the Earthquake?
+        h5 But what caused the Earthquake?
         p Only one piece of the mystery remains unsolved - what caused the second earthquake that unearthed the ancient Dailies? After all, the earthquake that destroyed Dilatory was caused by a build up of undone Dailies and To-Dos, wasn't it?
         p But *we've* all been doing our tasks...
 
   hr
-  h5.big_news_header 6/14/2014
+  h4 6/14/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header New Feature: Backgrounds!
+        h5 New Feature: Backgrounds!
         p We're debuting a brand-new feature - backgrounds for your avatar! Stroll through a Summer Forest, lounge upon a warm Beach, or dance in a Fairy Ring. You can buy the backgrounds in the new Background tab, under User. Have fun!
-        h5.small_news_header Summer Mystery Update
+        h5 Summer Mystery Update
         p It's been a while since we've seen Lemoness around - she's been a bit scarce since she started trying to decipher those ancient Dailies. We just stopped by her hut to check on her and found her..... missing?
         br
         p It looked like she'd taken her armor-enchanting crochet hook, but little else. There was a single scrawled note on the table: "I think I've translated it!!!! If I'm right, this is going to be QUITE the summer. Verifying claims - be back soon!!!"
@@ -1769,33 +1828,33 @@ mixin oldNews
   small.muted 6/14/2014
 
   hr
-  h5.big_news_header 6/10/2014
+  h4 6/10/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header New Pet Quest: The Call Of Octothulu!
+        h5 New Pet Quest: The Call Of Octothulu!
         p There's a new pet in town! The dreaded Octothulu, sticky spawn of the stars, has emerged from a whirlpool in a dark cave by the sea. It's up to you and your party to banish the foul beast by being extra-productive! If you manage to defeat it, you might just find some octopus eggs...
-        h5.small_news_header Earthquake Update
+        h5 Earthquake Update
         p Remember the strange earthquake we had recently? Well, this probably isn't related in any way, but Habiticans have recently noticed some mysterious black Dailies strewn along the beaches. Lemoness happily reports that they are scrawled upon with an ancient language, and that she is hard at work deciphering the script. More news as this develops!
 
   hr
-  h5.big_news_header 6/5/2014
+  h4 6/5/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header June Mystery Item
+        h5 June Mystery Item
         p Wow, what could it be? All Habiticans who are subscribed during the month of June will receive the June Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
     tr
       td
-        h5.small_news_header What Was That?
+        h5 What Was That?
         p Yikes! A mysterious earthquake has rocked Habitica! Luckily, nobody was hurt and there was no real damage, but our scholars are baffled. "We're not even IN a seismic zone," Lady Lemoness was heard muttering as she paged through an enormous tome. "There hasn't been an earthquake since.... but no, that's impossible." Well, if Lemoness says so, it must be true! Seems like it was just a false alarm.
 
   hr
-  h5.big_news_header 5/23/2014
+  h4 5/23/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header May Mystery Outfit Revealed!
+        h5 May Mystery Outfit Revealed!
         .pull-right.promo_mystery_201405.png
         p The May Mystery Item Set has been revealed for all subscribers... <strong>Flame Wielder Item Set</strong>! All people who are subscribed this May will receive two items:
         ul
@@ -1805,25 +1864,25 @@ mixin oldNews
 
 
   hr
-  h5.big_news_header 5/14/2014
+  h4 5/14/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header The Rat King
+        h5 The Rat King
         p Habitica's streets are filled with the skittering of little paws... looks like there's a new Pet Quest available in the Market! Can you and your party defeat the Rat King? If so, there will be some eggs to reward you...
         small.muted By: Pandah and Token
     tr
       td
-        h5.small_news_header Level Cap Lifted
+        h5 Level Cap Lifted
         p You can now level up beyond 100, the 100-cap has been lifted!
         small.muted By: Ryan
 
   hr
-  h5.big_news_header 5/5/2014
+  h4 5/5/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header Mobile Update
+        h5 Mobile Update
         p The new iOS update is live! <a href='https://itunes.apple.com/us/app/habitrpg/id689569235?mt=8' target='_blank'>You can download it here</a>. If you have Android, <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg' target='_blank'>the update is available here.</a>
         br
         p Note: to edit a task or view checklists, swipe left on the task. We're <a href='https://github.com/HabitRPG/habitrpg-mobile/issues/199' target='_blank'>working on click-to-view</a>, we'd love some developer help!
@@ -1831,48 +1890,48 @@ mixin oldNews
         p If you think the new app is an improvement, please consider rating us - many of our old reviews were (justifiably!) pretty low, especially on Apple, but we feel that this update is the first in a line of major improvements. Thanks for sticking with us!
     tr
       td
-        h5.small_news_header The HabitRPG Chrome Extension
+        h5 The HabitRPG Chrome Extension
         p Great news - we've fixed our Chrome Extension! Many thanks to new contributor <a href='https://github.com/HabitRPG/habitrpg-chrome/pull/88' target='_blank'>@GoldBattle<a/>. Now you can set the times and dates you want to only browse productive sites. If you're procrastinating, it will automatically start docking your character's health; if you're hard at work, it will reward you with GP and XP! <a href='https://chrome.google.com/webstore/detail/habitrpg/pidkmpibnnnhneohdgjclfdjpijggmjj' target='_blank'>Read more about it here.</a>
     tr
       td
         p Also, a quick change - May's mystery item will now be revealed on the 23rd, instead of the 25th. Rejoice, impatient Habiticans!
 
   hr
-  h5.big_news_header 4/30/2014
+  h4 4/30/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header May Mystery Item
+        h5 May Mystery Item
         p Ooh, how mysterious! All Habiticans who are subscribed during the month of May will receive the May Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled. Thanks for supporting the site <3
   hr
-  h5.big_news_header 4/30/2014
+  h4 4/30/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header Mobile Update
+        h5 Mobile Update
         p Great news! We've just released a big upgrade to our mobile app. One of our biggest priorities right now is improving the HabitRPG mobile experience, so this is an important first step. We've upgraded the framework to Ionic, which means a cleaner look and smoother feel, and best of all, it is now easier for the developers to add new updates and features! <a href='http://blog.habitrpg.com/post/84100207996/habitrpg-mobile-on-ionic' target='_blank'>Read more about the upgrade here.</a>
         p The Android App is <a href='https://play.google.com/store/apps/details?id=com.ocdevel.habitrpg' target='_blank'>available here</a>! The iOS app was submitted to the App Store, but Apple always takes a while to process things, so it may be a few more days. Let's hope they're quick this time around! We'll let you know when it goes through.
         p Have a productive day!
     tr
       td
-        h5.small_news_header Spread the Word Challenge
+        h5 Spread the Word Challenge
         p Also, at long last the staff has finished sorting through the 1.5K+ participants in the Spread The World Challenge, and we are pleased (and so, so relieved) to finally announce a winner!
         p Congratulations to ALEX KRALIE, the winner of the Spread The Word Challenge! 47K+ notes is truly momentous.
         p A warm congratulation is also due to the runner-ups: sarahtyler, HannahAR, Raiyna, thefandomsarecool, Chickenfox, Anrisa Ryn, frabajulous, galdrasdottir, Judith Meyer, jazzmoth, RavenclawKiba, daraxlaine, Phiso, Billieboo, Victor Fonic, nikoftime, Aedra, amBarthes, and thaichicken! You guys are great <3 Thanks for helping to get the word out about HabitRPG!
     tr
       td
 
-        h5.small_news_header Spring Fling
+        h5 Spring Fling
         p Reminder that today, 4/30, is the LAST DAY of the Spring Fling event! After today, you will no longer be able to purchase the Pastel Hair Set or the Limited-Edition class items. Additionally, the Egg Hunt scroll will no longer be available in the Market, although if you have started the quest, it will NOT disappear and you will be able to complete it at your leisure.
         p It is also the last day to get the Twilight Butterfly Item Set before it disappears forever! If you want the Twilight Butterfly Wings or the Twilight Butterfly head accessory, this is your last chance to subscribe and get them.
         p Happy Spring!
 
   hr
-  h5.big_news_header 4/25/2014
+  h4 4/25/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header April Mystery Outfit Revealed!
+        h5 April Mystery Outfit Revealed!
         //-img.pull-right(src='/marketing/promos/April14SAMPLE2.png')
         p The April Mystery Item Set has been revealed for all subscribers... <strong>Twilight Butterfly Armor Set</strong>! All people who are subscribed this April will receive two items:
         ul
@@ -1881,31 +1940,31 @@ mixin oldNews
         p You still have five more days to subscribe and get the item set. Thank you all for supporting us! We love you <3
 
   hr
-  h5.big_news_header 4/6/2014
+  h4 4/6/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header The Great Egg Hunt
+        h5 The Great Egg Hunt
         p A new quest is available in the Market between now and April 30th. Anyone who signed up before April 7th has one in their inventory free!
 
   hr
-  h5.big_news_header 4/3/2014
+  h4 4/3/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header Limited Edition Pastel Hair Color Set
+        h5 Limited Edition Pastel Hair Color Set
         p A new set of hair colors has been released: the Pastel Set! Now your avatar can have flowing locks in Pastel Blue, Pastel Pink, Pastel Purple, Pastel Orange, Pastel Green, or Pastel Yellow! You will only be able to purchase these hair colors until April 30th, so don't miss out!
 
   hr
-  h5.big_news_header 4/2/2014
+  h4 4/2/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header April Mystery Item
+        h5 April Mystery Item
         p  What could it be? All people who are subscribed during the month of April will receive the April Mystery Item Set! It will be revealed on the 25th, so keep your eyes peeled.
 
   hr
-  h5.big_news_header April F... irst
+  h4 April F... irst
   table.table.table-striped
     tr
       td
@@ -1915,7 +1974,7 @@ mixin oldNews
         small.muted By @lemoness and @baconsaur
 
   hr
-  h5.big_news_header 03/31/2014
+  h4 03/31/2014
   table.table.table-striped
     tr
       td
@@ -1923,11 +1982,11 @@ mixin oldNews
 
 
   hr
-  h5.big_news_header 03/25/2014
+  h4 03/25/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header March Mystery Item Set
+        h5 March Mystery Item Set
         //-img.pull-right(src='/marketing/promos/201403_Forest_Walker.png')
         p The March Mystery Item Set has been revealed for all subscribers... The Forest Walker Set! All people who are subscribed this March will receive two items: <strong>Forest Walker Armor</strong> and <strong>Forest Walker Antlers</strong>!
         br
@@ -1936,70 +1995,70 @@ mixin oldNews
         p You still have five more days to subscribe and get the item set. Thank you all for supporting us! We love you <3
     tr
       td
-        h5.small_news_header PayPal Subscriptions
+        h5 PayPal Subscriptions
         p We've added PayPal as a payment method for subscriptions. We still recommend the <strong>Card</strong> method, as <a href='https://stripe.com/' target='_blank'>Stripe</a> (the processor we use) has a more stable API and better account management tools. However, we realize not everyone owns a credit/debit card, so there's PayPal for ya!
 
   hr
-  h5.big_news_header 03/22/2014
+  h4 03/22/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header Spring Fling Event
+        h5 Spring Fling Event
         p Spring has come to Habitica, and flowers have sprouted everywhere: in the Stables, in the Marketplace... and even in your character customization pages!
     tr
       td
-        h5.small_news_header Head Accessories
+        h5 Head Accessories
         p That's right - we've introduced Head Accessories! Your avatar can now bedeck their helms with colorful flowers. And that's not the only place to get head accessories….
     tr
       td
-        h5.small_news_header Limited Edition Class Outfits
+        h5 Limited Edition Class Outfits
         p The Spring 2014 Limited Edition Class Outfits have been released!
         p From now until April 30th, you will be able to use your gold to buy your current class' armor set from the Rewards store! You can be a Stealthy Kitty, a Mighty Bunny, a Magic Mouse, or a Loving Pup. If you switch classes (system unlocked at level 10), you will gain access to your new classes' armor set. Make sure to collect yours first, though!
         p What are you waiting for? Go be productive and earn some gold!
     tr
       td
-        h5.small_news_header New Un-Equip Mechanic
+        h5 New Un-Equip Mechanic
         p Now to un-equip your gear, click the same item that you have currently equipped. We removed the "Base Equipment" tier for consistency with how un-equipping pets & mounts is handled, and to easily support adding new gear types.
     tr
       td
-        h5.small_news_header Pet Quest: The Ghost Stag
+        h5 Pet Quest: The Ghost Stag
         p The meadows of Habitica are bursting with flowers, sunshine, and.... ominous mist? Looks like a ghost stag is keeping winter alive! Defeat him, and maybe you'll get an egg or three....
     tr
       td
-        h5.small_news_header And More To Come...
+        h5 And More To Come...
         p This is only the beginning of all the treats that we've got in store for you. Stay tuned - and happy Spring Fling!
 
   hr
-  h5.big_news_header 03/18/2014
+  h4 03/18/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header New Pet Quest Mechanics
+        h5 New Pet Quest Mechanics
         p Great news - now it is easier to complete the Quest Pet sets! Pet Quest  Bosses will now drop 3 eggs instead of 2. Additionally, after you have defeated a Pet Quest Boss two times, those eggs will be gem-purchasable in the market like all other eggs, so that your party doesn't have to replay the same quest over and over :)
     tr
       td
-        h5.small_news_header WonderCon
+        h5 WonderCon
         p HabitRPG will be attending WonderCon from April 18th-20th! Come say hi to Tyler, Leslie, and Vicky, and chat about productivity and games. Tickets are available <a href='http://www.comic-con.org/wca/2014/badge-sale' target='_blank'>here</a>.
         p All the users who visit our booth will receive the <a href='http://goo.gl/2urFUt' target='_blank'>Unconventional Armor Accessory Set</a>! (It will also be available if we attend other cons in the future.)
     tr
       td
-        h5.small_news_header LifeHacker Poll
+        h5 LifeHacker Poll
         p HabitRPG is in the running to be Lifehacker's #1 To-Do list manager! We've got some tough competition, so if you like our site, please help us out <a href='http://lifehacker.com/5924093/five-best-to-do-list-managers' target='_blank'>by voting for us here</a> <3
 
   hr
-  h5.big_news_header 03/02/2014
+  h4 03/02/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header March Mystery Item
+        h5 March Mystery Item
         p Happy March! The awesome people who subscribe to HabitRPG will now receive the limited-edition March mystery item! The mystery item set will contain a stats-free costume piece that will <strong>only</strong> be available to the people who are subscribers this March. The set will be revealed on the 25th to everyone, but all people who are subscribers during the month of March will receive it. Get excited - and thank you so much for helping to support HabitRPG! We love you.
     tr
       td
-        h5.small_news_header Hedgehog Quest
+        h5 Hedgehog Quest
         p A new pet has been introduced, the Hedgehog. You can find some eggs by battling the Hedgebeast Boss, a quest scroll available in the market.
 
   hr
-  h5.big_news_header 02/22/2014
+  h4 02/22/2014
   table.table.table-striped
     tr
       td
@@ -2016,68 +2075,68 @@ mixin oldNews
 
 
   hr
-  h5.big_news_header 02/18/2014
+  h4 02/18/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header Translations
+        h5 Translations
         p Translations are well underway! Many of you should already be seeing HabitRPG in your own languages. If not, head <a href='https://trello.com/c/SvTsLdRF/12-translations' target='_blank'>here</a> to see your language's progress or to help translate.
         p
           small.muted by @paglias, @Sinza-, @Luveluen, and more.
     tr
       td
-        h5.small_news_header BountySource
+        h5 BountySource
         p We’ve started using BountySource, a service which lets users post bounties on bug fixes and feature requests. Any features or bugs in HabitRPG you’ve been dying to see resolved? <a href='https://www.bountysource.com/teams/habitrpg/issues' target='_blank'>Post a bounty</a> to attract contributor attention. <a href='http://blog.habitrpg.com/post/76898655192/bountysource' target='_blank'>Read more here</a>.
         p
           small.muted by @Cole, @lefnire, @Ryan
 
   hr
-  h5.big_news_header 02/13/2014
+  h4 02/13/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header Happy Valentine's Day!
+        h5 Happy Valentine's Day!
         p Help motivate all of the lovely people in your life by sending them a caring valentine. Valentines can be purchased for 10 gold from the Item Store. For spreading love and joy throughout the community, both the giver AND the receiver get a coveted "adoring friends" badge. Hooray!
         p
           small.muted By Lemoness and zoebeagle
 
 
   hr
-  h5.big_news_header 02/12/2014
+  h4 02/12/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header Chat & Invite Notifications
+        h5 Chat & Invite Notifications
         p Chat & group-invitation notifications are back! Miss them? They currently work for all chat updates in parties & guilds. Any devs willing to jump into @tagging in Tavern, <a href='http://goo.gl/uhcjkg' target='_blank'>see here</a>.
     tr
       td
-        h5.small_news_header Toolbar
+        h5 Toolbar
         p In order to make room for these notifs, we added a toolbar above the header. You can collapse the toolbar (far-right icon), but take care as Bailey notifs are inside the toolbar!
   hr
-  h5.big_news_header 02/07/2014
+  h4 02/07/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header February Mystery Item
+        h5 February Mystery Item
         p
           .pull-right.inventory_present
           | We're excited to announce a new feature a s a big thank-you to the awesome people who <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>subscribe</a> to HabitRPG! Every month, all subscribers will now receive a limited-edition mystery item! The mystery item will be a stats-free costume piece (like the Absurd Party Robes) that will <strong>only</strong> be available to the people who are subscribers each month. The February 2014 item will be revealed on the 23rd to everyone, but all people who are subscribers during the month of February will receive it. <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>Subscribe now</a>, get excited, and thank you so much for helping to support HabitRPG! We love you.
     tr
       td
-        h5.small_news_header Critical Hammer Of Bug-Crushing
+        h5 Critical Hammer Of Bug-Crushing
         p
           .pull-right.weapon_special_critical
           | Some of you may have noticed that we periodically have some bugs that are nastier than the norm - the dreaded critical bugs. These monstrous apparitions have been snapping at the heels of many a player. For updates on what we're currently working on to improve site stability, read <a href='https://github.com/HabitRPG/habitrpg/issues/milestones' target='_blank'>this link</a> - and then jump in to help!  Not only will programming assistance reward you with the usual contributor levels, but if you actually manage to fix a bug marked <a href='http://goo.gl/v4DnzB' target='_blank'>"critical,"</a> you will now receive the <em>Critical Hammer of Bug-Crushing</em> as your reward!
     tr
       td
 
-        h5.small_news_header Rainbow Hair Colors
+        h5 Rainbow Hair Colors
         p
           .pull-right.customize-option.hair_bangs_1_rainbow
           | Want to spruce up your avatar? Rainbow hair colors are now available! Dye your luscious locks purple, green, or even rainbow-striped, and passersby will look at you with envy.
     tr
       td
-        h5.small_news_header Stability Update
+        h5 Stability Update
         p We've stabilized the site a lot (we're still working out kinks, but we're way better now). Follow the <a href='https://github.com/HabitRPG/habitrpg/issues/milestones' target='_blank'>progress here</a>, but here are some workarounds for now:
         ul
           li Click slower. <a href='https://github.com/HabitRPG/habitrpg/issues/2301#issuecomment-34398206' target='_blank'>VersionError</a> is caused by clicking things off too fast (we're working on a fix).
@@ -2087,37 +2146,37 @@ mixin oldNews
     small.muted By Lemoness, mariahm, crystalphoenix, aiseant, zoebeagle, cole, lefnire
 
   hr
-  h5.big_news_header 02/01/2014
+  h4 02/01/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header Vice
+        h5 Vice
         p You awaken after the Winter Wonderland festivities and birthday celebrations with a smile. It's been a snowy, cheerful couple months, and the NPCs have finally returned to their normal attire. But today something is very wrong. Shadowy whisps cover the ground of Habitica, the sky has darkened. At the tavern you hear @DanielTheBard struming dark tales on his lute, and @Baconsaur peering into a mug, grumbling about her mounts swallowed in the shadows. They speak of the same thing: <strong>Vice</strong>, a dark an terrible foe. This new boss arc is a 3-part quest that requires level 30 to begin. Bring your strongest party members, and don't miss your dailies - there's a powerful weapon at the end!
         p
           small.muted by @baconsaur & @DanielTheBard
 
   hr
-  h5.big_news_header 01/30/2014
+  h4 01/30/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header Happy Birthday, HabitRPG!
+        h5 Happy Birthday, HabitRPG!
         p The fair land of Habitica is two years old on January 31st! The NPCs are celebrating in style, and it looks like some of the staff is, too! Won't you join in?
     tr
       td
-        h5.small_news_header Absurd Party Robtes
+        h5 Absurd Party Robtes
         p As part of the festivities, Absurd Party Robes are available free of charge in the Item Store! Swath yourself in those silly garbs and don your matching hats to celebrate this momentous day.
     tr
       td
-        h5.small_news_header Delicious Cake
+        h5 Delicious Cake
         p What would a birthday be without birthday cake in a myriad of flavors? Of course, pets are very picky, but luckily Lemoness and her team of bakers have plenty of slices to go around. Mmm, delicious!
     tr
       td
-        h5.small_news_header Last Day of Winter Wonderland Event
+        h5 Last Day of Winter Wonderland Event
         p Also, just a reminder - January 31st is the final day of the Winter Wonderland event, so it's your last day to get the Limited Edition Winter Hair Colors, the Winter Outfits, the snowballs, and the Trapper Santa and Find the Cub quest scrolls. Remember that mid-progress Trapper Santa and Find the Cub quests will not abort, nor will you lose your scrolls - they will simply be removed from Alexander's marketplace. We hope that you've had a wonderful winter!
     tr
       td
-        h5.small_news_header Birthday Bash Badge
+        h5 Birthday Bash Badge
         p Finally, to commemorate the fun, all party participants receive a birthday badge! Polish it frequently and wear it fondly.
 
   p Thanks so much for being a part of the HabitRPG community. We love you guys, and we can't wait to have you at our sides in the upcoming year! Stay productive, Habiteers, and have an awesome day.
@@ -2125,31 +2184,31 @@ mixin oldNews
   p.muted By @lemoness
 
   hr
-  h5.big_news_header 01/28/2014
+  h4 01/28/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header Group Plans
+        h5 Group Plans
         p We've begun adding <a href='/static/plans' targte='_blank'>plans for groups</a> (parents, teachers, health & wellness administrators, etc). These plans will provide group leaders with more control, privacy, security, and support. Currently only the Organization Plan (top tier) is available (due to tech limitations believe it or not), and we'll be releasing the Family & Group plans later. <a href='/static/plans' targte='_blank'>Click the "Contact Us" buttons</a> if you're interested, and we'll keep you updated!
     tr
       td
-        h5.small_news_header Individual Plan
+        h5 Individual Plan
         p We've introduced a $5/mo basic subscription plan. It comes with a number of perks, which <a href='https://habitrpg.com/#/options/settings/subscription' target='_blank'>you can see here</a>. We'll likely add more benefits over time, follow <a href='https://trello.com/c/euDUHPpn/371-basic-plan-subscription' target='_blank'>the conversation here</a>.
     tr
       td
-        h5.small_news_header Perfect Day Achievement
+        h5 Perfect Day Achievement
         p Now when you complete all your dailies, you stack this badge, plus and additional perk: you get a +(level/2) buff to all stats!
     tr
       td
-        h5.small_news_header <a href='/#/options/groups/challenges/95533e05-1ff9-4e46-970b-d77219f199e9' target='_blank'>Spread The Word Challenge</a> Update
+        h5 <a href='/#/options/groups/challenges/95533e05-1ff9-4e46-970b-d77219f199e9' target='_blank'>Spread The Word Challenge</a> Update
         p We have 1k+ submissions, holy cow! Great job everyone! Now, we need to go through these manually, so it will take a few days to a couple weeks to process. The challenge will stay open until we're done choosing our winners, but be sure to edit the To-Do with your submission URL before 1/31, as that's the cut-off date for processing. We'll send a Tweet out when the winner has been selected, so follow <a href='https://twitter.com/habitrpg' target='_blank'>@habitrpg</a> and stay tuned.
 
   hr
-  h5.big_news_header 01/25/2014
+  h4 01/25/2014
   table
     tr
       td
-        h5.small_news_header Gryphon Quest
+        h5 Gryphon Quest
         p A new pet has been introduced, the Gryphon. You can find some eggs by battling the Fiery Gryphon Boss, a quest scroll available in the market.
         p
           small.muted Note: we'll be fixing the beast-master achievement to work from the original 90 in coming days. Fear not current beast-masters, you'll get sorted soon!
@@ -2158,69 +2217,69 @@ mixin oldNews
 
 
   hr
-  h5.big_news_header 01/16/2014
+  h4 01/16/2014
   table.table.table-striped
     tr
       td
-        h5.small_news_header "Spread The Word" Challenge Updates
+        h5 "Spread The Word" Challenge Updates
         p If you're not yet participating, check out the <a target='_blank' href='/#/options/groups/challenges/95533e05-1ff9-4e46-970b-d77219f199e9'>Spread The Word Challenge</a>, which has a large prize and many winners. We've made some updates: upped the prize to 80 Gems for the top 20 posts, 100 Gems for the winner. Note: some people are listing their submission as a Tumblr reblog of someone else's post, often with added commentary. Though reblogs are greatly appreciated, we can only count original submissions. Read more <a target='_blank' href='/#/options/groups/challenges/95533e05-1ff9-4e46-970b-d77219f199e9'>challenge guidelines here</a>.
     tr
       td
-        h5.small_news_header Quest Deadlines
+        h5 Quest Deadlines
         p To clear some confusion, you have until Jan 31, 2014 to <strong>purchase</strong> your quest scrolls, after 1/31 Alexander no longer sells them. You can still begin / finish your quests any time after. Thanks to @Cole, you're now allowed to purchase the Cub quest even if you haven't finished Trapper. Stock up!
 
   hr
-  h5.big_news_header 01/06/2014
+  h4 01/06/2014
   h4 <a tooltip='Winter Wonderland Event' href='http://habitrpg.wikia.com/wiki/Winter_Wonderland' target='_blank'>WWE</a> Part 4: Winter Classes
   table.table.table-striped
     tr
       td
-        h5.small_news_header Limited-Edition Winter Class Outfits
+        h5 Limited-Edition Winter Class Outfits
         p Happy winter! Instead of a boring pair of earmuffs, why not use the gold that you earned with all your hard work to buy a Limited Edition class outfit?
         p From now until January 31st, you will be able to use your gold to buy your current class' armor set from the Rewards store! You can be a Yeti Tamer, a Ski-Sassin, a Candy Cane Mage, or a Snowflake Healer. If you switch classes (system unlocked at level 10), you will gain access to your new classes' armor set. Make sure to collect yours first, though!
         p What are you waiting for? Go be productive and earn some gold!
         small.muted by @lemoness
     tr
       td
-        h5.small_news_header Chat +1
+        h5 Chat +1
         p You can now +1 chat messages in Tavern, Guilds, & Parties
     tr
       td
-        h5.small_news_header Halls
+        h5 Halls
         p We've added the "Hall of Heroes" and "Hall of Patrons" <a href='https://habitrpg.com/#/options/groups/hall/heroes' target='_blank'>here</a>, which list our project contributors and Kickstarter backers. Want be amongst those immortalized in the Hall of Heroes? <a href='http://habitrpg.wikia.com/wiki/Contributor_Rewards' target='_blank'>Lend us your sword!</a>
 
   hr
-  h5.big_news_header 12/31/2013
+  h4 12/31/2013
   h4 Winter Wonderland Event Part 3: Party!
   table.table.table-striped
     tr
       td
-        h5.small_news_header Happy New Year!
+        h5 Happy New Year!
         p Happy New Year! Join the NPCs and Staff in showing off your new Absurd party hat.... and have a great night!
         small.muted by @lemoness
     tr
       td
-        h5.small_news_header Rebirth
+        h5 Rebirth
         p Nothing says New Year like a fresh start. Now when you reach level 50, Ultimate Gear, or BeastMaster, you can begin anew with the most prestigious of achievements: Rebirth. <a href='https://trello.com/c/SLiq4enr/333-rebirth-new-game' target='_blank'>Read more here</a>. But take heed! Scouts have reported <a href='https://github.com/HabitRPG/habitrpg/issues/945#issuecomment-31355229' target='_blank'>monster sightings</a>, harbinged by Trapper Santa. You may need all the strength you can muster come late January, Rebirth is for the hard-core.
         small.muted by @SabreCat
     tr
       td
-        h5.small_news_header Checklists
+        h5 Checklists
         p <a href='https://trello.com/c/PJ1iJ413/65-checklists' target='_blank'>Checklists</a> are here! You can break your Dailies and To-Dos down into bite-size chunks. Their game mechanic takes some learning, so <a href='http://habitrpg.wikia.com/wiki/Checklist' target='_blank'>read more here</a>.
         small.muted by @lefnire
     tr
       td
-        h5.small_news_header Task Icons & Markdown
+        h5 Task Icons & Markdown
         p Task titles now support Markdown and Emoji, so you can create something <a href='http://gyazo.com/f2021674925a79a1dec22101ef74a63c' target='_blank'>like this</a>. Read more <a href='https://trello.com/c/FCVdjdUd/102-task-reward-icons' target='_blank'>here</a>.
         small.muted by @lefnire
 
   hr
-  h5.big_news_header 12/25/2013
+  h4 12/25/2013
   h4 Winter Wonderland Event Part 2: Rescue the Bears
   table.table.table-striped
     tr
       td
-        h5.small_news_header Quests & Bosses!
+        h5 Quests & Bosses!
         p A beast is roaring in the distant mountains, mysterious tracks have appeared in the snow. A new feature has been unlocked, <a href='https://trello.com/c/VPPjVRlF/212-quests-bosses' target='_blank'>Quests & Bosses</a>. As a holiday present, HabitRPG gives you your first quest: "Trapper Santa". Check your inventory, you have until Jan 31 to complete it!
 
   p By @lefnire, @pandoro, @Shaners
@@ -2228,29 +2287,29 @@ mixin oldNews
   hr
 
 
-  h5.big_news_header 12/20/2013
+  h4 12/20/2013
   h4 Winter Wonderland Event Part 1: The Great Snowball Fight
   p It's time for HabitRPG's biggest event yet - Winter Wonderland! The fun starts today, on the first day of winter, and ends on January 31st - HabitRPG's birthday.
   p Get prepared to build new habits, earn fun drops, hold your party members accountable for their tasks, and decorate your avatar. Various features will be rolling out over the course of the event, so expect many updates! For starters...
   table.table.table-striped
     tr
       td
-        h5.small_news_header NPC Decorations
+        h5 NPC Decorations
         p Looks like everyone is really getting into the winter spirit! Check out the new NPC sprites. (And I heard a rumor that the final NPC might show up, just in time for the new year...)
     tr
       td
         .customize-option.hair_bangs_1_winternight.pull-right
-        h5.small_news_header Limited-Edition Holiday Hair-Colors
+        h5 Limited-Edition Holiday Hair-Colors
         p Now your avatar can dye their hair Candy Cane, Frost, Winter Sky, or Holly! You'll only be able to purchase these hair colors until January 31st, when they will be retired.
     tr
       td
         .shop_snowball.pull-right
-        h5.small_news_header The Great HabitRPG Snowball Fight
+        h5 The Great HabitRPG Snowball Fight
         p Yes, you can now buy snowballs and hurl them at all your friends... to, uh, help them improve their habits. How? Weeeeellll, let's just say that after getting walloped, they might find themselves needing some extra gold to escape their predicament...
           //-span.shop_head_special_candycane.item-img.shop-sprite
     tr
       td
-        h5.small_news_header More to Come
+        h5 More to Come
         p A beast is roaring in the distant mountains, mysterious tracks have appeared in the snow, and Lemoness is furiously crocheting something sparkly.
         p It's going to be a wild winter.
 
@@ -2258,7 +2317,7 @@ mixin oldNews
 
   hr
 
-  h5.big_news_header 12/16/2013
+  h4 12/16/2013
   p Good gracious, where do I start...
   br
   table.table.table-striped
@@ -2285,7 +2344,7 @@ mixin oldNews
   hr
   p By @lemoness @sabrecat @danielthebard @fuzzytrees @crystalphoenix @rosemonkeyct @fandekasp, and many more. (Who am I missing? We'll put up a CONTRIBUTORS.md soon)
 
-  h5.big_news_header 12/7/20132
+  h4 12/7/20132
   table.table.table-striped
     tr
       td
@@ -2296,7 +2355,7 @@ mixin oldNews
         p.
          By <a target='_blank' href='https://github.com/lemoness'>@lemoness</a> <a target='_blank' href='https://github.com/Shaners'>@Shaners</a> <a target='_blank' href='https://github.com/baconsaur'>@baconsaur</a> <a target='_blank' href='https://github.com/RandallStanhope'>@RandallStanhope</a> <a target='_blank' href='https://github.com/ashjolliffe'>@ashjolliffe</a> <a target='_blank' href='https://github.com/fuzzytrees'>@fuzzytrees</a>
 
-  h5.big_news_header 11/27/2013
+  h4 11/27/2013
   table.table.table-striped
     tr
       td
@@ -2318,13 +2377,13 @@ mixin oldNews
         p.
          The <a href='http://habitrpg.wikia.com/wiki/HabitRPG_Wiki' target='_blank'>HabitRPG wiki</a> is being speedily updated. If you’re confused about anything, go check it out - it’s a treasure trove.
 
-  h5.big_news_header 11/08/2013
+  h4 11/08/2013
   table.table.table-striped
     tr
       td.
         Contrib Gear. You can now unlock new a top-tier gear set and pet by contributing (code, art, docs, etc) to HabitRPG. <a href='http://habitrpg.wikia.com/wiki/Contributor_Rewards' target='_blank'>Read more</a>
 
-  h5.big_news_header 11/01/2013
+  h4 11/01/2013
   table.table.table-striped
     tr
       td.
@@ -2332,7 +2391,7 @@ mixin oldNews
     tr
       td Backend overhaul, including bookmark-able paths throughout the application. Will pave the way towards improved performance.
 
-  h5.big_news_header 10/22/2013
+  h4 10/22/2013
   table.table.table-striped
     tr
       td TRICK OR TREAT! It's Habit Halloween! Some of the NPCs have decorated for the occasion. Can you spot us?
@@ -2341,14 +2400,14 @@ mixin oldNews
     tr
       td Do note, skins won't work on mobile until the app is updated. We'll update Android ASAP, iPhone usually takes ~1wk to approve.
 
-  h5.big_news_header 10/19/2013
+  h4 10/19/2013
   table.table.table-striped
     tr
       td New custom skin colors are now available! Go check them out in the Profile section. Also, the new mobile update, 0.0.10, is now available to download! It includes the new skin tones and the ability to hide or show your helm, among other things.
     tr
       td You can now sell un-wanted drops to Alex the Merchant. Trade those troves of eggs for gold!
 
-  h5.big_news_header 09/01/2013
+  h4 09/01/2013
   table.table.table-striped
     tr
       td.
@@ -2357,7 +2416,7 @@ mixin oldNews
         Both apps and the website are open source, and we desparately need your help porting the rest of the features, and polishing off the bugs. <a target='_blank' href='http://habitrpg.wikia.com/wiki/Contributing_to_HabitRPG'>Read this guide</a> to getting started.
         We're working on a system of Contributor Gear to reward the awesome people who help out, so stay tuned!
 
-  h5.big_news_header The Rewrite! (Mid August)
+  h4 The Rewrite! (Mid August)
   table.table.table-striped
     tr
       td.
@@ -2376,7 +2435,7 @@ mixin oldNews
          We desparately need your help porting <a href='http://goo.gl/jYWTwl' target='_blank'>the rest of the features</a>, and polishing off the bugs. <a target='_blank' href='http://habitrpg.wikia.com/wiki/Contributing_to_HabitRPG'>Read this guide</a> to getting started.
          Thanks everyone for all your support and patience!
 
-  h5.big_news_header 8/20/2013
+  h4 8/20/2013
   table.table.table-striped
     tr
       td.
@@ -2385,7 +2444,7 @@ mixin oldNews
       td.
         API developers, the above means that <strong>cron</strong> is automatically run for your users! Weee, they no longer have to log into the website to reset their dailies!
 
-  h5.big_news_header 8/18/2013
+  h4 8/18/2013
   table.table.table-striped
     tr
       td.
@@ -2397,14 +2456,14 @@ mixin oldNews
         | of what we're currently working on! This weekend, we are working hard to fix the "Not Enough GP" bug, a cruel and greedy monster that has wrapped itself around the rewards box and is refusing to let anyone purchase anything. Rest assured that our heroic Tyler will slay this beast soon! Then it wiil be full steam ahead on the new site upgrade process.
         a(target='_blank', href='http://habitrpg.tumblr.com/post/57627483715/news-about-upgrade-and-app') Read more about how that will work in this post here
 
-  h5.big_news_header 6/03/2013
+  h4 6/03/2013
   table.table.table-striped
     tr
       td
         a(target='_blank', href='https://trello.com/card/groups-guilds/50e5d3684fe3a7266b0036d6/84') Guilds!
         | You can now belong to multiple groups, not just your party. There are public and private guilds, think "Subreddits" v "multiple friend groups".
 
-  h5.big_news_header 5/27/2013
+  h4 5/27/2013
   table.table.table-striped
     tr
       td
@@ -2415,7 +2474,7 @@ mixin oldNews
         a(href='http://habitrpg.tumblr.com/post/51476277225/upcoming-features-bugs-update-user-survey', target='_blank') New blog post
         | about upcoming Guilds & Challenges features, & huge bug-fixes on the horizon.
 
-  h5.big_news_header 5/25/2013
+  h4 5/25/2013
   table.table.table-striped
     tr
       td
@@ -2427,11 +2486,11 @@ mixin oldNews
         a(href='http://community.habitrpg.com/content/submitting-bugs', target='_blank') report a problem
         | if you experience any issues, (2) this is going to allow for much less buggy code (read previous link for reasoning).
 
-  h5.big_news_header 5/12/2013
+  h4 5/12/2013
   table.table.table-striped
     tr
       td Renamed "Tokens" to "Gems". Tokens caused confusion.
-  h5.big_news_header 5/10/2013
+  h4 5/10/2013
   table.table.table-striped
     tr
       td
@@ -2441,7 +2500,7 @@ mixin oldNews
     tr
       td Chat messages: can delete your own message, fix the duplicate messages issue.
 
-  h5.big_news_header 5/9/2013
+  h4 5/9/2013
   table.table.table-striped
     tr
       td
@@ -2450,28 +2509,28 @@ mixin oldNews
         a(href='https://trello.com/card/backer-items-availability-mechanic/50e5d3684fe3a7266b0036d6/188', target='_blank') here
         | , and if you're top-gear but not seeing backer stuff, message me from your KS profile.
 
-  h5.big_news_header 5/7/2013
+  h4 5/7/2013
   table.table.table-striped
     tr
       td
         a(_target='blank', href='https://trello.com/card/tags-categories/50e5d3684fe3a7266b0036d6/43') Tags
         | . You can now categorize your tasks, eg "Work", "Home", "Morning", "Taxes", etc.
 
-  h5.big_news_header 5/4/2013
+  h4 5/4/2013
   table.table.table-striped
     tr
       td
         a(_target='blank', href='https://trello.com/card/streaks-consecutive-bonus/50e5d3684fe3a7266b0036d6/182') Streaks
         | . You get a GP & drop-% increase the longer you hold daily streaks (they stack). You also get a stacking badge for each 21-day streak.
 
-  h5.big_news_header 5/3/2013
+  h4 5/3/2013
   table.table.table-striped
     tr
       td
         | Two new achievements: Beast Master & Ultimate Gear. Got ideas for more achievements?
         a(target='_blank', href='https://trello.com/card/awards-badges/50e5d3684fe3a7266b0036d6/19') chime in here
 
-  h5.big_news_header 5/2/2013
+  h4 5/2/2013
   table.table.table-striped
     tr
       td
@@ -2489,7 +2548,7 @@ mixin oldNews
         a(href='https://github.com/lefnire/habitrpg/issues/828') New "Game Options" layout
         | (click your avatar to see)
 
-  h5.big_news_header 3/27/2013
+  h4 3/27/2013
   table.table.table-striped
     tr
       td
@@ -2499,13 +2558,13 @@ mixin oldNews
         a(href='https://trello.com/card/pets/50e5d3684fe3a7266b0036d6/166') Trello Card
         | )
 
-  h5.big_news_header 3/21/2013
+  h4 3/21/2013
   table.table.table-striped
     tr
       td
         a(href='https://github.com/lefnire/habitrpg/issues/585') More design tweaks to header & avatars
 
-  h5.big_news_header 3/20/2013
+  h4 3/20/2013
   table.table.table-striped
     tr
       td
@@ -2523,7 +2582,7 @@ mixin oldNews
       td
         a(href='https://trello.com/card/undo-button/50e5d3684fe3a7266b0036d6/20') Undo Button
 
-  h5.big_news_header 3/3/2013
+  h4 3/3/2013
   table.table.table-striped
     tr
       td

--- a/website/views/static/layout.jade
+++ b/website/views/static/layout.jade
@@ -1,6 +1,7 @@
 include ../shared/mixins.jade
 
 //-Trick needed to pass 'env' to ./layout
+- var containerClass = '';
 block vars
 doctype html
 html(ng-app='habitrpg')
@@ -57,7 +58,7 @@ html(ng-app='habitrpg')
 
           button#header-play-button.btn.btn-primary.navbar-btn.navbar-right(ng-click='playButtonClick()')=env.t('playButton')
 
-      .container
+      .container(class='#{containerClass}')
         block content
 
   include ../shared/footer

--- a/website/views/static/old-news.jade
+++ b/website/views/static/old-news.jade
@@ -3,6 +3,7 @@ extends ./layout
 block vars
   - var layoutEnv = env
   - var menuItem = 'oldNews'
+  - var containerClass = 'static-old-news'
 
 block title
   title Old News


### PR DESCRIPTION
This is a fix for #5836.
I've redesigned the static/old-news page to more or less follow the same design as Bailey's modal.
I've also removed the "Old news" link when you're already on the old news page. I did this using CSS, but there might be a better way of doing this using expressJS?

This is my first pull request for Habitica, so please let me know if I've changed things I shouldn't have or if I didn't follow some coding standard. I think I've read about everything there is on contributing on the wiki and in these READMEs but I might have missed something...

Anyway, I would love some feedback from more experienced Habitica-contributors.
