### PR TITLE
Adding persistence for progress and reward tracking to welcome tour

### DIFF
--- a/common/script/index.js
+++ b/common/script/index.js
@@ -2056,6 +2056,10 @@ api.wrap = function(user, main) {
           cb(null, user);
         }
         return delta;
+      },
+      checkStats: function (req, cb) {
+        user.fns.updateStats(user.stats, req);
+        return typeof cb === "function" ? cb(null, user) : void 0;
       }
     };
   }

--- a/test/common/user.ops.checkStats.js
+++ b/test/common/user.ops.checkStats.js
@@ -1,0 +1,30 @@
+import {
+  generateUser,
+} from '../helpers/common.helper';
+
+describe('user.ops.checkStats', () => {
+  let user;
+
+  beforeEach(() => {
+    user = generateUser({});
+  });
+
+  context('Checking a user', () => {
+    it('does not affect stats when no updates are made', () => {
+      let _stats = user.stats;
+
+      user.ops.checkStats({});
+
+      expect(user.stats).to.eql(_stats);
+    });
+
+    it('levels a user when they are beyond the current exp threshold', () => {
+      user.stats.exp = 151;
+      user.stats.lvl = 1;
+
+      user.ops.checkStats({});
+
+      expect({lvl: user.stats.lvl, exp: user.stats.exp}).to.eql({lvl: 2, exp: 1});
+    });
+  });
+});

--- a/website/public/js/controllers/menuCtrl.js
+++ b/website/public/js/controllers/menuCtrl.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('habitrpg')
-  .controller('MenuCtrl', ['$scope', '$rootScope', '$http', 'Chat', 'Guide',
-    function($scope, $rootScope, $http, Chat, Guide) {
+  .controller('MenuCtrl', ['$scope', '$rootScope', '$http', 'Chat',
+    function($scope, $rootScope, $http, Chat) {
 
       $scope.logout = function() {
         localStorage.clear();
@@ -42,11 +42,6 @@ angular.module('habitrpg')
 
       $scope.hasNoNotifications = function() {
         return selectNotificationValue(false, false, false, false, false, true);
-      }
-
-      $scope.showTour = function() {
-        var lastKnownTourStep = parseInt(localStorage.getItem('habitrpg-tourStep'));
-        Guide.goto('intro', (lastKnownTourStep > -1 ? lastKnownTourStep + 1 : 0) , true);
       }
     }
 ]);

--- a/website/public/js/controllers/menuCtrl.js
+++ b/website/public/js/controllers/menuCtrl.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('habitrpg')
-  .controller('MenuCtrl', ['$scope', '$rootScope', '$http', 'Chat',
-    function($scope, $rootScope, $http, Chat) {
+  .controller('MenuCtrl', ['$scope', '$rootScope', '$http', 'Chat', 'Guide',
+    function($scope, $rootScope, $http, Chat, Guide) {
 
       $scope.logout = function() {
         localStorage.clear();
@@ -42,6 +42,11 @@ angular.module('habitrpg')
 
       $scope.hasNoNotifications = function() {
         return selectNotificationValue(false, false, false, false, false, true);
+      }
+
+      $scope.showTour = function() {
+        var lastKnownTourStep = parseInt(localStorage.getItem('habitrpg-tourStep'));
+        Guide.goto('intro', (lastKnownTourStep > -1 ? lastKnownTourStep + 1 : 0) , true);
       }
     }
 ]);

--- a/website/public/js/services/guideServices.js
+++ b/website/public/js/services/guideServices.js
@@ -198,6 +198,11 @@ function($rootScope, User, $timeout, $state, Analytics) {
         var ups = {};
         var lastKnownStep = User.user.flags.tour[k];
 
+        // Return early if user has already completed this tutorial
+        if (lastKnownStep === -2) {
+          return;
+        }
+
         if (i > lastKnownStep) {
           if (step.gold) ups['stats.gp'] = User.user.stats.gp + step.gold;
           if (step.experience) ups['stats.exp'] = User.user.stats.exp + step.experience;

--- a/website/views/shared/header/menu.jade
+++ b/website/views/shared/header/menu.jade
@@ -272,7 +272,7 @@ nav.toolbar(ng-controller='MenuCtrl')
 
     ul.toolbar-bailey(ng-class='{inactive: !_expandedMenu.menu}')
       li.toolbar-bailey-container(ng-if='user.flags.tour.intro!=-2')
-        .npc_justin_head.npc_bailey_head(popover='Continue Tour', popover-trigger='mouseenter', popover-placement='bottom', ng-click='showTour()')
+        .npc_justin_head.npc_bailey_head(popover='Continue Tour', popover-trigger='mouseenter', popover-placement='bottom', ng-click='Guide.goto("intro", user.flags.tour.intro + 1, true);')
 
     ul.toolbar-bailey(ng-class='{inactive: !_expandedMenu.menu}')
       li.toolbar-bailey-container(ng-if='user.flags.newStuff')

--- a/website/views/shared/header/menu.jade
+++ b/website/views/shared/header/menu.jade
@@ -272,7 +272,7 @@ nav.toolbar(ng-controller='MenuCtrl')
 
     ul.toolbar-bailey(ng-class='{inactive: !_expandedMenu.menu}')
       li.toolbar-bailey-container(ng-if='user.flags.tour.intro!=-2')
-        .npc_justin_head.npc_bailey_head(popover='Continue Tour', popover-trigger='mouseenter', popover-placement='bottom', ng-click='Guide.goto("intro", user.flags.tour.intro + 1, true);')
+        .npc_justin_head.npc_bailey_head(popover='Continue Tour', popover-trigger='mouseenter', popover-placement='bottom', ng-click='Guide.goto("intro", user.flags.tour.intro + 1, true)')
 
     ul.toolbar-bailey(ng-class='{inactive: !_expandedMenu.menu}')
       li.toolbar-bailey-container(ng-if='user.flags.newStuff')

--- a/website/views/shared/header/menu.jade
+++ b/website/views/shared/header/menu.jade
@@ -272,7 +272,7 @@ nav.toolbar(ng-controller='MenuCtrl')
 
     ul.toolbar-bailey(ng-class='{inactive: !_expandedMenu.menu}')
       li.toolbar-bailey-container(ng-if='user.flags.tour.intro!=-2')
-        .npc_justin_head.npc_bailey_head(popover='Continue Tour', popover-trigger='mouseenter', popover-placement='bottom', ng-click='Guide.goto("intro", user.flags.tour.intro, true)')
+        .npc_justin_head.npc_bailey_head(popover='Continue Tour', popover-trigger='mouseenter', popover-placement='bottom', ng-click='showTour()')
 
     ul.toolbar-bailey(ng-class='{inactive: !_expandedMenu.menu}')
       li.toolbar-bailey-container(ng-if='user.flags.newStuff')


### PR DESCRIPTION
Fixes #5852 and #5854.

I opted for localStorage to handle the persistence. The one caveat I see with that is that I never clear the key manually. The best spot for that, if it is a concern, would probably be on first login. That would ensure the key did not exist before a user sees the welcome dialog and tour tips. (I'm not sure where that would be added, or I would have done it.)

I added the `checkStats()` function to index.js because I didn't want to add unintentional bloat in the `update()` function, which is used with `User.set()`. If there's a smarter way to handle this level checking already, let me know. :)

I couldn't find a way to break this on my end, but it'd be worth having some other people test I think.
