### PR TITLE
Encode special characters when sending to paypal

### DIFF
--- a/website/public/js/services/paymentServices.js
+++ b/website/public/js/services/paymentServices.js
@@ -107,7 +107,7 @@ function($rootScope, User, $http, Content) {
       // because no easy method to intercept those types of closings
       // and we need to make some cleanup
       keyboard: false,
-      backdrop: 'static' 
+      backdrop: 'static'
     });
 
     modal.rendered.then(function(){
@@ -161,9 +161,9 @@ function($rootScope, User, $http, Content) {
     if(Payments.amazonPayments.type === 'single'){
       return Payments.amazonPayments.paymentSelected === true;
     }else if(Payments.amazonPayments.type === 'subscription'){
-      return Payments.amazonPayments.paymentSelected === true && 
+      return Payments.amazonPayments.paymentSelected === true &&
               // Mah.. one is a boolean the other a string...
-              Payments.amazonPayments.recurringConsent === 'true'; 
+              Payments.amazonPayments.recurringConsent === 'true';
     }else{
       return false;
     }
@@ -179,7 +179,7 @@ function($rootScope, User, $http, Content) {
       onPaymentSelect: function() {
         $rootScope.$apply(function(){
           Payments.amazonPayments.paymentSelected = true;
-        });        
+        });
       },
 
       onError: amazonOnError
@@ -194,7 +194,7 @@ function($rootScope, User, $http, Content) {
 
         new OffAmazonPayments.Widgets.Consent({
           sellerId: window.env.AMAZON_PAYMENTS.SELLER_ID,
-          amazonBillingAgreementId: Payments.amazonPayments.billingAgreementId, 
+          amazonBillingAgreementId: Payments.amazonPayments.billingAgreementId,
           design: {
             designMode: 'responsive'
           },
@@ -213,7 +213,7 @@ function($rootScope, User, $http, Content) {
           },
 
           onError: amazonOnError
-        }).bind('AmazonPayRecurring');     
+        }).bind('AmazonPayRecurring');
       }
     }else{
       walletParams.amazonOrderReferenceId = Payments.amazonPayments.orderReferenceId;
@@ -267,7 +267,8 @@ function($rootScope, User, $http, Content) {
 
   Payments.encodeGift = function(uuid, gift){
     gift.uuid = uuid;
-    return JSON.stringify(gift);
+    var encodedString = JSON.stringify(gift);
+    return encodeURIComponent(encodedString);
   }
 
   return Payments;


### PR DESCRIPTION
Fixes #6422.

Basically, we're sending the whole `gift` stringified object to paypal in the URL, but special characters (`&` in particular) mess with the GET parameters. Encoding it with `encodeURIComponent` fixes the issue.

Sorry for the unnecessary changes - my editor removes trailing whitespaces by default and I thought it'd be okay to leave it like this.

Screenshot of received message:
![gift_message](https://cloud.githubusercontent.com/assets/2514425/12059733/9309309c-af69-11e5-9262-4832970d367f.png)

My UserID in habitica is: `a187eae5-b3d2-479c-99c5-3e00b3857e24`
