### PR TITLE
Unpixelate homepage news logos

### DIFF
--- a/website/public/css/index.styl
+++ b/website/public/css/index.styl
@@ -198,10 +198,9 @@ a.label
 .markdown-preview markdown code
   white-space inherit
 
-// By default everything should render as pixelart, except images from img tags (which tend to be things like gravatars, 
-// screenshots and so on)
+// By default everything should render as pixelart
 *
   image-rendering: pixelated
 
-.img-rendering-auto, .emoji
+.img-rendering-auto, .img-rendering-auto *, .emoji
   image-rendering: auto

--- a/website/views/static/front.jade
+++ b/website/views/static/front.jade
@@ -84,7 +84,7 @@ html(ng-app='habitrpg', ng-controller='RootCtrl')
           h4= env.t('joinOthers', {userCount:'900,000'})
             small
               button#play-btn.btn.btn-primary.btn-lg.gamifybutton(ng-click='playButtonClick()')= env.t('free')
-        .presslogos.text-center
+        .presslogos.text-center.img-rendering-auto
           = env.t('featuredIn')
           br
           img(src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/presslogos/lifehacker.png')


### PR DESCRIPTION
Fixes problem with rendering of logos [noted](https://github.com/HabitRPG/habitrpg/issues/6485#issuecomment-170316419) in #6485. Also makes `.img-rendering-auto` apply to its descendants, purely to avoid copy-pasting classes when parent elements will only contain non-pixel art.

Before:
![image](https://cloud.githubusercontent.com/assets/9433472/12374938/8ffedb70-bca4-11e5-9d7f-ce6d259ca6a4.png)

After:
![image](https://cloud.githubusercontent.com/assets/9433472/12374940/975a87f2-bca4-11e5-827d-a0eff0eca648.png)
