### PR TITLE
Prevent cron running when a user's timezone changes

### DIFF
--- a/common/script/index.coffee
+++ b/common/script/index.coffee
@@ -47,9 +47,14 @@ api.planGemLimits =
 sanitizeOptions = (o) ->
   dayStart = if (!_.isNaN(+o.dayStart) and 0 <= +o.dayStart <= 24) then +o.dayStart else 0
   timezoneOffset = if o.timezoneOffset then +(o.timezoneOffset) else +moment().zone()
+  # console.log("     - sanitizeOptions -")
+  # console.log {timezoneOffset}
+  # console.log {oNow:moment(o.now).format('YYYY-MM-DD HH:mm:ss')}
   now = if o.now then moment(o.now).zone(timezoneOffset) else moment(+new Date).zone(timezoneOffset)
+  console.log {nowWithOffset:moment(now).format('YYYY-MM-DD HH:mm:ss')}
+  setAhead = o.setAhead || false
   # return a new object, we don't want to add "now" to user object
-  {dayStart, timezoneOffset, now}
+  {dayStart, timezoneOffset, now, setAhead}
 
 api.startOfWeek = api.startOfWeek = (options={}) ->
   o = sanitizeOptions(options)
@@ -60,10 +65,18 @@ api.startOfDay = (options={}) ->
   # It changes the time portion of the date-time to be the Custom Day Start hour, so that the date-time is now the user's correct start of day.
   # It SUBTRACTS a day if the date-time's original hour is before CDS (e.g., if your CDS is 5am and it's currently 4am, it's still the previous day).
   # This is NOT suitable for manipulating any dates that are displayed to the user as a date with no time portion, such as a Daily's Start Dates (e.g., a Start Date of today shows only the date, so it should be considered to be today even if the hidden time portion is before CDS).
+  console.log("   --- startOfDay sanitizeOptions ---")
   o = sanitizeOptions(options)
+  console.log("------ startOfDay (first is now, second is lastCron -------")
+  console.log {now:moment(o.now).format('YYYY-MM-DD HH:mm:ss')}
+  console.log {o_dayStart:o.dayStart}
   dayStart = moment(o.now).startOf('day').add({hours:o.dayStart})
-  if moment(o.now).hour() < o.dayStart
+  console.log("======================== dayStart1: " + moment(dayStart).format('YYYY-MM-DD HH:mm:ss'))
+  if o.setAhead
+    dayStart.add({days:1}).add({minutes:1}) # set to just after next CDS time
+  else if moment(o.now).hour() < o.dayStart
     dayStart.subtract({days:1})
+    console.log("======================== dayStart2: " + moment(dayStart).format('YYYY-MM-DD HH:mm:ss'))
   dayStart
 
 api.dayMapping = {0:'su',1:'m',2:'t',3:'w',4:'th',5:'f',6:'s'}
@@ -72,6 +85,7 @@ api.dayMapping = {0:'su',1:'m',2:'t',3:'w',4:'th',5:'f',6:'s'}
   Absolute diff from "yesterday" till now
 ###
 api.daysSince = (yesterday, options = {}) ->
+  console.log("   --- daysSince sanitizeOptions ---")
   o = sanitizeOptions options
   api.startOfDay(_.defaults {now:o.now}, o).diff(api.startOfDay(_.defaults {now:yesterday}, o), 'days')
 
@@ -1536,6 +1550,8 @@ api.wrap = (user, main=true) ->
         #console.log {progress:user.party.quest.progress}
 
       dropMultiplier = if user.purchased?.plan?.customerId then 2 else 1
+      return
+      # XXX TST remove that!
       return if (api.daysSince(user.items.lastDrop.date, user.preferences) is 0) and (user.items.lastDrop.count >= dropMultiplier * (5 + Math.floor(user._statsComputed.per / 25) + (user.contributor.level or 0)))
       if user.flags?.dropsEnabled and user.fns.predictableRandom(user.stats.exp) < chance
 
@@ -1695,7 +1711,9 @@ api.wrap = (user, main=true) ->
       {user}
     ###
     cron: (options={}) ->
+      console.log("\n\n------ cron -------")
       now = +options.now || +new Date
+      console.log {now:moment(now).format('YYYY-MM-DD HH:mm:ss')}
 
       # If the user's timezone has changed (due to travel or daylight savings),
       # cron can be triggered twice in one day. So if a zone change is detected,
@@ -1703,15 +1721,88 @@ api.wrap = (user, main=true) ->
       # a second cron (e.g., prevent damage from missed Dailies).
       # FIXME: This can probably also prevent the day's first cron under some
       # circumstances, and in those cases all cron code should be run.
