### PR TITLE
Add .img-rendering-auto to several images

### DIFF
--- a/website/views/static/front.jade
+++ b/website/views/static/front.jade
@@ -214,13 +214,13 @@ html(ng-app='habitrpg', ng-controller='RootCtrl')
                   img.sample-img.visible-lg-inline-block(src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/uses/coding.png')
                   .usetweet-groups.col-lg-5.col-md-6.visible-lg-inline-block.visible-md-inline-block
                     .usetweet-group
-                      img(data-toggle='tooltip', data-placement='top', title='frabjabulous', src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/testimonials/frabjabulous.png')
+                      img.img-rendering-auto(data-toggle='tooltip', data-placement='top', title='frabjabulous', src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/testimonials/frabjabulous.png')
                       .usetweet.tweet.popover.right
                         .arrow
                         .popover-content
                           = env.t('frabjabulousQuote')
                     .usetweet-group
-                      img(data-toggle='tooltip', data-placement='top', title='_AlexandraSo_', src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/testimonials/AlexandraSo.png')
+                      img.img-rendering-auto(data-toggle='tooltip', data-placement='top', title='_AlexandraSo_', src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/testimonials/AlexandraSo.png')
                       .usetweet.tweet.popover.right
                         .arrow
                         .popover-content
@@ -258,13 +258,13 @@ html(ng-app='habitrpg', ng-controller='RootCtrl')
                   img.sample-img.visible-lg-inline-block(src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/uses/clipart-rosemonkeyct-meditation.png')
                   .usetweet-groups.col-lg-5.col-md-6.visible-lg-inline-block.visible-md-inline-block
                     .usetweet-group
-                      img(data-toggle='tooltip', data-placement='top', title='EvaGantz', src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/testimonials/EvaGantz.png')
+                      img.img-rendering-auto(data-toggle='tooltip', data-placement='top', title='EvaGantz', src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/testimonials/EvaGantz.png')
                       .usetweet.tweet.popover.right
                         .arrow
                         .popover-content
                           = env.t('evagantzQuote')
                     .usetweet-group
-                      img(data-toggle='tooltip', data-placement='top', title='supermouse35', src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/testimonials/supermouse35.png')
+                      img.img-rendering-auto(data-toggle='tooltip', data-placement='top', title='supermouse35', src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/testimonials/supermouse35.png')
                       .usetweet.tweet.popover.right
                         .arrow
                         .popover-content
@@ -296,7 +296,7 @@ html(ng-app='habitrpg', ng-controller='RootCtrl')
                   img.sample-img.visible-lg-inline-block(src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/uses/publicSpaces.png')
                   .usetweet-groups.col-lg-5.col-md-6.visible-lg-inline-block.visible-md-inline-block
                     .usetweet-group
-                      img(data-toggle='tooltip', data-placement='top', title='Althaire', src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/testimonials/Althaire.png')
+                      img.img-rendering-auto(data-toggle='tooltip', data-placement='top', title='Althaire', src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/testimonials/Althaire.png')
                       .usetweet.tweet.popover.right
                         .arrow
                         .popover-content
@@ -334,12 +334,12 @@ html(ng-app='habitrpg', ng-controller='RootCtrl')
                   img.sample-img.visible-lg-inline-block(src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/uses/reading.png')
                   .usetweet-groups.col-lg-5.col-md-6.visible-lg-inline-block.visible-md-inline-block
                     .usetweet-group
-                      img(data-toggle='tooltip', data-placement='top', title='InfH', src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/testimonials/InfH.png')
+                      img.img-rendering-auto(data-toggle='tooltip', data-placement='top', title='InfH', src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/testimonials/InfH.png')
                       .usetweet.tweet.popover.right
                         .arrow
                         .popover-content= env.t('infhQuote')
                     .usetweet-group
-                      img(data-toggle='tooltip', data-placement='top', title='Drei-M', src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/testimonials/Drei-M.png')
+                      img.img-rendering-auto(data-toggle='tooltip', data-placement='top', title='Drei-M', src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/testimonials/Drei-M.png')
                       .usetweet.tweet.popover.right
                         .arrow
                         .popover-content
@@ -371,7 +371,7 @@ html(ng-app='habitrpg', ng-controller='RootCtrl')
                   img.sample-img.visible-lg-inline-block(src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/uses/gaining_an_achievement_by_cosmic_caterpillar-d7uyv5z.png')
                   .usetweet-groups.col-lg-5.col-md-6.visible-lg-inline-block.visible-md-inline-block
                     .usetweet-group
-                      img(data-toggle='tooltip', data-placement='top', title='Kazui', src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/testimonials/Kazui.png')
+                      img.img-rendering-auto(data-toggle='tooltip', data-placement='top', title='Kazui', src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/testimonials/Kazui.png')
                       .usetweet.tweet.popover.right
                         .arrow
                         .popover-content
@@ -403,12 +403,12 @@ html(ng-app='habitrpg', ng-controller='RootCtrl')
                   img.sample-img.visible-lg-inline-block(src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/uses/dusting_by_leephon.png')
                   .usetweet-groups.col-lg-5.col-md-6.visible-lg-inline-block.visible-md-inline-block
                     .usetweet-group
-                      img(data-toggle='tooltip', data-placement='top', title='autumnesquirrel', src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/testimonials/autumnesquirrel.png')
+                      img.img-rendering-auto(data-toggle='tooltip', data-placement='top', title='autumnesquirrel', src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/testimonials/autumnesquirrel.png')
                       .usetweet.tweet.popover.right
                         .arrow
                         .popover-content= env.t('autumnesquirrelQuote')
                     .usetweet-group
-                      img(data-toggle='tooltip', data-placement='top', title='irishfeet123', src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/testimonials/irishfeet123.png')
+                      img.img-rendering-auto(data-toggle='tooltip', data-placement='top', title='irishfeet123', src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/testimonials/irishfeet123.png')
                       .usetweet.tweet.popover.right
                         .arrow
                         .popover-content
@@ -440,7 +440,7 @@ html(ng-app='habitrpg', ng-controller='RootCtrl')
                 span.glyphicon.glyphicon-arrow-down
               img.img-responsive(src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/misc/shop_gold.png')
               img.img-responsive(src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/misc/shop_gold.png')
-              img.img-rendering-auto.img-responsive(src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/misc/shop_gold.png')
+              img.img-responsive(src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/misc/shop_gold.png')
               h2
                 span.glyphicon.glyphicon-arrow-down
               img.img-rendering-auto.img-responsive(src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/TVreward.png')
@@ -478,7 +478,7 @@ html(ng-app='habitrpg', ng-controller='RootCtrl')
             h2= env.t('punishHeading2')
             p.sectioninfo= env.t('punishByline')
             .scrolltweet.hidden-xs.hidden-sm
-              img.scrolltweet-image(data-toggle='tooltip', data-placement='top', title='Zelah Meyer', src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/testimonials/Zelah_Meyer.png')
+              img.img-rendering-auto.scrolltweet-image(data-toggle='tooltip', data-placement='top', title='Zelah Meyer', src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/testimonials/Zelah_Meyer.png')
               .tweet.popover.right.pull-right
                 .arrow
                 .popover-content
@@ -513,7 +513,7 @@ html(ng-app='habitrpg', ng-controller='RootCtrl')
               br
               = env.t('questByline2')
             .scrolltweet.hidden-xs.hidden-sm
-              img.scrolltweet-image(data-toggle='tooltip', data-placement='top', title='skysailor', src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/testimonials/skysailor.png')
+              img.img-rendering-auto.scrolltweet-image(data-toggle='tooltip', data-placement='top', title='skysailor', src='https://d2afqr2xdmyzvu.cloudfront.net/front/images/testimonials/skysailor.png')
               .tweet.popover.right.pull-right
                 .arrow
                 .popover-content


### PR DESCRIPTION
Whilst things like avatars are pixel art, the fact that they get resized means that they look very jagged when rendered pixelated. With `image-rendering: auto`, they look significantly better, for example supermouse35's avatar in the Health section of the carousel.

Live site:

![image](https://cloud.githubusercontent.com/assets/9433472/12702094/c0fbe692-c815-11e5-9682-b57cd5f9e07d.png)

![image](https://cloud.githubusercontent.com/assets/9433472/12702112/2edd847c-c816-11e5-9181-b3ec687c63df.png)

PR:

![image](https://cloud.githubusercontent.com/assets/9433472/12702105/ed68e8c4-c815-11e5-847b-e45199b09dee.png)

![image](https://cloud.githubusercontent.com/assets/9433472/12702115/3d680a62-c816-11e5-9cc4-7faef94e949a.png)
