### PR TITLE
Update vagrant provisioning script to create symlinks for any binaries the package might contain

### DIFF
--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -8,7 +8,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider "virtualbox" do |v|
     v.memory = 768
     v.cpus = 1
-    v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/vagrant", "1"]
   end
   config.vm.box = "thepeopleseason/habitrpg"
   config.ssh.forward_agent = true

--- a/vagrant.sh
+++ b/vagrant.sh
@@ -77,7 +77,7 @@ echo Installing gulp/bower...
 npm install -g gulp grunt-cli bower
 
 echo Installing Habitica
-npm install --no-bin-links
+npm install
 
 echo Installing Bower packages
 sudo -H -u vagrant bower --config.interactive=false install -f


### PR DESCRIPTION
created a new branch for the pull request: https://github.com/HabitRPG/habitrpg/pull/6092

Update vagrant provisioning script to create symlinks for any binaries the package might contain (default npm install behavior), as without those symlinks "npm test" gives the following error:

```
vagrant@habitrpg:/vagrant$ npm test

> habitrpg@0.0.0-152 test /vagrant
> gulp test

[Error: /vagrant/node_modules/bson/build/Release/bson.node: invalid ELF header]
js-bson: Failed to load c++ bson extension, using pure JS version
[07:07:48] Using gulpfile /vagrant/gulpfile.js
[07:07:48] Starting 'test:prepare:build'...
[07:07:48] Starting 'test:prepare:mongo'...
[07:07:48] Starting 'test:prepare:webdriver'...
[07:07:48] 'test:prepare:build' errored after 33 ms
[07:07:48] Error: Command failed: /bin/sh: 1: ./node_modules/.bin/grunt: not found

    at ChildProcess.exithandler (child_process.js:658:15)
    at ChildProcess.emit (events.js:98:17)
    at maybeClose (child_process.js:766:16)
    at Socket.<anonymous> (child_process.js:979:11)
    at Socket.emit (events.js:95:17)
    at Pipe.close (net.js:466:12)
[07:07:48] Finished 'test:prepare:mongo' after 78 ms
[07:08:50] Finished 'test:prepare:webdriver' after 1.02 min
npm ERR! Test failed.  See above for more details.
```
- "npm install" was giving the following error in earlier version of VirtualBox when creating symlinks with relative "../" path in shared folders. "--no-bin-links" was a workaround, but it's been fixed in the latest VirtualBox 5.0.8 (https://www.virtualbox.org/ticket/14563) 

```
vagrant@habitrpg:/vagrant$ npm install
npm WARN install Couldn't install optional dependency: Unsupported
npm WARN install Couldn't install optional dependency: Unsupported
npm WARN install Couldn't install optional dependency: Unsupported
npm WARN EPEERINVALID chai-as-promised@3.3.1 requires a peer of chai@>= 1.0.2 < 2 but none was installed.
npm WARN EPEERINVALID karma-requirejs@0.2.2 requires a peer of requirejs@~2.1 but none was installed.
npm ERR! Linux 3.2.0-23-generic
npm ERR! argv "node" "/usr/bin/npm" "install"
npm ERR! node v0.10.37
npm ERR! npm  v3.3.6
npm ERR! path ../acorn/bin/acorn
npm ERR! code UNKNOWN
npm ERR! errno -1

npm ERR! UNKNOWN, symlink '../acorn/bin/acorn'
npm ERR! 
npm ERR! If you need help, you may report this error at:
npm ERR!     <https://github.com/npm/npm/issues>

npm ERR! Please include the following file with any support request:
npm ERR!     /vagrant/npm-debug.log
```
