### PR TITLE
Added param to filter challenges by guild when a challenge is first clicked from guild

### DIFF
--- a/test/spec/controllers/challengesCtrlSpec.js
+++ b/test/spec/controllers/challengesCtrlSpec.js
@@ -148,6 +148,19 @@ describe('Challenges Controller', function() {
         expect(scope.filterChallenges(notOwnMem)).to.eql(false);
         expect(scope.filterChallenges(notOwnNotMem)).to.eql(true);
       });
+
+      it('it filters challenges to a single group when group id filter is set', inject(function($controller) {
+        scope.search = { };
+        scope.groups = {
+          0: specHelper.newGroup({_id: 'group-one'}),
+          1: specHelper.newGroup({_id: 'group-two'}),
+          2: specHelper.newGroup({_id: 'group-three'})
+        };
+
+        scope.groupIdFilter = 'group-one';
+        scope.filterInitialChallenges();
+        expect(scope.search.group).to.eql({'group-one': true});
+      }));
     });
 
     describe('selectAll', function() {

--- a/website/public/js/app.js
+++ b/website/public/js/app.js
@@ -148,6 +148,7 @@ window.habitrpg = angular.module('habitrpg',
         // Options > Social > Challenges
         .state('options.social.challenges', {
           url: "/challenges",
+          params: { groupIdFilter: null },
           controller: 'ChallengesCtrl',
           templateUrl: "partials/options.social.challenges.html"
         })
@@ -156,7 +157,6 @@ window.habitrpg = angular.module('habitrpg',
           templateUrl: 'partials/options.social.challenges.detail.html',
           controller: ['$scope', 'Challenges', '$stateParams',
             function($scope, Challenges, $stateParams){
-
               $scope.obj = $scope.challenge = Challenges.Challenge.get({cid:$stateParams.cid}, function(){
                 $scope.challenge._locked = true;
               });

--- a/website/public/js/controllers/challengesCtrl.js
+++ b/website/public/js/controllers/challengesCtrl.js
@@ -327,6 +327,21 @@ habitrpg.controller("ChallengesCtrl", ['$rootScope','$scope', 'Shared', 'User', 
       });
     };
 
+    $scope.filterInitialChallenges = function() {
+      $scope.groupsFilter = _.uniq(_.pluck($scope.challenges, 'group'), function(g){return g._id});
+      $scope.search = {
+        group: _.transform($scope.groups, function(m,g){m[g._id]=true;}),
+        _isMember: "either",
+        _isOwner: "either"
+      };
+      //If we game from a group, then override the filter to that group
+
+      if ($scope.groupIdFilter) {
+        $scope.search.group = {};
+        $scope.search.group[$scope.groupIdFilter] = true ;
+      }
+    }
+
     function _calculateMaxPrize(gid) {
 
       var userBalance = User.getBalanceInGems() || 0;
@@ -377,17 +392,7 @@ habitrpg.controller("ChallengesCtrl", ['$rootScope','$scope', 'Shared', 'User', 
       } else {
         Challenges.Challenge.query(function(challenges){
           $scope.challenges = challenges;
-          $scope.groupsFilter = _.uniq(_.pluck(challenges, 'group'), function(g){return g._id});
-          $scope.search = {
-            group: _.transform($scope.groups, function(m,g){m[g._id]=true;}),
-            _isMember: "either",
-            _isOwner: "either"
-          };
-          //If we game from a group, then override the filter to that group
-          if ($scope.groupIdFilter) {
-            $scope.search.group = {};
-            $scope.search.group[$scope.groupIdFilter] = true ;
-          }
+          $scope.filterInitialChallenges();
         });
       }
     };

--- a/website/public/js/controllers/challengesCtrl.js
+++ b/website/public/js/controllers/challengesCtrl.js
@@ -5,6 +5,8 @@ habitrpg.controller("ChallengesCtrl", ['$rootScope','$scope', 'Shared', 'User', 
     // challenge
     $scope.cid = $state.params.cid;
 
+    $scope.groupIdFilter = $stateParams.groupIdFilter;
+
     _getChallenges();
 
     // FIXME $scope.challenges needs to be resolved first (see app.js)
@@ -381,6 +383,11 @@ habitrpg.controller("ChallengesCtrl", ['$rootScope','$scope', 'Shared', 'User', 
             _isMember: "either",
             _isOwner: "either"
           };
+          //If we game from a group, then override the filter to that group
+          if ($scope.groupIdFilter) {
+            $scope.search.group = {};
+            $scope.search.group[$scope.groupIdFilter] = true ;
+          }
         });
       }
     };

--- a/website/views/options/social/challenge-box.jade
+++ b/website/views/options/social/challenge-box.jade
@@ -10,7 +10,7 @@
       table.table.table-striped
         tr(ng-repeat='challenge in group.challenges')
           td
-            a(ui-sref='options.social.challenges.detail({cid:challenge._id})') {{challenge.name}}
+            a(ui-sref='options.social.challenges.detail({cid:challenge._id, groupIdFilter: group._id})') {{challenge.name}}
     div(ng-if='group.challenges.length == 0')
       p
         |&nbsp;


### PR DESCRIPTION
This is a fix for #4602 and a reboot for https://github.com/HabitRPG/habitrpg/pull/4861 . I tried to simply update, but I deleted the old branch. 

This adds a parameter to the routes that will be set if a user clicks to view a challenge from the guild, then hits back to challenges from the challenge detail page. 

I tried adding tests, but I was unable to call the private method. I then tried to set the variable and call digest, but that causes a need for mocking a few $http requests. I wasn't sure if I was allowed to move the function to a $scope function. So, any help there would be nice. 
