### PR TITLE
Ensure NPM scripts always use local binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,11 +79,11 @@
     "node": "0.10.x"
   },
   "scripts": {
-    "test": "gulp test",
-    "start": "gulp run:dev",
-    "sprites": "gulp sprites:compile",
-    "postinstall": "bower --config.interactive=false install -f; gulp build;",
-    "coverage": "COVERAGE=true mocha --require register-handlers.js --reporter html-cov > coverage.html; open coverage.html"
+    "test": "$(npm bin)/gulp test",
+    "start": "$(npm bin)/gulp run:dev",
+    "sprites": "$(npm bin)/gulp sprites:compile",
+    "postinstall": "$(npm bin)/bower --config.interactive=false install -f; $(npm bin)/gulp build;",
+    "coverage": "COVERAGE=true $(npm bin)/mocha --require register-handlers.js --reporter html-cov > coverage.html; open coverage.html"
   },
   "devDependencies": {
     "chai": "^2.3.0",


### PR DESCRIPTION
This probably requires an update of the documentation.
Globally installing modules such as gulp or bower is no longer necessary for npm scripts to work.

Fixes #5933
