### PR TITLE
Color code quest accepted/rejected text

### DIFF
--- a/website/public/css/quests.styl
+++ b/website/public/css/quests.styl
@@ -8,3 +8,9 @@ quest-rewards
 
 .quest-icon
   margin: .6em
+
+.quest-participants .accepted
+  color: #2DB200
+
+.quest-participants .rejected
+  color: #B30409

--- a/website/views/options/social/quests/participants.jade
+++ b/website/views/options/social/quests/participants.jade
@@ -1,6 +1,6 @@
 mixin participants(questStart)
   -var isMember = 'group.quest.members[member._id]'
-  table.table.table-striped
+  table.table.table-striped.quest-participants
     tr(ng-repeat='member in group.members track by member._id',
       ng-if='#{!questStart} || #{isMember}')
       td
@@ -8,8 +8,8 @@ mixin participants(questStart)
         a: span(ng-click='clickMember(member._id, true)') {{::member.profile.name}}
 
       if !questStart
-        td(ng-if='#{isMember} === true')=env.t('accepted')
-        td(ng-if='#{isMember} === false')=env.t('rejected')
+        td.accepted(ng-if='#{isMember} === true')=env.t('accepted')
+        td.rejected(ng-if='#{isMember} === false')=env.t('rejected')
         td(ng-if='#{isMember} !== true && #{isMember} !== false')=env.t('pending')
 
   span="* " + env.t('questOwner')


### PR DESCRIPTION
I noticed that in the iOS app, the list of quest participants is easier to scan as party members who accept the quest are highlighted in green. As I'm more of a visual person, thought I'd dip a toe into the codebase and try to implement the same thing on the website.
