### PR TITLE
Add confirmation popovers for release pets & mounts, rebirth, and fortify. Fixes #4104

### DIFF
--- a/common/locales/en/pets.json
+++ b/common/locales/en/pets.json
@@ -80,6 +80,7 @@
     "petKeyPets": "Release My Pets",
     "petKeyMounts": "Release My Mounts",
     "petKeyBoth": "Release Both",
+    "confirmPetKey": "Are you sure?",
     "petKeyNeverMind": "Not Yet",
     "gemsEach": "gems each"
 }

--- a/common/locales/en/rebirth.json
+++ b/common/locales/en/rebirth.json
@@ -23,5 +23,6 @@
     "rebirthOrb100": "Used an Orb of Rebirth to start over after attaining Level 100 or higher",
     "rebirthPop": "Begin a new character at Level 1 while retaining achievements, collectibles, and tasks with history.",
     "rebirthName": "Orb of Rebirth",
-    "reborn": "Reborn, max level <%= reLevel %>"
+    "reborn": "Reborn, max level <%= reLevel %>",
+    "confirmReborn": "Are you sure?"
 }

--- a/common/locales/en/tasks.json
+++ b/common/locales/en/tasks.json
@@ -90,6 +90,7 @@
     "fortifyPop": "Return all tasks to neutral value (yellow color), and restore all lost Health.",
     "fortify": "Fortify",
     "fortifyText": "Fortify will return all your tasks to a neutral (yellow) state, as if you'd just added them, and top your Health off to full. This is great if all your red tasks are making the game too hard, or all your blue tasks are making the game too easy. If starting fresh sounds much more motivating, spend the Gems and catch a reprieve!",
+    "confirmFortify": "Are you sure?",
     "sureDelete": "Are you sure you want to delete the <%= taskType %> with the text \"<%= taskText %>\"?",
     "streakCoins": "Streak Bonus!",
     "pushTaskToTop": "Push task to top.  Hold ctrl or cmd to push to bottom.",

--- a/test/spec/controllers/settingsCtrlSpec.js
+++ b/test/spec/controllers/settingsCtrlSpec.js
@@ -106,24 +106,24 @@ describe('Settings Controller', function() {
       });
 
       it('destroys the previous popover if it exists', function() {
-        expect(scope.popoverEl).to.exist;
         sandbox.spy($.fn, 'popover');
         scope.reroll(false);
 
-        $.fn.popover.should.have.been.calledWith('destroy');
+        expect(scope.popoverEl).to.exist;
+        expect($.fn.popover).to.be.calledWith('destroy');
       });
 
       it('doesn\'t call reroll when not confirmed', function() {
         scope.reroll(false);
-        user.ops.reroll.should.not.have.been.called;
+        expect(user.ops.reroll).to.not.be.calledOnce;
       });
 
       it('calls reroll on the user when confirmed and navigates to tasks', function() {
         sandbox.stub(rootScope.$state, 'go');
         scope.reroll(true);
 
-        user.ops.reroll.should.have.been.calledWith({});
-        rootScope.$state.go.should.have.been.calledWith('tasks');
+        expect(user.ops.reroll).to.be.calledWith({});
+        expect(rootScope.$state.go).to.be.calledWith('tasks');
       });
     });
 
@@ -132,9 +132,9 @@ describe('Settings Controller', function() {
         sandbox.spy($.fn, 'popover');
         scope.clickReroll(actionClickEvent);
 
-        $.fn.popover.should.have.been.calledWith('destroy');
-        $.fn.popover.should.have.been.called;
-        $.fn.popover.should.have.been.calledWith('show');
+        expect($.fn.popover).to.be.calledWith('destroy');
+        expect($.fn.popover).to.be.called;
+        expect($.fn.popover).to.be.calledWith('show');
       });
     });
   });
@@ -146,24 +146,24 @@ describe('Settings Controller', function() {
       });
 
       it('destroys the previous popover if it exists', function() {
-        expect(scope.popoverEl).to.exist;
         sandbox.spy($.fn, 'popover');
         scope.rebirth(false);
 
-        $.fn.popover.should.have.been.calledWith('destroy');
+        expect(scope.popoverEl).to.exist;
+        expect($.fn.popover).to.be.calledWith('destroy');
       });
 
       it('doesn\'t call rebirth when not confirmed', function() {
         scope.rebirth(false);
-        user.ops.rebirth.should.not.have.been.called;
+        expect(user.ops.rebirth).to.not.be.calledOnce;
       });
 
       it('calls rebirth on the user when confirmed and navigates to tasks', function() {
         sandbox.stub(rootScope.$state, 'go');
         scope.rebirth(true);
 
-        user.ops.rebirth.should.have.been.calledWith({});
-        rootScope.$state.go.should.have.been.calledWith('tasks');
+        expect(user.ops.rebirth).to.be.calledWith({});
+        expect(rootScope.$state.go).to.be.calledWith('tasks');
       });
     });
 