-      partialCron = false
       userTimezoneOffset = +user.preferences.timezoneOffset || 0
+      console.log {userTimezoneOffset}
       browserTimezoneOffset = +options.timezoneOffset || userTimezoneOffset
-      if userTimezoneOffset != browserTimezoneOffset
-        partialCron = true
+      console.log {browserTimezoneOffset}
+
+
+      # This considers the case where the timezone is changing so that time
+      # goes backwards (e.g., at 2am the clocks change to 1am). More work is
+      # needed for the opposite direction.
+
+      # How many days have we missed using the timezone stored in the user's Habitica preferences:
+      daysMissedOldZone = api.daysSince user.lastCron, _.defaults({now}, user.preferences)
+      console.log {daysMissedOldZone:daysMissedOldZone}
+
+      daysMissed = 0
+      if userTimezoneOffset == browserTimezoneOffset
+        # No timezone change; normal cron processing.
+        daysMissed = daysMissedOldZone
+        console.log("same zones")
+      else
+        console.log("different zones")
+        # The user's timezone has changed (according to timezone data found in their browser), so store the new value in their Habitica preferences:
         user.preferences.timezoneOffset = browserTimezoneOffset
 
-      daysMissed = api.daysSince user.lastCron, _.defaults({now}, user.preferences)
+        # How many days have we missed using the new timezone:
+        daysMissedNewZone = api.daysSince user.lastCron, _.defaults({now}, user.preferences)
+        console.log {daysMissedNewZone}
+
+        # We run cron only if both timezones indicate that we should.
+        daysMissed = 0
+        if daysMissedOldZone > 0 and daysMissedNewZone > 0
+          console.log("different zones - 1 - run cron")
+          # Both old and new timezones indicate that we should run cron, so
+          # it is safe to do so.
+          daysMissed = daysMissedOldZone
+        else if daysMissedOldZone > 0
+          console.log("different zones - 2 - no cron but set nothing")
+          # The old timezone indicates that cron should run (i.e., cron has not
+          # yet run for that timezone), but the new timezone does not indicate
+          # cron. This means the new one will indicate it in future,
+          # when the Custom Day Start time is reached again.
+          # Since we're abandoning the old timezone now, we don't need to
+          # worry about what it says. Just don't run cron now.
+          daysMissed = 0
+        else if daysMissedNewZone > 0
+          console.log("different zones - 3 - set lastCron ahead")
+          # The old timezone indicates that cron should NOT run (i.e., cron has
+          # already run for that timezone), but the new timezone indicates
+          # that cron should run. However that would produce two crons in
+          # one day. We set last cron to just AFTER CDS for the new timezone
+          # to prevent the second cron.
+          daysMissed = 0
+          TSTvalue = api.startOfDay(_.defaults {now})
+          console.log {lastCronBeforeSetAhead:moment(TSTvalue).format('YYYY-MM-DD HH:mm:ss')}
+          user.lastCron = api.startOfDay(_.defaults {now, setAhead:true})
+          console.log {lastCronSetAhead:user.lastCron}
+        else
+          console.log("different zones - 4 - set lastCron ahead")
+          # The old timezone indicates that cron should NOT run (i.e., cron has
+          # already run for that timezone), and the new timezone also does not
+          # indicate cron. This means the new one will indicate it in future,
+          # when the Custom Day Start time is reached again. BUT we that would
+          # be a second cron so we prevent that.
+          daysMissed = 0
+          TSTvalue = api.startOfDay(_.defaults {now})
+          console.log {lastCronBeforeSetAhead:moment(TSTvalue).format('YYYY-MM-DD HH:mm:ss')}
+          user.lastCron = api.startOfDay(_.defaults {now, setAhead:true})
+          console.log {lastCronSetAhead:user.lastCron}
+        console.log("end zones")
+
+      console.log {daysMissedCombined:daysMissed}
+
+      console.log {userPreferencesTimezoneOffset: user.preferences.timezoneOffset}
+
+      console.log {userlastCron: moment(user.lastCron).format('YYYY-MM-DD HH:mm:ss')}
+      console.log(".....")
+      console.log(".....")
+      console.log("======================== CRON RUNS OR NOT =================")
       return unless daysMissed > 0
+      console.log("======================== CRON RUNS ========================")
+      # return
+      # XXX TST remove that!
 
       user.auth.timestamps.loggedin = new Date()
 
