### PR TITLE
added screen-reader labels from the popover title/text

### DIFF
--- a/website/views/options/inventory/drops.jade
+++ b/website/views/options/inventory/drops.jade
@@ -215,3 +215,6 @@
               p
                 | {{Content.spells.special[type.key].value}}
                 span(class='shop_gold')
+  script
+    include popoverToAriaLabel.js
+

--- a/website/views/options/inventory/equipment.jade
+++ b/website/views/options/inventory/equipment.jade
@@ -58,3 +58,5 @@
               popover='{{::item.notes()}}', popover-title='{{::item.text()}}',
               popover-trigger='mouseenter', popover-placement='right',
               popover-append-to-body='true')
+  script
+    include popoverToAriaLabel.js

--- a/website/views/options/inventory/mounts.jade
+++ b/website/views/options/inventory/mounts.jade
@@ -47,3 +47,5 @@ mixin mountList(eggSource, potionSource)
         each t,k in env.Content.specialMounts
           - var animal = k.split('-')[0], color = k.split('-')[1]
           button(ng-if='user.items.mounts["#{animal}-#{color}"]', class="pet-button Mount_Icon_#{animal}-#{color}", ng-class='{active: user.items.currentMount == "#{animal}-#{color}"}', ng-click='chooseMount("#{animal}", "#{color}")', popover=env.t(t), popover-trigger='mouseenter', popover-placement='bottom')
+  script
+    include popoverToAriaLabel.js

--- a/website/views/options/inventory/pets.jade
+++ b/website/views/options/inventory/pets.jade
@@ -65,3 +65,5 @@ mixin petList(eggSource, potionSource)
               .badge.badge-info.stack-count {{points}}
             // Remove this once we have images in
             p {{:: Content.food[food].text()}}
+  script
+    include popoverToAriaLabel.js

--- a/website/views/options/inventory/popoverToAriaLabel.js
+++ b/website/views/options/inventory/popoverToAriaLabel.js
@@ -2,11 +2,12 @@
 $( document ).ready(function() {
   $("button[popover]").each(function(){
     var text = $(this).attr('popover');
-    //not everything has a popover-title. If it does we want that for the aria label
+    //not everything has a popover-title. If it does we want that title for the aria-label
     if ($(this).attr('popover-title') !== undefined){
       var title = $(this).attr('popover-title');
       $(this).attr('aria-label', title);
     } else {
+      //fall back to just using the popover text if no title is present
       $(this).attr('aria-label', text);
     }
   });

--- a/website/views/options/inventory/popoverToAriaLabel.js
+++ b/website/views/options/inventory/popoverToAriaLabel.js
@@ -1,0 +1,23 @@
+
+$( document ).ready(function() {
+  $("button[popover]").each(function(){
+    var text = $(this).attr('popover');
+    //not everything has a popover-title. If it does we want that for the aria label
+    if ($(this).attr('popover-title') !== undefined){
+      var title = $(this).attr('popover-title');
+      $(this).attr('aria-label', title);
+    } else {
+      $(this).attr('aria-label', text);
+    }
+  });
+  //turns out some of the popovers are inside divs which hold the button
+  $("div[popover]").each(function(){
+    var label = "";
+    if ($(this).attr('popover-title') !== undefined){
+      label = $(this).attr('popover-title');
+    } else {
+      label = $(this).attr('popover');
+    }
+    $(this).find("button").attr('aria-label', label);
+  })
+});

--- a/website/views/options/inventory/quests.jade
+++ b/website/views/options/inventory/quests.jade
@@ -35,3 +35,5 @@ include ../../shared/mixins
                 span.shop_gold
               p(ng-if='quest.lvl && lockQuest(quest)')=env.t('level')
                 |  {{::quest.lvl}}
+  script
+    include popoverToAriaLabel.js

--- a/website/views/options/inventory/seasonal-shop.jade
+++ b/website/views/options/inventory/seasonal-shop.jade
@@ -55,3 +55,5 @@
         button.customize-option(popover='{{::Content.spells.special.nye.notes()}}', popover-title='{{::Content.spells.special.nye.text()}}', popover-trigger='mouseenter', popover-placement='right', popover-append-to-body='true', ng-click='castStart(Content.spells.special.nye)', class='inventory_special_nye')
         p {{Content.spells.special.nye.value}}
           span(class='shop_gold')
+  script
+    include popoverToAriaLabel.js

--- a/website/views/options/inventory/time-travelers.jade
+++ b/website/views/options/inventory/time-travelers.jade
@@ -36,3 +36,5 @@
               popover-trigger='mouseenter', popover-placement='right',
               popover-append-to-body='true',
               ng-click='user.ops.buyMysterySet({params:{key:set.key}})')
+  script
+    include popoverToAriaLabel.js


### PR DESCRIPTION
# what

Add a bunch of Aria-labels to various shop and equipment items. This is a new version that had such significant changes from the previous PR I'm submitting a new one.
# why

User mentions that much of the site is unlabeled for screen-readers [on a Trello card mainly concerned](https://trello.com/c/pxTcbKuD/381-accessibility-settings) with the chat ordering and sure enough when using a screen readers several areas are impossible to navigate.

If your curious about how widely aria-label works as an option for screen-readers, check [out this handy article](https://www.nczonline.net/blog/2013/04/01/making-accessible-icon-buttons/) that does some testing with multiple browsers.
# known issues

While the labelling now uses a nice bit of Jquery to grab either the popover-title or popover text to make the aria label, that JS is added to the Options pages with the extremely hacky step of including a js file in its folder in `/views` (!!) 

I know this isn't the best approach in general but the site's pattern didn't present an obvious place to store this script otherwise. I'm not certain we want this labelling happening on other pages, so for now it's stored there.

In all cases the label is drawn from the popup title, and in a couple of instances there might be a more useful string to add as the label. Right now for example it doesn't read how many of an item you have, and I don't think the badge number will be picked up by any screen readers. When I tried grabbing the badge values... everything broke so I rolled that back.
# test

0) turn on a screen-reading program (on OSX you can do this with CMD+f5) and see that there are no labels on many equipment and inventory items, they just say things like 'potion button' and 'equipment button'
1) switch to branch
2) go to the inventory pages and see that nothing is messed up on these pages for a sighted user
3) turn on a screen-reading program (on OSX you can do this with CMD+f5) and see those same things have labels!
3a) if you aren't familiar with screen readers (it took me some time to get in control of the Apple version), just inspect the buttons and see they now have reasonable 'aria-label's attached.
