### PR TITLE
Add user request class for integration tests

### DIFF
--- a/test/api/README.md
+++ b/test/api/README.md
@@ -4,7 +4,7 @@ That's great! This README will serve as a quick primer for style conventions and
 
 ## What is this?
 
-These are integration tests for the Habitica API. They are performed by making REST requests to the API's endpoints and asserting on the data that is returned.
+These are integration tests for the Habitica API. They are performed by making HTTP requests to the API's endpoints and asserting on the data that is returned.
 
 If the javascript looks weird to you, that's because it's written in [ES2015](http://www.ecma-international.org/ecma-262/6.0/) and transpiled by [Babel](https://babeljs.io/docs/learn-es2015/).
 
@@ -39,7 +39,6 @@ $ gulp test:api:safe
 If you'd like to run the tests individually and inspect the output from the server, in one pane you can run:
 
 ```bash
-$ export PORT=3003; export NODE_DB_URI="mongodb://localhost/habitrpgtest"
 $ gulp nodemon
 ```
 
@@ -71,22 +70,24 @@ POST-groups_id_leave.test.js
 
 ## Promises
 
-To mitigate [callback hell](http://callbackhell.com/) :imp:, we've written helper methods that [return promises](https://babeljs.io/docs/learn-es2015/#promises).  This makes it very easy to chain together commands. All you need to do to make a subsequent request is return another promise and then call `.then((result) => {})` on the surrounding block, like so:
+To mitigate [callback hell](http://callbackhell.com/) :imp:, we've written a helper method to generate a user object that can make http requests that [return promises](https://babeljs.io/docs/learn-es2015/#promises).  This makes it very easy to chain together commands. All you need to do to make a subsequent request is return another promise and then call `.then((result) => {})` on the surrounding block, like so:
 
 ```js
 it('does something', () => { 
-  let request;
-  return generateUser().then((user) => { // We return the initial promise so this test can be run asyncronously
-    request = requester(user);
-    return request.post('/groups', {
+  let user;
+
+  return generateUser().then((_user) => { // We return the initial promise so this test can be run asyncronously
+    user = _user;
+
+    return user.post('/groups', {
       type: 'party',
     });
   }).then((party) => { // the result of the promise above is the argument of the function
-    return request.put(`/groups/${party._id}`, {
+    return user.put(`/groups/${party._id}`, {
       name: 'My party',
     });
   }).then((result) => {
-    return request.get('/groups/party');
+    return user.get('/groups/party');
   }).then((party) => {
     expect(party.name).to.eql('My party');
   });
@@ -97,8 +98,7 @@ If the test is simple, you can use the [chai-as-promised](http://chaijs.com/plug
 
 ```js
 it('makes the party creator the leader automatically', () => { 
-  let api = requester(user);
-  return expect(request.post('/groups', {
+  return expect(user.post('/groups', {
     type: 'party',
   })).to.eventually.have.deep.property('leader._id', user._id);
 });
@@ -108,8 +108,7 @@ If the test is checking that the request returns an error, use the `.eventually.
 
 ```js
 it('returns an error', () => { 
-  let api = requester(user);
-  return expect(request.get('/groups/id-of-a-party-that-user-does-not-belong-to'))
+  return expect(user.get('/groups/id-of-a-party-that-user-does-not-belong-to'))
     .to.eventually.be.rejected.and.eql({
       code: 404,
       text: t('messageGroupNotFound'),

--- a/test/api/v2/groups/GET-groups.test.js
+++ b/test/api/v2/groups/GET-groups.test.js
@@ -2,14 +2,13 @@ import {
   generateGroup,
   generateUser,
   resetHabiticaDB,
-  requester,
 } from '../../../helpers/api-integration.helper';
 
 describe('GET /groups', () => {
   const NUMBER_OF_PUBLIC_GUILDS = 3;
   const NUMBER_OF_USERS_GUILDS = 2;
 
-  let user, api;
+  let user;
 
   before(() => {
     let leader, createdGroup;
@@ -26,7 +25,6 @@ describe('GET /groups', () => {
       });
     }).then((_user) => {
       leader = _user;
-      api = requester(leader);
 
       let publicGuildWithUserAsMember = generateGroup(leader, {
         name: 'public guild - is member',
@@ -70,8 +68,7 @@ describe('GET /groups', () => {
 
       return Promise.all(promises);
     }).then((groups) => {
-      api = requester(user);
-      return api.post('/groups', {
+      return user.post('/groups', {
         type: 'party',
         name: 'user\'s party',
         privacy: 'private',
@@ -87,7 +84,7 @@ describe('GET /groups', () => {
   context('tavern passed in as query', () => {
 
     it('returns only the tavern', () => {
-      return expect(api.get('/groups', null, {type: 'tavern'}))
+      return expect(user.get('/groups', null, {type: 'tavern'}))
         .to.eventually.have.a.lengthOf(1)
         .and.to.have.deep.property('[0]')
         .and.to.have.property('_id', 'habitrpg');
@@ -97,7 +94,7 @@ describe('GET /groups', () => {
   context('party passed in as query', () => {
 
     it('returns only the user\'s party', () => {
-      return expect(api.get('/groups', null, {type: 'party'}))
+      return expect(user.get('/groups', null, {type: 'party'}))
         .to.eventually.have.a.lengthOf(1)
         .and.to.have.deep.property('[0]')
         .and.to.have.property('leader', user._id);
@@ -107,7 +104,7 @@ describe('GET /groups', () => {
   context('public passed in as query', () => {
 
     it('returns all public guilds', () => {
-      return expect(api.get('/groups', null, {type: 'public'}))
+      return expect(user.get('/groups', null, {type: 'public'}))
         .to.eventually.have.a.lengthOf(NUMBER_OF_PUBLIC_GUILDS);
     });
   });
@@ -115,7 +112,7 @@ describe('GET /groups', () => {
   context('guilds passed in as query', () => {
 
     it('returns all guilds user is a part of ', () => {
-      return expect(api.get('/groups', null, {type: 'guilds'}))
+      return expect(user.get('/groups', null, {type: 'guilds'}))
         .to.eventually.have.a.lengthOf(NUMBER_OF_USERS_GUILDS);
     });
   });

--- a/test/api/v2/groups/POST-groups.test.js
+++ b/test/api/v2/groups/POST-groups.test.js
@@ -1,24 +1,22 @@
 import {
   generateGroup,
   generateUser,
-  requester,
   translate as t,
 } from '../../../helpers/api-integration.helper';
 
 describe('POST /groups', () => {
 
   context('All groups', () => {
-    let api, leader;
+    let leader;
 
     beforeEach(() => {
       return generateUser().then((user) => {
         leader = user;
-        api = requester(user);
       });
     });
 
     xit('returns defaults? (TODO: it\'s possible to create a group without a type. Should the group default to party? Should we require type to be set?', () => {
-      return api.post('/groups').then((group) => {
+      return leader.post('/groups').then((group) => {
         expect(group._id).to.exist;
         expect(group.name).to.eql(`${leader.profile.name}'s group`);
         expect(group.type).to.eql('party');
@@ -35,7 +33,7 @@ describe('POST /groups', () => {
         leaderMessage: 'Test Group Message',
       };
 
-      return api.post('/groups', group).then((createdGroup) => {
+      return leader.post('/groups', group).then((createdGroup) => {
         expect(createdGroup._id).to.exist;
         expect(createdGroup.leader).to.eql(leader._id);
         expect(createdGroup.name).to.eql(group.name);
@@ -47,7 +45,7 @@ describe('POST /groups', () => {
     });
 
     it('returns a populated members array', () => {
-      return api.post('/groups', {
+      return leader.post('/groups', {
         type: 'party',
       }).then((party) => {
         let member = party.members[0];
@@ -59,17 +57,16 @@ describe('POST /groups', () => {
   });
 
   context('Parties', () => {
-    let api, leader;
+    let leader;
 
     beforeEach(() => {
       return generateUser().then((user) => {
         leader = user;
-        api = requester(user);
       });
     });
 
     it('allows party creation without gems', () => {
-      return expect(api.post('/groups', {
+      return expect(leader.post('/groups', {
         type: 'party',
       })).to.eventually.have.property('_id');
     });
@@ -78,7 +75,7 @@ describe('POST /groups', () => {
       return expect(generateGroup(leader, {
         type: 'party',
       }).then((group) => {
-        return api.post('/groups', {
+        return leader.post('/groups', {
           type: 'party',
         });
       })).to.eventually.be.rejected.and.eql({
@@ -88,7 +85,7 @@ describe('POST /groups', () => {
     });
 
     xit('prevents creating a public party. TODO: it is possible to create a public party. Should we send back an error? Automatically switch the privacy to private?', () => {
-      return expect(api.post('/groups', {
+      return expect(leader.post('/groups', {
         type: 'party',
         privacy: 'public',
       })).to.eventually.be.rejected.and.eql({
@@ -99,14 +96,13 @@ describe('POST /groups', () => {
   });
 
   context('Guilds', () => {
-    let api, leader;
+    let leader;
 
     beforeEach(() => {
       return generateUser({
         balance: 2,
       }).then((user) => {
         leader = user;
-        api = requester(user);
       });
     });
 
@@ -114,8 +110,7 @@ describe('POST /groups', () => {
       return expect(generateUser({
         balance: 0.75,
       }).then((user) => {
-        api = requester(user);
-        return api.post('/groups', {
+        return user.post('/groups', {
           type: 'guild',
         });
       })).to.eventually.be.rejected.and.eql({
@@ -125,26 +120,26 @@ describe('POST /groups', () => {
     });
 
     it('can create a public guild', () => {
-      return expect(api.post('/groups', {
+      return expect(leader.post('/groups', {
         type: 'guild',
         privacy: 'public',
       })).to.eventually.have.property('leader', leader._id);
     });
 
     it('can create a private guild', () => {
-      return expect(api.post('/groups', {
+      return expect(leader.post('/groups', {
         type: 'guild',
         privacy: 'private',
       })).to.eventually.have.property('leader', leader._id);
     });
 
     it('deducts gems from user and adds them to guild bank', () => {
-      return expect(api.post('/groups', {
+      return expect(leader.post('/groups', {
         type: 'guild',
         privacy: 'private',
       }).then((group) => {
         expect(group.balance).to.eql(1);
-        return api.get('/user');
+        return leader.get('/user');
       })).to.eventually.have.deep.property('balance', 1);
     });
   });

--- a/test/api/v2/groups/POST-groups_id.test.js
+++ b/test/api/v2/groups/POST-groups_id.test.js
@@ -1,14 +1,13 @@
 import {
   generateGroup,
   generateUser,
-  requester,
   translate as t,
 } from '../../../helpers/api-integration.helper';
 
 describe('POST /groups/:id', () => {
 
   context('user is not the leader of the group', () => {
-    let api, user, otherUser, groupUserDoesNotOwn;
+    let user, otherUser, groupUserDoesNotOwn;
 
     beforeEach(() => {
       return Promise.all([
@@ -17,7 +16,6 @@ describe('POST /groups/:id', () => {
       ]).then((users) => {
         user = users[0];
         otherUser = users[1];
-        api = requester(user);
 
         return generateGroup(otherUser, {
           name: 'Group not Owned By User',
@@ -31,7 +29,7 @@ describe('POST /groups/:id', () => {
     });
 
     it('does not allow user to update group', () => {
-      return expect(api.post(`/groups/${groupUserDoesNotOwn._id}`, {
+      return expect(user.post(`/groups/${groupUserDoesNotOwn._id}`, {
         name: 'Change'
       })).to.eventually.be.rejected.and.eql({
         code: 401,
@@ -41,14 +39,13 @@ describe('POST /groups/:id', () => {
   });
 
   context('user is the leader of the group', () => {
-    let api, user, usersGroup;
+    let user, usersGroup;
 
     beforeEach(() => {
       return generateUser({
         balance: 10,
       }).then((_user) => {
         user = _user;
-        api = requester(user);
 
         return generateGroup(user, {
           name: 'Original Group Title',
@@ -61,11 +58,11 @@ describe('POST /groups/:id', () => {
     });
 
     it('allows user to update group', () => {
-      return api.post(`/groups/${usersGroup._id}`, {
+      return user.post(`/groups/${usersGroup._id}`, {
         name: 'New Group Title',
         description: 'New group description',
       }).then((group) => {
-        return api.get(`/groups/${usersGroup._id}`);
+        return user.get(`/groups/${usersGroup._id}`);
       }).then((group) => {
         expect(group.name).to.eql('New Group Title');
         expect(group.description).to.eql('New group description');

--- a/test/api/v2/groups/POST-groups_id_removeMember.test.js
+++ b/test/api/v2/groups/POST-groups_id_removeMember.test.js
@@ -2,7 +2,6 @@ import {
   createAndPopulateGroup,
   generateGroup,
   generateUser,
-  requester,
   translate as t,
 } from '../../../helpers/api-integration.helper';
 
@@ -17,7 +16,7 @@ describe('POST /groups/:id/removeMember', () => {
   });
 
   context('user is the leader of a guild', () => {
-    let api, leader, member, group;
+    let leader, member, group;
 
     beforeEach(() => {
       return createAndPopulateGroup({
@@ -31,13 +30,11 @@ describe('POST /groups/:id/removeMember', () => {
         leader = res.leader;
         member = res.members[0];
         group = res.group;
-
-        api = requester(leader);
       });
     });
 
     it('does not allow leader to remove themselves', () => {
-      return expect(api.post(`/groups/${group._id}/removeMember`, null, {
+      return expect(leader.post(`/groups/${group._id}/removeMember`, null, {
         uuid: leader._id,
       })).to.eventually.be.rejected.and.eql({
         code: 401,
@@ -46,10 +43,10 @@ describe('POST /groups/:id/removeMember', () => {
     });
 
     it('can remove other members of guild', () => {
-      return api.post(`/groups/${group._id}/removeMember`, null, {
+      return leader.post(`/groups/${group._id}/removeMember`, null, {
         uuid: member._id,
       }).then((res) => {
-        return api.get(`/groups/${group._id}`);
+        return leader.get(`/groups/${group._id}`);
       }).then((guild) => {
         expect(guild.members).to.have.a.lengthOf(1);
         expect(guild.members[0]._id).to.not.eql(member._id);

--- a/test/api/v2/groups/chat/DELETE-groups_id_chat.test.js
+++ b/test/api/v2/groups/chat/DELETE-groups_id_chat.test.js
@@ -1,12 +1,11 @@
 import {
   createAndPopulateGroup,
   generateUser,
-  requester,
   translate as t,
 } from '../../../../helpers/api-integration.helper';
 
 describe('DELETE /groups/:id/chat', () => {
-  let api, group, message, user;
+  let group, message, user;
 
   beforeEach(() => {
     return createAndPopulateGroup({
@@ -17,24 +16,23 @@ describe('DELETE /groups/:id/chat', () => {
     }).then((res) => {
       group = res.group;
       user = res.leader;
-      api = requester(user);
 
-      return api.post(`/groups/${group._id}/chat`, null, { message: 'Some message', });
+      return user.post(`/groups/${group._id}/chat`, null, { message: 'Some message', });
     }).then((res) => {
       message = res.message;
     });
   });
 
   it('deletes a message', () => {
-    return api.del(`/groups/${group._id}/chat/${message.id}`).then((res) => {
-      return api.get(`/groups/${group._id}/chat/`);
+    return user.del(`/groups/${group._id}/chat/${message.id}`).then((res) => {
+      return user.get(`/groups/${group._id}/chat/`);
     }).then((messages) => {
       expect(messages).to.have.length(0);
     });
   });
 
   it('returns an error is message does not exist', () => {
-    return expect(api.del(`/groups/${group._id}/chat/some-fake-id`)).to.eventually.be.rejected.and.eql({
+    return expect(user.del(`/groups/${group._id}/chat/some-fake-id`)).to.eventually.be.rejected.and.eql({
       code: 404,
       text: t('messageGroupChatNotFound'),
     });

--- a/test/api/v2/groups/chat/GET-groups_id_chat.test.js
+++ b/test/api/v2/groups/chat/GET-groups_id_chat.test.js
@@ -1,7 +1,6 @@
 import {
   createAndPopulateGroup,
   generateUser,
-  requester,
   translate as t,
 } from '../../../../helpers/api-integration.helper';
 
@@ -22,20 +21,18 @@ describe('GET /groups/:id/chat', () => {
         user = res.leader;
         member = res.members[0];
 
-        return requester(member).post(`/groups/${group._id}/chat`, null, { message: 'Group member message' });
+        return member.post(`/groups/${group._id}/chat`, null, { message: 'Group member message' });
       }).then((res) => {
         message1 = res.message;
 
-        return requester(user).post(`/groups/${group._id}/chat`, null, { message: 'User message' });
+        return user.post(`/groups/${group._id}/chat`, null, { message: 'User message' });
       }).then((res) => {
         message2 = res.message;
       });
     });
 
     it('gets messages', () => {
-      let api = requester(user);
-
-      return api.get(`/groups/${group._id}/chat`).then((messages) => {
+      return user.get(`/groups/${group._id}/chat`).then((messages) => {
         expect(messages).to.have.length(2);
 
         let message = messages[0];

--- a/test/api/v2/groups/chat/POST-groups_id_chat.test.js
+++ b/test/api/v2/groups/chat/POST-groups_id_chat.test.js
@@ -1,13 +1,12 @@
 import {
   createAndPopulateGroup,
   generateUser,
-  requester,
   translate as t,
 } from '../../../../helpers/api-integration.helper';
 
 describe('POST /groups/:id/chat', () => {
 
-  let api, group, user;
+  let group, user;
 
   beforeEach(() => {
     return createAndPopulateGroup({
@@ -18,12 +17,11 @@ describe('POST /groups/:id/chat', () => {
     }).then((res) => {
       group = res.group;
       user = res.leader;
-      api = requester(user);
     });
   });
 
   it('creates a chat message', () => {
-    return api.post(`/groups/${group._id}/chat`, null, {
+    return user.post(`/groups/${group._id}/chat`, null, {
       message: 'Test Message',
     }).then((res) => {
       let message = res.message;
@@ -36,7 +34,7 @@ describe('POST /groups/:id/chat', () => {
   });
 
   it('does not post an empty message', () => {
-    return expect(api.post(`/groups/${group._id}/chat`, null, {
+    return expect(user.post(`/groups/${group._id}/chat`, null, {
       message: '',
     })).to.eventually.be.rejected.and.eql({
       code: 400,

--- a/test/api/v2/groups/chat/POST-groups_id_chat_id_clearflags.test.js
+++ b/test/api/v2/groups/chat/POST-groups_id_chat_id_clearflags.test.js
@@ -1,7 +1,6 @@
 import {
   createAndPopulateGroup,
   generateUser,
-  requester,
   translate as t,
 } from '../../../../helpers/api-integration.helper';
 
@@ -27,16 +26,16 @@ describe('POST /groups/:id/chat/:id/clearflags', () => {
   });
 
   context('non admin', () => {
-    let api;
+    let nonadmin;
 
     beforeEach(() => {
       return generateUser().then((user) => {
-        api = requester(user);
+        nonadmin = user;
       });
     });
 
     it('cannot clear flags', () => {
-      return expect(api.post(`/groups/${group._id}/chat/message-to-clear/clearflags`))
+      return expect(nonadmin.post(`/groups/${group._id}/chat/message-to-clear/clearflags`))
         .to.eventually.be.rejected.and.eql({
           code: 401,
           text: t('messageGroupChatAdminClearFlagCount'),
@@ -45,34 +44,34 @@ describe('POST /groups/:id/chat/:id/clearflags', () => {
   });
 
   context('admin', () => {
-    let api;
+    let admin;
 
     beforeEach(() => {
       return generateUser({
         'contributor.admin': true,
       }).then((user) => {
-        api = requester(user);
+        admin = user;
       });
     });
 
     it('clears flags', () => {
-      return api.post(`/groups/${group._id}/chat/message-to-clear/clearflags`).then((res) => {
-        return api.get(`/groups/${group._id}/chat`);
+      return admin.post(`/groups/${group._id}/chat/message-to-clear/clearflags`).then((res) => {
+        return admin.get(`/groups/${group._id}/chat`);
       }).then((messages) => {
         expect(messages[0].flagCount).to.eql(0);
       });
     });
 
     it('leaves old flags on the flag object', () => {
-      return api.post(`/groups/${group._id}/chat/message-to-clear/clearflags`).then((res) => {
-        return api.get(`/groups/${group._id}/chat`);
+      return admin.post(`/groups/${group._id}/chat/message-to-clear/clearflags`).then((res) => {
+        return admin.get(`/groups/${group._id}/chat`);
       }).then((messages) => {
         expect(messages[0].flags).to.have.property('some-id', true);
       });
     });
 
     it('returns error if message does not exist', () => {
-      return expect(api.post(`/groups/${group._id}/chat/non-existant-message/clearflags`))
+      return expect(admin.post(`/groups/${group._id}/chat/non-existant-message/clearflags`))
         .to.eventually.be.rejected.and.eql({
           code: 404,
           text: t('messageGroupChatNotFound'),
@@ -111,10 +110,8 @@ describe('POST /groups/:id/chat/:id/clearflags', () => {
     });
 
     it('changes only the message that is flagged', () => {
-      let api = requester(admin);
-
-      return api.post(`/groups/${group._id}/chat/message-to-unflag/clearflags`).then((messages) => {
-        return api.get(`/groups/${group._id}/chat`);
+      return admin.post(`/groups/${group._id}/chat/message-to-unflag/clearflags`).then((messages) => {
+        return admin.get(`/groups/${group._id}/chat`);
       }).then((messages) => {
         expect(messages).to.have.lengthOf(4);
 

--- a/test/api/v2/groups/chat/POST-groups_id_chat_id_flag.test.js
+++ b/test/api/v2/groups/chat/POST-groups_id_chat_id_flag.test.js
@@ -1,7 +1,6 @@
 import {
   createAndPopulateGroup,
   generateUser,
-  requester,
   translate as t,
 } from '../../../../helpers/api-integration.helper';
 
@@ -22,18 +21,15 @@ describe('POST /groups/:id/chat/:id/flag', () => {
         user = res.leader;
         member = res.members[0];
 
-        return requester(member)
-          .post(`/groups/${group._id}/chat`, null, { message: 'Group member message', });
+        return member.post(`/groups/${group._id}/chat`, null, { message: 'Group member message', });
       }).then((res) => {
         message = res.message;
       });
     });
 
     it('flags message', () => {
-      let api = requester(user);
-
-      return api.post(`/groups/${group._id}/chat/${message.id}/flag`).then((messages) => {
-        return api.get(`/groups/${group._id}/chat`);
+      return user.post(`/groups/${group._id}/chat/${message.id}/flag`).then((messages) => {
+        return user.get(`/groups/${group._id}/chat`);
       }).then((messages) => {
         let message = messages[0];
         expect(message.flagCount).to.eql(1);
@@ -41,10 +37,8 @@ describe('POST /groups/:id/chat/:id/flag', () => {
     });
 
     it('cannot flag the same message twice', () => {
-      let api = requester(user);
-
-      return expect(api.post(`/groups/${group._id}/chat/${message.id}/flag`).then((messages) => {
-        return api.post(`/groups/${group._id}/chat/${message.id}/flag`);
+      return expect(user.post(`/groups/${group._id}/chat/${message.id}/flag`).then((messages) => {
+        return user.post(`/groups/${group._id}/chat/${message.id}/flag`);
       })).to.eventually.be.rejected.and.eql({
         code: 401,
         text: t('messageGroupChatFlagAlreadyReported'),
@@ -53,7 +47,7 @@ describe('POST /groups/:id/chat/:id/flag', () => {
   });
 
   context('own message', () => {
-    let api, group, message, user;
+    let group, message, user;
 
     beforeEach(() => {
       return createAndPopulateGroup({
@@ -65,18 +59,15 @@ describe('POST /groups/:id/chat/:id/flag', () => {
       }).then((res) => {
         group = res.group;
         user = res.leader;
-        api = requester(user);
 
-        return api.post(`/groups/${group._id}/chat`, null, { message: 'User\'s own message', });
+        return user.post(`/groups/${group._id}/chat`, null, { message: 'User\'s own message', });
       }).then((res) => {
         message = res.message;
       });
     });
 
     it('cannot flag message', () => {
-      let api = requester(user);
-
-      return expect(api.post(`/groups/${group._id}/chat/${message.id}/flag`))
+      return expect(user.post(`/groups/${group._id}/chat/${message.id}/flag`))
         .to.eventually.be.rejected.and.eql({
           code: 401,
           text: t('messageGroupChatFlagOwnMessage'),
@@ -85,7 +76,7 @@ describe('POST /groups/:id/chat/:id/flag', () => {
   });
 
   context('nonexistant message', () => {
-    let api, group, message, user;
+    let group, message, user;
 
     beforeEach(() => {
       return createAndPopulateGroup({
@@ -96,14 +87,11 @@ describe('POST /groups/:id/chat/:id/flag', () => {
       }).then((res) => {
         group = res.group;
         user = res.leader;
-        api = requester(user);
       });
     });
 
     it('returns error', () => {
-      let api = requester(user);
-
-      return expect(api.post(`/groups/${group._id}/chat/non-existant-message/flag`))
+      return expect(user.post(`/groups/${group._id}/chat/non-existant-message/flag`))
         .to.eventually.be.rejected.and.eql({
           code: 404,
           text: t('messageGroupChatNotFound'),
@@ -144,10 +132,8 @@ describe('POST /groups/:id/chat/:id/flag', () => {
     });
 
     it('changes only the message that is flagged', () => {
-      let api = requester(user);
-
-      return api.post(`/groups/${group._id}/chat/message-to-be-flagged/flag`).then((messages) => {
-        return requester(admin).get(`/groups/${group._id}/chat`);
+      return user.post(`/groups/${group._id}/chat/message-to-be-flagged/flag`).then((messages) => {
+        return admin.get(`/groups/${group._id}/chat`);
       }).then((messages) => {
         expect(messages).to.have.lengthOf(4);
 
@@ -190,18 +176,15 @@ describe('POST /groups/:id/chat/:id/flag', () => {
         user = res.leader;
         member = res.members[0];
 
-        return requester(member)
-          .post(`/groups/${group._id}/chat`, null, { message: 'Group member message', });
+        return member.post(`/groups/${group._id}/chat`, null, { message: 'Group member message', });
       }).then((res) => {
         message = res.message;
       });
     });
 
     it('sets flagCount to 5', () => {
-      let api = requester(user);
-
-      return api.post(`/groups/${group._id}/chat/${message.id}/flag`).then((messages) => {
-        return api.get(`/groups/${group._id}/chat`);
+      return user.post(`/groups/${group._id}/chat/${message.id}/flag`).then((messages) => {
+        return user.get(`/groups/${group._id}/chat`);
       }).then((messages) => {
         let message = messages[0];
         expect(message.flagCount).to.eql(5);

--- a/test/api/v2/status/GET-status.test.js
+++ b/test/api/v2/status/GET-status.test.js
@@ -1,9 +1,9 @@
 import {requester} from '../../../helpers/api-integration.helper';
 
 describe('Status', () => {
-
   it('returns a status of up when server is up', () => {
     let api = requester();
+
     return expect(api.get('/status'))
       .to.eventually.eql({status: 'up'});
   });

--- a/test/api/v2/user/DELETE-user.test.js
+++ b/test/api/v2/user/DELETE-user.test.js
@@ -3,23 +3,21 @@ import {
   createAndPopulateGroup,
   generateGroup,
   generateUser,
-  requester,
   translate as t,
 } from '../../../helpers/api-integration.helper';
 import { find } from 'lodash';
 
 describe('DELETE /user', () => {
-  let api, user;
+  let user;
 
   beforeEach(() => {
     return generateUser().then((usr) => {
-      api = requester(usr);
       user = usr;
     });
   });
 
   it('deletes the user', () => {
-    return expect(api.del('/user').then((fetchedUser) => {
+    return expect(user.del('/user').then((fetchedUser) => {
       return checkExistence('users', user._id);
     })).to.eventually.eql(false);
   });
@@ -41,7 +39,7 @@ describe('DELETE /user', () => {
     });
 
     it('deletes party when user is the only member', () => {
-    return expect(api.del('/user').then((result) => {
+    return expect(user.del('/user').then((result) => {
         return checkExistence('groups', party._id);
       })).to.eventually.eql(false);
     });
@@ -60,14 +58,14 @@ describe('DELETE /user', () => {
     });
 
     it('deletes guild when user is the only member', () => {
-    return expect(api.del('/user').then((result) => {
+    return expect(user.del('/user').then((result) => {
         return checkExistence('groups', guild._id);
       })).to.eventually.eql(false);
     });
   });
 
   context('groups user is leader of', () => {
-    let api, group, oldLeader, newLeader;
+    let group, oldLeader, newLeader;
 
     beforeEach(() => {
       return createAndPopulateGroup({
@@ -80,13 +78,12 @@ describe('DELETE /user', () => {
         group = res.group;
         newLeader = res.members[0];
         oldLeader = res.leader;
-        api = requester(oldLeader);
       });
     });
 
     it('chooses new group leader for any group user was the leader of', () => {
-      return api.del('/user').then((res) => {
-        return requester(newLeader).get(`/groups/${group._id}`);
+      return oldLeader.del('/user').then((res) => {
+        return newLeader.get(`/groups/${group._id}`);
       }).then((guild) => {
         expect(guild.leader).to.exist;
         expect(guild.leader._id).to.not.eql(oldLeader._id);
@@ -95,14 +92,13 @@ describe('DELETE /user', () => {
   });
 
   context('groups user is a part of', () => {
-    let api, group1, group2, userToDelete, otherUser;
+    let group1, group2, userToDelete, otherUser;
 
     beforeEach(() => {
       return generateUser({
         balance: 10,
       }).then((user) => {
         userToDelete = user;
-        api = requester(userToDelete);
 
         return generateGroup(userToDelete, {
           type: 'guild',
@@ -122,17 +118,17 @@ describe('DELETE /user', () => {
         group2 = res.group;
         otherUser = res.members[0];
 
-        return api.post(`/groups/${group2._id}/join`);
+        return userToDelete.post(`/groups/${group2._id}/join`);
       });
     });
 
     it('removes user from all groups user was a part of', () => {
-      return api.del('/user').then((res) => {
-        return requester(otherUser).get(`/groups/${group1._id}`);
+      return userToDelete.del('/user').then((res) => {
+        return otherUser.get(`/groups/${group1._id}`);
       }).then((fetchedGroup1) => {
         expect(fetchedGroup1.members).to.be.empty;
 
-        return requester(otherUser).get(`/groups/${group2._id}`);
+        return otherUser.get(`/groups/${group2._id}`);
       }).then((fetchedGroup2) => {
         expect(fetchedGroup2.members).to.not.be.empty;
 
@@ -147,7 +143,7 @@ describe('DELETE /user', () => {
   });
 
   context('pending invitation to group', () => {
-    let api, group, userToDelete, otherUser;
+    let group, userToDelete, otherUser;
 
     beforeEach(() => {
       return createAndPopulateGroup({
@@ -165,8 +161,8 @@ describe('DELETE /user', () => {
     });
 
     it('removes invitations from groups', () => {
-      return requester(userToDelete).del('/user').then((res) => {
-        return requester(otherUser).get(`/groups/${group._id}`);
+      return userToDelete.del('/user').then((res) => {
+        return otherUser.get(`/groups/${group._id}`);
       }).then((fetchedGroup) => {
         expect(fetchedGroup.invites).to.have.a.lengthOf(1);
         expect(fetchedGroup.invites[0]._id).to.not.eql(userToDelete._id);

--- a/test/api/v2/user/GET-user.test.js
+++ b/test/api/v2/user/GET-user.test.js
@@ -1,6 +1,5 @@
 import {
   generateUser,
-  requester,
 } from '../../../helpers/api-integration.helper';
 
 describe('GET /user', () => {
@@ -8,8 +7,7 @@ describe('GET /user', () => {
 
   before(() => {
     return generateUser().then((usr) => {
-      let api = requester(usr);
-      return api.get('/user');
+      return usr.get('/user');
     }).then((fetchedUser) => {
       user = fetchedUser;
     });

--- a/test/api/v2/user/GET-user_tags.test.js
+++ b/test/api/v2/user/GET-user_tags.test.js
@@ -1,20 +1,18 @@
 import {
   generateUser,
-  requester,
 } from '../../../helpers/api-integration.helper';
 
 describe('GET /user/tags', () => {
-  let api, user;
+  let user;
 
   beforeEach(() => {
     return generateUser().then((usr) => {
       user = usr;
-      api = requester(usr);
     });
   });
 
   it('gets the user\'s tags', () => {
-    return expect(api.get('/user/tags'))
+    return expect(user.get('/user/tags'))
       .to.eventually.eql(user.tags);
   });
 });

--- a/test/api/v2/user/GET-user_tags_id.test.js
+++ b/test/api/v2/user/GET-user_tags_id.test.js
@@ -1,26 +1,24 @@
 import {
   generateUser,
-  requester,
   translate as t,
 } from '../../../helpers/api-integration.helper';
 
 describe('GET /user/tags/id', () => {
-  let api, user;
+  let user;
 
   beforeEach(() => {
     return generateUser().then((usr) => {
       user = usr;
-      api = requester(usr);
     });
   });
 
   it('gets a user\'s tag by id', () => {
-    return expect(api.get('/user/tags/' + user.tags[0].id))
+    return expect(user.get('/user/tags/' + user.tags[0].id))
       .to.eventually.eql(user.tags[0]);
   });
 
   it('fails for non-existent tags', () => {
-    return expect(api.get('/user/tags/not-an-id'))
+    return expect(user.get('/user/tags/not-an-id'))
       .to.eventually.be.rejected.and.eql({
         code: 404,
         text: t('messageTagNotFound'),

--- a/test/api/v2/user/PUT-user.test.js
+++ b/test/api/v2/user/PUT-user.test.js
@@ -1,24 +1,22 @@
 import {
   generateUser,
-  requester,
   translate as t,
 } from '../../../helpers/api-integration.helper';
 
 import { each } from 'lodash';
 
 describe('PUT /user', () => {
-  let api, user;
+  let user;
 
   beforeEach(() => {
     return generateUser().then((usr) => {
       user = usr;
-      api = requester(user);
     });
   });
 
   context('allowed operations', () => {
     it('updates the user', () => {
-      return api.put('/user', {
+      return user.put('/user', {
         'profile.name' : 'Frodo',
         'preferences.costume': true,
         'stats.hp': 14,
@@ -47,7 +45,7 @@ describe('PUT /user', () => {
         each(data, (value, operation) => {
           errorText.push(t('messageUserOperationProtected', { operation: operation }));
         });
-        return expect(api.put('/user', data)).to.eventually.be.rejected.and.eql({
+        return expect(user.put('/user', data)).to.eventually.be.rejected.and.eql({
           code: 401,
           text: errorText,
         });
@@ -66,7 +64,7 @@ describe('PUT /user', () => {
         each(data, (value, operation) => {
           errorText.push(t('messageUserOperationProtected', { operation: operation }));
         });
-        return expect(api.put('/user', data)).to.eventually.be.rejected.and.eql({
+        return expect(user.put('/user', data)).to.eventually.be.rejected.and.eql({
           code: 401,
           text: errorText,
         });

--- a/test/api/v2/user/anonymized/GET-user_anonymized.test.js
+++ b/test/api/v2/user/anonymized/GET-user_anonymized.test.js
@@ -1,11 +1,10 @@
 import {
   generateUser,
-  requester,
 } from '../../../../helpers/api-integration.helper';
 import { each } from 'lodash';
 
 describe('GET /user/anonymized', () => {
-  let api, user;
+  let user;
 
   before(() => {
     return generateUser({
@@ -31,8 +30,8 @@ describe('GET /user/anonymized', () => {
         }
       }
     }).then((usr) => {
-      api = requester(usr);
-      return api.post('/user/tasks', {
+      user = usr;
+      return user.post('/user/tasks', {
         text: 'some private text',
         notes: 'some private notes',
         checklist: [
@@ -42,7 +41,7 @@ describe('GET /user/anonymized', () => {
         type: 'daily',
       });
     }).then((result) => {
-      return api.get('/user/anonymized');
+      return user.get('/user/anonymized');
     }).then((anonymizedUser) => {
       user = anonymizedUser;
     });

--- a/test/api/v2/user/batch-update/POST-user_batch-update.test.js
+++ b/test/api/v2/user/batch-update/POST-user_batch-update.test.js
@@ -1,18 +1,16 @@
 import {
   generateUser,
-  requester,
   translate as t,
 } from '../../../../helpers/api-integration.helper';
 
 import { each } from 'lodash';
 
 describe('POST /user/batch-update', () => {
-  let api, user;
+  let user;
 
   beforeEach(() => {
     return generateUser().then((usr) => {
       user = usr;
-      api = requester(user);
     });
   });
 
@@ -20,24 +18,26 @@ describe('POST /user/batch-update', () => {
     it('makes batch operations', () => {
       let task;
 
-      return api.get('/user/tasks').then((tasks) => {
+      return user.get('/user/tasks').then((tasks) => {
         task = tasks[0];
-        return api.post('/user/batch-update', [
+
+        return user.post('/user/batch-update', [
           {op: 'update', body: {'stats.hp': 30}},
           {op: 'update', body: {'profile.name': 'Samwise'}},
           {op: 'score', params: { direction: 'up', id: task.id }},
         ]);
-      }).then((user) => {
-        expect(user.stats.hp).to.eql(30);
-        expect(user.profile.name).to.eql('Samwise');
-        return api.get(`/user/tasks/${task.id}`);
+      }).then((updatedUser) => {
+        expect(updatedUser.stats.hp).to.eql(30);
+        expect(updatedUser.profile.name).to.eql('Samwise');
+
+        return user.get(`/user/tasks/${task.id}`);
       }).then((task) => {
         expect(task.value).to.be.greaterThan(0);
       });
     });
   });
 
-  context('development only operations', () => {
+  context('development only operations', () => { // These tests will fail if your NODE_ENV is set to 'development' instead of 'testing'
     let protectedOperations = {
       'Add Ten Gems': 'addTenGems',
       'Add Hourglass': 'addHourglass',
@@ -46,11 +46,11 @@ describe('POST /user/batch-update', () => {
     each(protectedOperations, (operation, description) => {
 
       it(`it sends back a 500 error for ${description} operation`, () => {
-        return expect(api.post('/user/batch-update', [
-          {op: operation},
+        return expect(user.post('/user/batch-update', [
+          { op: operation },
         ])).to.eventually.be.rejected.and.eql({
             code: 500,
-            text: t('messageUserOperationNotFound', { operation: operation}),
+            text: t('messageUserOperationNotFound', { operation }),
           });
       });
     });
@@ -58,7 +58,7 @@ describe('POST /user/batch-update', () => {
 
   context('unknown operations', () => {
     it('sends back a 500 error', () => {
-      return expect(api.post('/user/batch-update', [
+      return expect(user.post('/user/batch-update', [
         {op: 'aNotRealOperation'},
       ])).to.eventually.be.rejected.and.eql({
           code: 500,

--- a/test/api/v2/user/pushDevice/POST-pushDevice.test.js
+++ b/test/api/v2/user/pushDevice/POST-pushDevice.test.js
@@ -1,23 +1,23 @@
 import {
   generateUser,
-  requester,
 } from '../../../../helpers/api-integration.helper';
 
 describe('POST /user/pushDevice', () => {
-  let api;
+  let user;
 
   beforeEach(() => {
-    return generateUser().then((user) => {
-      api = requester(user);
+    return generateUser().then((_user) => {
+      user = _user;
     });
   });
 
   it('registers a device id', () => {
-    return api.post('/user/pushDevice', {
+    return user.post('/user/pushDevice', {
       regId: '123123',
       type: 'android',
     }).then((devices) => {
       let device = devices[0];
+
       expect(device._id).to.exist;
       expect(device.regId).to.eql('123123');
       expect(device.type).to.eql('android');

--- a/test/api/v2/user/tasks/DELETE-tasks_id.test.js
+++ b/test/api/v2/user/tasks/DELETE-tasks_id.test.js
@@ -1,24 +1,22 @@
 import {
   generateUser,
-  requester,
   translate as t,
 } from '../../../../helpers/api-integration.helper';
 
 describe('DELETE /user/tasks/:id', () => {
-  let api, user, task;
+  let user, task;
 
   beforeEach(() => {
     return generateUser().then((_user) => {
       user = _user;
       task = user.todos[0];
-      api = requester(user);
     });
   });
 
   it('deletes a task', () => {
-    return expect(api.del(`/user/tasks/${task.id}`)
+    return expect(user.del(`/user/tasks/${task.id}`)
       .then((res) => {
-        return api.get(`/user/tasks/${task.id}`);
+        return user.get(`/user/tasks/${task.id}`);
       })).to.eventually.be.rejected.and.eql({
         code: 404,
         text: t('messageTaskNotFound'),
@@ -26,7 +24,7 @@ describe('DELETE /user/tasks/:id', () => {
   });
 
   it('returns an error if the task does not exist', () => {
-    return expect(api.del('/user/tasks/task-that-does-not-exist'))
+    return expect(user.del('/user/tasks/task-that-does-not-exist'))
       .to.eventually.be.rejected.and.eql({
         code: 404,
         text: t('messageTaskNotFound'),
@@ -36,7 +34,7 @@ describe('DELETE /user/tasks/:id', () => {
   it('does not delete another user\'s task', () => {
     return expect(generateUser().then((otherUser) => {
       let otherUsersTask = otherUser.todos[0];
-      return api.del(`/user/tasks/${otherUsersTask.id}`);
+      return user.del(`/user/tasks/${otherUsersTask.id}`);
     })).to.eventually.be.rejected.and.eql({
       code: 404,
       text: 'Task not found.',

--- a/test/api/v2/user/tasks/GET-tasks.test.js
+++ b/test/api/v2/user/tasks/GET-tasks.test.js
@@ -1,11 +1,10 @@
 import {
   generateUser,
-  requester,
   translate as t,
 } from '../../../../helpers/api-integration.helper';
 
 describe('GET /user/tasks/', () => {
-  let api, user;
+  let user;
 
   beforeEach(() => {
     return generateUser({
@@ -17,12 +16,11 @@ describe('GET /user/tasks/', () => {
       ],
     }).then((_user) => {
       user = _user;
-      api = requester(user);
     });
   });
 
   it('gets all tasks', () => {
-    return api.get(`/user/tasks/`).then((tasks) => {
+    return user.get(`/user/tasks/`).then((tasks) => {
       expect(tasks).to.be.an('array');
       expect(tasks.length).to.be.greaterThan(3);
 

--- a/test/api/v2/user/tasks/GET-tasks_id.test.js
+++ b/test/api/v2/user/tasks/GET-tasks_id.test.js
@@ -1,22 +1,20 @@
 import {
   generateUser,
-  requester,
   translate as t,
 } from '../../../../helpers/api-integration.helper';
 
 describe('GET /user/tasks/:id', () => {
-  let api, user, task;
+  let user, task;
 
   beforeEach(() => {
     return generateUser().then((_user) => {
       user = _user;
       task = user.todos[0];
-      api = requester(user);
     });
   });
 
   it('gets a task', () => {
-    return api.get(`/user/tasks/${task.id}`).then((foundTask) => {
+    return user.get(`/user/tasks/${task.id}`).then((foundTask) => {
       expect(foundTask.id).to.eql(task.id);
       expect(foundTask.text).to.eql(task.text);
       expect(foundTask.notes).to.eql(task.notes);
@@ -26,7 +24,7 @@ describe('GET /user/tasks/:id', () => {
   });
 
   it('returns an error if the task does not exist', () => {
-    return expect(api.get('/user/tasks/task-that-does-not-exist'))
+    return expect(user.get('/user/tasks/task-that-does-not-exist'))
       .to.eventually.be.rejected.and.eql({
         code: 404,
         text: t('messageTaskNotFound'),
@@ -36,7 +34,8 @@ describe('GET /user/tasks/:id', () => {
   it('does not get another user\'s task', () => {
     return expect(generateUser().then((otherUser) => {
       let otherUsersTask = otherUser.todos[0];
-      return api.get(`/user/tasks/${otherUsersTask.id}`);
+
+      return user.get(`/user/tasks/${otherUsersTask.id}`);
     })).to.eventually.be.rejected.and.eql({
       code: 404,
       text: t('messageTaskNotFound'),

--- a/test/api/v2/user/tasks/POST-tasks.test.js
+++ b/test/api/v2/user/tasks/POST-tasks.test.js
@@ -1,33 +1,31 @@
 import {
   generateUser,
-  requester,
   translate as t,
 } from '../../../../helpers/api-integration.helper';
 
 describe('POST /user/tasks', () => {
 
-  let api, user;
+  let user;
 
   beforeEach(() => {
     return generateUser().then((_user) => {
       user = _user;
-      api = requester(user);
     });
   });
 
   it('creates a task', () => {
-    return api.post('/user/tasks').then((task) => {
+    return user.post('/user/tasks').then((task) => {
       expect(task.id).to.exist;
     });
   });
 
   it('creates a habit by default', () => {
-    return expect(api.post('/user/tasks'))
+    return expect(user.post('/user/tasks'))
       .to.eventually.have.property('type', 'habit');
   });
 
   it('creates a task with specified values', () => {
-    return api.post('/user/tasks', {
+    return user.post('/user/tasks', {
       type: 'daily',
       text: 'My task',
       notes: 'My notes',
@@ -43,7 +41,7 @@ describe('POST /user/tasks', () => {
   it('does not create a task with an id that already exists', () => {
     let todo = user.todos[0];
 
-    return expect(api.post('/user/tasks', {
+    return expect(user.post('/user/tasks', {
       id: todo.id,
     })).to.eventually.be.rejected.and.eql({
       code: 409,
@@ -52,7 +50,7 @@ describe('POST /user/tasks', () => {
   });
 
   xit('TODO: no error is thrown - throws a 500 validation error if invalid type is posted', () => {
-    return expect(api.post('/user/tasks', {
+    return expect(user.post('/user/tasks', {
       type: 'not-valid',
     })).to.eventually.be.rejected.and.eql({
       code: 500,
@@ -61,7 +59,7 @@ describe('POST /user/tasks', () => {
   });
 
   xit('TODO: no error is thrown - throws a 500 validation error if invalid data is posted', () => {
-    return expect(api.post('/user/tasks', {
+    return expect(user.post('/user/tasks', {
       frequency: 'not-valid',
     })).to.eventually.be.rejected.and.eql({
       code: 500,

--- a/test/api/v2/user/tasks/PUT-tasks_id.test.js
+++ b/test/api/v2/user/tasks/PUT-tasks_id.test.js
@@ -1,22 +1,20 @@
 import {
   generateUser,
-  requester,
   translate as t,
 } from '../../../../helpers/api-integration.helper';
 
 describe('PUT /user/tasks/:id', () => {
-  let api, user, task;
+  let user, task;
 
   beforeEach(() => {
     return generateUser().then((_user) => {
       user = _user;
-      api = requester(user);
       task = user.todos[0];
     });
   });
 
   it('does not update the id of the task', () => {
-    return api.put(`/user/tasks/${task.id}`, {
+    return user.put(`/user/tasks/${task.id}`, {
       id: 'some-thing',
     }).then((updatedTask) => {
       expect(updatedTask.id).to.eql(task.id);
@@ -25,7 +23,7 @@ describe('PUT /user/tasks/:id', () => {
   });
 
   it('does not update the type of the task', () => {
-    return api.put(`/user/tasks/${task.id}`, {
+    return user.put(`/user/tasks/${task.id}`, {
       type: 'habit',
     }).then((updatedTask) => {
       expect(updatedTask.type).to.eql(task.type);
@@ -34,7 +32,7 @@ describe('PUT /user/tasks/:id', () => {
   });
 
   it('updates text, attribute, priority, value and notes', () => {
-    return api.put(`/user/tasks/${task.id}`, {
+    return user.put(`/user/tasks/${task.id}`, {
       text: 'new text',
       notes: 'new notes',
       value: 10000,
@@ -50,7 +48,7 @@ describe('PUT /user/tasks/:id', () => {
   });
 
   it('returns an error if the task does not exist', () => {
-    return expect(api.put('/user/tasks/task-id-that-does-not-exist'))
+    return expect(user.put('/user/tasks/task-id-that-does-not-exist'))
       .to.eventually.be.rejected.and.eql({
         code: 404,
         text: 'Task not found.',
@@ -60,7 +58,7 @@ describe('PUT /user/tasks/:id', () => {
   it('does not update another user\'s task', () => {
     return expect(generateUser().then((otherUser) => {
       let otherUsersTask = otherUser.todos[0];
-      return api.put(`/user/tasks/${otherUsersTask._id}`, {
+      return user.put(`/user/tasks/${otherUsersTask._id}`, {
         name: 'some name',
       });
     })).to.eventually.be.rejected.and.eql({

--- a/test/helpers/api-integration.helper.js
+++ b/test/helpers/api-integration.helper.js
@@ -14,6 +14,17 @@ i18n.translations = require('../../website/src/libs/i18n.js').translations;
 
 const API_TEST_SERVER_PORT = 3003;
 
+class ApiUser {
+  constructor (options) {
+    assign(this, options);
+
+    this.get = _requestMaker(this, 'get');
+    this.post = _requestMaker(this, 'post');
+    this.put = _requestMaker(this, 'put');
+    this.del = _requestMaker(this, 'del');
+  }
+}
+
 // Sets up an abject that can make all REST requests
 // If a user is passed in, the uuid and api token of
 // the user are used to make the requests
@@ -85,7 +96,8 @@ export function generateUser (update = {}) {
       confirmPassword: password,
     }).then((user) => {
       _updateDocument('users', user, update, () => {
-        resolve(user);
+        let apiUser = new ApiUser(user);
+        resolve(apiUser);
       });
     }).catch(reject);
   });

--- a/test/helpers/api-integration.helper.js
+++ b/test/helpers/api-integration.helper.js
@@ -97,6 +97,7 @@ export function generateUser (update = {}) {
     }).then((user) => {
       _updateDocument('users', user, update, () => {
         let apiUser = new ApiUser(user);
+
         resolve(apiUser);
       });
     }).catch(reject);


### PR DESCRIPTION
I adjusted the user object that gets returned from the `generateUser` method to have the HTTP methods directly on it. This should make writing tests easier, since we no longer need a user && an api object. 

Will be merging this into the api-v3 branch as well shortly.

Pinging @TheHollidayInn @paglias @SabreCat @KristianTashkov since you're working on integration tests as well.
