### PR TITLE
Refactor integration tests to use await syntax

### DIFF
--- a/test/api/v3/integration/notFound.test.js
+++ b/test/api/v3/integration/notFound.test.js
@@ -1,10 +1,10 @@
 import { requester } from '../../../helpers/api-integration.helper';
 
 describe('notFound Middleware', () => {
-  it('returns a 404 error when the resource is not found', () => {
+  it('returns a 404 error when the resource is not found', async () => {
     let request = requester().get('/api/v3/dummy-url');
 
-    return expect(request).to.eventually.be.rejected.and.eql({
+    await expect(request).to.eventually.be.rejected.and.eql({
       code: 404,
       error: 'NotFound',
       message: 'Not found.',

--- a/test/api/v3/integration/tags/DELETE-tags_id.test.js
+++ b/test/api/v3/integration/tags/DELETE-tags_id.test.js
@@ -4,30 +4,25 @@ import {
 
 describe('DELETE /tags/:tagId', () => {
   let user;
+  let tagName = 'Tag 1';
 
-  before(() => {
-    return generateUser().then((generatedUser) => {
-      user = generatedUser;
-    });
+  before(async () => {
+    user = await generateUser();
   });
 
-  it('deletes a tag given it\'s id', () => {
-    let length;
-    let tag;
+  it('deletes a tag given it\'s id', async () => {
+    let tag = await user.post('/tags', {name: tagName});
+    let tags = await user.get('/tags');
+    let length = tags.length;
 
-    return user.post('/tags', {name: 'Tag 1'})
-    .then((createdTag) => {
-      tag = createdTag;
-      return user.get(`/tags`);
-    })
-    .then((tags) => {
-      length = tags.length;
-      return user.del(`/tags/${tag._id}`);
-    })
-    .then(() => user.get(`/tags`))
-    .then((tags) => {
-      expect(tags.length).to.equal(length - 1);
-      expect(tags[tags.length - 1].name).to.not.equal('Tag 1');
+    await user.del(`/tags/${tag._id}`);
+
+    tags = await user.get('/tags');
+    let tagNames = tags.map((t) => {
+      return t.name;
     });
+
+    expect(tags.length).to.equal(length - 1);
+    expect(tagNames).to.not.include(tagName);
   });
 });

--- a/test/api/v3/integration/tags/GET-tags.test.js
+++ b/test/api/v3/integration/tags/GET-tags.test.js
@@ -4,21 +4,21 @@ import {
 
 describe('GET /tags', () => {
   let user;
+  let tagName1 = 'Tag 1';
+  let tagName2 = 'Tag 2';
 
-  before(() => {
-    return generateUser().then((generatedUser) => {
-      user = generatedUser;
-    });
+  before(async () => {
+    user = await generateUser();
   });
 
-  it('returns all user\'s tags', () => {
-    return user.post('/tags', {name: 'Tag 1'})
-    .then(() => user.post('/tags', {name: 'Tag 2'}))
-    .then(() => user.get('/tags'))
-    .then((tags) => {
-      expect(tags.length).to.equal(2 + 3); // + 3 because 1 is a default task
-      expect(tags[tags.length - 2].name).to.equal('Tag 1');
-      expect(tags[tags.length - 1].name).to.equal('Tag 2');
-    });
+  it('returns all user\'s tags', async () => {
+    await user.post('/tags', {name: tagName1});
+    await user.post('/tags', {name: tagName2});
+
+    let tags = await user.get('/tags');
+
+    expect(tags.length).to.equal(2 + 3); // + 3 because 1 is a default task
+    expect(tags[tags.length - 2].name).to.equal(tagName1);
+    expect(tags[tags.length - 1].name).to.equal(tagName2);
   });
 });

--- a/test/api/v3/integration/tags/GET-tags_id.test.js
+++ b/test/api/v3/integration/tags/GET-tags_id.test.js
@@ -5,22 +5,14 @@ import {
 describe('GET /tags/:tagId', () => {
   let user;
 
-  before(() => {
-    return generateUser().then((generatedUser) => {
-      user = generatedUser;
-    });
+  before(async () => {
+    user = await generateUser();
   });
 
-  it('returns a tag given it\'s id', () => {
-    let createdTag;
+  it('returns a tag given it\'s id', async () => {
+    let createdTag = await user.post('/tags', {name: 'Tag 1'});
+    let tag = await user.get(`/tags/${createdTag._id}`);
 
-    return user.post('/tags', {name: 'Tag 1'})
-    .then((tag) => {
-      createdTag = tag;
-      return user.get(`/tags/${createdTag._id}`);
-    })
-    .then((tag) => {
-      expect(tag).to.deep.equal(createdTag);
-    });
+    expect(tag).to.deep.equal(createdTag);
   });
 });

--- a/test/api/v3/integration/tags/POST-tags.test.js
+++ b/test/api/v3/integration/tags/POST-tags.test.js
@@ -4,29 +4,22 @@ import {
 
 describe('POST /tags', () => {
   let user;
+  let tagName = 'Tag 1';
 
-  before(() => {
-    return generateUser().then((generatedUser) => {
-      user = generatedUser;
-    });
+  before(async () => {
+    user = await generateUser();
   });
 
-  it('creates a tag correctly', () => {
-    let createdTag;
-
-    return user.post('/tags', {
-      name: 'Tag 1',
+  it('creates a tag correctly', async () => {
+    let createdTag = await user.post('/tags', {
+      name: tagName,
       ignored: false,
-    }).then((tag) => {
-      createdTag = tag;
-
-      expect(tag.name).to.equal('Tag 1');
-      expect(tag.ignored).to.be.a('undefined');
-
-      return user.get(`/tags/${createdTag._id}`);
-    })
-    .then((tag) => {
-      expect(tag).to.deep.equal(createdTag);
     });
+
+    let tag = await user.get(`/tags/${createdTag._id}`);
+
+    expect(tag.name).to.equal(tagName);
+    expect(tag.ignored).to.be.undefined;
+    expect(tag).to.deep.equal(createdTag);
   });
 });

--- a/test/api/v3/integration/tags/PUT-tags_id.test.js
+++ b/test/api/v3/integration/tags/PUT-tags_id.test.js
@@ -4,30 +4,25 @@ import {
 
 describe('PUT /tags/:tagId', () => {
   let user;
+  let updatedTagName = 'Tag updated';
 
-  before(() => {
-    return generateUser().then((generatedUser) => {
-      user = generatedUser;
-    });
+  before(async () => {
+    user = await generateUser();
   });
 
-  it('updates a tag given it\'s id', () => {
-    return user.post('/tags', {name: 'Tag 1'})
-    .then((createdTag) => {
-      return user.put(`/tags/${createdTag._id}`, {
-        name: 'Tag updated',
-        ignored: true,
-      });
-    })
-    .then((updatedTag) => {
-      expect(updatedTag.name).to.equal('Tag updated');
-      expect(updatedTag.ignored).to.be.a('undefined');
-
-      return user.get(`/tags/${updatedTag._id}`);
-    })
-    .then((tag) => {
-      expect(tag.name).to.equal('Tag updated');
-      expect(tag.ignored).to.be.a('undefined');
+  it('updates a tag given it\'s id', async () => {
+    let createdTag = await user.post('/tags', {name: 'Tag 1'});
+    let updatedTag = await user.put(`/tags/${createdTag._id}`, {
+      name: updatedTagName,
+      ignored: true,
     });
+
+    createdTag = await user.get(`/tags/${updatedTag._id}`);
+
+    expect(updatedTag.name).to.equal(updatedTagName);
+    expect(updatedTag.ignored).to.be.undefined;
+
+    expect(createdTag.name).to.equal(updatedTagName);
+    expect(createdTag.ignored).to.be.undefined;
   });
 });

--- a/test/api/v3/integration/tasks/DELETE-tasks_id.test.js
+++ b/test/api/v3/integration/tasks/DELETE-tasks_id.test.js
@@ -6,60 +6,52 @@ import {
 describe('DELETE /tasks/:id', () => {
   let user;
 
-  before(() => {
-    return generateUser().then((generatedUser) => {
-      user = generatedUser;
-    });
+  before(async () => {
+    user = await generateUser();
   });
 
   context('task can be deleted', () => {
     let task;
 
-    beforeEach(() => {
-      return user.post('/tasks', {
+    beforeEach(async () => {
+      task = await user.post('/tasks', {
         text: 'test habit',
         type: 'habit',
-      }).then((createdTask) => {
-        task = createdTask;
       });
     });
 
-    it('deletes a user\'s task', () => {
-      return user.del(`/tasks/${task._id}`)
-        .then(() => {
-          return expect(user.get(`/tasks/${task._id}`)).to.eventually.be.rejected.and.eql({
-            code: 404,
-            error: 'NotFound',
-            message: t('taskNotFound'),
-          });
-        });
+    it('deletes a user\'s task', async () => {
+      await user.del(`/tasks/${task._id}`);
+
+      await expect(user.get(`/tasks/${task._id}`)).to.eventually.be.rejected.and.eql({
+        code: 404,
+        error: 'NotFound',
+        message: t('taskNotFound'),
+      });
     });
   });
 
   context('task cannot be deleted', () => {
-    it('cannot delete a non-existant task', () => {
-      return expect(user.del('/tasks/550e8400-e29b-41d4-a716-446655440000')).to.eventually.be.rejected.and.eql({
+    it('cannot delete a non-existant task', async () => {
+      await expect(user.del('/tasks/550e8400-e29b-41d4-a716-446655440000')).to.eventually.be.rejected.and.eql({
         code: 404,
         error: 'NotFound',
         message: t('taskNotFound'),
       });
     });
 
-    it('cannot delete a task owned by someone else', () => {
-      return generateUser()
-        .then((anotherUser) => {
-          return anotherUser.post('/tasks', {
-            text: 'test habit',
-            type: 'habit',
-          });
-        })
-        .then((task2) => {
-          return expect(user.del(`/tasks/${task2._id}`)).to.eventually.be.rejected.and.eql({
-            code: 404,
-            error: 'NotFound',
-            message: t('taskNotFound'),
-          });
-        });
+    it('cannot delete a task owned by someone else', async () => {
+      let anotherUser = await generateUser();
+      let task2 = await anotherUser.post('/tasks', {
+        text: 'test habit',
+        type: 'habit',
+      });
+
+      await expect(user.del(`/tasks/${task2._id}`)).to.eventually.be.rejected.and.eql({
+        code: 404,
+        error: 'NotFound',
+        message: t('taskNotFound'),
+      });
     });
 
     it('cannot delete active challenge tasks'); // TODO after challenges are implemented

--- a/test/api/v3/integration/tasks/GET-tasks.test.js
+++ b/test/api/v3/integration/tasks/GET-tasks.test.js
@@ -6,37 +6,27 @@ import Q from 'q';
 describe('GET /tasks', () => {
   let user;
 
-  before(() => {
-    return generateUser().then((generatedUser) => {
-      user = generatedUser;
-    });
+  beforeEach(async () => {
+    user = await generateUser();
   });
 
-  it('returns all user\'s tasks', () => {
-    let length;
-    return Q.all([
+  it('returns all user\'s tasks', async () => {
+    let createdTasks = await Q.all([
       user.post('/tasks', {text: 'test habit', type: 'habit'}),
-    ])
-    .then((createdTasks) => {
-      length = createdTasks.length;
-      return user.get('/tasks');
-    })
-    .then((tasks) => {
-      expect(tasks.length).to.equal(length + 1); // + 1 because 1 is a default task
-    });
+    ]);
+
+    let length = createdTasks.length;
+    let tasks = await user.get('/tasks');
+
+    expect(tasks.length).to.equal(length + 1); // + 1 because 1 is a default task
   });
 
-  it('returns only a type of user\'s tasks if req.query.type is specified', () => {
-    let habitId;
-    user.post('/tasks', {text: 'test habit', type: 'habit'})
-    .then((task) => {
-      habitId = task._id;
-      return user.get('/tasks?type=habit');
-    })
-    .then((tasks) => {
-      expect(tasks.length).to.equal(1);
-      expect(tasks[0]._id).to.equal(habitId);
-    });
+  it('returns only a type of user\'s tasks if req.query.type is specified', async () => {
+    let task = await user.post('/tasks', {text: 'test habit', type: 'habit'});
+    let tasks = await user.get('/tasks?type=habit');
+
+    expect(tasks.length).to.equal(1);
+    expect(tasks[0]._id).to.equal(task._id);
   });
 
   // TODO complete after task scoring is done

--- a/test/api/v3/integration/tasks/GET-tasks_id.test.js
+++ b/test/api/v3/integration/tasks/GET-tasks_id.test.js
@@ -7,29 +7,23 @@ import { v4 as generateUUID } from 'uuid';
 describe('GET /tasks/:id', () => {
   let user;
 
-  before(() => {
-    return generateUser().then((generatedUser) => {
-      user = generatedUser;
-    });
+  before(async () => {
+    user = await generateUser();
   });
 
-  context('task can be accessed', () => {
+  context('task can be accessed', async () => {
     let task;
 
-    beforeEach(() => {
-      return user.post('/tasks', {
+    beforeEach(async () => {
+      task = await user.post('/tasks', {
         text: 'test habit',
         type: 'habit',
-      }).then((createdTask) => {
-        task = createdTask;
       });
     });
 
-    it('gets specified task', () => {
-      return user.get(`/tasks/${task._id}`)
-      .then((getTask) => {
-        expect(getTask).to.eql(task);
-      });
+    it('gets specified task', async () => {
+      let getTask = await user.get(`/tasks/${task._id}`);
+      expect(getTask).to.eql(task);
     });
 
     // TODO after challenges are implemented
@@ -37,34 +31,28 @@ describe('GET /tasks/:id', () => {
   });
 
   context('task cannot be accessed', () => {
-    it('cannot get a non-existant task', () => {
+    it('cannot get a non-existant task', async () => {
       let dummyId = generateUUID();
 
-      return expect(user.get(`/tasks/${dummyId}`)).to.eventually.be.rejected.and.eql({
+      await expect(user.get(`/tasks/${dummyId}`)).to.eventually.be.rejected.and.eql({
         code: 404,
         error: 'NotFound',
         message: t('taskNotFound'),
       });
     });
 
-    it('cannot get a task owned by someone else', () => {
-      let anotherUser;
+    it('cannot get a task owned by someone else', async () => {
+      let anotherUser = await generateUser();
+      let task = await user.post('/tasks', {
+        text: 'test habit',
+        type: 'habit',
+      });
 
-      return generateUser()
-        .then((user2) => {
-          anotherUser = user2;
-
-          return user.post('/tasks', {
-            text: 'test habit',
-            type: 'habit',
-          });
-        }).then((task) => {
-          return expect(anotherUser.get(`/tasks/${task._id}`)).to.eventually.be.rejected.and.eql({
-            code: 404,
-            error: 'NotFound',
-            message: t('taskNotFound'),
-          });
-        });
+      await expect(anotherUser.get(`/tasks/${task._id}`)).to.eventually.be.rejected.and.eql({
+        code: 404,
+        error: 'NotFound',
+        message: t('taskNotFound'),
+      });
     });
   });
 });

--- a/test/api/v3/integration/tasks/PUT-tasks_id.test.js
+++ b/test/api/v3/integration/tasks/PUT-tasks_id.test.js
@@ -6,21 +6,17 @@ import { v4 as generateUUID } from 'uuid';
 describe('PUT /tasks/:id', () => {
   let user;
 
-  before(() => {
-    return generateUser().then((generatedUser) => {
-      user = generatedUser;
-    });
+  before(async () => {
+    user = await generateUser();
   });
 
   context('validates params', () => {
     let task;
 
-    beforeEach(() => {
-      return user.post('/tasks', {
+    beforeEach(async () => {
+      task = await user.post('/tasks', {
         text: 'test habit',
         type: 'habit',
-      }).then((createdTask) => {
-        task = createdTask;
       });
     });
 
@@ -52,236 +48,228 @@ describe('PUT /tasks/:id', () => {
       });
     });
 
-    it('ignores invalid fields', () => {
-      user.put(`/tasks/${task._id}`, {
+    it('ignores invalid fields', async () => {
+      let savedTask = await  user.put(`/tasks/${task._id}`, {
         notValid: true,
-      }).then((savedTask) => {
-        expect(savedTask.notValid).to.be.a('undefined');
       });
+
+      expect(savedTask.notValid).to.be.undefined;
     });
   });
 
   context('habits', () => {
     let habit;
 
-    beforeEach(() => {
-      return user.post('/tasks', {
+    beforeEach(async () => {
+      habit = await user.post('/tasks', {
         text: 'test habit',
         type: 'habit',
         notes: 1976,
-      }).then((createdHabit) => {
-        habit = createdHabit;
       });
     });
 
-    it('updates a habit', () => {
-      return user.put(`/tasks/${habit._id}`, {
+    it('updates a habit', async () => {
+      let savedHabit = await user.put(`/tasks/${habit._id}`, {
         text: 'some new text',
         up: false,
         down: false,
         notes: 'some new notes',
-      }).then((task) => {
-        expect(task.text).to.eql('some new text');
-        expect(task.notes).to.eql('some new notes');
-        expect(task.up).to.eql(false);
-        expect(task.down).to.eql(false);
       });
+
+      expect(savedHabit.text).to.eql('some new text');
+      expect(savedHabit.notes).to.eql('some new notes');
+      expect(savedHabit.up).to.eql(false);
+      expect(savedHabit.down).to.eql(false);
     });
   });
 
   context('todos', () => {
     let todo;
 
-    beforeEach(() => {
-      return user.post('/tasks', {
+    beforeEach(async () => {
+      todo = await user.post('/tasks', {
         text: 'test todo',
         type: 'todo',
         notes: 1976,
-      }).then((createdTodo) => {
-        todo = createdTodo;
       });
     });
 
-    it('updates a todo', () => {
-      return user.put(`/tasks/${todo._id}`, {
+    it('updates a todo', async () => {
+      let savedTodo = await user.put(`/tasks/${todo._id}`, {
         text: 'some new text',
         notes: 'some new notes',
-      }).then((task) => {
-        expect(task.text).to.eql('some new text');
-        expect(task.notes).to.eql('some new notes');
       });
+
+      expect(savedTodo.text).to.eql('some new text');
+      expect(savedTodo.notes).to.eql('some new notes');
     });
 
-    it('can update checklists (replace it)', () => {
-      return user.put(`/tasks/${todo._id}`, {
+    it('can update checklists (replace it)', async () => {
+      await user.put(`/tasks/${todo._id}`, {
         checklist: [
           {text: 123, completed: false},
           {text: 456, completed: true},
         ],
-      }).then(() => {
-        return user.put(`/tasks/${todo._id}`, {
-          checklist: [
-            {text: 789, completed: false},
-          ],
-        });
-      }).then((savedTodo2) => {
-        expect(savedTodo2.checklist.length).to.equal(1);
-        expect(savedTodo2.checklist[0].text).to.equal('789');
-        expect(savedTodo2.checklist[0].completed).to.equal(false);
       });
+
+      let savedTodo = await user.put(`/tasks/${todo._id}`, {
+        checklist: [
+          {text: 789, completed: false},
+        ],
+      });
+
+      expect(savedTodo.checklist.length).to.equal(1);
+      expect(savedTodo.checklist[0].text).to.equal('789');
+      expect(savedTodo.checklist[0].completed).to.equal(false);
     });
 
-    it('can update tags (replace them)', () => {
+    it('can update tags (replace them)', async () => {
       let finalUUID = generateUUID();
-      return user.put(`/tasks/${todo._id}`, {
+      await user.put(`/tasks/${todo._id}`, {
         tags: [generateUUID(), generateUUID()],
-      }).then(() => {
-        return user.put(`/tasks/${todo._id}`, {
-          tags: [finalUUID],
-        });
-      }).then((savedTodo2) => {
-        expect(savedTodo2.tags.length).to.equal(1);
-        expect(savedTodo2.tags[0]).to.equal(finalUUID);
       });
+
+      let savedTodo = await user.put(`/tasks/${todo._id}`, {
+        tags: [finalUUID],
+      });
+
+      expect(savedTodo.tags.length).to.equal(1);
+      expect(savedTodo.tags[0]).to.equal(finalUUID);
     });
   });
 
   context('dailys', () => {
     let daily;
 
-    beforeEach(() => {
-      return user.post('/tasks', {
+    beforeEach(async () => {
+      daily = await user.post('/tasks', {
         text: 'test daily',
         type: 'daily',
         notes: 1976,
-      }).then((createdDaily) => {
-        daily = createdDaily;
       });
     });
 
-    it('updates a daily', () => {
-      return user.put(`/tasks/${daily._id}`, {
+    it('updates a daily', async () => {
+      let savedDaily = await user.put(`/tasks/${daily._id}`, {
         text: 'some new text',
         notes: 'some new notes',
         frequency: 'daily',
         everyX: 5,
-      }).then((task) => {
-        expect(task.text).to.eql('some new text');
-        expect(task.notes).to.eql('some new notes');
-        expect(task.frequency).to.eql('daily');
-        expect(task.everyX).to.eql(5);
       });
+
+      expect(savedDaily.text).to.eql('some new text');
+      expect(savedDaily.notes).to.eql('some new notes');
+      expect(savedDaily.frequency).to.eql('daily');
+      expect(savedDaily.everyX).to.eql(5);
     });
 
-    it('can update checklists (replace it)', () => {
-      return user.put(`/tasks/${daily._id}`, {
+    it('can update checklists (replace it)', async () => {
+      await user.put(`/tasks/${daily._id}`, {
         checklist: [
           {text: 123, completed: false},
           {text: 456, completed: true},
         ],
-      }).then(() => {
-        return user.put(`/tasks/${daily._id}`, {
-          checklist: [
-            {text: 789, completed: false},
-          ],
-        });
-      }).then((savedDaily2) => {
-        expect(savedDaily2.checklist.length).to.equal(1);
-        expect(savedDaily2.checklist[0].text).to.equal('789');
-        expect(savedDaily2.checklist[0].completed).to.equal(false);
       });
+
+      let savedDaily = await user.put(`/tasks/${daily._id}`, {
+        checklist: [
+          {text: 789, completed: false},
+        ],
+      });
+
+      expect(savedDaily.checklist.length).to.equal(1);
+      expect(savedDaily.checklist[0].text).to.equal('789');
+      expect(savedDaily.checklist[0].completed).to.equal(false);
     });
 
-    it('can update tags (replace them)', () => {
+    it('can update tags (replace them)', async () => {
       let finalUUID = generateUUID();
-      return user.put(`/tasks/${daily._id}`, {
+      await user.put(`/tasks/${daily._id}`, {
         tags: [generateUUID(), generateUUID()],
-      }).then(() => {
-        return user.put(`/tasks/${daily._id}`, {
-          tags: [finalUUID],
-        });
-      }).then((savedDaily2) => {
-        expect(savedDaily2.tags.length).to.equal(1);
-        expect(savedDaily2.tags[0]).to.equal(finalUUID);
       });
+
+      let savedDaily = await user.put(`/tasks/${daily._id}`, {
+        tags: [finalUUID],
+      });
+
+      expect(savedDaily.tags.length).to.equal(1);
+      expect(savedDaily.tags[0]).to.equal(finalUUID);
     });
 
-    it('updates repeat, even if frequency is set to daily', () => {
-      return user.put(`/tasks/${daily._id}`, {
+    it('updates repeat, even if frequency is set to daily', async () => {
+      await user.put(`/tasks/${daily._id}`, {
         frequency: 'daily',
-      }).then(() => {
-        return user.put(`/tasks/${daily._id}`, {
-          repeat: {
-            m: false,
-            su: false,
-          },
-        });
-      }).then((savedDaily2) => {
-        expect(savedDaily2.repeat).to.eql({
+      });
+
+      let savedDaily = await user.put(`/tasks/${daily._id}`, {
+        repeat: {
           m: false,
-          t: true,
-          w: true,
-          th: true,
-          f: true,
-          s: true,
           su: false,
-        });
+        },
+      });
+
+      expect(savedDaily.repeat).to.eql({
+        m: false,
+        t: true,
+        w: true,
+        th: true,
+        f: true,
+        s: true,
+        su: false,
       });
     });
 
-    it('updates everyX, even if frequency is set to weekly', () => {
-      return user.put(`/tasks/${daily._id}`, {
+    it('updates everyX, even if frequency is set to weekly', async () => {
+      await user.put(`/tasks/${daily._id}`, {
         frequency: 'weekly',
-      }).then(() => {
-        return user.put(`/tasks/${daily._id}`, {
-          everyX: 5,
-        });
-      }).then((savedDaily2) => {
-        expect(savedDaily2.everyX).to.eql(5);
       });
+
+      let savedDaily = await user.put(`/tasks/${daily._id}`, {
+        everyX: 5,
+      });
+
+      expect(savedDaily.everyX).to.eql(5);
     });
 
-    it('defaults startDate to today if none date object is passed in', () => {
-      return user.put(`/tasks/${daily._id}`, {
+    it('defaults startDate to today if none date object is passed in', async () => {
+      let savedDaily = await user.put(`/tasks/${daily._id}`, {
         frequency: 'weekly',
-      }).then((savedDaily2) => {
-        expect((new Date(savedDaily2.startDate)).getDay()).to.eql((new Date()).getDay());
       });
+
+      expect((new Date(savedDaily.startDate)).getDay()).to.eql((new Date()).getDay());
     });
   });
 
   context('rewards', () => {
     let reward;
 
-    beforeEach(() => {
-      return user.post('/tasks', {
+    beforeEach(async () => {
+      reward = await user.post('/tasks', {
         text: 'test reward',
         type: 'reward',
         notes: 1976,
         value: 10,
-      }).then((createdReward) => {
-        reward = createdReward;
       });
     });
 
-    it('updates a reward', () => {
-      return user.put(`/tasks/${reward._id}`, {
+    it('updates a reward', async () => {
+      let savedReward = await user.put(`/tasks/${reward._id}`, {
         text: 'some new text',
         notes: 'some new notes',
         value: 10,
-      }).then((task) => {
-        expect(task.text).to.eql('some new text');
-        expect(task.notes).to.eql('some new notes');
-        expect(task.value).to.eql(10);
       });
+
+      expect(savedReward.text).to.eql('some new text');
+      expect(savedReward.notes).to.eql('some new notes');
+      expect(savedReward.value).to.eql(10);
     });
 
-    it('requires value to be coerced into a number', () => {
-      return user.put(`/tasks/${reward._id}`, {
+    it('requires value to be coerced into a number', async () => {
+      let savedReward = await user.put(`/tasks/${reward._id}`, {
         value: '100',
-      }).then((task) => {
-        expect(task.value).to.eql(100);
       });
+
+      expect(savedReward.value).to.eql(100);
     });
   });
 });

--- a/test/api/v3/integration/tasks/checklists/DELETE-tasks_taskId_checklist_itemId.test.js
+++ b/test/api/v3/integration/tasks/checklists/DELETE-tasks_taskId_checklist_itemId.test.js
@@ -7,39 +7,31 @@ import { v4 as generateUUID } from 'uuid';
 describe('DELETE /tasks/:taskId/checklist/:itemId', () => {
   let user;
 
-  before(() => {
-    return generateUser().then((generatedUser) => {
-      user = generatedUser;
-    });
+  before(async () => {
+    user = await generateUser();
   });
 
-  it('deletes a checklist item', () => {
-    let task;
-
-    return user.post('/tasks', {
+  it('deletes a checklist item', async () => {
+    let task = await user.post('/tasks', {
       type: 'daily',
       text: 'Daily with checklist',
-    }).then(createdTask => {
-      task = createdTask;
-      return user.post(`/tasks/${task._id}/checklist`, {text: 'Checklist Item 1', completed: false});
-    }).then((savedTask) => {
-      return user.del(`/tasks/${task._id}/checklist/${savedTask.checklist[0]._id}`);
-    }).then(() => {
-      return user.get(`/tasks/${task._id}`);
-    }).then((savedTask) => {
-      expect(savedTask.checklist.length).to.equal(0);
     });
+
+    let savedTask = await user.post(`/tasks/${task._id}/checklist`, {text: 'Checklist Item 1', completed: false});
+
+    await user.del(`/tasks/${task._id}/checklist/${savedTask.checklist[0]._id}`);
+    savedTask = await user.get(`/tasks/${task._id}`);
+
+    expect(savedTask.checklist.length).to.equal(0);
   });
 
-  it('does not work with habits', () => {
-    let habit;
-    return expect(user.post('/tasks', {
+  it('does not work with habits', async () => {
+    let habit = await user.post('/tasks', {
       type: 'habit',
       text: 'habit with checklist',
-    }).then(createdTask => {
-      habit = createdTask;
-      return user.del(`/tasks/${habit._id}/checklist/${generateUUID()}`);
-    })).to.eventually.be.rejected.and.eql({
+    });
+
+    await expect(user.del(`/tasks/${habit._id}/checklist/${generateUUID()}`)).to.eventually.be.rejected.and.eql({
       code: 400,
       error: 'BadRequest',
       message: t('checklistOnlyDailyTodo'),
@@ -59,21 +51,21 @@ describe('DELETE /tasks/:taskId/checklist/:itemId', () => {
     });
   });
 
-  it('fails on task not found', () => {
-    return expect(user.del(`/tasks/${generateUUID()}/checklist/${generateUUID()}`)).to.eventually.be.rejected.and.eql({
+  it('fails on task not found', async () => {
+    await expect(user.del(`/tasks/${generateUUID()}/checklist/${generateUUID()}`)).to.eventually.be.rejected.and.eql({
       code: 404,
       error: 'NotFound',
       message: t('taskNotFound'),
     });
   });
 
-  it('fails on checklist item not found', () => {
-    return expect(user.post('/tasks', {
+  it('fails on checklist item not found', async () => {
+    let createdTask = await user.post('/tasks', {
       type: 'daily',
       text: 'daily with checklist',
-    }).then(createdTask => {
-      return user.del(`/tasks/${createdTask._id}/checklist/${generateUUID()}`);
-    })).to.eventually.be.rejected.and.eql({
+    });
+
+    await expect(user.del(`/tasks/${createdTask._id}/checklist/${generateUUID()}`)).to.eventually.be.rejected.and.eql({
       code: 404,
       error: 'NotFound',
       message: t('checklistItemNotFound'),

--- a/test/api/v3/integration/tasks/checklists/POST-tasks_taskId_checklist.test.js
+++ b/test/api/v3/integration/tasks/checklists/POST-tasks_taskId_checklist.test.js
@@ -7,41 +7,38 @@ import { v4 as generateUUID } from 'uuid';
 describe('POST /tasks/:taskId/checklist/', () => {
   let user;
 
-  before(() => {
-    return generateUser().then((generatedUser) => {
-      user = generatedUser;
-    });
+  before(async () => {
+    user = await generateUser();
   });
 
-  it('adds a checklist item to a task', () => {
-    let task;
-
-    return user.post('/tasks', {
+  it('adds a checklist item to a task', async () => {
+    let task = await user.post('/tasks', {
       type: 'daily',
       text: 'Daily with checklist',
-    }).then(createdTask => {
-      task = createdTask;
-
-      return user.post(`/tasks/${task._id}/checklist`, {text: 'Checklist Item 1', ignored: false, _id: 123});
-    }).then((savedTask) => {
-      expect(savedTask.checklist.length).to.equal(1);
-      expect(savedTask.checklist[0].text).to.equal('Checklist Item 1');
-      expect(savedTask.checklist[0].completed).to.equal(false);
-      expect(savedTask.checklist[0]._id).to.be.a('string');
-      expect(savedTask.checklist[0]._id).to.not.equal('123');
-      expect(savedTask.checklist[0].ignored).to.be.an('undefined');
     });
+
+    let savedTask = await user.post(`/tasks/${task._id}/checklist`, {
+      text: 'Checklist Item 1',
+      ignored: false,
+      _id: 123,
+    });
+
+    expect(savedTask.checklist.length).to.equal(1);
+    expect(savedTask.checklist[0].text).to.equal('Checklist Item 1');
+    expect(savedTask.checklist[0].completed).to.equal(false);
+    expect(savedTask.checklist[0]._id).to.be.a('string');
+    expect(savedTask.checklist[0]._id).to.not.equal('123');
+    expect(savedTask.checklist[0].ignored).to.be.an('undefined');
   });
 
-  it('does not add a checklist to habits', () => {
-    let habit;
-
-    return expect(user.post('/tasks', {
+  it('does not add a checklist to habits', async () => {
+    let habit = await user.post('/tasks', {
       type: 'habit',
       text: 'habit with checklist',
-    }).then(createdTask => {
-      habit = createdTask;
-      return user.post(`/tasks/${habit._id}/checklist`, {text: 'Checklist Item 1'});
+    });
+
+    await expect(user.post(`/tasks/${habit._id}/checklist`, {
+      text: 'Checklist Item 1',
     })).to.eventually.be.rejected.and.eql({
       code: 400,
       error: 'BadRequest',
@@ -49,14 +46,14 @@ describe('POST /tasks/:taskId/checklist/', () => {
     });
   });
 
-  it('does not add a checklist to rewards', () => {
-    let reward;
-    return expect(user.post('/tasks', {
+  it('does not add a checklist to rewards', async () => {
+    let reward = await user.post('/tasks', {
       type: 'reward',
       text: 'reward with checklist',
-    }).then(createdTask => {
-      reward = createdTask;
-      return user.post(`/tasks/${reward._id}/checklist`, {text: 'Checklist Item 1'});
+    });
+
+    await expect(user.post(`/tasks/${reward._id}/checklist`, {
+      text: 'Checklist Item 1',
     })).to.eventually.be.rejected.and.eql({
       code: 400,
       error: 'BadRequest',
@@ -64,8 +61,8 @@ describe('POST /tasks/:taskId/checklist/', () => {
     });
   });
 
-  it('fails on task not found', () => {
-    return expect(user.post(`/tasks/${generateUUID()}/checklist`, {
+  it('fails on task not found', async () => {
+    await expect(user.post(`/tasks/${generateUUID()}/checklist`, {
       text: 'Checklist Item 1',
     })).to.eventually.be.rejected.and.eql({
       code: 404,

--- a/test/api/v3/integration/tasks/checklists/PUT-tasks_taskId_checklist_itemId.test.js
+++ b/test/api/v3/integration/tasks/checklists/PUT-tasks_taskId_checklist_itemId.test.js
@@ -7,29 +7,31 @@ import { v4 as generateUUID } from 'uuid';
 describe('PUT /tasks/:taskId/checklist/:itemId', () => {
   let user;
 
-  before(() => {
-    return generateUser().then((generatedUser) => {
-      user = generatedUser;
-    });
+  before(async () => {
+    user = await generateUser();
   });
 
-  it('updates a checklist item', () => {
-    let task;
-
-    return user.post('/tasks', {
+  it('updates a checklist item', async () => {
+    let task = await user.post('/tasks', {
       type: 'daily',
       text: 'Daily with checklist',
-    }).then(createdTask => {
-      task = createdTask;
-      return user.post(`/tasks/${task._id}/checklist`, {text: 'Checklist Item 1', completed: false});
-    }).then((savedTask) => {
-      return user.put(`/tasks/${task._id}/checklist/${savedTask.checklist[0]._id}`, {text: 'updated', completed: true, _id: 123});
-    }).then((savedTask) => {
-      expect(savedTask.checklist.length).to.equal(1);
-      expect(savedTask.checklist[0].text).to.equal('updated');
-      expect(savedTask.checklist[0].completed).to.equal(true);
-      expect(savedTask.checklist[0]._id).to.not.equal('123');
     });
+
+    let savedTask = await user.post(`/tasks/${task._id}/checklist`, {
+      text: 'Checklist Item 1',
+      completed: false,
+    });
+
+    savedTask = await user.put(`/tasks/${task._id}/checklist/${savedTask.checklist[0]._id}`, {
+      text: 'updated',
+      completed: true,
+      _id: 123,
+    });
+
+    expect(savedTask.checklist.length).to.equal(1);
+    expect(savedTask.checklist[0].text).to.equal('updated');
+    expect(savedTask.checklist[0].completed).to.equal(true);
+    expect(savedTask.checklist[0]._id).to.not.equal('123');
   });
 
   it('fails on habits', async () => {
@@ -58,21 +60,21 @@ describe('PUT /tasks/:taskId/checklist/:itemId', () => {
     });
   });
 
-  it('fails on task not found', () => {
-    return expect(user.put(`/tasks/${generateUUID()}/checklist/${generateUUID()}`)).to.eventually.be.rejected.and.eql({
+  it('fails on task not found', async () => {
+    await expect(user.put(`/tasks/${generateUUID()}/checklist/${generateUUID()}`)).to.eventually.be.rejected.and.eql({
       code: 404,
       error: 'NotFound',
       message: t('taskNotFound'),
     });
   });
 
-  it('fails on checklist item not found', () => {
-    return expect(user.post('/tasks', {
+  it('fails on checklist item not found', async () => {
+    let createdTask = await user.post('/tasks', {
       type: 'daily',
       text: 'daily with checklist',
-    }).then(createdTask => {
-      return user.put(`/tasks/${createdTask._id}/checklist/${generateUUID()}`);
-    })).to.eventually.be.rejected.and.eql({
+    });
+
+    await expect(user.put(`/tasks/${createdTask._id}/checklist/${generateUUID()}`)).to.eventually.be.rejected.and.eql({
       code: 404,
       error: 'NotFound',
       message: t('checklistItemNotFound'),

--- a/test/api/v3/integration/tasks/tags/DELETE-tasks_taskId_tags_tagId.test.js
+++ b/test/api/v3/integration/tasks/tags/DELETE-tasks_taskId_tags_tagId.test.js
@@ -7,40 +7,33 @@ import { v4 as generateUUID } from 'uuid';
 describe('DELETE /tasks/:taskId/tags/:tagId', () => {
   let user;
 
-  before(() => {
-    return generateUser().then((generatedUser) => {
-      user = generatedUser;
-    });
+  before(async () => {
+    user = await generateUser();
   });
 
-  it('removes a tag from a task', () => {
-    let tag;
-    let task;
-
-    return user.post('/tasks', {
+  it('removes a tag from a task', async () => {
+    let task = await user.post('/tasks', {
       type: 'habit',
       text: 'Task with tag',
-    }).then(createdTask => {
-      task = createdTask;
-      return user.post('/tags', {name: 'Tag 1'});
-    }).then(createdTag => {
-      tag = createdTag;
-      return user.post(`/tasks/${task._id}/tags/${tag._id}`);
-    }).then(() => {
-      return user.del(`/tasks/${task._id}/tags/${tag._id}`);
-    }).then(() => user.get(`/tasks/${task._id}`))
-    .then(updatedTask => {
-      expect(updatedTask.tags.length).to.equal(0);
     });
+
+    let tag = await user.post('/tags', {name: 'Tag 1'});
+
+    await user.post(`/tasks/${task._id}/tags/${tag._id}`);
+    await user.del(`/tasks/${task._id}/tags/${tag._id}`);
+
+    let updatedTask = await user.get(`/tasks/${task._id}`);
+
+    expect(updatedTask.tags.length).to.equal(0);
   });
 
-  it('only deletes existing tags', () => {
-    return expect(user.post('/tasks', {
+  it('only deletes existing tags', async () => {
+    let createdTask = await user.post('/tasks', {
       type: 'habit',
       text: 'Task with tag',
-    }).then(createdTask => {
-      return user.del(`/tasks/${createdTask._id}/tags/${generateUUID()}`);
-    })).to.eventually.be.rejected.and.eql({
+    });
+
+    await expect(user.del(`/tasks/${createdTask._id}/tags/${generateUUID()}`)).to.eventually.be.rejected.and.eql({
       code: 404,
       error: 'NotFound',
       message: t('tagNotFound'),

--- a/test/api/v3/integration/tasks/tags/POST-tasks_taskId_tags_tagId.test.js
+++ b/test/api/v3/integration/tasks/tags/POST-tasks_taskId_tags_tagId.test.js
@@ -7,59 +7,46 @@ import { v4 as generateUUID } from 'uuid';
 describe('POST /tasks/:taskId/tags/:tagId', () => {
   let user;
 
-  before(() => {
-    return generateUser().then((generatedUser) => {
-      user = generatedUser;
-    });
+  before(async () => {
+    user = await generateUser();
   });
 
-  it('adds a tag to a task', () => {
-    let tag;
-    let task;
-
-    return user.post('/tasks', {
+  it('adds a tag to a task', async () => {
+    let task = await user.post('/tasks', {
       type: 'habit',
       text: 'Task with tag',
-    }).then(createdTask => {
-      task = createdTask;
-      return user.post('/tags', {name: 'Tag 1'});
-    }).then(createdTag => {
-      tag = createdTag;
-      return user.post(`/tasks/${task._id}/tags/${tag._id}`);
-    }).then(savedTask => {
-      expect(savedTask.tags[0]).to.equal(tag._id);
     });
+
+    let tag = await user.post('/tags', {name: 'Tag 1'});
+    let savedTask = await user.post(`/tasks/${task._id}/tags/${tag._id}`);
+
+    expect(savedTask.tags[0]).to.equal(tag._id);
   });
 
-  it('does not add a tag to a task twice', () => {
-    let tag;
-    let task;
-
-    return expect(user.post('/tasks', {
+  it('does not add a tag to a task twice', async () => {
+    let task = await user.post('/tasks', {
       type: 'habit',
       text: 'Task with tag',
-    }).then(createdTask => {
-      task = createdTask;
-      return user.post('/tags', {name: 'Tag 1'});
-    }).then(createdTag => {
-      tag = createdTag;
-      return user.post(`/tasks/${task._id}/tags/${tag._id}`);
-    }).then(() => {
-      return user.post(`/tasks/${task._id}/tags/${tag._id}`);
-    })).to.eventually.be.rejected.and.eql({
+    });
+
+    let tag = await user.post('/tags', {name: 'Tag 1'});
+
+    await user.post(`/tasks/${task._id}/tags/${tag._id}`);
+
+    await expect(user.post(`/tasks/${task._id}/tags/${tag._id}`)).to.eventually.be.rejected.and.eql({
       code: 400,
       error: 'BadRequest',
       message: t('alreadyTagged'),
     });
   });
 
-  it('does not add a non existing tag to a task', () => {
-    return expect(user.post('/tasks', {
+  it('does not add a non existing tag to a task', async () => {
+    let task = await user.post('/tasks', {
       type: 'habit',
       text: 'Task with tag',
-    }).then((task) => {
-      return user.post(`/tasks/${task._id}/tags/${generateUUID()}`);
-    })).to.eventually.be.rejected.and.eql({
+    });
+
+    await expect(user.post(`/tasks/${task._id}/tags/${generateUUID()}`)).to.eventually.be.rejected.and.eql({
       code: 400,
       error: 'BadRequest',
       message: t('invalidReqParams'),

--- a/test/api/v3/integration/user/GET-user.test.js
+++ b/test/api/v3/integration/user/GET-user.test.js
@@ -5,25 +5,20 @@ import {
 describe('GET /user', () => {
   let user;
 
-  before(() => {
-    return generateUser().then((generatedUser) => {
-      user = generatedUser;
-    });
+  before(async () => {
+    user = await generateUser();
   });
 
-  it('returns the authenticated user', () => {
-    return user.get('/user')
-    .then(returnedUser => {
-      expect(returnedUser._id).to.equal(user._id);
-    });
+  it('returns the authenticated user', async () => {
+    let returnedUser = await user.get('/user');
+    expect(returnedUser._id).to.equal(user._id);
   });
 
-  it('does not return private paths (and apiToken)', () => {
-    return user.get('/user')
-    .then(returnedUser => {
-      expect(returnedUser.auth.local.hashed_password).to.not.exist;
-      expect(returnedUser.auth.local.salt).to.not.exist;
-      expect(returnedUser.apiToken).to.not.exist;
-    });
+  it('does not return private paths (and apiToken)', async () => {
+    let returnedUser = await user.get('/user');
+
+    expect(returnedUser.auth.local.hashed_password).to.not.exist;
+    expect(returnedUser.auth.local.salt).to.not.exist;
+    expect(returnedUser.apiToken).to.not.exist;
   });
 });

--- a/test/api/v3/integration/user/auth/POST-register_local.test.js
+++ b/test/api/v3/integration/user/auth/POST-register_local.test.js
@@ -8,26 +8,30 @@ import { each } from 'lodash';
 
 describe('POST /user/auth/local/register', () => {
   context('username and email are free', () => {
-    it('registers a new user', () => {
-      let api = requester();
+    let api;
+
+    beforeEach(async () => {
+      api = requester();
+    });
+
+    it('registers a new user', async () => {
       let username = generateRandomUserName();
       let email = `${username}@example.com`;
       let password = 'password';
 
-      return api.post('/user/auth/local/register', {
+      let user = await api.post('/user/auth/local/register', {
         username,
         email,
         password,
         confirmPassword: password,
-      }).then((user) => {
-        expect(user._id).to.exist;
-        expect(user.apiToken).to.exist;
-        expect(user.auth.local.username).to.eql(username);
       });
+
+      expect(user._id).to.exist;
+      expect(user.apiToken).to.exist;
+      expect(user.auth.local.username).to.eql(username);
     });
 
     it('requires password and confirmPassword to match', () => {
-      let api = requester();
       let username = generateRandomUserName();
       let email = `${username}@example.com`;
       let password = 'password';
@@ -46,7 +50,6 @@ describe('POST /user/auth/local/register', () => {
     });
 
     it('requires a username', () => {
-      let api = requester();
       let email = `${generateRandomUserName()}@example.com`;
       let password = 'password';
       let confirmPassword = 'password';
@@ -63,7 +66,6 @@ describe('POST /user/auth/local/register', () => {
     });
 
     it('requires an email', () => {
-      let api = requester();
       let username = generateRandomUserName();
       let password = 'password';
 
@@ -79,7 +81,6 @@ describe('POST /user/auth/local/register', () => {
     });
 
     it('requires a valid email', () => {
-      let api = requester();
       let username = generateRandomUserName();
       let email = 'notanemail@sdf';
       let password = 'password';
@@ -97,7 +98,6 @@ describe('POST /user/auth/local/register', () => {
     });
 
     it('requires a password', () => {
-      let api = requester();
       let username = generateRandomUserName();
       let email = `${username}@example.com`;
       let confirmPassword = 'password';
@@ -115,11 +115,13 @@ describe('POST /user/auth/local/register', () => {
   });
 
   context('login is already taken', () => {
-    let username, email;
+    let username, email, api;
 
-    beforeEach(() => {
+    beforeEach(async () => {
+      api = requester();
       username = generateRandomUserName();
       email = `${username}@example.com`;
+
       return generateUser({
         'auth.local.username': username,
         'auth.local.lowerCaseUsername': username,
@@ -128,7 +130,6 @@ describe('POST /user/auth/local/register', () => {
     });
 
     it('rejects if username is already taken', () => {
-      let api = requester();
       let uniqueEmail = `${generateRandomUserName()}@exampe.com`;
       let password = 'password';
 
@@ -145,7 +146,6 @@ describe('POST /user/auth/local/register', () => {
     });
 
     it('rejects if email is already taken', () => {
-      let api = requester();
       let uniqueUsername = generateRandomUserName();
       let password = 'password';
 
@@ -172,44 +172,44 @@ describe('POST /user/auth/local/register', () => {
       password = 'password';
     });
 
-    it('sets all site tour values to -2 (already seen)', () => {
-      return api.post('/user/auth/local/register', {
+    it('sets all site tour values to -2 (already seen)', async () => {
+      let user = await api.post('/user/auth/local/register', {
         username,
         email,
         password,
         confirmPassword: password,
-      }).then((user) => {
-        expect(user.flags.tour).to.not.be.empty;
+      });
 
-        each(user.flags.tour, (value) => {
-          expect(value).to.eql(-2);
-        });
+      expect(user.flags.tour).to.not.be.empty;
+
+      each(user.flags.tour, (value) => {
+        expect(value).to.eql(-2);
       });
     });
 
-    it('populates user with default todos, not no other task types', () => {
-      return api.post('/user/auth/local/register', {
+    it('populates user with default todos, not no other task types', async () => {
+      let user = await api.post('/user/auth/local/register', {
         username,
         email,
         password,
         confirmPassword: password,
-      }).then((user) => {
-        expect(user.tasksOrder.todos).to.not.be.empty;
-        expect(user.tasksOrder.dailys).to.be.empty;
-        expect(user.tasksOrder.habits).to.be.empty;
-        expect(user.tasksOrder.rewards).to.be.empty;
       });
+
+      expect(user.tasksOrder.todos).to.not.be.empty;
+      expect(user.tasksOrder.dailys).to.be.empty;
+      expect(user.tasksOrder.habits).to.be.empty;
+      expect(user.tasksOrder.rewards).to.be.empty;
     });
 
-    it('populates user with default tags', () => {
-      return api.post('/user/auth/local/register', {
+    it('populates user with default tags', async () => {
+      let user = await api.post('/user/auth/local/register', {
         username,
         email,
         password,
         confirmPassword: password,
-      }).then((user) => {
-        expect(user.tags).to.not.be.empty;
       });
+
+      expect(user.tags).to.not.be.empty;
     });
   });
 
@@ -223,44 +223,44 @@ describe('POST /user/auth/local/register', () => {
       password = 'password';
     });
 
-    it('sets all common tutorial flags to true', () => {
-      return api.post('/user/auth/local/register', {
+    it('sets all common tutorial flags to true', async () => {
+      let user = await api.post('/user/auth/local/register', {
         username,
         email,
         password,
         confirmPassword: password,
-      }).then((user) => {
-        expect(user.flags.tour).to.not.be.empty;
+      });
 
-        each(user.flags.tutorial.common, (value) => {
-          expect(value).to.eql(true);
-        });
+      expect(user.flags.tour).to.not.be.empty;
+
+      each(user.flags.tutorial.common, (value) => {
+        expect(value).to.eql(true);
       });
     });
 
-    it('populates user with default todos, habits, and rewards', () => {
-      return api.post('/user/auth/local/register', {
+    it('populates user with default todos, habits, and rewards', async () => {
+      let user = await api.post('/user/auth/local/register', {
         username,
         email,
         password,
         confirmPassword: password,
-      }).then((user) => {
-        expect(user.tasksOrder.todos).to.not.be.empty;
-        expect(user.tasksOrder.dailys).to.be.empty;
-        expect(user.tasksOrder.habits).to.not.be.empty;
-        expect(user.tasksOrder.rewards).to.not.be.empty;
       });
+
+      expect(user.tasksOrder.todos).to.not.be.empty;
+      expect(user.tasksOrder.dailys).to.be.empty;
+      expect(user.tasksOrder.habits).to.not.be.empty;
+      expect(user.tasksOrder.rewards).to.not.be.empty;
     });
 
-    it('populates user with default tags', () => {
-      return api.post('/user/auth/local/register', {
+    it('populates user with default tags', async () => {
+      let user = await api.post('/user/auth/local/register', {
         username,
         email,
         password,
         confirmPassword: password,
-      }).then((user) => {
-        expect(user.tags).to.not.be.empty;
       });
+
+      expect(user.tags).to.not.be.empty;
     });
   });
 });

--- a/test/api/v3/integration/user/auth/POST-register_local.test.js
+++ b/test/api/v3/integration/user/auth/POST-register_local.test.js
@@ -31,13 +31,13 @@ describe('POST /user/auth/local/register', () => {
       expect(user.auth.local.username).to.eql(username);
     });
 
-    it('requires password and confirmPassword to match', () => {
+    it('requires password and confirmPassword to match', async () => {
       let username = generateRandomUserName();
       let email = `${username}@example.com`;
       let password = 'password';
       let confirmPassword = 'not password';
 
-      return expect(api.post('/user/auth/local/register', {
+      await expect(api.post('/user/auth/local/register', {
         username,
         email,
         password,
@@ -49,12 +49,12 @@ describe('POST /user/auth/local/register', () => {
       });
     });
 
-    it('requires a username', () => {
+    it('requires a username', async () => {
       let email = `${generateRandomUserName()}@example.com`;
       let password = 'password';
       let confirmPassword = 'password';
 
-      return expect(api.post('/user/auth/local/register', {
+      await expect(api.post('/user/auth/local/register', {
         email,
         password,
         confirmPassword,
@@ -65,11 +65,11 @@ describe('POST /user/auth/local/register', () => {
       });
     });
 
-    it('requires an email', () => {
+    it('requires an email', async () => {
       let username = generateRandomUserName();
       let password = 'password';
 
-      return expect(api.post('/user/auth/local/register', {
+      await expect(api.post('/user/auth/local/register', {
         username,
         password,
         confirmPassword: password,
@@ -80,12 +80,12 @@ describe('POST /user/auth/local/register', () => {
       });
     });
 
-    it('requires a valid email', () => {
+    it('requires a valid email', async () => {
       let username = generateRandomUserName();
       let email = 'notanemail@sdf';
       let password = 'password';
 
-      return expect(api.post('/user/auth/local/register', {
+      await expect(api.post('/user/auth/local/register', {
         username,
         email,
         password,
@@ -97,12 +97,12 @@ describe('POST /user/auth/local/register', () => {
       });
     });
 
-    it('requires a password', () => {
+    it('requires a password', async () => {
       let username = generateRandomUserName();
       let email = `${username}@example.com`;
       let confirmPassword = 'password';
 
-      return expect(api.post('/user/auth/local/register', {
+      await expect(api.post('/user/auth/local/register', {
         username,
         email,
         confirmPassword,
@@ -129,11 +129,11 @@ describe('POST /user/auth/local/register', () => {
       });
     });
 
-    it('rejects if username is already taken', () => {
+    it('rejects if username is already taken', async () => {
       let uniqueEmail = `${generateRandomUserName()}@exampe.com`;
       let password = 'password';
 
-      return expect(api.post('/user/auth/local/register', {
+      await expect(api.post('/user/auth/local/register', {
         username,
         email: uniqueEmail,
         password,
@@ -145,11 +145,11 @@ describe('POST /user/auth/local/register', () => {
       });
     });
 
-    it('rejects if email is already taken', () => {
+    it('rejects if email is already taken', async () => {
       let uniqueUsername = generateRandomUserName();
       let password = 'password';
 
-      return expect(api.post('/user/auth/local/register', {
+      await expect(api.post('/user/auth/local/register', {
         username: uniqueUsername,
         email,
         password,


### PR DESCRIPTION
UserID: a187eae5-b3d2-479c-99c5-3e00b3857e24
See #6431.
- Refactored all `tasks`, `tags`, `user` and the `notFound` tests to use the `await` syntax instead of callbacks.
- Changed all uses of `return expect` to `await expect` for consistency

The only test I couldn't refactor is in `PUT-tasks_id.test.js`:23 - `ignores setting _id, type, userId, history, createdAt, updatedAt, challenge, completed, streak,  dateCompleted fields`. For some reason when I do this:

``` js
let savedTask = await user.put(`/tasks/${task._id}`, {
   // ...
});

// ...
expect(savedTask.completed).to.equal(false);
expect(savedTask.streak).to.equal(0);
expect(savedTask.streak).not.to.equal('never');
```

`savedTask.completed` and `savedTask.streak` are `undefined`, which makes the assertion fail. Not sure why this is happening, so I left the test as-is. 
