### PR TITLE
add extra text to flagging confirmation dialog and to top of PM inbox -- Fix for issue #4648, parts 3 and 4

### DIFF
--- a/common/locales/en/contrib.json
+++ b/common/locales/en/contrib.json
@@ -56,7 +56,7 @@
     "surveysMultiple": "Helped Habitica grow by filling out <%= surveys %> surveys. There are no active surveys.",
     "currentSurvey": "Current Survey",
     "surveyWhen": "The badge will be awarded to all participants when surveys have been processed, in late March.",
-    "blurbInbox": "This is where your private messages are stored! You can send someone a message by clicking on the envelope icon next to their name in Tavern, Party, or Guild Chat.",
+    "blurbInbox": "This is where your private messages are stored! You can send someone a message by clicking on the envelope icon next to their name in Tavern, Party, or Guild Chat. If you've received an inappropriate PM, you should email a screenshot of it to Lemoness (<a href=\"mailto:leslie@habitica.com\">leslie@habitica.com</a>)",
     "blurbGuildsPage": "Guilds are common-interest chat groups created by the players, for players. Browse through the list and join the Guilds that interest you!",
     "blurbChallenges": "Challenges are created by your fellow players. Joining a Challenge will add its tasks to your task dashboard, and winning a Challenge will give you an achievement and often a gem prize!",
     "blurbHallPatrons": "This is the Hall of Patrons, where we honor the noble adventurers who backed Habitica's original Kickstarter. We thank them for helping us bring Habitica to life!",

--- a/common/locales/en/groups.json
+++ b/common/locales/en/groups.json
@@ -101,7 +101,7 @@
     "inbox": "Inbox",
     "abuseFlag": "Report violation of Community Guidelines",
     "abuseFlagModalHeading": "Report <%= name %> for violation?",
-    "abuseFlagModalBody": "Are you sure you want to report this post? You should ONLY report a post that violates the <%= firstLinkStart %>Community Guidelines<%= linkEnd %> and/or <%= secondLinkStart %>Terms of Service<%= linkEnd %>. Inappropriately reporting a post is a violation of the Community Guidelines and may give you an infraction.",
+    "abuseFlagModalBody": "Are you sure you want to report this post? You should ONLY report a post that violates the <%= firstLinkStart %>Community Guidelines<%= linkEnd %> and/or <%= secondLinkStart %>Terms of Service<%= linkEnd %>. Inappropriately reporting a post is a violation of the Community Guidelines and may give you an infraction. Appropriate reasons to flag a post include but are not limited to: <p></p></br><ul style='margin-left: 10px;'><li>swearing, religous oaths</li><li>bigotry, slurs</li><li>adult topics</li><li>violence, including as a joke</li><li>spam, nonsensical messages</li></ul>",
     "abuseFlagModalButton": "Report Violation",
     "abuseReported": "Thank you for reporting this violation. The moderators have been notified.",
     "abuseAlreadyReported": "You have already reported this message.",

--- a/website/views/options/social/index.jade
+++ b/website/views/options/social/index.jade
@@ -9,7 +9,7 @@ include ./party
 
 script(type='text/ng-template', id='partials/options.social.inbox.html')
   .options-blurbmenu
-    small.muted=env.t('blurbInbox')
+    small.muted!=env.t('blurbInbox')
 
   .container-fluid
     .row


### PR DESCRIPTION
This addresses parts 3 and 4 of issue #4648. It's just a couple changes in the English translation files to clarify some things about when it is appropriate to flag a message or post.
