### PR TITLE
Make task help icons consistent across browsers

### DIFF
--- a/website/public/css/tasks.styl
+++ b/website/public/css/tasks.styl
@@ -149,8 +149,8 @@ for $stage in $stages
     font-weight: 300
 
   .option-box .glyphicon
-    zoom: 1.5
-    vertical-align: -webkit-baseline-middle
+    font-size: 1.5em
+    vertical-align: middle
 
 .task-column.preview
   padding: 0


### PR DESCRIPTION
The `zoom` CSS property isn't supported by Firefox, and nor is `vertical-align: -webkit-baseline-middle`. `font-size: 1.5em` has the same effect, and `vertical-align: middle` ensures that the tooltip doesn't overlap with the icon. I don't actually know what `-webkit-baseline-middle` does, but having a WebKit-specific value with no fallback seems odd, and frankly the difference is so slight that we may as well go for consistency.

Live site vs. PR, Chrome:

![image](https://cloud.githubusercontent.com/assets/9433472/12703080/85691b60-c831-11e5-8763-fccc6df414ec.png)

![image](https://cloud.githubusercontent.com/assets/9433472/12703084/8d911efa-c831-11e5-8d66-ba9a5514c5c2.png)

Live site vs. PR, Firefox:

![image](https://cloud.githubusercontent.com/assets/9433472/12703088/a23ca270-c831-11e5-82ef-289d25f84feb.png)

![image](https://cloud.githubusercontent.com/assets/9433472/12703089/a922bc64-c831-11e5-82df-a5010900c2ec.png)