@@ -1748,10 +1839,10 @@ api.wrap = (user, main=true) ->
           _.merge plan.consecutive, {count:0, offset:0, gemCapExtra:0}
           user.markModified? 'purchased.plan'
 
-      # User is resting at the inn or is going through what might be their second cron of the day due to a timezone change.
+      # User is resting in the inn or is going through what might be their second cron of the day due to a timezone change.
       # Buffs are cleared (only if resting) and all dailies are reset without performing damage
-      if user.preferences.sleep or partialCron
-        user.stats.buffs = clearBuffs unless partialCron
+      if user.preferences.sleep # or partialCron
+        user.stats.buffs = clearBuffs # unless partialCron
         user.dailys.forEach (daily) ->
           {completed, repeat} = daily
           thatDay = moment(now).subtract({days: 1})

--- a/common/script/public/userServices.js
+++ b/common/script/public/userServices.js
@@ -171,8 +171,10 @@ angular.module('habitrpg')
 
         authenticate: function (uuid, token, cb) {
           if (!!uuid && !!token) {
+            var offset = moment().zone(); // eg, 240 - this will be converted on server as -(offset/60)
             $http.defaults.headers.common['x-api-user'] = uuid;
             $http.defaults.headers.common['x-api-key'] = token;
+            $http.defaults.headers.common['x-user-timezoneOffset'] = offset;
             authenticated = true;
             settings.auth.apiId = uuid;
             settings.auth.apiToken = token;
@@ -180,7 +182,6 @@ angular.module('habitrpg')
             if (user && user._v) user._v--; // shortcut to always fetch new updates on page reload
             userServices.log({}, function(){
               // If they don't have timezone, set it
-              var offset = moment().zone(); // eg, 240 - this will be converted on server as -(offset/60)
               if (user.preferences.timezoneOffset !== offset)
                 userServices.set({'preferences.timezoneOffset': offset});
               cb && cb();

--- a/website/src/controllers/user.js
+++ b/website/src/controllers/user.js
@@ -330,7 +330,7 @@ api.update = function(req, res, next) {
 
 api.cron = function(req, res, next) {
   var user = res.locals.user,
-    progress = user.fns.cron({analytics:utils.analytics}),
+    progress = user.fns.cron({analytics:utils.analytics, timezoneOffset:req.headers['x-user-timezoneoffset']}),
     ranCron = user.isModified(),
     quest = shared.content.quests[user.party.quest.key];
 


### PR DESCRIPTION
**DO NOT MERGE - MORE TESTING IS BEING DONE**

@blade @paglias It would be wise to have extra eyes on this.

@lemoness I'm seeking approval from you for new behaviour. I believe we should deploy this to production before 1 November USA time.

_tl;dr  This will (I think) prevent second crons due to timezone or daylight savings changes. But it could also sometimes prevent a legitimate first cron on a day when the zone changes._

After a user's timezone has changed (either because of travel or daylight savings changes), cron can run even if it has already run once that day (e.g., if the timezone change moves the user back to before the custom day start time). The second cron can cause great damage because most Dailies are not completed.

This PR adds a check at the start of cron to compare the user's previous timezone (which is stored in `user.preferences.timezoneOffset`) to the current timezone (which is captured by Habitica when the user logs in and which is then passed through HTTP headers to cron). If the two timezones are different, cron does not run, and it updates `user.preferences.timezoneOffset`

I believe this PR will prevent players and their party mates taking unfair damage from all timezone changes.

The disadvantage is that it will prevent legitimate crons from running in situations where cron has not already run on the day when the timezone change is noticed. However that will be less distressing for many users than having unfair damage. The worst part will be that their Dailies will not be unticked for reuse. We'll need to tell the Socialites to expect questions about that (the solution is to open up Fix Character Values in one window to capture all your stats, then untick all your Dailies, then save the FCV form to reapply your correct stats).

One catch with timezone changes is that Habitica notices the change only when the user reloads or logs in using the login form (not when they merely use Habitica or sync). This means that a user's PC might have its timezone changed today, but if the user doesn't log out of Habitica or reload until tomorrow, then the missed cron won't happen until tomorrow.

Improvements for the future:
- Find some way to identify if cron has already run that day and only prevent a new cron if it has. Maybe it's enough to just compare the previous cron time with the current time and if they are close, then assume the second cron is not legitimate. However I'm too brain-warped by timezone maths to be certain of that yet. The requirement to reload or log in might prevent this being reliable.
- If that can't be done, then when the timezone changes, allow some parts of cron to run but not all (e.g., untick Dailies but do not assign damage from them). We'd need to think carefully about exactly what behaviour we wanted.
