### PR TITLE
Adds user details to the removal modal

### DIFF
--- a/website/public/css/index.styl
+++ b/website/public/css/index.styl
@@ -109,13 +109,6 @@ html, body
 /* Misc
 -------------------------------------------------- */
 //move
-
-.modal-subheading {
-  margin: 12px 0 8px;
-  font-size: 24px;
-  font-weight: bold;
-}
-
 .new-stuff-modal // a .modal-body
   h2, h3
     font-weight: 700

--- a/website/public/css/index.styl
+++ b/website/public/css/index.styl
@@ -110,6 +110,12 @@ html, body
 -------------------------------------------------- */
 //move
 
+.modal-subheading {
+  margin: 12px 0 8px;
+  font-size: 24px;
+  font-weight: bold;
+}
+
 .new-stuff-modal // a .modal-body
   h2, h3
     font-weight: 700

--- a/website/views/shared/modals/members.jade
+++ b/website/views/shared/modals/members.jade
@@ -116,7 +116,7 @@ script(type='text/ng-template', id='modals/abuse-flag.html')
 script(type='text/ng-template', id='modals/remove-member.html')
   .modal-header.text-center
     h4=env.t('sureKick')
-    p.modal-subheading {{::removeMemberData.member.profile.name}}
+    p.lead: strong {{::removeMemberData.member.profile.name}}
   .modal-body
     textarea.form-control(type='text',rows='5',placeholder=env.t('optionalMessage'),ng-model='removeMemberData.message')
   .modal-footer

--- a/website/views/shared/modals/members.jade
+++ b/website/views/shared/modals/members.jade
@@ -114,7 +114,7 @@ script(type='text/ng-template', id='modals/abuse-flag.html')
     button.btn.btn-danger(ng-click='reportAbuse(user, abuseObject, groupId)')=env.t("abuseFlagModalButton")
 
 script(type='text/ng-template', id='modals/remove-member.html')
-  .modal-header(class='text-center')
+  .modal-header.text-center
     h4=env.t('sureKick')
     p(class='modal-subheading') {{removeMemberData.member.profile.name}}
   .modal-body

--- a/website/views/shared/modals/members.jade
+++ b/website/views/shared/modals/members.jade
@@ -114,9 +114,9 @@ script(type='text/ng-template', id='modals/abuse-flag.html')
     button.btn.btn-danger(ng-click='reportAbuse(user, abuseObject, groupId)')=env.t("abuseFlagModalButton")
 
 script(type='text/ng-template', id='modals/remove-member.html')
-  .modal-header
-    h4(class='text-center')=env.t('sureKick')
-    p(class='modal-subheading text-center') {{removeMemberData.member.profile.name}}
+  .modal-header(class='text-center')
+    h4=env.t('sureKick')
+    p(class='modal-subheading') {{removeMemberData.member.profile.name}}
   .modal-body
     textarea.form-control(type='text',rows='5',placeholder=env.t('optionalMessage'),ng-model='removeMemberData.message')
   .modal-footer

--- a/website/views/shared/modals/members.jade
+++ b/website/views/shared/modals/members.jade
@@ -115,7 +115,8 @@ script(type='text/ng-template', id='modals/abuse-flag.html')
 
 script(type='text/ng-template', id='modals/remove-member.html')
   .modal-header
-    h4=env.t('sureKick')
+    h4(class='text-center')=env.t('sureKick')
+    p(class='modal-subheading text-center') {{removeMemberData.member.profile.name}}
   .modal-body
     textarea.form-control(type='text',rows='5',placeholder=env.t('optionalMessage'),ng-model='removeMemberData.message')
   .modal-footer

--- a/website/views/shared/modals/members.jade
+++ b/website/views/shared/modals/members.jade
@@ -116,7 +116,7 @@ script(type='text/ng-template', id='modals/abuse-flag.html')
 script(type='text/ng-template', id='modals/remove-member.html')
   .modal-header.text-center
     h4=env.t('sureKick')
-    p(class='modal-subheading') {{removeMemberData.member.profile.name}}
+    p.modal-subheading {{::removeMemberData.member.profile.name}}
   .modal-body
     textarea.form-control(type='text',rows='5',placeholder=env.t('optionalMessage'),ng-model='removeMemberData.message')
   .modal-footer


### PR DESCRIPTION
Fixes #6578 

Adds the ability to see the username within the removal modal for parties and guilds.
