### PR TITLE
Screen reader labels

### DIFF
--- a/website/views/options/inventory/drops.jade
+++ b/website/views/options/inventory/drops.jade
@@ -9,12 +9,10 @@
           menu.pets-menu(label=(env.t('eggs') + ' ({{eggCount}})'))
             p.muted(ng-show='eggCount < 1')=env.t('noEggs')
             div(ng-repeat='(egg,points) in ownedItems(user.items.eggs)')
-              - var title = env.t("egg", {eggType: "{{::Content.eggs[egg].text()}}"})
               button.customize-option(class='Pet_Egg_{{::egg}}',
                 ng-class='{selectableInventory: selectedPotion && !(user.items.pets[egg+"-"+selectedPotion.key]>0) && (Content.dropEggs[egg] || !selectedPotion.premium)}',
                 popover='{{::Content.eggs[egg].notes()}}', popover-append-to-body='true',
-                popover-title=title,
-                aria-label=title,
+                popover-title!=env.t("egg", {eggType: "{{::Content.eggs[egg].text()}}"}),
                 popover-trigger='mouseenter', popover-placement='right',
                 ng-click='chooseEgg(egg)')
                 .badge.badge-info.stack-count {{points}}
@@ -23,12 +21,10 @@
           menu.pets-menu(label=(env.t('hatchingPotions') + ' ({{potCount}})'))
             p.muted(ng-show='potCount < 1')=env.t('noHatchingPotions')
             div(ng-repeat='(pot,points) in ownedItems(user.items.hatchingPotions)')
-              - var title = env.t("potion", {potionType: "{{::Content.hatchingPotions[pot].text()}}"})
               button.customize-option(class='Pet_HatchingPotion_{{::pot}}',
                 ng-class='{selectableInventory: selectedEgg && !(user.items.pets[selectedEgg.key+"-"+pot]>0) && (Content.dropEggs[selectedEgg.key] || !Content.hatchingPotions[pot].premium)}',
                 popover='{{::Content.hatchingPotions[pot].notes()}} {{::Content.hatchingPotions[pot].addlNotes()}}',
-                popover-title=title,
-                aria-label=title,
+                popover-title!=env.t("potion", {potionType: "{{::Content.hatchingPotions[pot].text()}}"}),
                 popover-trigger='mouseenter', popover-placement='right',
                 popover-append-to-body='true',
                 ng-click='choosePotion(pot)')
@@ -44,7 +40,9 @@
             div(ng-repeat='(food,points) in ownedItems(user.items.food)')
               - var title = '{{::Content.food[food].text()}}'
               button.customize-option(class='Pet_Food_{{::food}}',
-                popover='{{::Content.food[food].notes()}}', popover-title=title,
+                popover='{{::Content.food[food].notes()}}', 
+                popover-title=title,
+                aria-label = title,
                 popover-trigger='mouseenter', popover-placement='right',
                 popover-append-to-body='true',
                 ng-click='chooseFood(food)')

--- a/website/views/options/inventory/drops.jade
+++ b/website/views/options/inventory/drops.jade
@@ -9,10 +9,12 @@
           menu.pets-menu(label=(env.t('eggs') + ' ({{eggCount}})'))
             p.muted(ng-show='eggCount < 1')=env.t('noEggs')
             div(ng-repeat='(egg,points) in ownedItems(user.items.eggs)')
+              - var title = env.t("egg", {eggType: "{{::Content.eggs[egg].text()}}"})
               button.customize-option(class='Pet_Egg_{{::egg}}',
                 ng-class='{selectableInventory: selectedPotion && !(user.items.pets[egg+"-"+selectedPotion.key]>0) && (Content.dropEggs[egg] || !selectedPotion.premium)}',
                 popover='{{::Content.eggs[egg].notes()}}', popover-append-to-body='true',
-                popover-title!=env.t("egg", {eggType: "{{::Content.eggs[egg].text()}}"}),
+                popover-title=title,
+                aria-label=title,
                 popover-trigger='mouseenter', popover-placement='right',
                 ng-click='chooseEgg(egg)')
                 .badge.badge-info.stack-count {{points}}
