### PR TITLE
Toggle chevron direction

### DIFF
--- a/website/public/css/tasks.styl
+++ b/website/public/css/tasks.styl
@@ -441,6 +441,8 @@ form
         font-size: 0.75em
         content: "\E114"
         padding-left: 0.75em
+      &.active:after
+        content: "\E113"
     //&:not(.mega):after
       //content: ':'
 

--- a/website/views/shared/tasks/edit/advanced_options.jade
+++ b/website/views/shared/tasks/edit/advanced_options.jade
@@ -1,5 +1,6 @@
 div(ng-if='::task.type!="reward"')
   button.advanced-options-toggle.option-title.mega(type='button',
+    ng-class='{active: task._advanced}',
     ng-click='task._advanced = !task._advanced', tooltip=env.t('expandCollapse'))
     =env.t('advancedOptions')
 

--- a/website/views/shared/tasks/edit/tags.jade
+++ b/website/views/shared/tasks/edit/tags.jade
@@ -1,5 +1,5 @@
 fieldset.option-group(ng-if='!$state.includes("options.social.challenges")')
-  p.option-title.mega(ng-click='task._tags = !task._tags', tooltip=env.t('expandCollapse'))=env.t('tags')
+  p.option-title.mega(ng-class='{active: task._tags}', ng-click='task._tags = !task._tags', tooltip=env.t('expandCollapse'))=env.t('tags')
   label.checkbox(ng-repeat='tag in user.tags', ng-if='task._tags')
     input(type='checkbox', ng-model='task.tags[tag.id]')
     markdown(text='tag.name')


### PR DESCRIPTION
When editing a task, there are some expandable options available with a chevron next to them (e.g. 'Tags' and 'Advanced Options'). This commit makes the chevrons' directions toggle based on whether the related option is expanded or collapsed, up and down respectively.

Before:
![habitica-chevron-before](https://cloud.githubusercontent.com/assets/3090888/10292681/de57152a-6bb0-11e5-886f-76f74874a39c.png)
After:
![habitica-chevron-after](https://cloud.githubusercontent.com/assets/3090888/10292680/de517bec-6bb0-11e5-9f47-35d5838a074c.png)

If I did everything correctly, this should only apply to elements with the `option-title` and `mega` classes; I've tested all the tasks I could find, and it seems to work fine, but I'm not overconfident with the Habitica codebase, so I recommend QAint properly before merging (if it's a desired change, that is).
