### PR TITLE
Fixed grammatical errors in Tech Info section of DOCS-README

### DIFF
--- a/DOCS-README.md
+++ b/DOCS-README.md
@@ -66,7 +66,7 @@ It's that easy!
 
 ## Tech Info
 
-The generator we are using is [Docker](https://github.com/jbt/docker), which is a fork of [Docco](http://jashkenas.github.io/docco/). Docker supports the same wide-range of filetypes, including being able to generate documentation for a whole project, including an index.
+The generator we are using is [Docker](https://github.com/jbt/docker), which is a fork of [Docco](http://jashkenas.github.io/docco/). Docker supports the same wide range of file types and can generate documentation for a whole project, including an index.
 
 We also use the [Grunt-Docker](https://github.com/Prevole/grunt-docker) node module for automatic processing.
 


### PR DESCRIPTION
There were some grammatical errors in the Tech Info section that I changed:
- "Wide range" is not a hyphenated phrase, so I took out the hyphen
- "File types" are two separate words, so I added a space between them
- The "including being able to generate documentation" is not the correct sentence structure (does not match with the structure of the first half of the sentence), so I modified that structure
