### PR TITLE
Add option to reverse chat order

### DIFF
--- a/common/locales/en/settings.json
+++ b/common/locales/en/settings.json
@@ -10,6 +10,8 @@
     "newTaskEditPop": "With this option set, new tasks will immediately open for you to add details like notes and tags.",
     "dailyDueDefaultView": "Set Dailies default to 'due' tab",
     "dailyDueDefaultViewPop": "With this option set, the Dailies tasks will default to 'due' instead of 'all'",
+    "reverseChatOrder": "Show chat messages in reverse order",
+    "reverseChatOrderPop": "Show the messages in the Tarvern, Guild, and Party chats in reverse order, so that the oldest are on top.",
     "startCollapsed": "Tag list in tasks starts collapsed",
     "startCollapsedPop": "With this option set, the list of task tags will be hidden when you first open a task for editing.",
     "startAdvCollapsed": "Advanced Options in tasks start collapsed",

--- a/website/src/models/user.js
+++ b/website/src/models/user.js
@@ -360,6 +360,7 @@ var UserSchema = new Schema({
     tagsCollapsed: {type: Boolean, 'default': false},
     advancedCollapsed: {type: Boolean, 'default': false},
     toolbarCollapsed: {type:Boolean, 'default':false},
+    reverseChatOrder: {type:Boolean, 'default':false},
     background: String,
     displayInviteToPartyWhenPartyIs1: { type:Boolean, 'default':true},
     webhooks: {type: Schema.Types.Mixed, 'default': {}},

--- a/website/views/options/social/chat-box.jade
+++ b/website/views/options/social/chat-box.jade
@@ -18,3 +18,10 @@ form.chat-form(ng-if='user.flags.communityGuidelinesAccepted' ng-submit='postCha
       input.btn(type='submit', value=env.t('sendChat'), ng-disabled='_sending')
       button.btn(type="button", ng-click='sync(group)', ng-disabled='_sending')=env.t('toolTipMsg')
     include ../../shared/formatting-help
+  .chat-controls.clearfix
+    .chat-buttons
+      .checkbox
+        label
+          input(type='checkbox', ng-model='user.preferences.reverseChatOrder', ng-change='set({"preferences.reverseChatOrder": user.preferences.reverseChatOrder?true: false})')
+          span.hint(popover-trigger='mouseenter', popover-placement='top', popover=env.t('reverseChatOrderPop'))=env.t('reverseChatOrder')
+

--- a/website/views/options/social/chat-message.jade
+++ b/website/views/options/social/chat-message.jade
@@ -1,6 +1,9 @@
 mixin chatMessages(inbox)
   ul.list-unstyled.tavern-chat
-    - var ngRepeat = inbox ? 'message in user.inbox.messages | toArray:true | orderBy:"sort":true' : 'message in group.chat track by message.id'
+    -
+      var ngRepeat = inbox ?
+        'message in user.inbox.messages | toArray:true | orderBy:"sort":true' :
+        'message in group.chat | orderBy:"timestamp":!user.preferences.reverseChatOrder track by message.id'
     li.chat-message(ng-repeat=ngRepeat, ng-class=':: {highlight: isUserMentioned(user,message) || message.uuid=="system", "own-message": user._id == message.uuid}')
       span.pull-right.text-danger(ng-if="user.contributor.admin && message.flagCount > 0")
         | {{message.flagCount > 1 ? "Message Hidden" : "1 flag"}}


### PR DESCRIPTION
Fixes #6006.
- Added a user setting `reverseChatOrder` that reverses the order of chat messages in Party/Tavern/Guild chats.
- ~~Added the setting under **Settings -> Site** (screenshot attached)~~
- As discussed in the issue, I tried to add it in the chat box as well. (screenshots attached) It reorders the chat on-click. I'm not sure if it's okay like this, but I tried multiple variants of where/how to present the option and this seemed to me like the best way because it's consistent with the Site Settings and it's descriptive. Anyway, It's easy to change/remove if needed.

My user id is: `a187eae5-b3d2-479c-99c5-3e00b3857e24`

~~Settings -> Site~~ (change reverted)
<img width="572" alt="options" src="https://cloud.githubusercontent.com/assets/2514425/12044637/b885f5a2-ae9d-11e5-9fd4-d0f5775cce3c.png">
**Chat Box**
<img width="830" alt="chatbox" src="https://cloud.githubusercontent.com/assets/2514425/12044639/bbe0a1ca-ae9d-11e5-9bba-4156184170d5.png">
**Chat Box - popover**
<img width="827" alt="chatbox_tooltip" src="https://cloud.githubusercontent.com/assets/2514425/12044640/bf1eed1a-ae9d-11e5-839b-83d8c751ad29.png">
