### PR TITLE
Fixes #2711 - "Auto-equip new gear" setting

### DIFF
--- a/common/locales/en/character.json
+++ b/common/locales/en/character.json
@@ -52,6 +52,7 @@
     "classEquipBonus": "Class Bonus",
     "battleGear": "Battle Gear",
     "battleGearText": "This is the gear you wear into battle; it affects numbers when interacting with your tasks.",
+    "autoEquipBattleGear": "Auto-equip new gear",
     "costume": "Costume",
     "costumeText": "If you prefer the look of other gear to what you have equipped, check the \"Use Costume\" box to visually don a costume while wearing your battle gear underneath.",
     "useCostume": "Use Costume",

--- a/common/script/index.coffee
+++ b/common/script/index.coffee
@@ -970,7 +970,7 @@ api.wrap = (user, main=true) ->
             message = i18n.t('armoireExp', req.language)
             armoireResp = {"type": "experience", "value": armoireExp}
         else
-          user.items.gear.equipped[item.type] = item.key
+          if user.preferences.autoEquip then user.items.gear.equipped[item.type] = item.key
           user.items.gear.owned[item.key] = true
           message = user.fns.handleTwoHanded(item, null, req)
           message ?= i18n.t('messageBought', {itemText: item.text(req.language)}, req.language)

--- a/test/common/algos.mocha.coffee
+++ b/test/common/algos.mocha.coffee
@@ -30,7 +30,9 @@ newUser = (addTasks=true)->
       quest:
         progress:
           down: 0
-    preferences: {}
+    preferences: {
+      autoEquip: true
+    }
     dailys: []
     todos: []
     rewards: []
@@ -145,7 +147,7 @@ describe 'User', ->
     buffs = {per:0, int:0, con:0, str:0, stealth: 0, streaks: false}
     expect(user.stats).to.eql { str: 1, con: 1, per: 1, int: 1, hp: 50, mp: 32, lvl: 1, exp: 0, gp: 0, class: 'warrior', buffs: buffs }
     expect(user.items.gear).to.eql { equipped: base_gear, costume: base_gear, owned: {weapon_warrior_0: true} }
-    expect(user.preferences).to.eql { costume: false }
+    expect(user.preferences).to.eql { autoEquip: true, costume: false }
 
   it 'calculates max MP', ->
     user = newUser()
@@ -411,6 +413,17 @@ describe 'User', ->
       expect(user.items.gear.owned).to.eql { weapon_warrior_0: true, armor_warrior_1: true }
       expect(user.items.gear.equipped).to.eql { armor: 'armor_warrior_1', weapon: 'weapon_base_0', head: 'head_base_0', shield: 'shield_base_0' }
       expect(user).toHaveGP 1
+    
+    it 'buys equipment but does not auto-equip', ->
+      user = newUser()
+      user.stats.gp = 31
+      user.preferences.autoEquip = false
+      user.ops.buy {params: {key: 'armor_warrior_1'}}
+      expect(user.items.gear.owned).to.eql { weapon_warrior_0: true, armor_warrior_1: true }
+      expect(user.items.gear.equipped).to.eql { armor: 'armor_base_0', weapon: 'weapon_base_0', head: 'head_base_0', shield: 'shield_base_0' }
+      expect(user).toHaveGP 1
+    
+
 
     it 'does not buy equipment without enough Gold', ->
       user = newUser()

--- a/test/common/user.fns.buy.test.js
+++ b/test/common/user.fns.buy.test.js
@@ -41,6 +41,7 @@ describe('user.fns.buy', function() {
 
   context('Gear', function() {
     it('buys equipment');
+    it('buys equipment but does not auto-equip');
 
     it('does not buy equipment without enough Gold');
   });

--- a/website/src/models/user.js
+++ b/website/src/models/user.js
@@ -324,6 +324,7 @@ var UserSchema = new Schema({
     language: String,
     automaticAllocation: Boolean,
     allocationMode: {type:String, enum: ['flat','classbased','taskbased'], 'default': 'flat'},
+    autoEquip: {type: Boolean, 'default': true},
     costume: Boolean,
     dateFormat: {type: String, enum:['MM/dd/yyyy', 'dd/MM/yyyy', 'yyyy/MM/dd'], 'default': 'MM/dd/yyyy'},
     sleep: {type: Boolean, 'default': false},
@@ -579,7 +580,7 @@ UserSchema.methods.unlink = function(options, cb) {
 
 module.exports.schema = UserSchema;
 module.exports.model = mongoose.model("User", UserSchema);
-// Initially export an empty object so external requires will get 
+// Initially export an empty object so external requires will get
 // the right object by reference when it's defined later
 // Otherwise it would remain undefined if requested before the query executes
 module.exports.mods = [];

--- a/website/views/options/inventory/equipment.jade
+++ b/website/views/options/inventory/equipment.jade
@@ -4,6 +4,13 @@
       h3.equipment-title.hint(popover-trigger='mouseenter',
         popover-placement='right', popover-append-to-body='true',
         popover=env.t('battleGearText'))=env.t('battleGear')
+      
+      .checkbox.equipment-title
+        label
+          input(type="checkbox", ng-model="user.preferences.autoEquip",
+            ng-change='set({"preferences.autoEquip":user.preferences.autoEquip ? true : false})')
+          | &nbsp;
+          =env.t('autoEquipBattleGear')
 
       div
         button.btn.btn-default(type="button", ng-click='dequip("battleGear");') {{env.t("unequipBattleGear")}}


### PR DESCRIPTION
Fixes #2711.

As discussed in the linked issue, this adds an `Auto-equip new gear` toggle to the Equipment section.
When checked, newly bought gear will be auto-equipped. When unchecked, newly bought gear will not be auto-equipped.
By default this option will be turned on.
# UI change

![Auto-equip new gear](https://cloud.githubusercontent.com/assets/32344/10267968/4105fd0a-6aa1-11e5-863d-d0d036d67b3f.png)
# Tasks
- [x] Update UI
- [x] Update user schema
- [x] Add localization key
- [x] Update equipping logic
- [x] Test functionality
