### PR TITLE
Store data for next mobile update

### DIFF
--- a/common/script/index.js
+++ b/common/script/index.js
@@ -815,9 +815,12 @@ api.wrap = function(user, main) {
             message: i18n.t('messageTaskNotFound', req.language)
           }) : void 0;
         }
-        _.merge(task, _.omit(req.body, ['checklist', 'id', 'type']));
+        _.merge(task, _.omit(req.body, ['checklist', 'remidners', 'id', 'type']));
         if (req.body.checklist) {
           task.checklist = req.body.checklist;
+        }
+        if (req.body.reminders) {
+          task.reminders = req.body.reminders;
         }
         if (typeof task.markModified === "function") {
           task.markModified('tags');

--- a/common/script/index.js
+++ b/common/script/index.js
@@ -815,7 +815,7 @@ api.wrap = function(user, main) {
             message: i18n.t('messageTaskNotFound', req.language)
           }) : void 0;
         }
-        _.merge(task, _.omit(req.body, ['checklist', 'remidners', 'id', 'type']));
+        _.merge(task, _.omit(req.body, ['checklist', 'reminders', 'id', 'type']));
         if (req.body.checklist) {
           task.checklist = req.body.checklist;
         }

--- a/test/api/v2/user/PUT-user.test.js
+++ b/test/api/v2/user/PUT-user.test.js
@@ -175,4 +175,27 @@ describe('PUT /user', () => {
       });
     });
   });
+
+  context('Improvement Categories', () => {
+    it('sets valid categories', async () => {
+      await user.put('/user', {
+        'preferences.improvementCategories': ['work', 'school'],
+      });
+
+      await user.sync();
+
+      expect(user.preferences.improvementCategories).to.eql(['work', 'school']);
+    });
+
+    it('discards invalid categories', async () => {
+      await expect(user.put('/user', {
+        'preferences.improvementCategories': ['work', 'procrastination', 'school'],
+      })).to.eventually.be.rejected.and.eql({
+        code: 400,
+        text: [
+          'Validator failed for path `preferences.improvementCategories` with value `work,procrastination,school`',
+        ],
+      });
+    });
+  });
 });

--- a/website/src/controllers/api-v2/user.js
+++ b/website/src/controllers/api-v2/user.js
@@ -355,7 +355,15 @@ api.update = (req, res, next) => {
 
   user.save((err) => {
     if (!_.isEmpty(errors)) return res.json(401, {err: errors});
-    if (err) return next(err);
+    if (err) {
+      if (err.name == 'ValidationError') {
+        let errorMessages = _.map(_.values(err.errors), (error) => {
+          return error.message;
+        });
+        return res.json(400, {err: errorMessages});
+      }
+      return next(err);
+    }
 
     res.json(200, user);
     user = errors = null;

--- a/website/src/models/task.js
+++ b/website/src/models/task.js
@@ -28,7 +28,12 @@ var TaskSchema = {
     broken: String, // CHALLENGE_DELETED, TASK_DELETED, UNSUBSCRIBED, CHALLENGE_CLOSED
     winner: String // user.profile.name
     // group: {type: 'Strign', ref: 'Group'} // if we restore this, rename `id` above to `challenge`
-  }
+  },
+  reminders: [{
+    id: {type:String,'default':shared.uuid},
+    startDate: Date,
+    time: Date
+  }]
 };
 
 var HabitSchema = new Schema(

--- a/website/src/models/user.js
+++ b/website/src/models/user.js
@@ -395,7 +395,7 @@ var UserSchema = new Schema({
       type: Array,
       validate: (categories) => {
         const validCategories = ['work', 'exercise', 'healthWellness', 'school', 'teams', 'chores', 'creativity'];
-        let isValidCategory = categories.every(category => validValues.indexOf(category) !== -1);
+        let isValidCategory = categories.every(category => validCategories.indexOf(category) !== -1);
         return isValidCategory;
     }}
   },

--- a/website/src/models/user.js
+++ b/website/src/models/user.js
@@ -391,15 +391,15 @@ var UserSchema = new Schema({
       raisePet: {type: Boolean, 'default': false},
       streak: {type: Boolean, 'default': false}
     },
-    improvementCategories: {
-      "work": {type: Boolean, 'default': false},
-      "exercise": {type: Boolean, 'default': false},
-      "healthWellness": {type: Boolean, 'default': false},
-      "school": {type: Boolean, 'default': false},
-      "teams": {type: Boolean, 'default': false},
-      "chores": {type: Boolean, 'default': false},
-      "creativity": {type: Boolean, 'default': false},
-    }
+    improvementCategories: {type: Array, validate: function (categories) {
+      var validValues = true;
+      categories.forEach(function (cat) {
+        if (['work', 'exercise', 'healthWellness', 'school', 'teams', 'chores', 'creativity'].indexOf(cat) === -1){
+          validValues = false;
+        }
+      });
+      return validValues;
+    }}
   },
   profile: {
     blurb: String,

--- a/website/src/models/user.js
+++ b/website/src/models/user.js
@@ -390,6 +390,15 @@ var UserSchema = new Schema({
       hatchPet: {type: Boolean, 'default': false},
       raisePet: {type: Boolean, 'default': false},
       streak: {type: Boolean, 'default': false}
+    },
+    improvementCategories: {
+      "work": {type: Boolean, 'default': false},
+      "exercise": {type: Boolean, 'default': false},
+      "healthWellness": {type: Boolean, 'default': false},
+      "school": {type: Boolean, 'default': false},
+      "teams": {type: Boolean, 'default': false},
+      "chores": {type: Boolean, 'default': false},
+      "creativity": {type: Boolean, 'default': false},
     }
   },
   profile: {

--- a/website/src/models/user.js
+++ b/website/src/models/user.js
@@ -391,14 +391,12 @@ var UserSchema = new Schema({
       raisePet: {type: Boolean, 'default': false},
       streak: {type: Boolean, 'default': false}
     },
-    improvementCategories: {type: Array, validate: function (categories) {
-      var validValues = true;
-      categories.forEach(function (cat) {
-        if (['work', 'exercise', 'healthWellness', 'school', 'teams', 'chores', 'creativity'].indexOf(cat) === -1){
-          validValues = false;
-        }
-      });
-      return validValues;
+    improvementCategories: {
+      type: Array,
+      validate: (categories) => {
+        const validCategories = ['work', 'exercise', 'healthWellness', 'school', 'teams', 'chores', 'creativity'];
+        let isValidCategory = categories.every(category => validValues.indexOf(category) !== -1);
+        return isValidCategory;
     }}
   },
   profile: {


### PR DESCRIPTION
This PR adds  storage for two new things:
- a list of reminders associated with a task.
- different areas in which the user wants to improve their life. This is chosen during mobile signup and can be used to p.e. suggest guilds.

**Reminders:** Currently the iOS app supports reminders for dailies and todos. Daily reminders are triggered on each day the daily is active at the time specified in the _time_ property. Todos also use the _startDate_ property to determine the day when the reminder should be displayed. Currently a reminder for a todo is only displayed once, but I plan on adding repeat options in the future (hence _startDate_). The intention of saving the reminders on the server is to 1. have them persistently between app and device installs and 2. eventually have the reminders on different plattforms too.

**Improvement Categories/areas** during the setup of the iOS and android app, the user has the option to select one or multiple categories they want to improve in. Currently this only creates default tasks based on this. The guilds feature that will be available in the next update for the android and iOS app will also feature guild suggestions for people that aren't in many guilds yet. In order to tailor the suggestions to the user, the choices made during setup have to be persisted. Having those choices available can later also be used to expand on such suggestions.
