### PR TITLE
Prevented modal from showing when user tries to hatch a pet they own

### DIFF
--- a/test/spec/controllers/inventoryCtrlSpec.js
+++ b/test/spec/controllers/inventoryCtrlSpec.js
@@ -78,7 +78,21 @@ describe('Inventory Controller', function() {
       expect(rootScope.openModal).to.have.been.calledOnce;
       expect(rootScope.openModal).to.have.been.calledWith('hatchPet');
     });
-    
+
+    it('does not show modal if user tries to hatch a pet they own', function(){
+      scope.chooseEgg('Cactus');
+      scope.choosePotion('Base');
+      expect(user.items.eggs).to.eql({Cactus: 0});
+      expect(user.items.hatchingPotions).to.eql({Base: 0});
+      expect(user.items.pets).to.eql({'Cactus-Base': 5});
+      expect(scope.selectedEgg).to.eql(null);
+      expect(scope.selectedPotion).to.eql(null);
+      expect(rootScope.openModal).to.have.been.calledOnce;
+      scope.chooseEgg('Cactus');
+      scope.choosePotion('Base');
+      expect(rootScope.openModal).to.not.have.been.calledTwice;
+    });
+
     it('does not show pet hatching modal if user has opted out', function(){
       user.preferences.suppressModals.hatchPet = true;
       scope.chooseEgg('Cactus');

--- a/website/public/js/controllers/inventoryCtrl.js
+++ b/website/public/js/controllers/inventoryCtrl.js
@@ -114,8 +114,12 @@ habitrpg.controller("InventoryCtrl",
       var eggName = Content.eggs[egg.key].text();
       var potName = Content.hatchingPotions[potion.key].text();
       if (!$window.confirm(window.env.t('hatchAPot', {potion: potName, egg: eggName}))) return;
+
+      var userHasPet = user.items.pets[egg.key + '-' + potion.key];
+
       user.ops.hatch({params:{egg:egg.key, hatchingPotion:potion.key}});
-      if (!user.preferences.suppressModals.hatchPet) {
+
+      if (!user.preferences.suppressModals.hatchPet && !userHasPet) {
         $scope.hatchedPet = {
           egg: eggName,
           potion: potName,


### PR DESCRIPTION
This is a fix for #6272 . I added a front-end check to see if the user already owns the pet before showing the hatch modal. 
