### PR TITLE
Add tests for group join route

### DIFF
--- a/website/src/controllers/api-v3/groups.js
+++ b/website/src/controllers/api-v3/groups.js
@@ -228,7 +228,7 @@ api.joinGroup = {
       user.party._id = group._id; // Set group as user's party
 
       isUserInvited = true;
-    } else if (group.type === 'guild' && user.invitations.guilds) {
+    } else if (group.type === 'guild') {
       let i = _.findIndex(user.invitations.guilds, {id: group._id});
 
       if (i !== -1) {


### PR DESCRIPTION
@crookedneighbor added awaits to `user.update` calls.
I tested most of the functionality in the join route. The ones left are:
1. When joining a party with a non-active quest, invite the new user. I believe the quest logic is still not implemented so I skipped it.
2. When joining a group(public guild?) with 0 member make the joining user the leader. I couldn't make a guild with zero members, the leave route kept crashing.

UUID: bb8db09b-5822-4608-bba3-1486964b8537
