### PR TITLE
adding two deps to dockerfile required for karma

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN apt-get install -y \
     build-essential \
     curl \
     git \
+    libfontconfig1 \
+    libfreetype6 \
     libkrb5-dev \
     python
 


### PR DESCRIPTION
Under a docker image, karma was missing two libraries and failing to run.  This adds those two libraries to the docker build.

Tested with:
    gulp test:karma

user id: bf56a7cf-0970-40f2-af1b-f4df3f9bda4d