@@ -172,9 +172,9 @@ describe('Settings Controller', function() {
         sandbox.spy($.fn, 'popover');
         scope.clickRebirth(actionClickEvent);
 
-        $.fn.popover.should.have.been.calledWith('destroy');
-        $.fn.popover.should.have.been.called;
-        $.fn.popover.should.have.been.calledWith('show');
+        expect($.fn.popover).to.be.calledWith('destroy');
+        expect($.fn.popover).to.be.called;
+        expect($.fn.popover).to.be.calledWith('show');
       });
     });
   })
@@ -189,7 +189,7 @@ describe('Settings Controller', function() {
         sandbox.spy($.fn, 'popover');
         scope.release('', false);
 
-        $.fn.popover.should.have.been.calledWith('destroy');
+        expect($.fn.popover).to.be.calledWith('destroy');
       });
 
       it('doesn\'t call any release methods if not confirmed', function() {
@@ -202,9 +202,9 @@ describe('Settings Controller', function() {
         scope.release('both', false);
         scope.release('dummy', false);
 
-        petsSpy.should.not.have.been.called;
-        mountsSpy.should.not.have.been.called;
-        bothSpy.should.not.have.been.called;
+        expect(petsSpy).to.not.be.called;
+        expect(mountsSpy).to.not.be.called;
+        expect(bothSpy).to.not.be.called;
       });
 
       it('calls the correct release method based on it\'s input', function() {
@@ -213,24 +213,25 @@ describe('Settings Controller', function() {
         var bothSpy = sandbox.spy(scope, 'releaseBoth');
 
         scope.release('pets', true);
-        petsSpy.should.have.been.calledOnce;
+        expect(petsSpy).to.be.calledOnce;
+        expect(mountsSpy).to.not.be.called;
         petsSpy.reset();
 
         scope.release('mounts', true);
-        mountsSpy.should.have.been.calledOnce;
-        petsSpy.should.not.have.been.called;
+        expect(mountsSpy).to.be.calledOnce;
+        expect(petsSpy).to.not.be.called;
         mountsSpy.reset();
 
         scope.release('both', true);
-        bothSpy.should.have.been.calledOnce;
-        mountsSpy.should.not.have.been.called;
-        petsSpy.should.not.have.been.called;
+        expect(petsSpy).to.not.be.called;
+        expect(mountsSpy).to.not.be.called;
+        expect(bothSpy).to.be.calledOnce;
         bothSpy.reset();
 
         scope.release('dummy', true);
-        petsSpy.should.not.have.been.called;
-        mountsSpy.should.not.have.been.called;
-        bothSpy.should.not.have.been.called;
+        expect(petsSpy).to.not.be.called;
+        expect(mountsSpy).to.not.be.called;
+        expect(bothSpy).to.not.be.called;
       });
     });
 
@@ -239,8 +240,8 @@ describe('Settings Controller', function() {
         sandbox.stub(rootScope.$state, 'go');
         scope.releasePets();
 
-        user.ops.releasePets.should.have.been.calledWith({});
-        rootScope.$state.go.should.have.been.calledWith('tasks');
+        expect(user.ops.releasePets).to.be.calledWith({});
+        expect(rootScope.$state.go).to.be.calledWith('tasks');
       });
     });
 
@@ -249,8 +250,8 @@ describe('Settings Controller', function() {
         sandbox.stub(rootScope.$state, 'go');
         scope.releaseMounts();
 
-        user.ops.releaseMounts.should.have.been.calledWith({});
-        rootScope.$state.go.should.have.been.calledWith('tasks');
+        expect(user.ops.releaseMounts).to.be.calledWith({});
+        expect(rootScope.$state.go).to.be.calledWith('tasks');
       });
     });
 
