### PR TITLE
Fix for issue #5182: Allow cancel editing group infobox

### DIFF
--- a/test/spec/controllers/groupCtrlSpec.js
+++ b/test/spec/controllers/groupCtrlSpec.js
@@ -24,7 +24,6 @@ describe('Groups Controller', function() {
   });
 
   describe("Group Membership Behavior", function() {
-
     var party, guild;
 
     beforeEach(function() {
@@ -80,18 +79,15 @@ describe('Groups Controller', function() {
      *
      * This coercion business is troublesome...
      */
-    /*
-    describe("isMember behavior", function() { 
+    describe.skip("isMember behavior", function() { 
       it("should return true dependent on whether the user id belongs to the group", function() {
         expect(scope.isMember(user, guild)).to.eql(truthy);
         expect(scope.isMember(user, party)).to.eql(falsy);
       });
     });
-    */
   });
 
-  describe("Quest Membership Behavior", function() { 
-
+  describe("isMemberOfPendingQuest/isMemberOfRunningQuest", function() { 
     var runningQuestParty, pendingQuestParty;
 
     beforeEach(function() {
@@ -146,9 +142,7 @@ describe('Groups Controller', function() {
     });
   });
    
-
-  describe("Group Edit Behavior", function() {
-
+  describe("editGroup", function() {
     var guild, editGuild;
 
     beforeEach(function() {
@@ -160,8 +154,7 @@ describe('Groups Controller', function() {
       });
 
       // verify initial state, 
-      var editGuild = scope.groupCopy;
-      expect(editGuild).to.eql({});
+      expect(scope.groupCopy).to.eql({});
       expect(guild._editing).to.eql(undefined);
     });
 
@@ -169,22 +162,20 @@ describe('Groups Controller', function() {
     it('should allow for editing without changing group resource', function() {
       // switch to edit mode
       scope.editGroup(guild);
-      var editGuild = scope.groupCopy;
       expect(guild._editing).to.eql(true);
 
       // all values should be identical in edit copy
-      for(var key in editGuild) {
-        expect(editGuild[key]).to.eql(guild[key]);
+      for(var key in scope.groupCopy) {
+        expect(scope.groupCopy[key]).to.eql(guild[key]);
       }
 
       // change value and verify original is untouched
-      editGuild.leader = 'testLeader';
-      expect(editGuild.leader).to.not.eql(guild.leader);
+      scope.groupCopy.leader = 'testLeader';
+      expect(scope.groupCopy.leader).to.not.eql(guild.leader);
 
       // stop editing and verify copy is removed
       scope.cancelEdit(guild);
-      editGuild = scope.groupCopy;
-      expect(editGuild).to.eql({});
+      expect(scope.groupCopy).to.eql({});
       expect(guild._editing).to.eql(false);
 
     });
@@ -194,36 +185,40 @@ describe('Groups Controller', function() {
 
       // switch to edit mode
       scope.editGroup(guild);
-      var editGuild = scope.groupCopy;
       expect(guild._editing).to.eql(true);
 
+      var testName = 'testName';
+      var testLogo = 'testLogo';
+      var testNewLeader = 'testNewLeader';
+      var testDescription = 'testDesc';
+
       // get copy for editing
-      editGuild.name= 'testName';
-      editGuild.logo = 'testLogo';
-      editGuild.description = 'testDesc';
-      editGuild._newLeader= 'testNewLeader';
+      scope.groupCopy.name = testName;
+      scope.groupCopy.logo = testLogo;
+      scope.groupCopy._newLeader = testNewLeader;
+      scope.groupCopy.description = testDescription;
 
 
-      expect(guild.name).to.not.eql(editGuild.name);
-      expect(guild.logo).to.not.eql(editGuild.logo);
-      expect(guild.description).to.not.eql(editGuild.description);
-      expect(guild._newLeader).to.not.eql(editGuild._newLeader);
+      expect(guild.name).to.not.eql(testName);
+      expect(guild.logo).to.not.eql(testLogo);
+      expect(guild._newLeader).to.not.eql(testNewLeader);
+      expect(guild.description).to.not.eql(testDescription);
 
       scope.saveEdit(guild);
-      expect(guild.name).to.eql(editGuild.name);
-      expect(guild.logo).to.eql(editGuild.logo);
-      expect(guild.description).to.eql(editGuild.description);
-      expect(guild._newLeader).to.eql(editGuild._newLeader);
+      expect(guild.name).to.eql(testName);
+      expect(guild.logo).to.eql(testLogo);
+      expect(guild._newLeader).to.eql(testNewLeader);
+      expect(guild.description).to.eql(testDescription);
       expect(guildSave).to.be.calledOnce;
 
     });
   });
-  /* TODO: Modal testing
-  describe("deleteAllMessages", function() { });
-  describe("clickMember", function() { });
-  describe("removeMember", function() { });
-  describe("confirmRemoveMember", function() { });
-  describe("openInviteModal", function() { });
-  describe("quickReply", function() { });
-  */
+
+  /* TODO: Modal testing */
+  describe.skip("deleteAllMessages", function() { });
+  describe.skip("clickMember", function() { });
+  describe.skip("removeMember", function() { });
+  describe.skip("confirmRemoveMember", function() { });
+  describe.skip("openInviteModal", function() { });
+  describe.skip("quickReply", function() { });
 });

--- a/test/spec/controllers/groupCtrlSpec.js
+++ b/test/spec/controllers/groupCtrlSpec.js
@@ -70,4 +70,81 @@ describe('Groups Controller', function() {
       expect(myGuilds).to.be.calledOnce;
     });
   });
+
+  describe("Group Edit Behavior", function() {
+    it('should allow for editing without changing group resource', function() {
+      var guild = specHelper.newGroup({
+        _id: "unique-guild-id",
+        type: 'guild',
+        members: ['not-user-id']
+      });
+
+
+      // verify initial state, 
+      // TODO: Check how to do this once per test in this "describe"
+      var editGuild = scope.groupCopy;
+      expect(editGuild).to.eql({});
+      expect(guild._editing).to.eql(undefined);
+
+      // switch to edit mode
+      scope.editGroup(guild);
+      var editGuild = scope.groupCopy;
+      expect(guild._editing).to.eql(true);
+
+      // all values should be identical in edit copy
+      for(var key in editGuild) {
+        expect(editGuild[key]).to.eql(guild[key]);
+      }
+
+      // change value and verify original is untouched
+      editGuild.leader = 'testLeader';
+      expect(editGuild.leader).to.not.eql(guild.leader);
+
+      // stop editing and verify copy is removed
+      scope.cancelEdit(guild);
+      editGuild = scope.groupCopy;
+      expect(editGuild).to.eql({});
+      expect(guild._editing).to.eql(false);
+
+    });
+
+    it('should update group resource only on save', function() {
+      var guild = specHelper.newGroup({
+        _id: "unique-guild-id",
+        type: 'guild',
+        members: ['not-user-id']
+      });
+
+      guild.$save = function() { };
+
+      // verify initial state
+      var editGuild = scope.groupCopy;
+      expect(editGuild).to.eql({});
+      expect(guild._editing).to.eql(undefined);
+
+      // switch to edit mode
+      scope.editGroup(guild);
+      var editGuild = scope.groupCopy;
+      expect(guild._editing).to.eql(true);
+
+      // get copy for editing
+      editGuild.name= 'testName';
+      editGuild.logo = 'testLogo';
+      editGuild.description = 'testDesc';
+      editGuild._newLeader= 'testNewLeader';
+
+
+      expect(guild.name).to.not.eql(editGuild.name);
+      expect(guild.logo).to.not.eql(editGuild.logo);
+      expect(guild.description).to.not.eql(editGuild.description);
+      expect(guild._newLeader).to.not.eql(editGuild._newLeader);
+
+      scope.saveEdit(guild);
+      expect(guild.name).to.eql(editGuild.name);
+      expect(guild.logo).to.eql(editGuild.logo);
+      expect(guild.description).to.eql(editGuild.description);
+      expect(guild._newLeader).to.eql(editGuild._newLeader);
+
+    });
+  });
 });

--- a/website/public/js/controllers/groupsCtrl.js
+++ b/website/public/js/controllers/groupsCtrl.js
@@ -42,19 +42,6 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '
     $scope._editing = {group:false};
     $scope.groupCopy= {};
 
-    /**
-    $scope.save = function(group){
-      if(group._newLeader && group._newLeader._id) group.leader = group._newLeader._id;
-      group.$save();
-      group._editing = false;
-    };
-
-    $scope.cancelSave = function(group) {
-      group = group.$get();
-      group._editing = false;
-    }
-    */
-
     $scope.editGroup = function(group) {
       angular.copy(group, $scope.groupCopy);
       group._editing = true;
@@ -65,7 +52,6 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '
       if(group._newLeader && group._newLeader._id) group.leader = group._newLeader._id;
       angular.copy($scope.groupCopy, group);
       group.$save();
-      group._editing = false;
       $scope.cancelEdit(group);
     }
 

--- a/website/public/js/controllers/groupsCtrl.js
+++ b/website/public/js/controllers/groupsCtrl.js
@@ -12,7 +12,7 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '
     $scope.isMemberOfRunningQuest = function(userid, group) {
       if (!group.quest || !group.quest.members) return false;
       if (!group.quest.active) return false; // quest is pending, not started
-      return group.quest.members[userid];
+      return userid in group.quest.members && group.quest.members[userid] != false;
     };
 
     $scope.isMemberOfGroup = function(userid, group){

--- a/website/public/js/controllers/groupsCtrl.js
+++ b/website/public/js/controllers/groupsCtrl.js
@@ -47,6 +47,11 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '
       group._editing = false;
     };
 
+    $scope.cancelSave = function(group) {
+      group = group.$get();
+      group._editing = false;
+    }
+
     $scope.deleteAllMessages = function() {
       if (confirm(window.env.t('confirmDeleteAllMessages'))) {
         User.user.ops.clearPMs({});

--- a/website/public/js/controllers/groupsCtrl.js
+++ b/website/public/js/controllers/groupsCtrl.js
@@ -49,7 +49,7 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '
 
 
     $scope.saveEdit = function(group) {
-      if(group._newLeader && group._newLeader._id) group.leader = group._newLeader._id;
+      if($scope.groupCopy._newLeader && $scope.groupCopy._newLeader._id) $scope.groupCopy.leader = $scope.groupCopy._newLeader._id;
       angular.copy($scope.groupCopy, group);
       group.$save();
       $scope.cancelEdit(group);

--- a/website/public/js/controllers/groupsCtrl.js
+++ b/website/public/js/controllers/groupsCtrl.js
@@ -40,7 +40,9 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '
 
     $scope.Members = Members;
     $scope._editing = {group:false};
+    $scope.groupCopy= {};
 
+    /**
     $scope.save = function(group){
       if(group._newLeader && group._newLeader._id) group.leader = group._newLeader._id;
       group.$save();
@@ -50,6 +52,26 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '
     $scope.cancelSave = function(group) {
       group = group.$get();
       group._editing = false;
+    }
+    */
+
+    $scope.editGroup = function(group) {
+      angular.copy(group, $scope.groupCopy);
+      group._editing = true;
+    }
+
+
+    $scope.saveEdit = function(group) {
+      if(group._newLeader && group._newLeader._id) group.leader = group._newLeader._id;
+      angular.copy($scope.groupCopy, group);
+      group.$save();
+      group._editing = false;
+      $scope.cancelEdit(group);
+    }
+
+    $scope.cancelEdit = function(group) {
+      group._editing = false;
+      $scope.groupCopy = {};
     }
 
     $scope.deleteAllMessages = function() {

--- a/website/views/options/social/group.jade
+++ b/website/views/options/social/group.jade
@@ -23,30 +23,30 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
                 =env.t('leave')
               a.btn.btn-success.pull-right(ng-if=':: !isMemberOfGroup(User.user._id, group)', ng-click='join(group)')=env.t('join')
             span(ng-if='group.leader._id == user.id')
-              button.btn.btn-sm.btn-primary.pull-right(ng-click='cancelSave(group)', ng-hide='!group._editing')=env.t('cancel')
-              button.btn.btn-sm.btn-primary.pull-right(ng-click='save(group)', ng-show='group._editing')=env.t('save')
-              button.btn.btn-sm.btn-default.pull-right(ng-click='group._editing = true', ng-hide='group._editing')=env.t('editGroup')
+              button.btn.btn-sm.btn-primary.pull-right(ng-click='cancelEdit(group)', ng-hide='!group._editing')=env.t('cancel')
+              button.btn.btn-sm.btn-primary.pull-right(ng-click='saveEdit(group)', ng-show='group._editing')=env.t('save')
+              button.btn.btn-sm.btn-default.pull-right(ng-click='editGroup(group)', ng-hide='group._editing')=env.t('editGroup')
 
         .panel-body
           form(ng-show='group._editing')
             .form-group
               label=env.t('groupName')
-              input.form-control(type='text', ng-model='group.name', placeholder=env.t('groupName'))
+              input.form-control(type='text', ng-model='groupCopy.name', placeholder=env.t('groupName'))
             .form-group
               label=env.t('description')
-              textarea.form-control(rows=6, ng-model='group.description')
+              textarea.form-control(rows=6, ng-model='groupCopy.description')
               include ../../shared/formatting-help
             .form-group
               label=env.t('logoUrl')
-              input.form-control(type='url', placeholder=env.t('logoUrl'), ng-model='group.logo')
+              input.form-control(type='url', placeholder=env.t('logoUrl'), ng-model='groupCopy.logo')
             .form-group
               .checkbox
                 label
-                  input(type='checkbox', ng-model='group.leaderOnly.challenges')
+                  input(type='checkbox', ng-model='groupCopy.leaderOnly.challenges')
                   =env.t('leaderOnlyChallenges')
 
             h4=env.t('assignLeader')
-            select#group-leader-selection(ng-model='group._newLeader', ng-options='member.profile.name for member in group.members')
+            select#group-leader-selection(ng-model='groupCopy._newLeader', ng-options='member.profile.name for member in group.members')
 
           div(ng-show='!group._editing')
             img.img-rendering-auto.pull-right(ng-show='group.logo', ng-src='{{group.logo}}')

--- a/website/views/options/social/group.jade
+++ b/website/views/options/social/group.jade
@@ -18,11 +18,12 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
           h3.panel-title
             span {{group.name}}
             span.group-leave-join(ng-if='group')
-              a.btn.btn-sm.btn-danger.pull-right(ng-if=":: isMemberOfGroup(User.user._id, group)", ng-click='clickLeave(group, $event)')
+              a.btn.btn-sm.btn-danger.pull-right(ng-if=":: isMemberOfGroup(User.user._id, group)", ng-hide='group._editing', ng-click='clickLeave(group, $event)')
                 span.glyphicon.glyphicon-ban-circle
                 =env.t('leave')
               a.btn.btn-success.pull-right(ng-if=':: !isMemberOfGroup(User.user._id, group)', ng-click='join(group)')=env.t('join')
             span(ng-if='group.leader._id == user.id')
+              button.btn.btn-sm.btn-primary.pull-right(ng-click='cancelSave(group)', ng-hide='!group._editing')=env.t('cancel')
               button.btn.btn-sm.btn-primary.pull-right(ng-click='save(group)', ng-show='group._editing')=env.t('save')
               button.btn.btn-sm.btn-default.pull-right(ng-click='group._editing = true', ng-hide='group._editing')=env.t('editGroup')
 


### PR DESCRIPTION
Added cancel button that is available only when editing a group, which reverts changes from the server when clicked.  Also hides the "leave" button when in "Edit Mode"