@@ -21,10 +23,12 @@
           menu.pets-menu(label=(env.t('hatchingPotions') + ' ({{potCount}})'))
             p.muted(ng-show='potCount < 1')=env.t('noHatchingPotions')
             div(ng-repeat='(pot,points) in ownedItems(user.items.hatchingPotions)')
+              - var title = env.t("potion", {potionType: "{{::Content.hatchingPotions[pot].text()}}"})
               button.customize-option(class='Pet_HatchingPotion_{{::pot}}',
                 ng-class='{selectableInventory: selectedEgg && !(user.items.pets[selectedEgg.key+"-"+pot]>0) && (Content.dropEggs[selectedEgg.key] || !Content.hatchingPotions[pot].premium)}',
                 popover='{{::Content.hatchingPotions[pot].notes()}} {{::Content.hatchingPotions[pot].addlNotes()}}',
-                popover-title!=env.t("potion", {potionType: "{{::Content.hatchingPotions[pot].text()}}"}),
+                popover-title=title,
+                aria-label=title,
                 popover-trigger='mouseenter', popover-placement='right',
                 popover-append-to-body='true',
                 ng-click='choosePotion(pot)')
@@ -38,8 +42,10 @@
           menu.pets-menu(label=env.t('food') + ' ({{foodCount}})')
             p.muted(ng-show='foodCount < 1')=env.t('noFood')
             div(ng-repeat='(food,points) in ownedItems(user.items.food)')
+              - var title = '{{::Content.food[food].text()}}'
               button.customize-option(class='Pet_Food_{{::food}}',
-                popover='{{::Content.food[food].notes()}}', popover-title='{{::Content.food[food].text()}}',
+                aria-label = title,
+                popover='{{::Content.food[food].notes()}}', popover-title=title,
                 popover-trigger='mouseenter', popover-placement='right',
                 popover-append-to-body='true',
                 ng-click='chooseFood(food)')
@@ -52,6 +58,7 @@
                 button.customize-option(class='inventory_special_#{k}',
                   popover='{{::Content.special.#{k}.notes()}}',
                   popover-title='{{::Content.special.#{k}.text()}}',
+                  aria-label='{{::Content.special.#{k}.text()}}',
                   popover-trigger='mouseenter', popover-placement='right',
                   popover-append-to-body='true',
                   ng-click='castStart(Content.special.#{k})')

--- a/website/views/options/inventory/drops.jade
+++ b/website/views/options/inventory/drops.jade
@@ -9,10 +9,11 @@
           menu.pets-menu(label=(env.t('eggs') + ' ({{eggCount}})'))
             p.muted(ng-show='eggCount < 1')=env.t('noEggs')
             div(ng-repeat='(egg,points) in ownedItems(user.items.eggs)')
+              - var title = env.t("egg", {eggType: "{{::Content.eggs[egg].text()}}"})
               button.customize-option(class='Pet_Egg_{{::egg}}',
                 ng-class='{selectableInventory: selectedPotion && !(user.items.pets[egg+"-"+selectedPotion.key]>0) && (Content.dropEggs[egg] || !selectedPotion.premium)}',
                 popover='{{::Content.eggs[egg].notes()}}', popover-append-to-body='true',
-                popover-title!=env.t("egg", {eggType: "{{::Content.eggs[egg].text()}}"}),
+                popover-title = title, aria-label = title,
                 popover-trigger='mouseenter', popover-placement='right',
                 ng-click='chooseEgg(egg)')
                 .badge.badge-info.stack-count {{points}}
@@ -41,8 +42,7 @@
               - var title = '{{::Content.food[food].text()}}'
               button.customize-option(class='Pet_Food_{{::food}}',
                 popover='{{::Content.food[food].notes()}}', 
-                popover-title=title,
-                aria-label = title,
+                popover-title=title, aria-label = title,
                 popover-trigger='mouseenter', popover-placement='right',
                 popover-append-to-body='true',
                 ng-click='chooseFood(food)')
@@ -118,9 +118,10 @@
             p.muted!=env.t('dropsExplanation')
 
             div(ng-repeat='egg in Content.eggs', ng-if='egg.canBuy(user)')