@@ -259,19 +260,19 @@ describe('Settings Controller', function() {
         sandbox.stub(rootScope.$state, 'go');
         scope.releaseBoth();
 
-        user.ops.releaseBoth.should.have.been.calledWith({});
-        rootScope.$state.go.should.have.been.calledWith('tasks');
+        expect(user.ops.releaseBoth).to.be.calledWith({});
+        expect(rootScope.$state.go).to.be.calledWith('tasks');
       });
     });
 
     describe('#clickRelease', function() {
       it('displays a confirmation popover for the user', function() {
         sandbox.spy($.fn, 'popover');
-        scope.clickRelease("dummy", actionClickEvent);
+        scope.clickRelease('dummy', actionClickEvent);
 
-        $.fn.popover.should.have.been.calledWith('destroy');
-        $.fn.popover.should.have.been.called;
-        $.fn.popover.should.have.been.calledWith('show');
+        expect($.fn.popover).to.be.calledWith('destroy');
+        expect($.fn.popover).to.be.called;
+        expect($.fn.popover).to.be.calledWith('show');
       });
     });
   });

--- a/test/spec/controllers/settingsCtrlSpec.js
+++ b/test/spec/controllers/settingsCtrlSpec.js
@@ -10,6 +10,12 @@ describe('Settings Controller', function() {
         set: sandbox.stub(),
         user: user
       };
+
+      User.user.ops = {
+        reroll: sandbox.stub(),
+        rebirth: sandbox.stub(),
+      };
+
       $provide.value('User', User);
       $provide.value('Guide', sandbox.stub());
     });
@@ -83,4 +89,81 @@ describe('Settings Controller', function() {
       });
     });
   });
+
+  describe('#reroll', function() {
+    beforeEach(function() {
+      scope.clickReroll(document.createElement('div'));
+    });
+
+    it('destroys the previous popover if it exists', function() {
+      expect(scope.popoverEl).to.exist;
+      sandbox.spy($.fn, 'popover');
+      scope.reroll(false);
+
+      $.fn.popover.should.have.been.calledWith('destroy');
+    });
+
+    it('doesn\'t call reroll when not confirmed', function() {
+      scope.reroll(false); 
+      user.ops.reroll.should.not.have.been.called;
+    });
+
+    it('calls reroll on the user when confirmed and navigates to tasks', function() {
+      sandbox.stub(rootScope.$state, 'go');
+      scope.reroll(true);
+
+      user.ops.reroll.should.have.been.calledWith({});
+      rootScope.$state.go.should.have.been.calledWith('tasks');
+    });
+  });
+
+  describe('#clickReroll', function() {
+    it('displays a confirmation popover for the user', function() {
+      sandbox.spy($.fn, 'popover');
+      scope.clickReroll(document.createElement('div'));
+
+      $.fn.popover.should.have.been.calledWith('destroy');
+      $.fn.popover.should.have.been.called;
+      $.fn.popover.should.have.been.calledWith('show');
+    });
+  });
+
+  describe('#rebirth', function() {
+    beforeEach(function() {
+      scope.clickRebirth(document.createElement('div'));
+    });
+
+    it('destroys the previous popover if it exists', function() {
+      expect(scope.popoverEl).to.exist;
+      sandbox.spy($.fn, 'popover');
+      scope.rebirth(false);
+
+      $.fn.popover.should.have.been.calledWith('destroy');
+    });
+
+    it('doesn\'t call rebirth when not confirmed', function() {
+      scope.rebirth(false); 
+      user.ops.rebirth.should.not.have.been.called;
+    });
+
+    it('calls rebirth on the user when confirmed and navigates to tasks', function() {
+      sandbox.stub(rootScope.$state, 'go');
+      scope.rebirth(true);
+
+      user.ops.rebirth.should.have.been.calledWith({});
+      rootScope.$state.go.should.have.been.calledWith('tasks');
+    });
+  });
+
+  describe('#clickRebirth', function() {
+    it('displays a confirmation popover for the user', function() {
+      sandbox.spy($.fn, 'popover');
+      scope.clickRebirth(document.createElement('div'));
+
+      $.fn.popover.should.have.been.calledWith('destroy');
+      $.fn.popover.should.have.been.called;
+      $.fn.popover.should.have.been.calledWith('show');
+    });
+  });
+
 });

