### PR TITLE
Potential fix for #6085 - fix subscriber benefits comparisons; round down 3 month blocks for perks - fixes #6085

### DIFF
--- a/website/public/js/controllers/settingsCtrl.js
+++ b/website/public/js/controllers/settingsCtrl.js
@@ -206,10 +206,10 @@ habitrpg.controller('SettingsCtrl',
       var baseCap = 25;
       var gemCapExtra = User.user.purchased.plan.consecutive.gemCapExtra;
       // @TODO: What are these magic numbers? 3? 5?
-      var blocks = Content.subscriptionBlocks[subscription.key].months / 3 * 5;
+      var blocks = Content.subscriptionBlocks[subscription.key].months / 3;
       var flooredBlocks = Math.floor(blocks);
 
-      var userTotalDropCap = baseCap + gemCapExtra + flooredBlocks;
+      var userTotalDropCap = baseCap + gemCapExtra + flooredBlocks * 5;
       var maxDropCap = 50;
 
       return [userTotalDropCap, maxDropCap];

--- a/website/public/js/controllers/settingsCtrl.js
+++ b/website/public/js/controllers/settingsCtrl.js
@@ -204,12 +204,13 @@ habitrpg.controller('SettingsCtrl',
 
     $scope.gemGoldCap = function(subscription) {
       var baseCap = 25;
+      var gemCapIncrement = 5;
+      var capIncrementThreshold = 3;
       var gemCapExtra = User.user.purchased.plan.consecutive.gemCapExtra;
-      // @TODO: What are these magic numbers? 3? 5?
-      var blocks = Content.subscriptionBlocks[subscription.key].months / 3;
+      var blocks = Content.subscriptionBlocks[subscription.key].months / capIncrementThreshold;
       var flooredBlocks = Math.floor(blocks);
 
-      var userTotalDropCap = baseCap + gemCapExtra + flooredBlocks * 5;
+      var userTotalDropCap = baseCap + gemCapExtra + flooredBlocks * gemCapIncrement;
       var maxDropCap = 50;
 
       return [userTotalDropCap, maxDropCap];

--- a/website/views/options/settings.jade
+++ b/website/views/options/settings.jade
@@ -269,7 +269,7 @@ mixin subPerks()
     tr
       td
         span.hint(popover=env.t('buyGemsGoldText', {gemCost: "{{Shared.planGemLimits.convRate}}", gemLimit: "{{Shared.planGemLimits.convCap}}"}),popover-trigger='mouseenter',popover-placement='right') #{env.t('buyGemsGold')}&nbsp;
-        span.badge.badge-success(ng-show='_subscription.key!="basic_earned"')=env.t('buyGemsGoldCap', {amount: '{{:: gemGoldCap(_subscription)  | min }}'})
+        span.badge.badge-success(ng-show='_subscription.key!="basic_earned"')=env.t('buyGemsGoldCap', {amount: '{{gemGoldCap(_subscription)  | min }}'})
     tr
       td
         span.hint(popover=env.t('retainHistoryText'),popover-trigger='mouseenter',popover-placement='right')=env.t('retainHistory')
@@ -280,7 +280,7 @@ mixin subPerks()
       td
         span.hint(popover=env.t('mysteryItemText'),popover-trigger='mouseenter',popover-placement='right') #{env.t('mysteryItem')}&nbsp;
         div(ng-show='_subscription.key!="basic_earned"')
-          .badge.badge-success=env.t('mysticHourglass', {amount: '+{{:: numberOfMysticHourglasses(_subscription)}}'})
+          .badge.badge-success=env.t('mysticHourglass', {amount: '+{{numberOfMysticHourglasses(_subscription)}}'})
           .small.muted=env.t('mysticHourglassText')
     tr
       td


### PR DESCRIPTION
The view had the subscriber benefits bound to the basic subscription, so I changed that to be dynamic.  Also, the controller now rounds down number of 3 month blocks before adding to the subscriber perks.
