### PR TITLE
Added test to check that group invites are removed when user cancels account

### DIFF
--- a/test/api/users.coffee
+++ b/test/api/users.coffee
@@ -31,103 +31,109 @@ describe "Users", ->
 
       ], done
 
-    it "Should choose a new group leader when deleting a user", (done) ->
-      userToDelete = undefined
-      userToBecomeLeader = undefined
-      guildToHaveNewLeader = undefined
-      async.waterfall [
-        (cb) ->
-          registerManyUsers 2, cb
+    context "handle group changes when user cancels", ->
+      it "Should choose a new group leader when deleting a user", (done) ->
+        userToDelete = undefined
+        userToBecomeLeader = undefined
+        guildToHaveNewLeader = undefined
+        async.waterfall [
+          (cb) ->
+            registerManyUsers 2, cb
 
-        (_users, cb) ->
-          userToDelete = _users[0]
-          userToBecomeLeader = _users[1]
-          User.findByIdAndUpdate userToDelete._id,
-            $set:
-              "balance": 4
-            , (err, _user) ->
+          (_users, cb) ->
+            userToDelete = _users[0]
+            userToBecomeLeader = _users[1]
+            User.findByIdAndUpdate userToDelete._id,
+              $set:
+                "balance": 4
+              , (err, _user) ->
+                cb()
+
+          (cb) ->
+            request.post(baseURL + "/groups").send(
+              name: "GuildToGainNewLeader"
+              type: "guild"
+            )
+            .set("X-API-User", userToDelete._id)
+            .set("X-API-Key", userToDelete.apiToken)
+            .end (res) ->
+              expectCode res, 200
+              guildToHaveNewLeader = res.body
+              expect(guildToHaveNewLeader.leader).to.eql(userToDelete._id)
               cb()
 
-        (cb) ->
-          request.post(baseURL + "/groups").send(
-            name: "GuildToGainNewLeader"
-            type: "guild"
-          )
-          .set("X-API-User", userToDelete._id)
-          .set("X-API-Key", userToDelete.apiToken)
-          .end (res) ->
-            expectCode res, 200
-            guildToHaveNewLeader = res.body
-            expect(guildToHaveNewLeader.leader).to.eql(userToDelete._id)
-            cb()
+          (cb) ->
+            inviteURL = baseURL + "/groups/" + guildToHaveNewLeader._id + "/invite"
+            request.post(inviteURL)
+              .send( uuids: [userToBecomeLeader._id])
+              .end (res) ->
+                expectCode res, 200
+                cb()
 
-        (cb) ->
-          inviteURL = baseURL + "/groups/" + guildToHaveNewLeader._id + "/invite"
-          request.post(inviteURL)
-            .send( uuids: [userToBecomeLeader._id])
+          (cb) ->
+            request.post(baseURL + "/groups/" + guildToHaveNewLeader._id + "/join")
+              .set("X-API-User", userToBecomeLeader._id)
+              .set("X-API-Key", userToBecomeLeader.apiToken)
+              .end (res) ->
+                expectCode res, 200
+                cb()
+
+          (cb) ->
+            request.del(baseURL + "/user")
+            .set("X-API-User", userToDelete._id)
+            .set("X-API-Key", userToDelete.apiToken)
             .end (res) ->
               expectCode res, 200
               cb()
 
-        (cb) ->
-          request.post(baseURL + "/groups/" + guildToHaveNewLeader._id + "/join")
+          (cb) ->
+            request.get(baseURL + "/groups/" + guildToHaveNewLeader._id)
             .set("X-API-User", userToBecomeLeader._id)
             .set("X-API-Key", userToBecomeLeader.apiToken)
             .end (res) ->
               expectCode res, 200
+              g = res.body
+              userInGroup = _.find(g.members, (member) -> return member._id == userToDelete._id; )
+              expect(userInGroup).to.equal(undefined)
+              expect(g.leader._id).to.equal(userToBecomeLeader._id)
               cb()
 
-        (cb) ->
-          request.del(baseURL + "/user")
-          .set("X-API-User", userToDelete._id)
-          .set("X-API-Key", userToDelete.apiToken)
-          .end (res) ->
-            expectCode res, 200
-            cb()
+        ], done
 
-        (cb) ->
-          request.get(baseURL + "/groups/" + guildToHaveNewLeader._id)
-          .set("X-API-User", userToBecomeLeader._id)
-          .set("X-API-Key", userToBecomeLeader.apiToken)
-          .end (res) ->
-            expectCode res, 200
-            g = res.body
-            userInGroup = _.find(g.members, (member) -> return member._id == userToDelete._id; )
-            expect(userInGroup).to.equal(undefined)
-            expect(g.leader._id).to.equal(userToBecomeLeader._id)
-            cb()
+      context "handle group and invite removals", ->
+        guild = undefined
+        party = undefined
+        before (done) ->
+          User.findByIdAndUpdate user._id,
+            $set:
+              "balance": 4
+            , (err, _user) ->
+              async.waterfall [
+                (cb) ->
+                  request.post(baseURL + "/groups").send(
+                    name: "TestPrivateGroup"
+                    type: "party"
+                  )
+                  .end (res) ->
+                    expectCode res, 200
+                    party = res.body
+                    cb()
 
-      ], done
+                (cb) ->
+                  request.post(baseURL + "/groups").send(
+                    name: "TestPrivateGroup"
+                    type: "guild"
+                  )
+                  .end (res) ->
+                    expectCode res, 200
+                    guild = res.body
+                    cb()
 
-    it 'Should remove a user from a group when deleting a user', (done) ->
-      userToDelete = undefined
-      guild = undefined
-      party = undefined
-      User.findByIdAndUpdate user._id,
-        $set:
-          "balance": 4
-        , (err, _user) ->
+              ], done
+
+        it 'Should remove a user from a group when deleting a user', (done) ->
+          userToDelete = undefined
           async.waterfall [
-            (cb) ->
-              request.post(baseURL + "/groups").send(
-                name: "TestPrivateGroup"
-                type: "party"
-              )
-              .end (res) ->
-                expectCode res, 200
-                party = res.body
-                cb()
-
-            (cb) ->
-              request.post(baseURL + "/groups").send(
-                name: "TestPrivateGroup"
-                type: "guild"
-              )
-              .end (res) ->
-                expectCode res, 200
-                guild = res.body
-                cb()
-
             (cb) ->
               registerManyUsers 1, cb
 
@@ -189,6 +195,58 @@ describe "Users", ->
                 g = res.body
                 userInGroup = _.find(g.members, (member) -> return member._id == userToDelete._id; );
                 expect(userInGroup).to.equal(undefined)
+                cb()
+
+          ], done
+
+        it 'Should remove invitations when deleting a user', (done) ->
+          userToDeleteInvites = undefined
+          async.waterfall [
+            (cb) ->
+              registerManyUsers 1, cb
+
+            # Send them invitations
+            (_users, cb) ->
+              userToDeleteInvites = _users[0]
+              inviteURL = baseURL + "/groups/" + party._id + "/invite"
+              request.post(inviteURL)
+                .send( uuids: [userToDeleteInvites._id])
+                .end (res) ->
+                  expectCode res, 200
+                  cb()
+
+            (cb) ->
+              inviteURL = baseURL + "/groups/" + guild._id + "/invite"
+              request.post(inviteURL)
+                .send( uuids: [userToDeleteInvites._id])
+                .end (res) ->
+                  expectCode res, 200
+                  cb()
+
+            (cb) ->
+              request.del(baseURL + "/user")
+              .set("X-API-User", userToDeleteInvites._id)
+              .set("X-API-Key", userToDeleteInvites.apiToken)
+              .end (res) ->
+                expectCode res, 200
+                cb()
+
+            (cb) ->
+              request.get(baseURL + "/groups/" + party._id)
+              .end (res) ->
+                expectCode res, 200
+                g = res.body
+                userInviteForGroup = _.find(g.invites, (invite) -> return invite._id == userToDeleteInvites._id; )
+                expect(userInviteForGroup).to.equal(undefined)
+                cb()
+
+            (cb) ->
+              request.get(baseURL + "/groups/" + guild._id)
+              .end (res) ->
+                expectCode res, 200
+                g = res.body
+                userInviteForGroup = _.find(g.invites, (invite) -> return invite._id == userToDeleteInvites._id; )
+                expect(userInviteForGroup).to.equal(undefined)
                 cb()
 
           ], done


### PR DESCRIPTION
Part of #5871 is "user should be removed from all the groups he's invited to" . I believe this is already happening unless I am misunderstanding the goal. I added tests to show that when a user leaves, their invites are removed form the groups invite list.
