### PR TITLE
Fix header overlap on small screens

### DIFF
--- a/website/public/css/header.styl
+++ b/website/public/css/header.styl
@@ -12,6 +12,8 @@
   overflow-y: hidden
   overflow-x: auto
   // position relative
+  @media screen and (min-width: 768px) and (max-width: 1014px) //extra padding for smaller screen sizes
+    padding-top: 92px
   @media screen and (max-width: $xs-max-screen-width)  // remove padding-top when toolbar is static
     padding: 0
 .toolbar.active ~ .header-wrap


### PR DESCRIPTION
Tiny CSS fix for #6562, where the navigation bar was covering tags and search on smaller screens.

Used specific widths instead of variables as the problem didn't really bear much relation to existing breakpoints. See before and after pic:

![header-menu-css-fix](https://cloud.githubusercontent.com/assets/1240249/12568922/e70f160e-c3c1-11e5-8170-8f4754984eb7.jpg)

Please note: Only tested on Windows (Chrome, FF, IE11)
