### PR TITLE
Return enable symlinks in vagrant and use npm@3

### DIFF
--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -8,6 +8,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider "virtualbox" do |v|
     v.memory = 768
     v.cpus = 1
+    v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/vagrant", "1"]
   end
   config.vm.box = "thepeopleseason/habitrpg"
   config.ssh.forward_agent = true

--- a/vagrant_scripts/install_node.sh
+++ b/vagrant_scripts/install_node.sh
@@ -16,7 +16,7 @@ nvm use
 nvm alias default current
 
 echo Update npm...
-npm install -g npm@2
+npm install -g npm@3
 
 echo Installing global modules...
 npm install -g gulp bower grunt-cli mocha


### PR DESCRIPTION
We need symlinks enabled so we can have the symlinks in `./node_modules/.bin/` for binaries used during testing.

When trying to `npm install` with npm@2 I get a lot of errors and a failed installation. This doesn't occur with npm@3.

Also it's interesting to note that while these changes work for me, there seems to be a problem with npm that requires `npm install` to be called twice. I found other people with the same issue and the npm guys confirming it's a bug. [source](https://github.com/npm/npm/issues/10727)

UUID: bb8db09b-5822-4608-bba3-1486964b8537
