### PR TITLE
fix a minor syntax error when opening reroll modal.

### DIFF
--- a/website/views/shared/modals/reroll.jade
+++ b/website/views/shared/modals/reroll.jade
@@ -9,7 +9,7 @@ script(type='text/ng-template', id='modals/reroll.html')
   .modal-footer
     button.btn.btn-default(ng-click='$close()')=env.t('neverMind')
     span(ng-if='user.balance < 1')
-      a.btn.btn-success(ng-click='openModal("buyGems",{track:{"Gems > Reroll"}})')=env.t('buyMoreGems')
+      a.btn.btn-success(ng-click='openModal("buyGems",{track:"Gems > Reroll"})')=env.t('buyMoreGems')
       span.gem-cost=env.t('notEnoughGems')
     span(ng-if='user.balance >= 1', ng-controller='SettingsCtrl')
       a.btn.btn-danger(ng-click='$close(); reroll()')=env.t('fortify')


### PR DESCRIPTION
This is a very minor syntax error that Angular rightfully complained about when clicked on fortify potion.
