### PR TITLE
Quick allocation of attribute points from level-up modal

### DIFF
--- a/common/locales/en/character.json
+++ b/common/locales/en/character.json
@@ -160,5 +160,7 @@
     "str": "STR",
     "con": "CON",
     "per": "PER",
-    "int": "INT"
+    "int": "INT",
+    "showHideQuickAllocation": "Show/hide stat allocation",
+    "quickAllocationLevelPopover": "Each level earns you one point to assign to an attribute of your choice. You can do so manually, or let the game decide for you using one of the Automatic Allocation options found in User -> Stats."
 }

--- a/website/views/options/profile.jade
+++ b/website/views/options/profile.jade
@@ -207,13 +207,7 @@ mixin profileStats
                       span.glyphicon.glyphicon-download
                       |&nbsp;
                       =env.t('distributePoints')
-            each statInfo, stat in { str: {title:"allocateStr",popover:'strengthText',allocatepop:'allocateStrPop'},int: {title:"allocateInt",popover:'intText',allocatepop:'allocateIntPop'},con: {title:"allocateCon",popover:'conText',allocatepop:'allocateConPop'},per: {title:"allocatePer",popover:'perText',allocatepop:'allocatePerPop'} }
-              tr
-                td
-                  span.hint(popover-trigger='mouseenter', popover-placement='right', popover=env.t(statInfo.popover))
-                    =env.t(statInfo.title) + ' {{user.stats.' + stat + '}}'
-                td
-                  a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("#{stat}")', popover-trigger='mouseenter', popover-placement='right', popover=env.t(statInfo.allocatepop)) +
+            +statAllocation
 
 
       div(ng-class='user.flags.classSelected && !user.preferences.disableClasses ? "col-md-4" : "col-md-6"')

--- a/website/views/shared/mixins.jade
+++ b/website/views/shared/mixins.jade
@@ -33,3 +33,12 @@ mixin ownedQuests(popoverAppend, popoverPlacement)
             popover-append-to-body='#{popoverAppend}',
             popover-placement='#{popoverPlacement}')
               .badge.badge-info.stack-count {{points}}
+
+mixin statAllocation
+  each statInfo, stat in { str: {title:"allocateStr",popover:'strengthText',allocatepop:'allocateStrPop'},int: {title:"allocateInt",popover:'intText',allocatepop:'allocateIntPop'},con: {title:"allocateCon",popover:'conText',allocatepop:'allocateConPop'},per: {title:"allocatePer",popover:'perText',allocatepop:'allocatePerPop'} }
+    tr
+      td
+        span.hint(popover-trigger='mouseenter', popover-placement='right', popover=env.t(statInfo.popover))
+          =env.t(statInfo.title) + ' {{user.stats.' + stat + '}}'
+      td
+        a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("#{stat}")', popover-trigger='mouseenter', popover-placement='right', popover=env.t(statInfo.allocatepop)) +

--- a/website/views/shared/modals/level-up.jade
+++ b/website/views/shared/modals/level-up.jade
@@ -29,13 +29,7 @@ script(type='text/ng-template', id='modals/levelUp.html')
                     | {{user.stats.points}}&nbsp;
                   strong.hint(popover-trigger='mouseenter', popover-placement='right', popover=env.t('quickAllocationLevelPopover'))=env.t('unallocated')
               td
-            each statInfo, stat in { str: {title:"allocateStr",popover:'strengthText',allocatepop:'allocateStrPop'},int: {title:"allocateInt",popover:'intText',allocatepop:'allocateIntPop'},con: {title:"allocateCon",popover:'conText',allocatepop:'allocateConPop'},per: {title:"allocatePer",popover:'perText',allocatepop:'allocatePerPop'} }
-              tr
-                td
-                  span.hint(popover-trigger='mouseenter', popover-placement='right', popover=env.t(statInfo.popover))
-                    =env.t(statInfo.title) + ' {{user.stats.' + stat + '}}'
-                td
-                  a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("#{stat}")', popover-trigger='mouseenter', popover-placement='right', popover=env.t(statInfo.allocatepop)) +
+            +statAllocation
       button.btn.btn-primary(ng-click='$close()')=env.t('huzzah')
       .checkbox
         label(style='display:inline-block')=env.t('dontShowAgain')

--- a/website/views/shared/modals/level-up.jade
+++ b/website/views/shared/modals/level-up.jade
@@ -16,6 +16,35 @@ script(type='text/ng-template', id='modals/levelUp.html')
       h4(style='margin-top: 1em')!=env.t('leveledUp', {level:'{{user.stats.lvl}}'})
       p=env.t('fullyHealed')
       br
