### PR TITLE
Show mount modal more often

### DIFF
--- a/test/spec/controllers/inventoryCtrlSpec.js
+++ b/test/spec/controllers/inventoryCtrlSpec.js
@@ -88,6 +88,82 @@ describe('Inventory Controller', function() {
     });
   });
 
+  describe('Feeding and Raising Pets', function() {
+    beforeEach(function() {
+      sandbox.stub(rootScope, 'openModal');
+      user.items.pets = {'PandaCub-Base':5};
+      user.items.mounts = {'PandaCub-Base':false};
+    });
+
+    it('feeds a pet', function() {
+      scope.chooseFood('Meat');
+      scope.choosePet('PandaCub','Base');
+
+      expect(user.items.pets['PandaCub-Base']).to.eql(10);
+    });
+
+    it('gives weaker benefit when feeding inappropriate food', function() {
+      user.items.food.Honey = 1;
+
+      scope.chooseFood('Honey');
+      scope.choosePet('PandaCub','Base');
+
+      expect(user.items.pets['PandaCub-Base']).to.eql(7);
+    });
+
+    it('raises pet to a mount when feeding gauge maxes out', function() {
+      user.items.pets['PandaCub-Base'] = 45;
+
+      scope.chooseFood('Meat');
+      scope.choosePet('PandaCub','Base');
+
+      expect(user.items.pets['PandaCub-Base']).to.eql(-1);
+      expect(user.items.mounts['PandaCub-Base']).to.exist;
+    });
+
+    it('raises pet to a mount instantly when using a Saddle', function() {
+      user.items.food.Saddle = 1;
+
+      scope.chooseFood('Saddle');
+      scope.choosePet('PandaCub','Base');
+
+      expect(user.items.pets['PandaCub-Base']).to.eql(-1);
+      expect(user.items.mounts['PandaCub-Base']).to.exist;
+    });
+
+    it('displays mount raising modal for drop pets', function() {
+      user.items.food.Saddle = 1;
+
+      scope.chooseFood('Saddle');
+      scope.choosePet('PandaCub','Base');
+
+      expect(rootScope.openModal).to.have.been.calledOnce;
+      expect(rootScope.openModal).to.have.been.calledWith('raisePet');
+    });
+
+    it('displays mount raising modal for quest pets', function() {
+      user.items.food.Saddle = 1;
+      user.items.pets['Snake-Base'] = 1;
+
+      scope.chooseFood('Saddle');
+      scope.choosePet('Snake','Base');
+
+      expect(rootScope.openModal).to.have.been.calledOnce;
+      expect(rootScope.openModal).to.have.been.calledWith('raisePet');
+    });
+
+    it('displays mount raising modal for premium pets', function() {
+      user.items.food.Saddle = 1;
+      user.items.pets['TigerCub-Spooky'] = 1;
+
+      scope.chooseFood('Saddle');
+      scope.choosePet('TigerCub','Spooky');
+
+      expect(rootScope.openModal).to.have.been.calledOnce;
+      expect(rootScope.openModal).to.have.been.calledWith('raisePet');
+    });
+  });
+
   it('sells an egg', function(){
     scope.chooseEgg('Cactus');
     scope.sellInventory();

--- a/website/public/js/controllers/inventoryCtrl.js
+++ b/website/public/js/controllers/inventoryCtrl.js
@@ -159,7 +159,7 @@ habitrpg.controller("InventoryCtrl",
       // Feeding Pet
       if ($scope.selectedFood) {
         var food = $scope.selectedFood;
-        var startingMounts = Stats.totalCount(user.items.mounts);
+        var startingMounts = $rootScope.countExists(user.items.mounts);
         if (food.key === 'Saddle') {
           if (!$window.confirm(window.env.t('useSaddle', {pet: petDisplayName}))) return;
         } else if (!$window.confirm(window.env.t('feedPet', {name: petDisplayName, article: food.article, text: food.text()}))) {
@@ -169,7 +169,7 @@ habitrpg.controller("InventoryCtrl",
         $scope.selectedFood = null;
 
         _updateDropAnimalCount(user.items);
-        if (Stats.totalCount(user.items.mounts) > startingMounts && !user.preferences.suppressModals.raisePet) {
+        if ($rootScope.countExists(user.items.mounts) > startingMounts && !user.preferences.suppressModals.raisePet) {
           $scope.raisedPet = {
             displayName: petDisplayName,
             spriteName: pet,


### PR DESCRIPTION
Fixes #6288. Previously, we used a count of all properties within the user's items.pets.mounts to determine whether or not they'd gained a new mount. That would not work as expected if they had mounts with a null or false status, such as after using the Key to the Kennels. This commit also adds some tests to the inventory controller in Angular for pet raising.
