### PR TITLE
Updated vagrant provisioning script to update npm to the latest version

### DIFF
--- a/vagrant.sh
+++ b/vagrant.sh
@@ -68,6 +68,8 @@ echo Updating repositories...
 apt-get update -qq
 echo Installing node.js
 apt-get install -qq nodejs
+echo Updating npm...
+npm install -g npm
 
 cd /vagrant
 


### PR DESCRIPTION
Updated vagrant provisioning script to update npm to the latest version as the older version (1.4.28) was causing the following error during npm install.

npm ERR! EEXIST, open '/home/vagrant/.npm/9fb4c098-adable-stream-1-0-33-package-tgz.lock'
File exists: /home/vagrant/.npm/9fb4c098-adable-stream-1-0-33-package-tgz.lock
Move it away, and try again.

npm ERR! System Linux 3.2.0-23-generic
npm ERR! command "/usr/bin/node" "/usr/bin/npm" "install" "--no-bin-links"
npm ERR! cwd /vagrant
npm ERR! node -v v0.10.37
npm ERR! npm -v 1.4.28
npm ERR! path /home/vagrant/.npm/9fb4c098-adable-stream-1-0-33-package-tgz.lock
npm ERR! code EEXIST
npm ERR! errno 47
npm ERR! not ok code 0
