### PR TITLE
Fixes #6252 - Guild description is too narrow on guild page

### DIFF
--- a/website/public/css/alerts.styl
+++ b/website/public/css/alerts.styl
@@ -16,6 +16,9 @@
 .wide-popover
   max-width: 400px
 
+.fill-popover
+  max-width: max-content
+
 // Small alerts
 alert-sm-mixin()
   padding-top: 8px

--- a/website/public/css/alerts.styl
+++ b/website/public/css/alerts.styl
@@ -14,9 +14,6 @@
   display: inline-block
 
 .wide-popover
-  max-width: 400px
-
-.fill-popover
   max-width: max-content
 
 // Small alerts

--- a/website/views/options/social/group.jade
+++ b/website/views/options/social/group.jade
@@ -135,7 +135,7 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
       table(ng-show='group.leaderMessage')
         tr
           td
-            .popover.static-popover.fade.right.in.fill-popover
+            .popover.static-popover.fade.right.in.wide-popover
               .arrow
               h3.popover-title {{group.leader.profile.name}}
               .popover-content

--- a/website/views/options/social/group.jade
+++ b/website/views/options/social/group.jade
@@ -132,14 +132,15 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
     .col-md-8
       div
         textarea.form-control(ng-show='group._editing', rows=6, placeholder=env.t('leaderMsg'), ng-model='group.leaderMessage')
-      table(ng-show='group.leaderMessage')
-        tr
-          td
-            .popover.static-popover.fade.right.in.wide-popover
-              .arrow
-              h3.popover-title {{group.leader.profile.name}}
-              .popover-content
-                markdown(text='group.leaderMessage')
+      .slight-vertical-padding
+        table(ng-show='group.leaderMessage')
+          tr
+            td
+              .popover.static-popover.fade.right.in.wide-popover
+                .arrow
+                h3.popover-title {{group.leader.profile.name}}
+                .popover-content
+                  markdown(text='group.leaderMessage')
       div(ng-controller='ChatCtrl')
         h3=env.t('chat')
         include ./chat-box

--- a/website/views/options/social/group.jade
+++ b/website/views/options/social/group.jade
@@ -135,7 +135,7 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
       table(ng-show='group.leaderMessage')
         tr
           td
-            .popover.static-popover.fade.right.in.wide-popover
+            .popover.static-popover.fade.right.in.fill-popover
               .arrow
               h3.popover-title {{group.leader.profile.name}}
               .popover-content


### PR DESCRIPTION
Attempted to fix #6252 by creating a new popover class. 
