### PR TITLE
Docker changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,13 @@ RUN npm install -g gulp grunt-cli bower
 # Clone Habitica repo and install dependencies
 WORKDIR /habitrpg
 RUN git clone https://github.com/HabitRPG/habitrpg.git /habitrpg
+#RUN test -e /habitrpg || git clone https://github.com/HabitRPG/habitrpg.git /habitrpg
 RUN npm install
 RUN bower install --allow-root
 
 # Create environment config file and build directory
 RUN cp config.json.example config.json
+#RUN test -e config.json || cp config.json.example config.json
 RUN mkdir -p ./website/build
 
 # Start Habitica

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,13 +28,11 @@ RUN npm install -g gulp grunt-cli bower
 # Clone Habitica repo and install dependencies
 WORKDIR /habitrpg
 RUN git clone https://github.com/HabitRPG/habitrpg.git /habitrpg
-#RUN test -e /habitrpg || git clone https://github.com/HabitRPG/habitrpg.git /habitrpg
 RUN npm install
 RUN bower install --allow-root
 
 # Create environment config file and build directory
 RUN cp config.json.example config.json
-#RUN test -e config.json || cp config.json.example config.json
 RUN mkdir -p ./website/build
 
 # Start Habitica

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:trusty
 MAINTAINER Sabe Jones <sabe@habitica.com>
 
 # Avoid ERROR: invoke-rc.d: policy-rc.d denied execution of start.
-RUN echo "#!/bin/sh\nexit 0" > /usr/sbin/policy-rc.d
+RUN echo -e '#!/bin/sh\nexit 0' > /usr/sbin/policy-rc.d
 
 # Install prerequisites
 RUN apt-get update
@@ -22,20 +22,19 @@ RUN apt-get install -y nodejs
 RUN apt-get clean
 RUN rm -rf /var/lib/apt/lists/*
 
-# Clone Habitica repo and install dependencies
-RUN git clone https://github.com/HabitRPG/habitrpg.git
+# Install global packages
 RUN npm install -g gulp grunt-cli bower
-RUN cd /habitrpg && npm install
-RUN cd /habitrpg && bower install --allow-root
+
+# Clone Habitica repo and install dependencies
+WORKDIR /habitrpg
+RUN git clone https://github.com/HabitRPG/habitrpg.git /habitrpg
+RUN npm install
+RUN bower install --allow-root
 
 # Create environment config file and build directory
-RUN cd /habitrpg && cp config.json.example config.json
-RUN mkdir -p /habitrpg/website/build
-
-# Point config.json to Mongo instance. Edit the IP address to your running Mongo container's IP before running.
-RUN cd /habitrpg && sed -i 's/localhost/0.0.0.0/g' config.json
+RUN cp config.json.example config.json
+RUN mkdir -p ./website/build
 
 # Start Habitica
 EXPOSE 3000
-WORKDIR /habitrpg/
 CMD ["npm", "start"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,3 @@
+web:
+  volumes:
+  - '.:/habitrpg'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+web:
+  build: .
+  ports:
+   - "3000:3000"
+  links:
+  - mongo
+  environment:
+  - NODE_DB_URI=mongodb://mongo/habitrpg
+
+mongo:
+  image: mongo
+  ports:
+   - "27017:27017"


### PR DESCRIPTION
Simplify and speedup spinup in docker containers.  Option for modifying the application outside of the container for flexibility and persistence.

I believe these changes are backwards compatible except for the mongo url which was probably breaking BASE_URL anyhow.

Along with these changes is a rewrite of the docker documentation.  Here is my proposed version:

Docker allows development in containers requiring very little setup and asserting that everyone uses a consistent environment.  It also means that you do not need to muddy up your host version with dependencies.  Before beginning, follow the instructions for installing docker and docker-compose: https://docs.docker.com/compose/install/ .

Clone the application using the instructions above then use docker-compose to build and start both the mongo database and habitrpg application.

```
docker-compose up -d
```

This will start two containers in the background.

```
docker ps

CONTAINER ID   IMAGE          COMMAND                  CREATED          STATUS          PORTS                        NAMES
4c9bcb599e97   habitrpg_web   "npm start"              31 seconds ago   Up 29 seconds   0.0.0.0:3000->3000/tcp       habitrpg_web_1
80e79eae6ceb   mongo          "/entrypoint.sh mongo"   28 minutes ago   Up 28 minutes   127.0.0.1:27017->27017/tcp   habitrpg_mongo_1
```

Habitrpg is available on port 3000 and mongo is on port 27017.  When done, use docker-compose again to stop these containers.

```
docker-compose stop
```

The application lives in the container and the container is ephemeral so it is lost when stopped.  This is inconvenient if you intend to make changes to the application.  If you want to make changes to the habitrpg application and retain the results, use the dev override file to mount the local clone inside the container.

```
docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d
```

Now changes made to the local clone will be served via the container.

To use the docker container directly against an existing mongodb instance, override NODE_DB_URI env variable.

```
docker run --env mongodb://your/database habitrpg_web
```
