### PR TITLE
Proposed fix for issue #6332

### DIFF
--- a/website/public/css/tasks.styl
+++ b/website/public/css/tasks.styl
@@ -190,7 +190,7 @@ for $stage in $stages
     float: right
     font-size: 0.85em
   .empty-task-notification
-    height: 100%;
+    //height: 100%;
 
 // message in Dailies column when Resting in Inn
 // ------------------------


### PR DESCRIPTION
Fixes cosmetic bug where "add task" button jumps from being centered to not. Removed one line of CSS specifying "height:100%" 
