### PR TITLE
Challenges join route and tests

### DIFF
--- a/common/locales/en/api-v3.json
+++ b/common/locales/en/api-v3.json
@@ -54,6 +54,7 @@
   "noCompletedTodosChallenge": "\"includeComepletedTodos\" is not supported when fetching a challenge tasks.",
   "userTasksNoChallengeId": "When \"tasksOwner\" is \"user\" \"challengeId\" can't be passed.",
   "onlyChalLeaderEditTasks": "Tasks belonging to a challenge can only be edited by the leader.",
+  "userAlreadyInChallenge": "User is already participating in this challenge.",
   "invalidTasksOwner": "\"tasksOwner\" must be \"user\" or \"challenge\".",
   "partyMustbePrivate": "Parties must be private",
   "userAlreadyInGroup": "User already in that group.",

--- a/test/api/v3/integration/challenges/POST-challenges_challengeId_join.test.js
+++ b/test/api/v3/integration/challenges/POST-challenges_challengeId_join.test.js
@@ -1,0 +1,113 @@
+import {
+  generateUser,
+  createAndPopulateGroup,
+  translate as t,
+} from '../../../../helpers/api-v3-integration.helper';
+import { v4 as generateUUID } from 'uuid';
+
+describe('POST /challenges/:challengeId/join', () => {
+  it('returns error when challengeId is not a valid UUID', async () => {
+    let user = await generateUser({ balance: 1});
+
+    await expect(user.post('/challenges/test/join')).to.eventually.be.rejected.and.eql({
+      code: 400,
+      error: 'BadRequest',
+      message: t('invalidReqParams'),
+    });
+  });
+
+  it('returns error when challengeId is not for a valid challenge', async () => {
+    let user = await generateUser({ balance: 1});
+
+    await expect(user.post(`/challenges/${generateUUID()}/join`)).to.eventually.be.rejected.and.eql({
+      code: 404,
+      error: 'NotFound',
+      message: t('challengeNotFound'),
+    });
+  });
+
+  context('Joining a valid challenge', () => {
+    let groupLeader;
+    let group;
+    let challenge;
+    let authorizedUser;
+
+    beforeEach(async () => {
+      let populatedGroup = await createAndPopulateGroup({
+        members: 1,
+      });
+
+      groupLeader = populatedGroup.groupLeader;
+      group = populatedGroup.group;
+      authorizedUser = populatedGroup.members[0];
+
+      challenge = await groupLeader.post('/challenges', {
+        groupId: group._id,
+        name: 'Test Challenge',
+        shortName: 'T.C.',
+      });
+    });
+
+    it('returns error when user doesn\'t have permissions to access the challenge', async () => {
+      let unauthorizedUser = await generateUser();
+
+      await expect(unauthorizedUser.post(`/challenges/${challenge._id}/join`)).to.eventually.be.rejected.and.eql({
+        code: 404,
+        error: 'NotFound',
+        message: t('challengeNotFound'),
+      });
+    });
+
+    it('adds challenge to user challenges', async () => {
+      await authorizedUser.post(`/challenges/${challenge._id}/join`);
+
+      await authorizedUser.sync();
+
+      expect(authorizedUser).to.have.property('challenges').to.include(challenge._id);
+    });
+
+    it('returns error when user has already joined the challenge', async () => {
+      await authorizedUser.post(`/challenges/${challenge._id}/join`);
+
+      await expect(authorizedUser.post(`/challenges/${challenge._id}/join`)).to.eventually.be.rejected.and.eql({
+        code: 401,
+        error: 'NotAuthorized',
+        message: t('userAlreadyInChallenge'),
+      });
+    });
+
+    it('increases memberCount of challenge', async () => {
+      let oldMemberCount = challenge.memberCount;
+
+      await authorizedUser.post(`/challenges/${challenge._id}/join`);
+
+      challenge = await authorizedUser.get(`/challenges/${challenge._id}`); // Switch to sync syntax when it's implemented for challenges
+
+      expect(challenge).to.have.property('memberCount', oldMemberCount + 1);
+    });
+
+    it('syncs challenge tasks to joining user', async () => {
+      let taskText = 'Test Text';
+
+      await groupLeader.post(`/tasks/challenge/${challenge._id}`, [
+        {type: 'habit', text: taskText},
+      ]);
+
+      await authorizedUser.post(`/challenges/${challenge._id}/join`);
+      let tasks = await authorizedUser.get('/tasks/user');
+      let tasksTexts = tasks.map((task) => {
+        return task.text;
+      });
+
+      expect(tasksTexts).to.include(taskText);
+    });
+
+    it('adds challenge tag to user tags', async () => {
+      let userTagsLenght = (await authorizedUser.get('/tags')).length;
+
+      await authorizedUser.post(`/challenges/${challenge._id}/join`);
+
+      await expect(authorizedUser.get('/tags')).to.eventually.have.length(userTagsLenght + 1);
+    });
+  });
+});

