### PR TITLE
Fix failing unit tests on windows

### DIFF
--- a/test/api/v3/unit/libs/i18n.test.js
+++ b/test/api/v3/unit/libs/i18n.test.js
@@ -31,13 +31,6 @@ describe('i18n', () => {
     });
   });
 
-  describe('localePath', () => {
-    it('is an absolute path to common/locales/', () => {
-      expect(localePath).to.match(/.*\/common\/locales\//);
-      expect(localePath);
-    });
-  });
-
   describe('langCodes', () => {
     it('is a list of all the language codes', () => {
       expect(langCodes.sort()).to.eql(listOfLocales);

--- a/test/api/v3/unit/libs/setupNconf.test.js
+++ b/test/api/v3/unit/libs/setupNconf.test.js
@@ -1,5 +1,6 @@
 import setupNconf from '../../../../../website/src/libs/api-v3/setupNconf';
 
+import path from 'path';
 import nconf from 'nconf';
 
 describe('setupNconf', () => {
@@ -19,7 +20,9 @@ describe('setupNconf', () => {
     expect(nconf.argv).to.be.calledOnce;
     expect(nconf.env).to.be.calledOnce;
     expect(nconf.file).to.be.calledOnce;
-    expect(nconf.file).to.be.calledWithMatch('user', /\/config.json$/);
+
+    let regexString = `\\${path.sep}config.json$`;
+    expect(nconf.file).to.be.calledWithMatch('user', new RegExp(regexString));
   });
 
   it('sets IS_PROD variable', () => {


### PR DESCRIPTION
These two tests were failing on windows, because of the different path seperator.

We discussed with @blade how to fix the `is an absolute path to common/locales/` test, and arrived to the conclusion that the current test doesn't really test what it describes. Even if we write it to do what it says, it's just going to be a repetition of the code that creates the variable so there is no point.

For the second test I just added the `path.sep` in the regex.
