### PR TITLE
Added check to make sure user has not been terminated before giving rewards

### DIFF
--- a/migrations/mystery_items.js
+++ b/migrations/mystery_items.js
@@ -27,6 +27,9 @@ if (_id) {
   db.users.update({_id:_id}, update);
 } else {
   // multiple (once @ start of event)
-  db.users.update({'purchased.plan.customerId':{$ne:null}}, update, {multi:true});
+  var query = {
+    'purchased.plan.customerId': { $ne:null },
+    'purchased.plan.dateTerminated': { $gt : new Date() }
+  }
+  db.users.update({query, update, {multi:true});
 }
-


### PR DESCRIPTION
This is a fix for #6043 . I wasn't sure how to test, so this is my process.

1: Find a user and grab their `_id`

2: Add a subscription to the user

```
var update = {
  $set:{
    'purchased.plan':{
      customerId: "",
      dateCreated: new Date(),
      dateTerminated: null,
      dateUpdated:new Date(),
      gemsBought: 0,
      mysteryItems: [],
      paymentMethod: "Paypal",
      planId : "basic_earned"
    }
  }
};
db.users.update({"_id" : "686928a9-6da5-428d-bc88-6a973bf1faf7"}, update )
```

3: Use the current query filters to ensure user would receive the reward

```
db.users.find({ 'purchased.plan.customerId':{$ne:null} }, { 'purchased.plan' : 1});
```

4:  Unsubscribe the user

```
var update = {
  $set:{
    'purchased.plan.dateTerminated': new Date(),
  }
};
db.users.update({"_id" : "686928a9-6da5-428d-bc88-6a973bf1faf7"}, update );
db.users.find({ 'purchased.plan.customerId':{$ne:null} }, { 'purchased.plan' : 1});
```

5: Check to make sure user is excluded and other users are included with new query filters

```
var query = {
  'purchased.plan.customerId':{ $ne:null },
  'purchased.plan.dateTerminated': { $gt : new Date() }
}
db.users.find(query, { 'purchased.plan' : 1});
```