--- a/test/helpers/api-integration/v3/object-generators.js
+++ b/test/helpers/api-integration/v3/object-generators.js
@@ -73,17 +73,20 @@ export async function createAndPopulateGroup (settings = {}) {
   let group = await generateGroup(groupLeader, groupDetails);
 
   let members = await Q.all(
-    times(numberOfMembers, () => {
-      return generateUser();
+    times(numberOfMembers, async () => {
+      let user = await generateUser();
+
+      if (group.type === 'party') {
+        await user.update({ 'party._id': group._id});
+      } else {
+        await user.update({ guilds: [group._id] });
+      }
+
+      return user;
     })
   );
 
-  let memberIds = members.map((member) => {
-    return member._id;
-  });
-  memberIds.push(groupLeader._id);
-
-  await group.update({ members: memberIds });
+  group.update({ memberCount: numberOfMembers + 1});
 
   let invitees = await Q.all(
     times(numberOfInvites, () => {

--- a/website/src/models/challenge.js
+++ b/website/src/models/challenge.js
@@ -22,7 +22,7 @@ let schema = new Schema({
   leader: {type: String, ref: 'User', validate: [validator.isUUID, 'Invalid uuid.'], required: true},
   groupId: {type: String, ref: 'Group', validate: [validator.isUUID, 'Invalid uuid.'], required: true}, // TODO no update, no set?
   timestamp: {type: Date, default: Date.now, required: true}, // TODO what is this? use timestamps from plugin? not settable?
-  memberCount: {type: Number, default: 0},
+  memberCount: {type: Number, default: 1},
   prize: {type: Number, default: 0, min: 0}, // TODO no update?
 });
 
@@ -64,6 +64,13 @@ function _syncableAttrs (task) {
   if (t.type !== 'reward') omitAttrs.push('value');
   return _.omit(t, omitAttrs);
 }
+
+schema.methods.hasAccess = function hasAccessToChallenge (user) {
+  let userGroups = user.guilds.slice(0);
+  if (user.party._id) userGroups.push(user.party._id);
+  userGroups.push('habitrpg'); // tavern challenges
+  return this.leader === user._id || userGroups.indexOf(this.groupId) !== -1;
+};
 
 // Sync challenge to user, including tasks and tags.
 // Used when user joins the challenge or to force sync.


### PR DESCRIPTION
Some notes:
- Changed `createAndPopulateGroup` to properly create users who are members.
- I added `hasAccess` which is a method from a @paglias branch but it should merge easily since he told me where to put it :smile_cat: 
- I found a couple of routes that were crashing due to bad validation `checkQuery` instead of `checkParams` and `res.local` which was `undefined` for me. Am I missing something or are all these copy paste errors?
- Added a default value of 1 for Challenge `memberCount` since the creator always enters the challenge.

Most of the api logic with the join route is executed in `syncToUser`. I didn't want to make a thousand tests for every branch in this method, because this should be a unit test. So I created a couple of tests to check for the most important logic of `syncToUser` to make sure it is called and correctly executes in this route.

UUID: bb8db09b-5822-4608-bba3-1486964b8537
