### PR TITLE
Resolving visual issues in the Profile modal

### DIFF
--- a/website/public/css/avatar.styl
+++ b/website/public/css/avatar.styl
@@ -11,11 +11,22 @@ future re: pets and whatnot, this is just temporary.
 
 // see http://stackoverflow.com/questions/24166568/set-bootstrap-modal-body-height-by-percentage
 .profile-modal
-  .modal-dialog,.modal-content
-    height: 96%
+  .modal-dialog
+    height: 100%
+    width: auto
+    max-width: 920px
+    margin: 0 auto
+    padding: 10px
+    @media screen and (min-width:768px)
+      padding: 30px 10px
+  .modal-content
+    height: 100%
   .modal-body
-    max-height: calc(100% - 150px) //100% = dialog height, 150px = header + footer
+    max-height: calc(100% - 137px) // 100% = dialog height, 150px = header (70px) + footer (67px)
     overflow-y: scroll
+  .modal-footer
+    margin: 0
+    padding: 16px 20px
 
 .herobox
   // Base styles


### PR DESCRIPTION
I can't find a GitHub issue around this, but I noticed some visual issues with the Profile modal after viewing my party members.

This commit fixes the following issues:
- An unintentional scrollbar was being created on the .modal container element after opening.
- There was a 15px gap between the footer and scrollable content, creating an odd visual lapse.
- The modal was too wide between 768px and 900px, bleeding off the page.

This idea of creating a full height modal could be abstracted out into a component/modifier of the `.modal` element, but I kept it scoped to the `.profile-modal` for simplicity sake. I'd be happy to elaborate on this solution, if needed.
