### PR TITLE
Issue #2606 - Verify/fix indices during sortTask

### DIFF
--- a/website/src/controllers/user.js
+++ b/website/src/controllers/user.js
@@ -635,9 +635,7 @@ api.batchUpdate = function(req, res, next) {
     // Fetch full user object
     } else if (response.wasModified){
       // Preen 3-day past-completed To-Dos from Angular & mobile app
-      response.todos = _.where(response.todos, function(t) {
-        return !t.completed || (t.challenge && t.challenge.id) || moment(t.dateCompleted).isAfter(moment().subtract({days:3}));
-      });
+      response.todos = shared.preenTodos(response.todos);
       res.json(200, response);
 
     // return only the version number


### PR DESCRIPTION
Because the 'sortTask' operation uses a 'from' index and a 'to'
index as parameters, the server needs to check if these indices
are valid before performing the client's request. If the task ID
doesn't match the task at the 'from' index, then it's clear that
the client was looking at a preened list of todos (everything except
more-than-3-days-old-non-quest completed tasks). In that case, try
to recalculate the indices before continuing.
