### PR TITLE
Added get group challenges route and initial tests

### DIFF
--- a/test/api/v3/integration/challenges/GET-challenges_group_groupid.test.js
+++ b/test/api/v3/integration/challenges/GET-challenges_group_groupid.test.js
@@ -30,15 +30,19 @@ describe('GET challenges/group/:groupId', () => {
     it('should return group challenges for non member', async () => {
       let challenges = await nonMember.get(`/challenges/groups/${publicGuild._id}`);
 
-      expect(_.findIndex(challenges, {_id: challenge._id})).to.be.above(-1);
-      expect(_.findIndex(challenges, {_id: challenge2._id})).to.be.above(-1);
+      let foundChallenge1 = _.find(challenges, { _id: challenge._id });
+      expect(foundChallenge1).to.exist;
+      let foundChallenge2 = _.find(challenges, { _id: challenge2._id });
+      expect(foundChallenge2).to.exist;
     });
 
     it('should return group challenges for member', async () => {
       let challenges = await user.get(`/challenges/groups/${publicGuild._id}`);
 
-      expect(_.findIndex(challenges, {_id: challenge._id})).to.be.above(-1);
-      expect(_.findIndex(challenges, {_id: challenge2._id})).to.be.above(-1);
+      let foundChallenge1 = _.find(challenges, { _id: challenge._id });
+      expect(foundChallenge1).to.exist;
+      let foundChallenge2 = _.find(challenges, { _id: challenge2._id });
+      expect(foundChallenge2).to.exist;
     });
   });
 
@@ -75,8 +79,10 @@ describe('GET challenges/group/:groupId', () => {
     it('should return group challenges for member', async () => {
       let challenges = await user.get(`/challenges/groups/${privateGuild._id}`);
 
-      expect(_.findIndex(challenges, {_id: challenge._id})).to.be.above(-1);
-      expect(_.findIndex(challenges, {_id: challenge2._id})).to.be.above(-1);
+      let foundChallenge1 = _.find(challenges, { _id: challenge._id });
+      expect(foundChallenge1).to.exist;
+      let foundChallenge2 = _.find(challenges, { _id: challenge2._id });
+      expect(foundChallenge2).to.exist;
     });
   });
 });

--- a/test/api/v3/integration/challenges/GET-challenges_group_groupid.test.js
+++ b/test/api/v3/integration/challenges/GET-challenges_group_groupid.test.js
@@ -1,0 +1,82 @@
+import {
+  generateUser,
+  generateChallenge,
+  createAndPopulateGroup,
+  translate as t,
+} from '../../../../helpers/api-v3-integration.helper';
+
+describe('GET challenges/group/:groupId', () => {
+  context('Public Guild', () => {
+    let publicGuild, user, nonMember, challenge, challenge2;
+
+    before(async () => {
+      let { group, groupLeader } = await createAndPopulateGroup({
+        groupDetails: {
+          name: 'TestGuild',
+          type: 'guild',
+          privacy: 'public',
+        },
+      });
+
+      publicGuild = group;
+      user = groupLeader;
+
+      nonMember = await generateUser();
+
+      challenge = await generateChallenge(user, group);
+      challenge2 = await generateChallenge(user, group);
+    });
+
+    it('should return group challenges for non member', async () => {
+      let challenges = await nonMember.get(`/challenges/groups/${publicGuild._id}`);
+
+      expect(_.findIndex(challenges, {_id: challenge._id})).to.be.above(-1);
+      expect(_.findIndex(challenges, {_id: challenge2._id})).to.be.above(-1);
+    });
+
+    it('should return group challenges for member', async () => {
+      let challenges = await user.get(`/challenges/groups/${publicGuild._id}`);
+
+      expect(_.findIndex(challenges, {_id: challenge._id})).to.be.above(-1);
+      expect(_.findIndex(challenges, {_id: challenge2._id})).to.be.above(-1);
+    });
+  });
+
+  context('Private Guild', () => {
+    let privateGuild, user, nonMember, challenge, challenge2;
+
+    before(async () => {
+      let { group, groupLeader } = await createAndPopulateGroup({
+        groupDetails: {
+          name: 'TestPrivateGuild',
+          type: 'guild',
+          privacy: 'private',
+        },
+      });
+
+      privateGuild = group;
+      user = groupLeader;
+
+      nonMember = await generateUser();
+
+      challenge = await generateChallenge(user, group);
+      challenge2 = await generateChallenge(user, group);
+    });
+
+    it('should prevent non-member from seeing challenges', async () => {
+      await expect(nonMember.get(`/challenges/groups/${privateGuild._id}`))
+        .to.eventually.be.rejected.and.eql({
+          code: 404,
+          error: 'NotFound',
+          message: t('groupNotFound'),
+        });
+    });
+
+    it('should return group challenges for member', async () => {
+      let challenges = await user.get(`/challenges/groups/${privateGuild._id}`);
+
+      expect(_.findIndex(challenges, {_id: challenge._id})).to.be.above(-1);
+      expect(_.findIndex(challenges, {_id: challenge2._id})).to.be.above(-1);
+    });
+  });
+});

