### PR TITLE
Issue 5542a - remove FIXME comment from invitations section in user model

### DIFF
--- a/website/src/models/user.js
+++ b/website/src/models/user.js
@@ -195,7 +195,6 @@ var UserSchema = new Schema({
     todos: Array //[{data: Date, value: Number}] // big peformance issues if these are defined
   },
 
-  // FIXME remove?
   invitations: {
     guilds: {type: Array, 'default': []},
     party: Schema.Types.Mixed
@@ -603,7 +602,7 @@ UserSchema.methods.unlink = function(options, cb) {
 
 module.exports.schema = UserSchema;
 module.exports.model = mongoose.model("User", UserSchema);
-// Initially export an empty object so external requires will get 
+// Initially export an empty object so external requires will get
 // the right object by reference when it's defined later
 // Otherwise it would remain undefined if requested before the query executes
 module.exports.mods = [];


### PR DESCRIPTION
This address a tiny part of issue #5542, regarding the invitations object. I am making this commit just in case it is verified that the invitations object is still needed - in my testing, the object still appears to be used. All I did was remove the FIXME comment, assuming the invitations object should indeed remain. 
