### PR TITLE
Add HP to party page

### DIFF
--- a/website/views/options/social/group.jade
+++ b/website/views/options/social/group.jade
@@ -82,7 +82,7 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
                     span.glyphicon.glyphicon-ban-circle(tooltip=env.t('banTip'))
                 a.media-body
                   span(ng-click='clickMember(member._id, true)')
-                    | {{member.profile.name}} (<strong>{{member.stats.hp}}</strong> #{env.t('hp')})
+                    | {{member.profile.name}} (<strong>{{member.stats.hp.toFixed(1)}}</strong> #{env.t('hp')})
             tr(ng-if='::group.memberCount > group.members.length')
               td
                 span.badge {{group.memberCount - group.members.length}}

--- a/website/views/options/social/group.jade
+++ b/website/views/options/social/group.jade
@@ -82,7 +82,7 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
                     span.glyphicon.glyphicon-ban-circle(tooltip=env.t('banTip'))
                 a.media-body
                   span(ng-click='clickMember(member._id, true)')
-                    | {{member.profile.name}}
+                    | {{member.profile.name}} (<strong>{{member.stats.hp}}</strong> #{env.t('hp')})
             tr(ng-if='::group.memberCount > group.members.length')
               td
                 span.badge {{group.memberCount - group.members.length}}

--- a/website/views/options/social/group.jade
+++ b/website/views/options/social/group.jade
@@ -82,7 +82,7 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
                     span.glyphicon.glyphicon-ban-circle(tooltip=env.t('banTip'))
                 a.media-body
                   span(ng-click='clickMember(member._id, true)')
-                    | {{member.profile.name}} (<strong>{{member.stats.hp.toFixed(1)}}</strong> #{env.t('hp')})
+                    | {{member.profile.name}} (#[strong {{member.stats.hp.toFixed(1)}}] #{env.t('hp')})
             tr(ng-if='::group.memberCount > group.members.length')
               td
                 span.badge {{group.memberCount - group.members.length}}


### PR DESCRIPTION
Party page now displays each party member's health next to their name
(healers don't have to click on each party member to see their health)
![image](https://cloud.githubusercontent.com/assets/9312226/12699471/243b1124-c771-11e5-8999-9bc98e25cf22.png)
