### PR TITLE
#6332, #5148: Fix 'add task' button jumping around

### DIFF
--- a/website/public/css/tasks.styl
+++ b/website/public/css/tasks.styl
@@ -193,11 +193,6 @@ for $stage in $stages
     border: 0
     float: right
     font-size: 0.85em
-  .empty-task-notification
-    // @TODO: This causes weird centering behavior (see #6332)
-    // however, this is required to show the tooltip on the task button
-    // Figure out how to fix the centering behavior while preserving the tooltip
-    height: 100%;
 
 // message in Dailies column when Resting in Inn
 // ------------------------

--- a/website/views/shared/tasks/task_view/add_new.jade
+++ b/website/views/shared/tasks/task_view/add_new.jade
@@ -2,9 +2,9 @@ form.task-add(name='new{{list.type}}form', ng-hide='obj._locked', ng-submit='add
   textarea(rows='6', focus-element='list.bulk && list.focus', ng-model='list.newTask', placeholder='{{list.placeHolderBulk}}', ng-if='list.bulk', ui-keydown='{"meta-enter ctrl-enter":"addTask(obj[list.type+\'s\'],list)"}', required)
   input(type='text', focus-element='!list.bulk && list.focus', ng-model='list.newTask', placeholder='{{list.placeHolder}}', ng-if='!list.bulk', required)
   button(type='submit', ng-disabled='new{{list.type}}form.$invalid')
-   div.empty-task-notification( ng-show='new{{list.type}}form.$invalid', tooltip=env.t("emptyTask") )
-     span.glyphicon.glyphicon-plus
-   span.glyphicon.glyphicon-plus(ng-show='!new{{list.type}}form.$invalid')
+    div(ng-show='new{{list.type}}form.$invalid', tooltip=env.t("emptyTask"))
+      span.glyphicon.glyphicon-plus
+    span.glyphicon.glyphicon-plus(ng-show='!new{{list.type}}form.$invalid')
   small.help-block.btn-link.pull-right(ng-click='toggleBulk(list)')
     span(ng-if='!list.bulk')=env.t('addmultiple')
     span(ng-if='list.bulk')=env.t('addsingle')


### PR DESCRIPTION
Stops the plus icon jumping down when text is entered in the 'new task' textbox.

Related: #6333, #6332, #5327, #5304 and #5148.

[Comment 1 (crookedneighbor)](https://github.com/HabitRPG/habitrpg/pull/5327#issuecomment-111784268):

> That div was created to generate a tooltip when a user tries to press the plus button when no task information has been supplied. It's also what is causing the plus button to get pushed around.
> 
> The tooltip should appear when hovering over the button, and only if the input is empty. It seems to not be behaving correctly :frowning:. It was flaky before, but without that styling, it's extra flaky.

[Comment 2 (crookedneighbor)](https://github.com/HabitRPG/habitrpg/pull/6333#issuecomment-164201578):

> This has been suggested before, but that height style is required for the tooltip to show up. I'm going to add a comment to that effect.

I've tested on Chrome 47 and Firefox 43 (both on Ubuntu), and the behaviour with this change is exactly the same as on the live site, except the icon not jumping around. On Chrome, the tooltip appears and behaves the same on both live site and local server. On Firefox, I can't get the tooltip to show up at all on either my local server or the live site, but that seems like a separate issue.

Before:

![image](https://cloud.githubusercontent.com/assets/9433472/12432326/8dff5002-bef2-11e5-8aec-db2499f3799a.png)

After:

![image](https://cloud.githubusercontent.com/assets/9433472/12432306/7e8845ac-bef2-11e5-838f-c4ae2bb08c64.png)
