### PR TITLE
Fix capitalization of “GitHub” on Contact Us page

### DIFF
--- a/website/views/static/contact.jade
+++ b/website/views/static/contact.jade
@@ -19,7 +19,7 @@ block content
         br
         =env.t('reportBug')
         | &colon;&nbsp;
-        a(target='_blank', href='https://github.com/HabitRPG/habitrpg/issues?q=is%3Aopen') Github
+        a(target='_blank', href='https://github.com/HabitRPG/habitrpg/issues?q=is%3Aopen') GitHub
         br
         =env.t('reportCommunityIssues')
         | &colon;&nbsp;


### PR DESCRIPTION
The live page is at https://habitica.com/static/contact.
