### PR TITLE
Use nvm to install node 4 to vagrant env

### DIFF
--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -16,5 +16,5 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.hostname = "habitrpg"
   config.vm.network "forwarded_port", guest: 3000, host: 3000, auto_correct: true
   config.vm.usable_port_range = (3000..3050)
-  config.vm.provision :shell, :path => "vagrant.sh"
+  config.vm.provision :shell, :path => "vagrant_scripts/vagrant.sh"
 end

--- a/vagrant_scripts/install.sh
+++ b/vagrant_scripts/install.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+echo Installing nvm...
+curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.30.1/install.sh | bash
+source ~/.profile
+
+echo Setup node 4...
+nvm install 4
+nvm use 4
+nvm alias default 4
+
+echo Update npm...
+npm install -g npm
+
+echo Installing global modules...
+npm install -g gulp bower grunt-cli
+
+echo Installing Habitica...
+npm install --no-bin-links

--- a/vagrant_scripts/vagrant.sh
+++ b/vagrant_scripts/vagrant.sh
@@ -38,6 +38,9 @@ apt-get update -qq
 echo Installing Unix build tools - needed for node-gyp to use make...
 apt-get install -qq build-essential
 
+echo Installing python sofrware properties...
+apt-get install -qq python-software-properties
+
 echo Installing GraphicsMagick - provides gm and convert...
 apt-get install -qq graphicsmagick
 
@@ -59,19 +62,26 @@ apt-get update
 apt-get install mongodb-10gen
 apt-get install -y mongodb-org=2.6.4 mongodb-org-server=2.6.4 mongodb-org-shell=2.6.4 mongodb-org-mongos=2.6.4 mongodb-org-tools=2.6.4
 
+echo Adding PPA repository for gcc...
+add-apt-repository ppa:ubuntu-toolchain-r/test
+apt-get update -qq
+
+echo Installing gcc 4.8...
+apt-get install -qq gcc-4.8 g++-4.8
+
+update-alternatives --remove-all gcc
+update-alternatives --remove-all g++
+update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 20
+update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 20
+update-alternatives --config gcc
+update-alternatives --config g++
+
 echo Installing Git...
 apt-get install -qq git
 
-echo Installing npm...
-apt-get install -qq python-software-properties
-echo Adding repository node.js...
-apt-add-repository -y ppa:chris-lea/node.js
-echo Updating repositories...
-apt-get update -qq
-echo Installing node.js
-apt-get install -qq nodejs
-echo Updating npm...
-npm install -g npm
+echo Installing curl...
+apt-get install -qq curl
+
 echo Installing Xvfb...
 apt-get install -qq xvfb
 echo Installing Java7...
@@ -82,16 +92,9 @@ echo Installing Firefox...
 dpkg -i firefox.deb
 rm firefox.deb
 
-cd /vagrant
+echo Installing ntp...
+apt-get install -qq ntp
 
-echo Installing gulp/bower...
-npm install -g gulp grunt-cli bower
-
-echo Installing Habitica
-npm install --no-bin-links
-
-echo Installing Bower packages
-sudo -H -u vagrant bower --config.interactive=false install -f
 
 ## # echo Seeding Mongodb...
 ## node ./src/seed.js


### PR DESCRIPTION
Reasons for the changes:
- NVM needs `curl` to download node versions
- Node 4 needs `gcc 4.8` or above to build files
- I was having problem with make skipping files because my host OS was changing their modified times. The `ntp` server seems to fix it.

`install.sh` should be ran after ssh-ing to the vagrant machine.

Keep in mind, we are using `npm install --no-bin-links` because apparently there are problems with some host OSes and symlinks. But our test setup is made to search for mocha in `./node_modules/bin/mocha` where the symlinks are. So only `npm start` will work while we use `--no-bin-links` and tests will fail.

UUID: bb8db09b-5822-4608-bba3-1486964b8537