+      div(ng-if='user.flags.classSelected && !user.preferences.disableClasses && !user.preferences.automaticAllocation')
+        a.btn.btn-default(data-toggle='collapse', data-target='#stat-allocation', aria-expanded=false, aria-controls='stat-allocation')=env.t('showHideQuickAllocation')
+        p &nbsp;
+        div.collapse#stat-allocation
+          table.table.text-left
+            tr
+              td
+                p(ng-if='::user.stats.lvl >= 100')!=env.t('noMoreAllocate')
+                p(ng-if='user.stats.points || user.stats.lvl < 100')
+                  strong.inline
+                    | {{user.stats.points}}&nbsp;
+                  strong.hint(popover-trigger='mouseenter', popover-placement='right', popover=env.t('quickAllocationLevelPopover'))=env.t('unallocated')
+              td
+            tr
+              td= env.t('allocateStr') + ' {{user.stats.str}}'
+              td
+                a.btn.btn-default.btn-xs(ng-show='user.stats.points', ng-click='allocate("str")', popover-trigger='mouseenter', popover-placement='right', popover=env.t('allocateStrPop')) +
+            tr
+              td= env.t('allocateInt') + ' {{user.stats.int}}'
+              td
+                a.btn.btn-default.btn-xs(ng-show='user.stats.points', ng-click='allocate("int")', popover-trigger='mouseenter', popover-placement='right', popover=env.t('allocateIntPop')) +
+            tr
+              td= env.t('allocateCon') + ' {{user.stats.con}}'
+              td
+                a.btn.btn-default.btn-xs(ng-show='user.stats.points', ng-click='allocate("con")', popover-trigger='mouseenter', popover-placement='right', popover=env.t('allocateConPop')) +
+            tr
+              td= env.t('allocatePer') + ' {{user.stats.per}}'
+              td
+                a.btn.btn-default.btn-xs(ng-show='user.stats.points', ng-click='allocate("per")', popover-trigger='mouseenter', popover-placement='right', popover=env.t('allocatePerPop')) +
       button.btn.btn-primary(ng-click='$close()')=env.t('huzzah')
       .checkbox
         label(style='display:inline-block')=env.t('dontShowAgain')

--- a/website/views/shared/modals/level-up.jade
+++ b/website/views/shared/modals/level-up.jade
@@ -29,22 +29,13 @@ script(type='text/ng-template', id='modals/levelUp.html')
                     | {{user.stats.points}}&nbsp;
                   strong.hint(popover-trigger='mouseenter', popover-placement='right', popover=env.t('quickAllocationLevelPopover'))=env.t('unallocated')
               td
-            tr
-              td= env.t('allocateStr') + ' {{user.stats.str}}'
-              td
-                a.btn.btn-default.btn-xs(ng-show='user.stats.points', ng-click='allocate("str")', popover-trigger='mouseenter', popover-placement='right', popover=env.t('allocateStrPop')) +
-            tr
-              td= env.t('allocateInt') + ' {{user.stats.int}}'
-              td
-                a.btn.btn-default.btn-xs(ng-show='user.stats.points', ng-click='allocate("int")', popover-trigger='mouseenter', popover-placement='right', popover=env.t('allocateIntPop')) +
-            tr
-              td= env.t('allocateCon') + ' {{user.stats.con}}'
-              td
-                a.btn.btn-default.btn-xs(ng-show='user.stats.points', ng-click='allocate("con")', popover-trigger='mouseenter', popover-placement='right', popover=env.t('allocateConPop')) +
-            tr
-              td= env.t('allocatePer') + ' {{user.stats.per}}'
-              td
-                a.btn.btn-default.btn-xs(ng-show='user.stats.points', ng-click='allocate("per")', popover-trigger='mouseenter', popover-placement='right', popover=env.t('allocatePerPop')) +
+            each statInfo, stat in { str: {title:"allocateStr",popover:'strengthText',allocatepop:'allocateStrPop'},int: {title:"allocateInt",popover:'intText',allocatepop:'allocateIntPop'},con: {title:"allocateCon",popover:'conText',allocatepop:'allocateConPop'},per: {title:"allocatePer",popover:'perText',allocatepop:'allocatePerPop'} }
+              tr
+                td
+                  span.hint(popover-trigger='mouseenter', popover-placement='right', popover=env.t(statInfo.popover))
+                    =env.t(statInfo.title) + ' {{user.stats.' + stat + '}}'
+                td
+                  a.btn.btn-primary(ng-show='user.stats.points', ng-click='allocate("#{stat}")', popover-trigger='mouseenter', popover-placement='right', popover=env.t(statInfo.allocatepop)) +
       button.btn.btn-primary(ng-click='$close()')=env.t('huzzah')
       .checkbox
         label(style='display:inline-block')=env.t('dontShowAgain')


### PR DESCRIPTION
Resolves #6720; a more detailed description of behaviour can be found there, but it looks like this:

![image](https://cloud.githubusercontent.com/assets/9433472/13199543/7061d744-d820-11e5-8f29-a0f3137311f4.png)

![image](https://cloud.githubusercontent.com/assets/9433472/13199544/7a183756-d820-11e5-9150-db4e4b8c9806.png)
