### PR TITLE
Fix e2e test in vagrant environment

### DIFF
--- a/vagrant.sh
+++ b/vagrant.sh
@@ -26,6 +26,8 @@ function autostart_habitrpg {
 # Main provisioning
 echo Setting up Habitica...
 echo cd /vagrant >> /home/vagrant/.bashrc
+# Needed for running e2e tests
+echo export DISPLAY=:99 >> /home/vagrant/.bashrc
 
 # Prevent warnings: "dpkg-preconfigure: unable to re-open stdin ..."
 export DEBIAN_FRONTEND=noninteractive
@@ -70,6 +72,15 @@ echo Installing node.js
 apt-get install -qq nodejs
 echo Updating npm...
 npm install -g npm
+echo Installing Xvfb...
+apt-get install -qq xvfb
+echo Installing Java7...
+apt-get install -qq openjdk-7-jre 
+echo Downloading Firefox...
+wget http://sourceforge.net/projects/ubuntuzilla/files/mozilla/apt/pool/main/f/firefox-mozilla-build/firefox-mozilla-build_40.0.3-0ubuntu1_amd64.deb/download -O firefox.deb >/dev/null 2>&1
+echo Installing Firefox...
+dpkg -i firefox.deb
+rm firefox.deb
 
 cd /vagrant
 


### PR DESCRIPTION
I saw a comment of @crookedneighbor mentioning that e2e tests don't work in a vagrant environment. I've been investigating why it crashes/hangs. I have found several issues causing it:
1. The xvfb package is not installed and it's part of the e2e test suite preparations
2. Protractor raises a selenium server which needs Java 7. We didn't have it installed before.
3. We don't have Firefox installed for the e2e tests and not all versions play nice with the selenium server. I managed to find that Firefox 40 is one of the newer versions that work. Since you can't apt-get a previous release we need to wget it and install it via dpkg.
4. Part of the e2e preparations are to set the DISPLAY environment variable, but they don't seem to propagate to the selenium server. I checked how the travis CI build passed despite this problem and it seems it exports it in a before script. So I added it to the .bashrc file. A better way would be to fix the test to set the DISPLAY variable properly, but I can't seem to find a way and setting the DISPLAY variable for a vagrant ssh'ed environment without a display is not a bad solution. I'm open to ideas.

The proposed fix installs all the needed dependencies and environment variables for the test to work.
