### PR TITLE
Add screenreader Labels to the 'plus' and 'minus' checkboxes

### DIFF
--- a/website/views/shared/tasks/task_view/index.jade
+++ b/website/views/shared/tasks/task_view/index.jade
@@ -7,12 +7,14 @@
     input.task-input.habit.visuallyhidden(
       ng-if='task.up',
       type='checkbox',
+      aria-label='plus',
       ui-keypress='{ 13:"score(task, \'up\')" }' )
     a(ng-if='task.up', ng-click='applyingAction || score(task,"up")')
       span.glyphicon.glyphicon-plus
     input.task-input.habit.visuallyhidden(
       ng-if='task.down',
       type='checkbox',
+      aria-label='minus',
       ui-keypress='{ 13:"score(task, \'down\')" }' )
     a(ng-if='task.down', ng-click='applyingAction || score(task,"down")')
       span.glyphicon.glyphicon-minus

--- a/website/views/shared/tasks/task_view/index.jade
+++ b/website/views/shared/tasks/task_view/index.jade
@@ -8,6 +8,7 @@
       ng-if='task.up',
       type='checkbox',
       aria-label='plus',
+      role='button', 
       ui-keypress='{ 13:"score(task, \'up\')" }' )
     a(ng-if='task.up', ng-click='applyingAction || score(task,"up")')
       span.glyphicon.glyphicon-plus
@@ -15,6 +16,7 @@
       ng-if='task.down',
       type='checkbox',
       aria-label='minus',
+      role='button',
       ui-keypress='{ 13:"score(task, \'down\')" }' )
     a(ng-if='task.down', ng-click='applyingAction || score(task,"down")')
       span.glyphicon.glyphicon-minus


### PR DESCRIPTION
# What

Adds `aria-label =plus` (or `minus`) and `role=button` attributes to the checkboxes for habits
# Why

This is an accessibility issue: some screen readers currently won't select the <a> object and therefore call both the positive and negative buttons 'checkbox' with no other information. Changing the role to 'button` ensures that keyboard navigation tools will act correctly (ie letting you click it repeatedly).
# Test

0) before switching to this branch, turn on a screen reader with Cmd+f5 in OSX or on windows grab the [JAWS free trial](http://www.freedomscientific.com/Downloads/JAWS) and see on the Habits page that you can select and press a context-free 'checkbox'
0a) Alternatively, note that the buttons for habits with no readable label lack `aria-label` attributes which isn't best practices for accessibility

1) switch to this branch

2) hooray there are now labels on the plus or minus buttons as appropriate. You may notice that the button role makes them easier to press, but this varies a bit by navigation tool.
2a) alternatively, just inspect the buttons and see that `aria-label` attributes are there now!
# Known issues

Right now the 'rewards' at the far right are still unusable for some blind users: they can find the price of the buttons but not the associated button.  I'm still working on a best solution for this, since I don't think I can use `aria-labelledby` here. 
# open questions

Why are these checkboxes here? Why not just the links or, even better, buttons? I'm not a front-end pro so this may be a dumb question (does it maybe have something to do with wanting to prevent double-clicks?)