--- a/test/spec/controllers/settingsCtrlSpec.js
+++ b/test/spec/controllers/settingsCtrlSpec.js
@@ -1,7 +1,13 @@
 'use strict';
 
 describe('Settings Controller', function() {
-  var rootScope, scope, user, User, ctrl;
+  var rootScope, scope, user, User, ctrl, actionClickEvent;
+
+  before(function() {
+    actionClickEvent = {
+      target: document.createElement('button'),
+    };
+  });
 
   beforeEach(function() {
     module(function($provide) {
@@ -14,6 +20,9 @@ describe('Settings Controller', function() {
       User.user.ops = {
         reroll: sandbox.stub(),
         rebirth: sandbox.stub(),
+        releasePets: sandbox.stub(),
+        releaseMounts: sandbox.stub(),
+        releaseBoth: sandbox.stub(),
       };
 
       $provide.value('User', User);
@@ -90,80 +99,180 @@ describe('Settings Controller', function() {
     });
   });
 
-  describe('#reroll', function() {
-    beforeEach(function() {
-      scope.clickReroll(document.createElement('div'));
+  context('Player Reroll', function() {
+    describe('#reroll', function() {
+      beforeEach(function() {
+        scope.clickReroll(actionClickEvent);
+      });
+
+      it('destroys the previous popover if it exists', function() {
+        expect(scope.popoverEl).to.exist;
+        sandbox.spy($.fn, 'popover');
+        scope.reroll(false);
+
+        $.fn.popover.should.have.been.calledWith('destroy');
+      });
+
+      it('doesn\'t call reroll when not confirmed', function() {
+        scope.reroll(false);
+        user.ops.reroll.should.not.have.been.called;
+      });
+
+      it('calls reroll on the user when confirmed and navigates to tasks', function() {
+        sandbox.stub(rootScope.$state, 'go');
+        scope.reroll(true);
+
+        user.ops.reroll.should.have.been.calledWith({});
+        rootScope.$state.go.should.have.been.calledWith('tasks');
+      });
     });
 
-    it('destroys the previous popover if it exists', function() {
-      expect(scope.popoverEl).to.exist;
-      sandbox.spy($.fn, 'popover');
-      scope.reroll(false);
+    describe('#clickReroll', function() {
+      it('displays a confirmation popover for the user', function() {
+        sandbox.spy($.fn, 'popover');
+        scope.clickReroll(actionClickEvent);
 
-      $.fn.popover.should.have.been.calledWith('destroy');
-    });
-
-    it('doesn\'t call reroll when not confirmed', function() {
-      scope.reroll(false); 
-      user.ops.reroll.should.not.have.been.called;
-    });
-
-    it('calls reroll on the user when confirmed and navigates to tasks', function() {
-      sandbox.stub(rootScope.$state, 'go');
-      scope.reroll(true);
-
-      user.ops.reroll.should.have.been.calledWith({});
-      rootScope.$state.go.should.have.been.calledWith('tasks');
-    });
-  });
-
-  describe('#clickReroll', function() {
-    it('displays a confirmation popover for the user', function() {
-      sandbox.spy($.fn, 'popover');
-      scope.clickReroll(document.createElement('div'));
-
-      $.fn.popover.should.have.been.calledWith('destroy');
-      $.fn.popover.should.have.been.called;
-      $.fn.popover.should.have.been.calledWith('show');
-    });
-  });
-
-  describe('#rebirth', function() {
-    beforeEach(function() {
-      scope.clickRebirth(document.createElement('div'));
-    });
-
-    it('destroys the previous popover if it exists', function() {
-      expect(scope.popoverEl).to.exist;
-      sandbox.spy($.fn, 'popover');
-      scope.rebirth(false);
-
-      $.fn.popover.should.have.been.calledWith('destroy');
-    });
-
-    it('doesn\'t call rebirth when not confirmed', function() {
-      scope.rebirth(false); 
-      user.ops.rebirth.should.not.have.been.called;
-    });
-
-    it('calls rebirth on the user when confirmed and navigates to tasks', function() {
-      sandbox.stub(rootScope.$state, 'go');
-      scope.rebirth(true);
-
-      user.ops.rebirth.should.have.been.calledWith({});
-      rootScope.$state.go.should.have.been.calledWith('tasks');
+        $.fn.popover.should.have.been.calledWith('destroy');
+        $.fn.popover.should.have.been.called;
+        $.fn.popover.should.have.been.calledWith('show');
+      });
     });
   });
 
-  describe('#clickRebirth', function() {
-    it('displays a confirmation popover for the user', function() {
-      sandbox.spy($.fn, 'popover');
-      scope.clickRebirth(document.createElement('div'));
+  context('Player Rebirth', function() {
+    describe('#rebirth', function() {
+      beforeEach(function() {
+        scope.clickRebirth(actionClickEvent);
+      });
 
-      $.fn.popover.should.have.been.calledWith('destroy');
-      $.fn.popover.should.have.been.called;
-      $.fn.popover.should.have.been.calledWith('show');
+      it('destroys the previous popover if it exists', function() {
+        expect(scope.popoverEl).to.exist;
+        sandbox.spy($.fn, 'popover');
+        scope.rebirth(false);
+
+        $.fn.popover.should.have.been.calledWith('destroy');
+      });
+
+      it('doesn\'t call rebirth when not confirmed', function() {
+        scope.rebirth(false);
+        user.ops.rebirth.should.not.have.been.called;
+      });
+
+      it('calls rebirth on the user when confirmed and navigates to tasks', function() {
+        sandbox.stub(rootScope.$state, 'go');
+        scope.rebirth(true);
+
+        user.ops.rebirth.should.have.been.calledWith({});
+        rootScope.$state.go.should.have.been.calledWith('tasks');
+      });
+    });
+
+    describe('#clickRebirth', function() {
+      it('displays a confirmation popover for the user', function() {
+        sandbox.spy($.fn, 'popover');
+        scope.clickRebirth(actionClickEvent);
+
+        $.fn.popover.should.have.been.calledWith('destroy');
+        $.fn.popover.should.have.been.called;
+        $.fn.popover.should.have.been.calledWith('show');
+      });
+    });
+  })
+
+  context('Releasing pets and mounts', function() {
+    describe('#release', function() {
+      beforeEach(function() {
+        scope.clickRelease('dummy', actionClickEvent);
+      });
+
+      it('destroys the previous popover if it exists', function() {
+        sandbox.spy($.fn, 'popover');
+        scope.release('', false);
+
+        $.fn.popover.should.have.been.calledWith('destroy');
+      });
+
+      it('doesn\'t call any release methods if not confirmed', function() {
+        var petsSpy = sandbox.spy(scope, 'releasePets');
+        var mountsSpy = sandbox.spy(scope, 'releaseMounts');
+        var bothSpy = sandbox.spy(scope, 'releaseBoth');
+
+        scope.release('pets', false);
+        scope.release('mounts', false);
+        scope.release('both', false);
+        scope.release('dummy', false);
+
+        petsSpy.should.not.have.been.called;
+        mountsSpy.should.not.have.been.called;
+        bothSpy.should.not.have.been.called;
+      });
+
+      it('calls the correct release method based on it\'s input', function() {
+        var petsSpy = sandbox.spy(scope, 'releasePets');
+        var mountsSpy = sandbox.spy(scope, 'releaseMounts');
+        var bothSpy = sandbox.spy(scope, 'releaseBoth');
+
+        scope.release('pets', true);
+        petsSpy.should.have.been.calledOnce;
+        petsSpy.reset();
+
+        scope.release('mounts', true);
+        mountsSpy.should.have.been.calledOnce;
+        petsSpy.should.not.have.been.called;
+        mountsSpy.reset();
+
+        scope.release('both', true);
+        bothSpy.should.have.been.calledOnce;
+        mountsSpy.should.not.have.been.called;
+        petsSpy.should.not.have.been.called;
+        bothSpy.reset();
+
+        scope.release('dummy', true);
+        petsSpy.should.not.have.been.called;
+        mountsSpy.should.not.have.been.called;
+        bothSpy.should.not.have.been.called;
+      });
+    });
+
+    describe('#releasePets', function() {
+      it('calls releasePets on the user and redirects to tasks', function() {
+        sandbox.stub(rootScope.$state, 'go');
+        scope.releasePets();
+
+        user.ops.releasePets.should.have.been.calledWith({});
+        rootScope.$state.go.should.have.been.calledWith('tasks');
+      });
+    });
+
+    describe('#releaseMounts', function() {
+      it('calls releaseMounts on the user and redirects to tasks', function() {
+        sandbox.stub(rootScope.$state, 'go');
+        scope.releaseMounts();
+
+        user.ops.releaseMounts.should.have.been.calledWith({});
+        rootScope.$state.go.should.have.been.calledWith('tasks');
+      });
+    });
+
+    describe('#releaseBoth', function() {
+      it('calls releaseBoth on the user and redirects to tasks', function() {
+        sandbox.stub(rootScope.$state, 'go');
+        scope.releaseBoth();
+
+        user.ops.releaseBoth.should.have.been.calledWith({});
+        rootScope.$state.go.should.have.been.calledWith('tasks');
+      });
+    });
+
+    describe('#clickRelease', function() {
+      it('displays a confirmation popover for the user', function() {
+        sandbox.spy($.fn, 'popover');
+        scope.clickRelease("dummy", actionClickEvent);
+
+        $.fn.popover.should.have.been.calledWith('destroy');
+        $.fn.popover.should.have.been.called;
+        $.fn.popover.should.have.been.calledWith('show');
+      });
     });
   });
-
 });

--- a/website/public/js/controllers/guildsCtrl.js
+++ b/website/public/js/controllers/guildsCtrl.js
@@ -57,27 +57,29 @@ habitrpg.controller("GuildsCtrl", ['$scope', 'Groups', 'User', 'Challenges', '$r
           $scope.popoverEl = $($event.target);
           var html, title;
           Challenges.Challenge.query(function(challenges) {
-              challenges = _.pluck(_.filter(challenges, function(c) {
-                  return c.group._id == group._id;
-              }), '_id');
-              if (_.intersection(challenges, User.user.challenges).length > 0) {
-                  html = $compile(
-              '<a ng-controller="GroupsCtrl" ng-click="leave(\'remove-all\')">' + window.env.t('removeTasks') + '</a><br/>\n<a ng-click="leave(\'keep-all\')">' + window.env.t('keepTasks') + '</a><br/>\n<a ng-click="leave(\'cancel\')">' + window.env.t('cancel') + '</a><br/>'
-          )($scope);
-                  title = window.env.t('leaveGroupCha');
-              } else {
-                  html = $compile(
-                      '<a ng-controller="GroupsCtrl" ng-click="leave(\'keep-all\')">' + window.env.t('confirm') + '</a><br/>\n<a ng-click="leave(\'cancel\')">' + window.env.t('cancel') + '</a><br/>'
-                  )($scope);
-                  title = window.env.t('leaveGroup')
-              }
-          $scope.popoverEl.popover('destroy').popover({
+            challenges = _.pluck(_.filter(challenges, function(c) {
+                return c.group._id == group._id;
+            }), '_id');
+
+            if (_.intersection(challenges, User.user.challenges).length > 0) {
+                html = $compile(
+                    '<a ng-controller="GroupsCtrl" ng-click="leave(\'remove-all\')">' + window.env.t('removeTasks') + '</a><br/>\n<a ng-click="leave(\'keep-all\')">' + window.env.t('keepTasks') + '</a><br/>\n<a ng-click="leave(\'cancel\')">' + window.env.t('cancel') + '</a><br/>'
+                )($scope);
+                title = window.env.t('leaveGroupCha');
+            } else {
+                html = $compile(
+                    '<a ng-controller="GroupsCtrl" ng-click="leave(\'keep-all\')">' + window.env.t('confirm') + '</a><br/>\n<a ng-click="leave(\'cancel\')">' + window.env.t('cancel') + '</a><br/>'
+                )($scope);
+                title = window.env.t('leaveGroup')
+            }
+
+            $scope.popoverEl.popover('destroy').popover({
               html: true,
               placement: 'top',
               trigger: 'manual',
-                  title: title,
+              title: title,
               content: html
-          }).popover('show');
+            }).popover('show');
           });
       }
 

--- a/website/public/js/controllers/settingsCtrl.js
+++ b/website/public/js/controllers/settingsCtrl.js
@@ -2,8 +2,8 @@
 
 // Make user and settings available for everyone through root scope.
 habitrpg.controller('SettingsCtrl',
-  ['$scope', 'User', '$rootScope', '$http', 'ApiUrl', 'Guide', '$location', '$timeout', 'Content', 'Notification', 'Shared',
-  function($scope, User, $rootScope, $http, ApiUrl, Guide, $location, $timeout, Content, Notification, Shared) {
+  ['$scope', 'User', '$rootScope', '$http', 'ApiUrl', 'Guide', '$location', '$timeout', 'Content', 'Notification', 'Shared', '$compile',
+  function($scope, User, $rootScope, $http, ApiUrl, Guide, $location, $timeout, Content, Notification, Shared, $compile) {
 
     // FIXME we have this re-declared everywhere, figure which is the canonical version and delete the rest
 //    $scope.auth = function (id, token) {
@@ -95,9 +95,29 @@ habitrpg.controller('SettingsCtrl',
       $rootScope.$state.go('tasks');
     }
 
-    $scope.rebirth = function(){
-      User.user.ops.rebirth({});
-      $rootScope.$state.go('tasks');
+    $scope.rebirth = function(confirm){
+      $scope.popoverEl.popover('destroy')
+
+      if (confirm) {
+        User.user.ops.rebirth({});
+        $rootScope.$state.go('tasks');
+      }
+    }
+
+    $scope.clickRebirth = function($event){
+      $scope.popoverEl = $($event.target);
+
+      var html = $compile(
+          '<a ng-controller="SettingsCtrl" ng-click="$close(); rebirth(true)">' + window.env.t('confirm') + '</a><br/>\n<a ng-click="rebirth(false)">' + window.env.t('cancel') + '</a><br/>'
+      )($scope);
+
+      $scope.popoverEl.popover('destroy').popover({
+        html: true,
+        placement: 'top',
+        trigger: 'manual',
+        title: window.env.t('confirmReborn'),
+        content: html
+      }).popover('show');
     }
 
     $scope.changeUser = function(attr, updates){

--- a/website/public/js/controllers/settingsCtrl.js
+++ b/website/public/js/controllers/settingsCtrl.js
@@ -229,9 +229,9 @@ habitrpg.controller('SettingsCtrl',
 
       if (confirm) {
         switch (type) {
-          case "pets": $scope.releasePets();
-          case "mounts": $scope.releaseMounts();
-          case "both": $scope.releaseBoth();
+          case "pets": $scope.releasePets(); break;
+          case "mounts": $scope.releaseMounts(); break;
+          case "both": $scope.releaseBoth(); break;
           default: return;
         }
       }

--- a/website/public/js/controllers/settingsCtrl.js
+++ b/website/public/js/controllers/settingsCtrl.js
@@ -91,7 +91,7 @@ habitrpg.controller('SettingsCtrl',
     $scope.availableFormats = ['MM/dd/yyyy','dd/MM/yyyy', 'yyyy/MM/dd'];
 
     $scope.reroll = function(confirm){
-      $scope.popoverEl.popover('destroy')
+      $scope.popoverEl.popover('destroy');
 
       if (confirm) {
         User.user.ops.reroll({});
@@ -116,7 +116,7 @@ habitrpg.controller('SettingsCtrl',
     }
 
     $scope.rebirth = function(confirm){
-      $scope.popoverEl.popover('destroy')
+      $scope.popoverEl.popover('destroy');
 
       if (confirm) {
         User.user.ops.rebirth({});
@@ -198,6 +198,43 @@ habitrpg.controller('SettingsCtrl',
           if (code!==200) return;
           window.location.href = '/api/v2/coupons?limit='+codes.count+'&_id='+User.user._id+'&apiToken='+User.user.apiToken;
         })
+    }
+
+    $scope.clickRelease = function(type, $event){
+      // Close other popovers if they're open
+      $(".release_popover").not($event.target).popover('destroy');
+
+      // Handle clicking on the gem icon
+      if ($event.target.nodeName == "SPAN") {
+        $scope.releasePopoverEl = $($event.target.parentNode);
+      } else {
+        $scope.releasePopoverEl = $($event.target);
+      }
+
+      var html = $compile(
+          '<a ng-controller="SettingsCtrl" ng-click="$close(); release(\'' + type + '\', true)">' + window.env.t('confirm') + '</a><br/>\n<a ng-click="release(\'' + type + '\', false)">' + window.env.t('cancel') + '</a><br/>'
+      )($scope);
+
+      $scope.releasePopoverEl.popover('destroy').popover({
+        html: true,
+        placement: 'top',
+        trigger: 'manual',
+        title: window.env.t('confirmPetKey'),
+        content: html
+      }).popover('show');
+    }
+
+    $scope.release = function(type, confirm) {
+      $scope.releasePopoverEl.popover('destroy');
+
+      if (confirm) {
+        switch (type) {
+          case "pets": $scope.releasePets();
+          case "mounts": $scope.releaseMounts();
+          case "both": $scope.releaseBoth();
+          default: return;
+        }
+      }
     }
 
     $scope.releasePets = function() {

--- a/website/public/js/controllers/settingsCtrl.js
+++ b/website/public/js/controllers/settingsCtrl.js
@@ -90,9 +90,29 @@ habitrpg.controller('SettingsCtrl',
 
     $scope.availableFormats = ['MM/dd/yyyy','dd/MM/yyyy', 'yyyy/MM/dd'];
 
-    $scope.reroll = function(){
-      User.user.ops.reroll({});
-      $rootScope.$state.go('tasks');
+    $scope.reroll = function(confirm){
+      $scope.popoverEl.popover('destroy')
+
+      if (confirm) {
+        User.user.ops.reroll({});
+        $rootScope.$state.go('tasks');
+      }
+    }
+
+    $scope.clickReroll = function($event){
+      $scope.popoverEl = $($event.target);
+
+      var html = $compile(
+          '<a ng-controller="SettingsCtrl" ng-click="$close(); reroll(true)">' + window.env.t('confirm') + '</a><br/>\n<a ng-click="reroll(false)">' + window.env.t('cancel') + '</a><br/>'
+      )($scope);
+
+      $scope.popoverEl.popover('destroy').popover({
+        html: true,
+        placement: 'top',
+        trigger: 'manual',
+        title: window.env.t('confirmFortify'),
+        content: html
+      }).popover('show');
     }
 
     $scope.rebirth = function(confirm){

--- a/website/views/shared/modals/drops.jade
+++ b/website/views/shared/modals/drops.jade
@@ -36,17 +36,17 @@ script(type='text/ng-template', id='modals/pet-key.html')
       a.btn.btn-success(ng-click='openModal("buyGems")')=env.t('buyMoreGems')
       span.gem-cost=env.t('notEnoughGems')
     span(ng-if='user.balance >= 1 && petCount >= 90', ng-controller='SettingsCtrl')
-      a.btn.btn-danger(ng-click='$close(); releasePets()')
+      a.btn.btn-danger.release_popover(ng-click='clickRelease("pets", $event)')
         =env.t('petKeyPets')
         | : 4&nbsp;
         span.Pet_Currency_Gem1x.inline-gems
     span(ng-if='user.balance >= 1 && mountCount >= 90', ng-controller='SettingsCtrl')
-      a.btn.btn-danger(ng-click='$close(); releaseMounts()')
+      a.btn.btn-danger.release_popover(ng-click='clickRelease("mounts", $event)')
         =env.t('petKeyMounts')
         | : 4&nbsp;
         span.Pet_Currency_Gem1x.inline-gems
     span(ng-if='(user.balance >= 1.5 || user.achievements.triadBingo) && petCount >= 90 && mountCount >= 90', ng-controller='SettingsCtrl')
-      a.btn.btn-danger(ng-click='$close(); releaseBoth()')
+      a.btn.btn-danger.release_popover(ng-click='clickRelease("both", $event)')
         =env.t('petKeyBoth')
         span(ng-if='!user.achievements.triadBingo')
           | : 6&nbsp;

--- a/website/views/shared/modals/rebirth.jade
+++ b/website/views/shared/modals/rebirth.jade
@@ -46,7 +46,7 @@ script(type='text/ng-template', id='modals/rebirth.html')
       a.btn.btn-success(ng-click='openModal("buyGems",{track:"Gems > Rebirth"})')=env.t('buyMoreGems')
       span.gem-cost=env.t('notEnoughGems')
     span(ng-if='user.balance >= 2 || user.stats.lvl >= 100', ng-controller='SettingsCtrl')
-      a.btn.btn-danger(ng-click='$close(); rebirth()')=env.t('beReborn')
+      a.btn.btn-danger(ng-click='clickRebirth($event)')=env.t('beReborn')
       span.gem-cost(ng-if='user.stats.lvl < 100')
         | 8&nbsp;
         =env.t('gems')

--- a/website/views/shared/modals/reroll.jade
+++ b/website/views/shared/modals/reroll.jade
@@ -12,7 +12,7 @@ script(type='text/ng-template', id='modals/reroll.html')
       a.btn.btn-success(ng-click='openModal("buyGems",{track:"Gems > Reroll"})')=env.t('buyMoreGems')
       span.gem-cost=env.t('notEnoughGems')
     span(ng-if='user.balance >= 1', ng-controller='SettingsCtrl')
-      a.btn.btn-danger(ng-click='$close(); reroll()')=env.t('fortify')
+      a.btn.btn-danger(ng-click='clickReroll($event)')=env.t('fortify')
       span.gem-cost
         | 4&nbsp;
         = env.t('gems')


### PR DESCRIPTION
Hi all,

This will be my first contribution :smile: I decided to take a shot at #4104 since it's marked as 'help needed' and it seems there's no progress. I've added confirmation popups for the actions (as it was discussed in [this PR](https://github.com/HabitRPG/habitrpg/pull/6100)).

I'm not sure if I should add some tests for this, as the SettingsCtrl is not heavily tested right now. Also, I'm not sure for the titles of the popovers ("Are you sure?") - made them like this for consistency, but if you think they should be more precise (e.g. "Release pets?", "Rebirth?", etc.) it's an easy change.

Also, the change in guildsCtrl is just formatting - while reading it I was annoyed that the indentation was not okay and decided to leave it in. 

Cheers,
George

Here are some screenshots:
<img width="602" alt="rebirth" src="https://cloud.githubusercontent.com/assets/2514425/11851120/a31f94ac-a439-11e5-89d7-de6c9a688f93.png">
<img width="910" alt="release" src="https://cloud.githubusercontent.com/assets/2514425/11851121/a5df3cb0-a439-11e5-81ea-f015fd0219c7.png">
<img width="602" alt="fortify" src="https://cloud.githubusercontent.com/assets/2514425/11851123/a730479e-a439-11e5-9fe6-8712b42b577e.png">
