### PR TITLE
Fixed partially hidden button in chat box

### DIFF
--- a/website/views/options/social/chat-box.jade
+++ b/website/views/options/social/chat-box.jade
@@ -1,6 +1,6 @@
 div.chat-form.guidelines-not-accepted(ng-if='!user.flags.communityGuidelinesAccepted')
   p!=env.t('requestAcceptGuidelines', {linkStart: '<a target="_blank", href="/static/community-guidelines">', linkEnd: '</a>'})
-  .chat-controls
+  .chat-controls.clearfix
     div
       button.btn.btn-warning(ng-click='acceptCommunityGuidelines()')=env.t('iAcceptCommunityGuidelines')
     .chat-buttons


### PR DESCRIPTION
Fixed #6740

There was just a ".clearfix" missing, which prevents the following items to overlap the button.

![2016-02-19 22_03_06-fotos](https://cloud.githubusercontent.com/assets/8058487/13189339/11d44320-d757-11e5-9f22-83631df26575.png)