+              - var title = env.t("egg", {eggType: "{{::egg.text()}}"})
               button.customize-option(class='Pet_Egg_{{::egg.key}}',
                 popover='{{::egg.notes()}}', popover-append-to-body='true',
-                popover-title!=env.t("egg", {eggType: "{{::egg.text()}}"}),
+                popover-title = title, aria-label = title,
                 popover-trigger='mouseenter', popover-placement='top',
                 ng-click='purchase("eggs", egg)')
               p {{::egg.value}}&nbsp;
@@ -130,9 +131,10 @@
           menu.pets-menu(label=env.t('hatchingPotions'))
             p.muted!=env.t('dropsExplanation')
             div(ng-repeat='pot in Content.hatchingPotions', ng-if='!pot.premium')
+              - var title = env.t("potion", {potionType: "{{::pot.text()}}"})
               button.customize-option(class='Pet_HatchingPotion_{{::pot.key}}',
                 popover='{{::pot.notes()}}', popover-append-to-body='true',
-                popover-title!=env.t("potion", {potionType: "{{::pot.text()}}"}),
+                popover-title = title, aria-label = title,
                 popover-trigger='mouseenter', popover-placement='top',
                 ng-click='purchase("hatchingPotions", pot)')
               p
@@ -143,9 +145,10 @@
           menu.pets-menu!=env.t('magicHatchingPotions') + " - " + env.t('winterEventAvailability')
             p.muted=env.t('premiumPotionNoDropExplanation')
             div(ng-repeat='pot in Content.hatchingPotions', ng-if='pot.premium && pot.canBuy(user)')
+              - var title = env.t("potion", {potionType: "{{::pot.text()}}"})
               button.customize-option(class='Pet_HatchingPotion_{{::pot.key}}',
                 popover='{{::pot.notes()}} {{::pot.addlNotes()}}', popover-append-to-body='true',
-                popover-title!=env.t("potion", {potionType: "{{::pot.text()}}"}),
+                popover-title = title, aria-label = title,
                 popover-trigger='mouseenter', popover-placement='top',
                 ng-click='purchase("hatchingPotions", pot)')
               p
@@ -157,7 +160,9 @@
             p.muted!=env.t('dropsExplanation')
             div(ng-repeat='food in Content.food', ng-if='food.canBuy(user)')
               button.customize-option(class='Pet_Food_{{::food.key}}',
-                popover='{{::food.notes()}}', popover-title='{{::food.text()}}',
+                popover='{{::food.notes()}}', 
+                popover-title!='{{::food.text()}}',
+                aria-label!='{{::food.text()}}',
                 popover-trigger='mouseenter', popover-placement='top',
                 popover-append-to-body='true',
                 ng-click='purchase("food", food)')
@@ -175,6 +180,7 @@
               button.customize-option(class='inventory_special_fortify',
                 popover=env.t('fortifyPop'),
                 popover-title=env.t('fortifyName'),
+                aria-label=env.t('fortifyName'),
                 popover-trigger='mouseenter', popover-placement='top',
                 popover-append-to-body='true',
                 ng-click='openModal("reroll")')
@@ -209,9 +215,10 @@
                 | 20&nbsp;
                 span.shop_gold
             div(ng-repeat='type in Content.cardTypes', ng-show='type.yearRound')
+              - var title = '{{::Content.spells.special[type.key].text()}}'
               button.customize-option(class='inventory_special_{{::type.key}}',
               popover='{{::Content.spells.special[type.key].notes()}}',
-              popover-title='{{::Content.spells.special[type.key].text()}}',
+              popover-title=title, aria-label=title,
               popover-trigger='mouseenter', popover-placement='right',
               popover-append-to-body='true',
               ng-click='castStart(Content.spells.special[type.key])')

