### PR TITLE
Open links from task notes into new browser window/context (Fixes #5622)

### DIFF
--- a/common/script/public/directives.js
+++ b/common/script/public/directives.js
@@ -145,7 +145,7 @@
     return function(input){
       var html = md.toHtml(input);
 
-      html = html.replace(' href',' target="_self" href');
+      html = html.replace(' href',' target="_blank" href');
 
       return html;
     };


### PR DESCRIPTION
Makes all links in task notes open in a separate browser tab/window so Habitica stays open in the current tab.

Note: Speculative fix. I had trouble setting up Habitica to run on my system and haven't gotten it running yet (version issues w/ Vagrant, ruby gems, etc.), so I haven't confirmed this works as intended. Please review carefully.

Fixes #5622.
