### PR TITLE
Added quest cancel route and initial tests

### DIFF
--- a/common/locales/en/api-v3.json
+++ b/common/locales/en/api-v3.json
@@ -73,5 +73,6 @@
   "questNotFound": "Quest \"<%= key %>\" not found.",
   "questNotOwned": "You don't own that quest scroll.",
   "questLevelTooHigh": "You must be Level <%= level %> to begin this quest.",
-  "questAlreadyUnderway": "Your party is already on a quest. Try again when the current quest has ended."
+  "questAlreadyUnderway": "Your party is already on a quest. Try again when the current quest has ended.",
+  "cantCancelActiveQuest": "You can not cancel an active quest"
 }

--- a/test/api/v3/integration/quests/POST-groups_groupid_quests_cancel.test.js
+++ b/test/api/v3/integration/quests/POST-groups_groupid_quests_cancel.test.js
@@ -1,0 +1,66 @@
+import {
+  createAndPopulateGroup,
+  translate as t,
+} from '../../../../helpers/api-v3-integration.helper';
+import { v4 as generateUUID } from 'uuid';
+
+describe('POST /groups/:groupId/quests/leave', () => {
+  let questingGroup, member, leader;
+  const PET_QUEST = 'whale';
+  let userQuestUpdate = {
+    items: {
+      quests: {},
+    },
+    'party.quest.RSVPNeeded': true,
+    'party.quest.key': PET_QUEST,
+  };
+
+  before(async () => {
+    let { group, groupLeader, members } = await createAndPopulateGroup({
+      groupDetails: { type: 'party', privacy: 'private' },
+      members: 1,
+    });
+
+    leader = groupLeader;
+    questingGroup = group;
+    member = members[0];
+
+    userQuestUpdate.items.quests[PET_QUEST] = 1;
+  });
+
+  it('returns an error when group is not found', async () => {
+    await expect(leader.post(`/groups/${generateUUID()}/quests/cancel`))
+      .to.eventually.be.rejected.and.eql({
+        code: 404,
+        error: 'NotFound',
+        message: t('groupNotFound'),
+      });
+  });
+
+  it('cancels a quest', async () => {
+    await member.update(userQuestUpdate);
+    await questingGroup.update({'quest.key': PET_QUEST});
+
+    let questMembers = {};
+    questMembers[member._id] = true;
+    await questingGroup.update({'quest.members': questMembers});
+
+    await leader.post(`/groups/${questingGroup._id}/quests/cancel`);
+    let userThatCanceled = await member.get('/user');
+    let updatedGroup = await member.get(`/groups/${questingGroup._id}`);
+
+    expect(userThatCanceled.party.quest.key).to.be.null;
+    expect(userThatCanceled.party.quest.RSVPNeeded).to.be.false;
+    expect(updatedGroup.quest.members).to.be.empty;
+  });
+
+  it('returns an error when quest is active', async () => {
+    await questingGroup.update({'quest.active': true});
+    await expect(leader.post(`/groups/${questingGroup._id}/quests/cancel`))
+      .to.eventually.be.rejected.and.eql({
+        code: 401,
+        error: 'NotAuthorized',
+        message: t('cantCancelActiveQuest'),
+      });
+  });
+});

--- a/website/src/controllers/api-v3/quests.js
+++ b/website/src/controllers/api-v3/quests.js
@@ -4,6 +4,9 @@ import {
   model as Group,
 } from '../../models/group';
 import {
+  model as User,
+} from '../../models/user';
+import {
   NotFound,
   NotAuthorized,
 } from '../../libs/api-v3/errors';
@@ -64,5 +67,51 @@ api.inviteToQuest = {
     res.respond(200, {});
   },
 };
+
+/**
+ * @api {post} /groups/:groupId/quests/cancel Cancels a quest
+ * @apiVersion 3.0.0
+ * @apiName CancelQuest
+ * @apiGroup Group
+ *
+ * @apiParam {string} groupId The group _id (or 'party')
+ *
+ * @apiSuccess {Object} Group Object
+ */
+api.cancelQuest = {
+  method: 'POST',
+  url: '/groups/:groupId/quests/cancel',
+  middlewares: [authWithHeaders(), cron],
+  async handler (req, res) {
+    // Cancel a quest BEFORE it has begun (i.e., in the invitation stage)
+    // Quest scroll has not yet left quest owner's inventory so no need to return it.
+    // Do not wipe quest progress for members because they'll want it to be applied to the next quest that's started.
+    let user = res.locals.user;
+    let groupId = req.params.groupId;
+
+    req.checkParams('groupId', res.t('groupIdRequired')).notEmpty();
+
+    let validationErrors = req.validationErrors();
+    if (validationErrors) throw validationErrors;
+
+    let group = await Group.getGroup({user, groupId, fields: 'type quest'});
+    if (!group) throw new NotFound(res.t('groupNotFound'));
+
+    if (group.quest.active) throw new NotAuthorized(res.t('cantCancelActiveQuest'));
+
+    group.quest = {key: null, progress: {}, leader: null, members: {}};
+    group.markModified('quest');
+    await group.save();
+
+    await User.update(
+      {'party._id': groupId},
+      {$set: {'party.quest.RSVPNeeded': false, 'party.quest.key': null}},
+      {multi: true}
+    );
+
+    res.respond(200, group);
+  },
+};
+
 
 export default api;


### PR DESCRIPTION
Here is the quest cancel route and initial tests for #6509 .

I'm unsure about the return object, and we have started a discussion in Slack as to whether or not we should verify that a user is a group or quest leader before cancelling. 