--- a/website/views/options/inventory/drops.jade
+++ b/website/views/options/inventory/drops.jade
@@ -44,7 +44,6 @@
             div(ng-repeat='(food,points) in ownedItems(user.items.food)')
               - var title = '{{::Content.food[food].text()}}'
               button.customize-option(class='Pet_Food_{{::food}}',
-                aria-label = title,
                 popover='{{::Content.food[food].notes()}}', popover-title=title,
                 popover-trigger='mouseenter', popover-placement='right',
                 popover-append-to-body='true',
@@ -58,7 +57,6 @@
                 button.customize-option(class='inventory_special_#{k}',
                   popover='{{::Content.special.#{k}.notes()}}',
                   popover-title='{{::Content.special.#{k}.text()}}',
-                  aria-label='{{::Content.special.#{k}.text()}}',
                   popover-trigger='mouseenter', popover-placement='right',
                   popover-append-to-body='true',
                   ng-click='castStart(Content.special.#{k})')

--- a/website/views/options/inventory/equipment.jade
+++ b/website/views/options/inventory/equipment.jade
@@ -20,7 +20,6 @@
           ng-repeat='(klass,label) in {warrior:env.t("warrior"), wizard:env.t("mage"), rogue:env.t("rogue"), healer:env.t("healer"), special:env.t("special"), mystery:env.t("mystery"), armoire:env.t("armoireText")}')
           div(ng-repeat='item in gear[klass]')
             button.customize-option(, class='shop_{{::item.key}}',
-              aria-label='{{::item.text()}}',
               ng-class='{selectableInventory: user.items.gear.equipped[item.type] == item.key}',
               ng-click='equip(item.key, "equipped")',
               popover='{{::item.notes()}}', popover-title='{{::item.text()}}',
@@ -57,5 +56,6 @@
               ng-class='{selectableInventory: user.items.gear.costume[item.type] == item.key}',
               ng-click='equip(item.key, "costume")',
               popover='{{::item.notes()}}', popover-title='{{::item.text()}}',
+              aria-label='{{::item.text()}}',
               popover-trigger='mouseenter', popover-placement='right',
               popover-append-to-body='true')

--- a/website/views/options/inventory/equipment.jade
+++ b/website/views/options/inventory/equipment.jade
@@ -20,6 +20,7 @@
           ng-repeat='(klass,label) in {warrior:env.t("warrior"), wizard:env.t("mage"), rogue:env.t("rogue"), healer:env.t("healer"), special:env.t("special"), mystery:env.t("mystery"), armoire:env.t("armoireText")}')
           div(ng-repeat='item in gear[klass]')
             button.customize-option(, class='shop_{{::item.key}}',
+              aria-label='{{::item.text()}}',
               ng-class='{selectableInventory: user.items.gear.equipped[item.type] == item.key}',
               ng-click='equip(item.key, "equipped")',
               popover='{{::item.notes()}}', popover-title='{{::item.text()}}',


### PR DESCRIPTION
# what

Add a bunch of Aria-labels to various shop and equipment items
# why

User mentions that much of the site is unlabeled for screen-readers [on a Trello card mainly concerned with the chat ordering](https://trello.com/c/pxTcbKuD/381-accessibility-settings) and sure enough when using a screen readers several areas are impossible to navigate.

If your curious about how widely aria-label works as an option for screen-readers, check out [this handy article](https://www.nczonline.net/blog/2013/04/01/making-accessible-icon-buttons/) that does some testing with multiple browsers.
# known issues

In all cases the label is drawn from the popup title, and in a couple of instances there might be a more useful string to add as the label. Right now for example it doesn't read how many of an item you have, and I don't think the badge number will be picked up by any screen readers. When I tried grabbing the badge values... everything broke so I rolled that back.
# test

0)  turn on a screen-reading program (on OSX you can do this with CMD+f5) and see that there are no labels on many equipment and inventory items, they just say things like 'potion button' and 'equipment button'
1) switch to branch
2) go to the two pages I modified http://localhost:3000/#/options/inventory/drops and http://localhost:3000/#/options/inventory/equipment and see that nothing is messed up on these pages for a sighted user
3)  turn on a screen-reading program (on OSX you can do this with CMD+f5) and see those same things have labels!
3a) if you aren't familiar with screen readers (it took me some time to get in control of the Apple version), just inspect the buttons and see they now have reasonable 'aria-label's attached.
