### PR TITLE
#6474: Align progress and help icons on to-dos column

### DIFF
--- a/website/public/css/tasks.styl
+++ b/website/public/css/tasks.styl
@@ -146,6 +146,10 @@ for $stage in $stages
     padding: 0
     font-weight: 300
 
+  .option-box .glyphicon
+    zoom: 1.5
+    vertical-align: -webkit-baseline-middle
+
 .task-column.preview
   padding: 0
   background: transparent

--- a/website/views/shared/tasks/task_view/graph.jade
+++ b/website/views/shared/tasks/task_view/graph.jade
@@ -1,6 +1,6 @@
 span.option-box.pull-right(ng-if='::main')
   a.option-action(ng-if='list.type=="todo"', ng-show='obj.history.todos', ng-click='toggleChart("todos")', tooltip=env.t('progress'), style='margin-right:5px;')
-    span.glyphicon.glyphicon-signal
+    span.glyphicon.glyphicon-signal(style={'zoom':1.5,'vertical-align':'-webkit-baseline-middle'})
   //a.option-action(ng-href='/v1/users/{{user.id}}/calendar.ics?apiToken={{user.apiToken}}', tooltip='iCal')
   //-a.option-action(ng-if='list.type=="todo"', ng-click='notPorted()', tooltip='iCal', ng-show='false')
     span.glyphicon.glyphicon-calendar

--- a/website/views/shared/tasks/task_view/graph.jade
+++ b/website/views/shared/tasks/task_view/graph.jade
@@ -1,9 +1,9 @@
 span.option-box.pull-right(ng-if='::main')
   a.option-action(ng-if='list.type=="todo"', ng-show='obj.history.todos', ng-click='toggleChart("todos")', tooltip=env.t('progress'), style='margin-right:5px;')
-    span.glyphicon.glyphicon-signal(style={'zoom':1.5,'vertical-align':'-webkit-baseline-middle'})
+    span.glyphicon.glyphicon-signal
   //a.option-action(ng-href='/v1/users/{{user.id}}/calendar.ics?apiToken={{user.apiToken}}', tooltip='iCal')
   //-a.option-action(ng-if='list.type=="todo"', ng-click='notPorted()', tooltip='iCal', ng-show='false')
     span.glyphicon.glyphicon-calendar
   // <a href="https://www.google.com/calendar/render?cid={{encodeiCalLink(_user.id, _user.apiToken)}}" rel=tooltip title="Google Calendar"><i class=icon-calendar></i></a>
   a.option-action(ng-click='list.help=!list.help', tooltip=env.t('clickForHelp'))
-    span.glyphicon.glyphicon-question-sign(style={'zoom':1.5,'vertical-align':'-webkit-baseline-middle'})
+    span.glyphicon.glyphicon-question-sign


### PR DESCRIPTION
As per #6474, progress and help icons on the to-dos column were previously misaligned due to inconsistent inline styles. This commit adds the same inline styles to both icons (namely, `zoom: 1.5; vertical-align: -webkit-baseline-middle;`).

I haven't run any tests (can't get Vagrant working), but it's a one-line copy-paste... what can go wrong?
