### PR TITLE
Added markdown directive to challenge titles

### DIFF
--- a/website/views/options/social/challenge-box.jade
+++ b/website/views/options/social/challenge-box.jade
@@ -10,7 +10,8 @@
       table.table.table-striped
         tr(ng-repeat='challenge in group.challenges')
           td
-            a(ui-sref='options.social.challenges.detail({cid:challenge._id})') {{challenge.name}}
+            a(ui-sref='options.social.challenges.detail({cid:challenge._id})') 
+              markdown(text='challenge.name')
     div(ng-if='group.challenges.length == 0')
       p
         |&nbsp;

--- a/website/views/options/social/challenges.jade
+++ b/website/views/options/social/challenges.jade
@@ -203,7 +203,8 @@ script(type='text/ng-template', id='partials/options.social.challenges.html')
                   a.btn.btn-sm.btn-success(ng-hide='challenge._isMember', ng-click='join(challenge)')
                     span.glyphicon.glyphicon-ok
                     =env.t('join')
-              a.accordion-toggle(id="{{challenge._id}}" ng-click='toggle(challenge._id)') {{challenge.name}}
+              a.accordion-toggle(id="{{challenge._id}}" ng-click='toggle(challenge._id)') 
+                markdown(text='challenge.name')
             .panel-body(ng-class='{collapse: !$stateParams.cid == challenge._id}')
               .accordion-inner(ng-if='$stateParams.cid == challenge._id')
                 div(ui-view)


### PR DESCRIPTION
This is a fix for #6297 . I simply added the markdown directive to display the emojis. Here is a screenshot of the guild page, but I made the modification on the challenges page as well.
<img width="403" alt="screen shot 2015-11-25 at 12 54 07 pm" src="https://cloud.githubusercontent.com/assets/1253400/11406596/bad4c9e0-9373-11e5-9251-070438283361.png">
