### PR TITLE
Fix modal display when rehatching pets

### DIFF
--- a/test/spec/controllers/inventoryCtrlSpec.js
+++ b/test/spec/controllers/inventoryCtrlSpec.js
@@ -79,6 +79,15 @@ describe('Inventory Controller', function() {
       expect(rootScope.openModal).to.have.been.calledWith('hatchPet');
     });
 
+    it('shows modal even if user has raised that pet to a mount', function(){
+      user.items.pets['Cactus-Base'] = -1;
+      scope.chooseEgg('Cactus');
+      scope.choosePotion('Base');
+
+      expect(rootScope.openModal).to.have.been.calledOnce;
+      expect(rootScope.openModal).to.have.been.calledWith('hatchPet');
+    });
+
     it('does not show modal if user tries to hatch a pet they own', function(){
       scope.chooseEgg('Cactus');
       scope.choosePotion('Base');

--- a/website/public/js/controllers/inventoryCtrl.js
+++ b/website/public/js/controllers/inventoryCtrl.js
@@ -115,7 +115,7 @@ habitrpg.controller("InventoryCtrl",
       var potName = Content.hatchingPotions[potion.key].text();
       if (!$window.confirm(window.env.t('hatchAPot', {potion: potName, egg: eggName}))) return;
 
-      var userHasPet = (user.items.pets[egg.key + '-' + potion.key] > 0) ? true:false;
+      var userHasPet = user.items.pets[egg.key + '-' + potion.key] > 0;
 
       user.ops.hatch({params:{egg:egg.key, hatchingPotion:potion.key}});
 

--- a/website/public/js/controllers/inventoryCtrl.js
+++ b/website/public/js/controllers/inventoryCtrl.js
@@ -115,7 +115,7 @@ habitrpg.controller("InventoryCtrl",
       var potName = Content.hatchingPotions[potion.key].text();
       if (!$window.confirm(window.env.t('hatchAPot', {potion: potName, egg: eggName}))) return;
 
-      var userHasPet = user.items.pets[egg.key + '-' + potion.key];
+      var userHasPet = (user.items.pets[egg.key + '-' + potion.key] > 0) ? true:false;
 
       user.ops.hatch({params:{egg:egg.key, hatchingPotion:potion.key}});
 


### PR DESCRIPTION
Corrects an issue with #6281 that would cause the pet hatching modal to fail to display if the pet had a value of -1 (i.e. raised to a mount and not yet re-hatched).

@Alys @TheHollidayInn 
