### PR TITLE
Fix GET chat tests stopping execution of other tests in api-v3-groups branch

### DIFF
--- a/test/api/v3/integration/chat/GET-chat.test.js
+++ b/test/api/v3/integration/chat/GET-chat.test.js
@@ -5,7 +5,7 @@ import {
   translate as t,
 } from '../../../../helpers/api-integration.helper';
 
-describe.only('GET /groups/:groupId/chat', () => {
+describe('GET /groups/:groupId/chat', () => {
   let user, api;
 
   before(() => {


### PR DESCRIPTION
Note: The travis CI is failing because of lint errors from the commit before me. We can rerun the tests once the lint errors are fixed.
