### PR TITLE
Revert "Removed user's party invites when last user leaves party"

### DIFF
--- a/test/api/groups.coffee
+++ b/test/api/groups.coffee
@@ -172,11 +172,11 @@ describe "Guilds", ->
               cb()
         ], done
 
-    it "deletes all invites to a group (guild) when the last member leaves", (done) ->
+    it "deletes all invites to a group when the last member leaves", (done) ->
       groupToDeleteAfterLeave = undefined
       userToRemoveInvite = undefined
       request.post(baseURL + "/groups").send(
-        name: "TestGroupToDeleteAfterLeave"
+        name: "TestGroupToDeleteAfteLeave"
         type: "guild"
         privacy: "private"
       ).end (res) ->
@@ -212,53 +212,6 @@ describe "Guilds", ->
 
           (cb) ->
             request.post(baseURL + "/groups/" + groupToDeleteAfterLeave._id)
-            .end (res) ->
-              expectCode res, 404
-              cb()
-        ], done
-
-    it "deletes all invites to a group (party) when the last member leaves", (done) ->
-      partyToDeleteAfterLeave = undefined
-      userToRemovePartyInvite = undefined
-      request.post(baseURL + "/groups").send(
-        name: "TestPartyToDeleteAfterLeave"
-        type: "party"
-      ).end (res) ->
-        partyToDeleteAfterLeave = res.body
-        async.waterfall [
-          (cb) ->
-            registerManyUsers 1, cb
-
-          (_members, cb) ->
-            userToRemovePartyInvite = _members[0]
-            inviteURL = baseURL + "/groups/" + partyToDeleteAfterLeave._id + "/invite"
-            request.post(inviteURL).send(
-              uuids: [userToRemovePartyInvite._id]
-            )
-            .end ->
-              cb()
-
-          (cb) ->
-            request.post(baseURL + "/groups/" + partyToDeleteAfterLeave._id + "/leave")
-            .end (res) ->
-              expectCode res, 204
-              cb()
-
-          (cb) ->
-            request.get(baseURL + '/user')
-              .set("X-API-User", userToRemovePartyInvite._id)
-              .set("X-API-Key", userToRemovePartyInvite.apiToken)
-              .end (err, res) ->
-                expectCode res, 200
-                party = partyToDeleteAfterLeave
-                partyInvitation = _.find(res.body.invitations.party, (invite) ->
-                  return invite == party._id
-                )
-                expect(partyInvitation).to.not.exist
-                cb()
-
-          (cb) ->
-            request.post(baseURL + "/groups/" + partyToDeleteAfterLeave._id)
             .end (res) ->
               expectCode res, 404
               cb()

--- a/website/src/models/group.js
+++ b/website/src/models/group.js
@@ -89,22 +89,15 @@ GroupSchema.pre('remove', function(next) {
   var group = this;
   async.waterfall([
     function(cb) {
-      var invitationQuery = {};
-      var groupType = group.type;
-      //Add an 's' to group type guild because the model has the plural version
-      if (group.type == "guild") groupType += "s";
-      invitationQuery['invitations.' + groupType + '.id'] = group._id;
-      User.find(invitationQuery, cb);
+      User.find({
+        'invitations.guilds.id': group._id
+      }, cb);
     },
     function(users, cb) {
       if (users) {
         users.forEach(function (user, index, array) {
-          if ( group.type == "party" ) {
-            user.invitations.party = {};
-          } else {
-            var i = _.findIndex(user.invitations.guilds, {id: group._id});
-            user.invitations.guilds.splice(i, 1);
-          }
+          var i = _.findIndex(user.invitations.guilds, {id: group._id});
+          user.invitations.guilds.splice(i, 1);
           user.save();
         });
       }


### PR DESCRIPTION
Reverts HabitRPG/habitrpg#5912

Unfortunately, this has the potential to cause very severe performance problems when a party is removed. While we have an index specified in the database for `users.invites.guilds.id`, there's no such index for `users.invites.party.id`. I believe this was causing significant performance issues.

Reverted pending the addition of a migration to the original PR which adds the necessary index.
