### PR TITLE
Fix npm install error - Phantomjs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "event-stream": "^3.2.2",
     "expect.js": "~0.2.0",
     "istanbul": "^0.3.14",
+    "phantomjs": "^1.9",
     "karma": "~0.13.15",
     "karma-chai-plugins": "~0.6.0",
     "karma-coverage": "^0.5.3",


### PR DESCRIPTION
Like suggested by @Alys into issue #5801, was added the dependency `phantomjs` on `package.json` file. This problems happens in latest versions of **Karma** and **Node.js**

My User ID in habitica service is: _fa87aaf3-076e-4084-8f58-8cfa80422bb8_
