### PR TITLE
Display attribute info in Character Build

### DIFF
--- a/common/locales/en/character.json
+++ b/common/locales/en/character.json
@@ -136,7 +136,7 @@
     "respawn": "Respawn!",
     "youDied": "You Died!",
     "dieText": "You've lost a Level, all your Gold, and a random piece of Equipment. Arise, Habiteer, and try again! Curb those negative Habits, be vigilant in completion of Dailies, and hold death at arm's length with a Health Potion if you falter!",
-    "sureReset": "Are you sure? This will reset your character's class and allocated points (you'll get them all back to re-allocate), and costs 3 gems",
+    "sureReset": "Are you sure? This will reset your character's class and allocated points (you'll get them all back to re-allocate), and costs 3 gems.",
     "purchaseFor": "Purchase for <%= cost %> Gems?",
     "notEnoughMana": "Not enough mana.",
     "invalidTarget": "Invalid target",

--- a/website/views/options/profile.jade
+++ b/website/views/options/profile.jade
@@ -207,30 +207,13 @@ mixin profileStats
                       span.glyphicon.glyphicon-download
                       |&nbsp;
                       =env.t('distributePoints')
-            tr
-              td
-                span.hint(popover-trigger='mouseenter', popover-placement='right', popover=env.t('strengthText'))
-                  =env.t('allocateStr') + ' {{user.stats.str}}'
-              td
-                a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("str")', popover-trigger='mouseenter', popover-placement='right', popover=env.t('allocateStrPop')) +
-            tr
-              td
-                span.hint(popover-trigger='mouseenter', popover-placement='right', popover=env.t('intText'))
-                  =env.t('allocateInt') + ' {{user.stats.int}}'
-              td
-                a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("int")', popover-trigger='mouseenter', popover-placement='right', popover=env.t('allocateIntPop')) +
-            tr
-              td
-                span.hint(popover-trigger='mouseenter', popover-placement='right', popover=env.t('conText'))
-                  =env.t('allocateCon') + ' {{user.stats.con}}'
-              td
-                a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("con")', popover-trigger='mouseenter', popover-placement='right', popover=env.t('allocateConPop')) +
-            tr
-              td
-                span.hint(popover-trigger='mouseenter', popover-placement='right', popover=env.t('perText'))
-                  =env.t('allocatePer') + ' {{user.stats.per}}'
-              td
-                a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("per")', popover-trigger='mouseenter', popover-placement='right', popover=env.t('allocatePerPop')) +
+            each statInfo, stat in { str: {title:"allocateStr",popover:'strengthText',allocatepop:'allocateStrPop'},int: {title:"allocateInt",popover:'intText',allocatepop:'allocateIntPop'},con: {title:"allocateCon",popover:'conText',allocatepop:'allocateConPop'},per: {title:"allocatePer",popover:'perText',allocatepop:'allocatePerPop'} }
+              tr
+                td
+                  span.hint(popover-trigger='mouseenter', popover-placement='right', popover=env.t(statInfo.popover))
+                    =env.t(statInfo.title) + ' {{user.stats.' + stat + '}}'
+                td
+                  a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("#{stat}")', popover-trigger='mouseenter', popover-placement='right', popover=env.t(statInfo.allocatepop)) +
 
 
       div(ng-class='user.flags.classSelected && !user.preferences.disableClasses ? "col-md-4" : "col-md-6"')

--- a/website/views/options/profile.jade
+++ b/website/views/options/profile.jade
@@ -208,19 +208,27 @@ mixin profileStats
                       |&nbsp;
                       =env.t('distributePoints')
             tr
-              td= env.t('allocateStr') + ' {{user.stats.str}}'
+              td
+                span.hint(popover-trigger='mouseenter', popover-placement='right', popover=env.t('strengthText'))
+                  =env.t('allocateStr') + ' {{user.stats.str}}'
               td
                 a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("str")', popover-trigger='mouseenter', popover-placement='right', popover=env.t('allocateStrPop')) +
             tr
-              td= env.t('allocateInt') + ' {{user.stats.int}}'
+              td
+                span.hint(popover-trigger='mouseenter', popover-placement='right', popover=env.t('intText'))
+                  =env.t('allocateInt') + ' {{user.stats.int}}'
               td
                 a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("int")', popover-trigger='mouseenter', popover-placement='right', popover=env.t('allocateIntPop')) +
             tr
-              td= env.t('allocateCon') + ' {{user.stats.con}}'
+              td
+                span.hint(popover-trigger='mouseenter', popover-placement='right', popover=env.t('conText'))
+                  =env.t('allocateCon') + ' {{user.stats.con}}'
               td
                 a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("con")', popover-trigger='mouseenter', popover-placement='right', popover=env.t('allocateConPop')) +
             tr
-              td= env.t('allocatePer') + ' {{user.stats.per}}'
+              td
+                span.hint(popover-trigger='mouseenter', popover-placement='right', popover=env.t('perText'))
+                  =env.t('allocatePer') + ' {{user.stats.per}}'
               td
                 a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("per")', popover-trigger='mouseenter', popover-placement='right', popover=env.t('allocatePerPop')) +
 


### PR DESCRIPTION
When I have unallocated attribute points I never know which attribute to allocate them to because I don't really know what the attributes do. I thought it would be useful to display information about the attributes in the "Character Build" section where one allocate points. Come to find out there is already detailed information about the attributes it just was off the screen in the Attribute section. I still think it make sense to have that information accessible right where you will be allocating the points though, rather than having to mouse over to the Attribute section and then back to the allocation part.