--- a/test/api/v3/integration/challenges/GET-challenges_user.test.js
+++ b/test/api/v3/integration/challenges/GET-challenges_user.test.js
@@ -1,0 +1,72 @@
+import {
+  generateUser,
+  generateChallenge,
+  createAndPopulateGroup,
+} from '../../../../helpers/api-v3-integration.helper';
+
+describe('GET challenges/user', () => {
+  let user, member, nonMember, challenge, challenge2;
+
+  before(async () => {
+    let { group, groupLeader, members } = await createAndPopulateGroup({
+      groupDetails: {
+        name: 'TestGuild',
+        type: 'guild',
+        privacy: 'public',
+      },
+      members: 1,
+    });
+
+    user = groupLeader;
+
+    member = members[0];
+    nonMember = await generateUser();
+
+    challenge = await generateChallenge(user, group);
+    challenge2 = await generateChallenge(user, group);
+  });
+
+  it('should return challenges user has joined', async () => {
+    await nonMember.post(`/challenges/${challenge._id}/join`);
+
+    let challenges = await nonMember.get(`/challenges/user`);
+
+    let foundChallenge = _.find(challenges, { _id: challenge._id });
+    expect(foundChallenge).to.exist;
+  });
+
+  it('should return challenges user has created', async () => {
+    let challenges = await user.get(`/challenges/user`);
+
+    let foundChallenge1 = _.find(challenges, { _id: challenge._id });
+    expect(foundChallenge1).to.exist;
+    let foundChallenge2 = _.find(challenges, { _id: challenge2._id });
+    expect(foundChallenge2).to.exist;
+  });
+
+  it('should return challenges in user\'s group', async () => {
+    let challenges = await member.get(`/challenges/user`);
+
+    let foundChallenge1 = _.find(challenges, { _id: challenge._id });
+    expect(foundChallenge1).to.exist;
+    let foundChallenge2 = _.find(challenges, { _id: challenge2._id });
+    expect(foundChallenge2).to.exist;
+  });
+
+  it('should not return challenges user doesn\'t have access to', async () => {
+    let { group, groupLeader } = await createAndPopulateGroup({
+      groupDetails: {
+        name: 'TestPrivateGuild',
+        type: 'guild',
+        privacy: 'private',
+      },
+    });
+
+    let privateChallenge = await generateChallenge(groupLeader, group);
+
+    let challenges = await nonMember.get(`/challenges/user`);
+
+    let foundChallenge = _.find(challenges, { _id: privateChallenge._id });
+    expect(foundChallenge).to.not.exist;
+  });
+});

--- a/website/src/controllers/api-v3/challenges.js
+++ b/website/src/controllers/api-v3/challenges.js
@@ -121,7 +121,8 @@ api.joinChallenge = {
     let challenge = await Challenge.findOne({ _id: req.params.challengeId });
     if (!challenge) throw new NotFound(res.t('challengeNotFound'));
 
-    if (!challenge.hasAccess(user)) throw new NotFound(res.t('challengeNotFound'));
+    let group = await Group.getGroup({user, groupId: challenge.groupId, fields: '_id type privacy', optionalMembership: true});
+    if (!group || !challenge.canView(user, group)) throw new NotFound(res.t('challengeNotFound'));
 
     if (_.contains(user.challenges, challenge._id)) throw new NotAuthorized(res.t('userAlreadyInChallenge'));
 
@@ -172,16 +173,16 @@ api.leaveChallenge = {
 };
 
 /**
- * @api {get} /challenges Get challenges for a user
+ * @api {get} /challenges/user Get challenges for a user
  * @apiVersion 3.0.0
- * @apiName GetChallenges
+ * @apiName GetUserChallenges
  * @apiGroup Challenge
  *
  * @apiSuccess {Array} challenges An array of challenges
  */
-api.getChallenges = {
+api.getUserChallenges = {
   method: 'GET',
-  url: '/challenges',
+  url: '/challenges/user',
   middlewares: [authWithHeaders(), cron],
   async handler (req, res) {
     let user = res.locals.user;

--- a/website/src/controllers/api-v3/challenges.js
+++ b/website/src/controllers/api-v3/challenges.js
@@ -209,6 +209,43 @@ api.getChallenges = {
 };
 
 /**
+ * @api {get} /challenges/group/group:Id Get challenges for a group
+ * @apiVersion 3.0.0
+ * @apiName GetGroupChallenges
+ * @apiGroup Challenge
+ *
+ * @apiParam {groupId} groupId The group _id
+ *
+ * @apiSuccess {Array} challenges An array of challenges
+ */
+api.getGroupChallenges = {
+  method: 'GET',
+  url: '/challenges/groups/:groupId',
+  middlewares: [authWithHeaders(), cron],
+  async handler (req, res) {
+    let user = res.locals.user;
+    let groupId = req.params.groupId;
+
+    req.checkParams('groupId', res.t('groupIdRequired')).notEmpty();
+
+    let validationErrors = req.validationErrors();
+    if (validationErrors) throw validationErrors;
+
+    let group = await Group.getGroup({user, groupId});
+    if (!group) throw new NotFound(res.t('groupNotFound'));
+
+    let challenges = await Challenge.find({groupId})
+      .sort('-official -timestamp')
+      // TODO populate
+      // .populate('group', '_id name type')
+      // .populate('leader', 'profile.name')
+      .exec();
+
+    res.respond(200, challenges);
+  },
+};
+
+/**
  * @api {get} /challenges/:challengeId Get a challenge given its id
  * @apiVersion 3.0.0
  * @apiName GetChallenge


### PR DESCRIPTION
This address Get challenges for group and tests in #6509. I didn't see much logic here that needed to be abstracted, @paglias . Let me know if you disagree.
