### PR TITLE
TEST_DB_URI env override

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -6,6 +6,7 @@
     "FACEBOOK_KEY":"123456789012345",
     "FACEBOOK_SECRET":"aaaabbbbccccddddeeeeffff00001111",
     "NODE_DB_URI":"mongodb://localhost/habitrpg",
+    "TEST_DB_URI":"mongodb://localhost/habitrpg_test",
     "NODE_ENV":"development",
     "SESSION_SECRET":"YOUR SECRET HERE",
     "ADMIN_EMAIL": "you@example.com",

--- a/tasks/gulp-tests.js
+++ b/tasks/gulp-tests.js
@@ -12,12 +12,12 @@ import gulp                       from 'gulp';
 import Q                          from 'q';
 import runSequence                from 'run-sequence';
 import os                         from 'os';
+import nconf                      from 'nconf';
 
 const TEST_SERVER_PORT  = 3003
-const TEST_DB           = 'habitrpg_test'
 let server;
 
-const TEST_DB_URI       = `mongodb://localhost/${TEST_DB}`
+const TEST_DB_URI       = nconf.get('TEST_DB_URI');
 
 const API_V2_TEST_COMMAND = 'npm run test:api-v2:integration';
 const LEGACY_API_TEST_COMMAND = 'npm run test:api-legacy';
@@ -51,7 +51,7 @@ gulp.task('test:nodemon', (done) => {
   process.env.PORT = TEST_SERVER_PORT;
   process.env.NODE_DB_URI=TEST_DB_URI;
 
-  runSequence('nodemon')
+  runSequence('nodemon');
 });
 
 gulp.task('test:prepare:mongo', (cb) => {


### PR DESCRIPTION
Allow individuals to override TEST_DB_URI when running tests.  This facilitates development under docker or other environments where mongo may not be running on localhost.

Tested with:
    TEST_DB_URI=mongodb://habitrpg_mongo_1/habitrpg_test gulp test:content

user id: bf56a7cf-0970-40f2-af1b-f4df3f9bda4d
