### PR TITLE
API v3 Fix basilist scroll giving logic when joining party

### DIFF
--- a/test/api/v3/integration/groups/POST-groups.test.js
+++ b/test/api/v3/integration/groups/POST-groups.test.js
@@ -45,6 +45,7 @@ describe('POST /group', () => {
           expect(result._id).to.exist;
           expect(result.name).to.equal(groupName);
           expect(result.type).to.equal(groupType);
+          expect(result.memberCount).to.equal(1);
         });
       });
     });
@@ -66,6 +67,7 @@ describe('POST /group', () => {
           expect(result._id).to.exist;
           expect(result.name).to.equal(groupName);
           expect(result.type).to.equal(groupType);
+          expect(result.memberCount).to.equal(1);
           expect(result.privacy).to.equal(groupPrivacy);
         });
       });
@@ -85,6 +87,7 @@ describe('POST /group', () => {
         expect(result._id).to.exist;
         expect(result.name).to.equal(groupName);
         expect(result.type).to.equal(groupType);
+        expect(result.memberCount).to.equal(1);
       });
     });
 

--- a/test/api/v3/integration/groups/POST-groups_groupId_join.js
+++ b/test/api/v3/integration/groups/POST-groups_groupId_join.js
@@ -1,0 +1,72 @@
+import {
+  generateUser,
+} from '../../../../helpers/api-integration.helper';
+
+describe('POST /group/:groupId/join', () => {
+  let user;
+  let group;
+
+  context('Accepting invitation to a guild', () => {
+    it('does not give basilist quest to inviter when joining a guild', async () => {
+      user = await generateUser({balance: 1});
+      group = await user.post('/groups', {
+        name: 'Test Guild',
+        type: 'guild',
+      });
+
+      let invitedUser = await generateUser({
+        'invitations.guilds': [{ id: group._id}],
+      });
+      await invitedUser.post(`/groups/${group._id}/join`);
+
+      await expect(user.get('/user')).to.eventually.not.have.deep.property('items.quests.basilist');
+    });
+
+    it('does not increment basilist quest count to inviter with basilist when joining a guild', async () => {
+      user = await generateUser({balance: 1, 'items.quests.basilist': 1});
+      group = await user.post('/groups', {
+        name: 'Test Guild',
+        type: 'guild',
+      });
+
+      let invitedUser = await generateUser({
+        'invitations.guilds': [{ id: group._id}],
+      });
+      await invitedUser.post(`/groups/${group._id}/join`);
+
+      await expect(user.get('/user')).to.eventually.have.deep.property('items.quests.basilist', 1);
+    });
+  });
+
+  context('Accepting invitation to a party', () => {
+    it('gives basilist quest item to the inviter when joining a party', async () => {
+      user = await generateUser();
+      group = await user.post('/groups', {
+        name: 'Test Party',
+        type: 'party',
+      });
+
+      let joiningUser = await generateUser({
+        'invitations.party': { id: group._id, inviter: user._id },
+      });
+      await joiningUser.post(`/groups/${group._id}/join`);
+
+      await expect(user.get('/user')).to.eventually.have.deep.property('items.quests.basilist', 1);
+    });
+
+    it('increments basilist quest item count to inviter with basilist when joining a party', async () => {
+      user = await generateUser({'items.quests.basilist': 1 });
+      group = await user.post('/groups', {
+        name: 'Test Party',
+        type: 'party',
+      });
+
+      let joiningUser = await generateUser({
+        'invitations.party': { id: group._id, inviter: user._id },
+      });
+      await joiningUser.post(`/groups/${group._id}/join`);
+
+      await expect(user.get('/user')).to.eventually.have.deep.property('items.quests.basilist', 2);
+    });
+  });
+});

--- a/website/src/models/group.js
+++ b/website/src/models/group.js
@@ -35,7 +35,7 @@ export let schema = new Schema({
     challenges: {type: Boolean, default: false, required: true},
     // invites: {type:Boolean, 'default':false} // TODO ?
   },
-  memberCount: {type: Number, default: 0},
+  memberCount: {type: Number, default: 1},
   challengeCount: {type: Number, default: 0},
   balance: {type: Number, default: 0},
   logo: String,


### PR DESCRIPTION
While testing the guild code I noticed that `group.memberCount` is not set to 1 when we create a group, so the first member to join (after the creator) becomes the leader, so I fixed it in this commit. I can remove it and add it in a separate PR if you want.

UserID: bb8db09b-5822-4608-bba3-1486964b8537
