### PR TITLE
Add GET routes for /user/tags and /user/tags/{id}

### DIFF
--- a/common/script/index.coffee
+++ b/common/script/index.coffee
@@ -673,6 +673,14 @@ api.wrap = (user, main=true) ->
         user.tags.splice to, 0, user.tags.splice(from, 1)[0]
         cb? null, user.tags
 
+      getTags: (req, cb) ->
+        cb? null, user.tags
+
+      getTag: (req, cb) ->
+        tid = req.params.id
+        i = _.findIndex user.tags, {id: tid}
+        return cb?({code:404,message:i18n.t('messageTagNotFound', req.language)}) if !~i
+        cb? null, user.tags[i]
 
       updateTag: (req, cb) ->
         tid = req.params.id

--- a/test/api/user/GET-user_tags.test.js
+++ b/test/api/user/GET-user_tags.test.js
@@ -1,0 +1,20 @@
+import {
+  generateUser,
+  requester,
+} from '../../helpers/api.helper';
+
+describe('GET /user/tags', () => {
+  let api, user;
+
+  beforeEach(() => {
+    return generateUser().then((usr) => {
+      user = usr;
+      api = requester(usr);
+    });
+  });
+
+  it('gets the user\'s tags', () => {
+    return expect(api.get('/user/tags'))
+      .to.eventually.eql(user.tags);
+  });
+});

--- a/test/api/user/GET-user_tags_id.test.js
+++ b/test/api/user/GET-user_tags_id.test.js
@@ -1,0 +1,25 @@
+import {
+  generateUser,
+  requester,
+} from '../../helpers/api.helper';
+
+describe('GET /user/tags/id', () => {
+  let api, user;
+
+  beforeEach(() => {
+    return generateUser().then((usr) => {
+      user = usr;
+      api = requester(usr);
+    });
+  });
+
+  it('gets a user\'s tag by id', () => {
+    return expect(api.get('/user/tags/' + user.tags[0].id))
+      .to.eventually.eql(user.tags[0]);
+  });
+
+  it('fails for non-existent tags', () => {
+    return expect(api.get('/user/tags/not-an-id'))
+      .to.eventually.be.rejected.with.property('code', 404);
+  });
+});

--- a/website/src/routes/apiv2.coffee
+++ b/website/src/routes/apiv2.coffee
@@ -347,14 +347,32 @@ module.exports = (swagger, v2) ->
       action: user.batchUpdate
 
     # Tags
-    "/user/tags":
+    "/user/tags/{id}:GET":
       spec:
+        path: '/user/tags/{id}'
+        method: 'GET'
+        description: "Get a tag"
+        parameters: [
+          path 'id','The id of the tag to get','string'
+        ]
+      action: user.getTag
+
+    "/user/tags:POST":
+      spec:
+        path: "/user/tags"
         method: 'POST'
         description: 'Create a new tag'
         parameters: [
           body '','New tag (see UserSchema.tags)','object'
         ]
       action: user.addTag
+
+    "/user/tags:GET":
+      spec:
+        path: "/user/tags"
+        method: 'GET'
+        description: 'List all of a user\'s tags'
+      action: user.getTags
 
     "/user/tags/sort":
       spec:


### PR DESCRIPTION
An operation that is useful for tools to be able to do is to list a user's tags without having to pull down the entire user object (which is likely significantly larger than the tags). This commit adds a route to GET /user/tags, to get a list of the user's tags, as well as a GET /user/tags/{id} to get the details of a particular tag.

This is relevant to issue #3621. No existing routes were changed, though, so the API is not completely restful.
