### PR TITLE
Implement Party Cap - fixes #6756

### DIFF
--- a/common/locales/en/groups.json
+++ b/common/locales/en/groups.json
@@ -121,6 +121,7 @@
     "inviteAlertInfo": "If you have friends already using Habitica, invite them by <a href='http://habitica.wikia.com/wiki/API_Options' target='_blank'>User ID</a> here.",
     "inviteExistUser": "Invite Existing Users",
     "byColon": "By:",
+    "partyCapWarning":  "Parties have a maximum size of <%= partyCap %>.  Your party currently has <%= memberAndInviteCount %> members and  invites.",
     "inviteNewUsers": "Invite New Users",
     "sendInvitations": "Send Invitations",
     "invitationsSent": "Invitations sent!",

--- a/website/public/js/controllers/groupsCtrl.js
+++ b/website/public/js/controllers/groupsCtrl.js
@@ -111,6 +111,7 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '
         }, undefined, function(){
           if($scope.removeMemberData.isMember){
             _.pull($scope.removeMemberData.group.members, $scope.removeMemberData.member);
+            $scope.removeMemberData.group.memberCount -= 1;
           }else{
             _.pull($scope.removeMemberData.group.invites, $scope.removeMemberData.member);
           }

--- a/website/public/js/controllers/groupsCtrl.js
+++ b/website/public/js/controllers/groupsCtrl.js
@@ -123,6 +123,8 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '
       }
     };
 
+    $scope.isOverPartyCap = Groups.isOverPartyCap;
+
     $scope.openInviteModal = function(group){
       if (group.type !== 'party' && group.type !== 'guild') {
         return console.log('Invalid group type.')

--- a/website/public/js/controllers/inviteToGroupCtrl.js
+++ b/website/public/js/controllers/inviteToGroupCtrl.js
@@ -26,11 +26,9 @@ habitrpg.controller('InviteToGroupCtrl', ['$scope', 'User', 'Groups', 'injectedG
       _inviteByMethod(inviteMethod);
     };
 
-    $scope.getMemberAndInviteCount = function(group) {
-      return (group && group.memberCount) 
-              ? group.memberCount + (group.invites ?  group.invites.length: 0)
-              : 0;
-    }
+    $scope.isOverPartyCap = Groups.isOverPartyCap;
+    $scope.isOverPartyCapWarning = Groups.isOverPartyCapWarning;
+    $scope.memberAndInviteCount = Groups.memberAndInviteCount;
 
     function _inviteByMethod(inviteMethod) {
       var invitationDetails;
@@ -47,7 +45,7 @@ habitrpg.controller('InviteToGroupCtrl', ['$scope', 'User', 'Groups', 'injectedG
 
       Groups.Group.invite({gid: $scope.group._id}, invitationDetails, function(group){
         Notification.text(window.env.t('invitationsSent'));
-        if (group.invites) $scope.group.invites = group.invites;
+        if (group && group.invites) $scope.group.invites = group.invites;
         _resetInvitees();
       }, function(){
         _resetInvitees();

--- a/website/public/js/controllers/inviteToGroupCtrl.js
+++ b/website/public/js/controllers/inviteToGroupCtrl.js
@@ -26,6 +26,10 @@ habitrpg.controller('InviteToGroupCtrl', ['$scope', 'User', 'Groups', 'injectedG
       _inviteByMethod(inviteMethod);
     };
 
+    $scope.getMemberAndInviteCount = function(group) {
+      return group.memberCount + group.invites.length;
+    }
+
     function _inviteByMethod(inviteMethod) {
       var invitationDetails;
 
@@ -39,8 +43,9 @@ habitrpg.controller('InviteToGroupCtrl', ['$scope', 'User', 'Groups', 'injectedG
         return console.log('Invalid invite method.')
       }
 
-      Groups.Group.invite({gid: $scope.group._id}, invitationDetails, function(){
+      Groups.Group.invite({gid: $scope.group._id}, invitationDetails, function(group){
         Notification.text(window.env.t('invitationsSent'));
+        if (group.invites) $scope.group.invites = group.invites;
         _resetInvitees();
       }, function(){
         _resetInvitees();

--- a/website/public/js/controllers/inviteToGroupCtrl.js
+++ b/website/public/js/controllers/inviteToGroupCtrl.js
@@ -27,6 +27,7 @@ habitrpg.controller('InviteToGroupCtrl', ['$scope', 'User', 'Groups', 'injectedG
     };
 
     $scope.getMemberAndInviteCount = function(group) {
+
       return group.memberCount + group.invites.length;
     }
 

--- a/website/public/js/controllers/inviteToGroupCtrl.js
+++ b/website/public/js/controllers/inviteToGroupCtrl.js
@@ -27,8 +27,7 @@ habitrpg.controller('InviteToGroupCtrl', ['$scope', 'User', 'Groups', 'injectedG
     };
 
     $scope.getMemberAndInviteCount = function(group) {
-
-      return group.memberCount + group.invites.length;
+      return group.memberCount + (group.invites ? group.invites.length: 0);
     }
 
     function _inviteByMethod(inviteMethod) {

--- a/website/public/js/controllers/inviteToGroupCtrl.js
+++ b/website/public/js/controllers/inviteToGroupCtrl.js
@@ -27,7 +27,9 @@ habitrpg.controller('InviteToGroupCtrl', ['$scope', 'User', 'Groups', 'injectedG
     };
 
     $scope.getMemberAndInviteCount = function(group) {
-      return group.memberCount + (group.invites ? group.invites.length: 0);
+      return (group && group.memberCount) 
+              ? group.memberCount + (group.invites ?  group.invites.length: 0)
+              : 0;
     }
 
     function _inviteByMethod(inviteMethod) {

--- a/website/public/js/services/groupServices.js
+++ b/website/public/js/services/groupServices.js
@@ -77,6 +77,21 @@
         $location.path("/options/groups/party");
       }
     }
+    
+    function isOverPartyCap(group) {
+      return group.memberCount + group.invites.length >= group.partyCap;
+    }
+
+    function isOverPartyCapWarning(group) {
+      var partyCapWarningBoundary = 5;
+      return group.memberCount + group.invites.length > group.partyCap - partyCapWarningBoundary;
+    }
+
+    function memberAndInviteCount(group) {
+      if(!group) return 0;
+      if(!group.invites) return group.memberCount;
+      return group.memberCount + group.invites.length;
+    };
 
     return {
       party: party,
@@ -84,6 +99,9 @@
       myGuilds: myGuilds,
       tavern: tavern,
       inviteOrStartParty: inviteOrStartParty,
+      isOverPartyCap: isOverPartyCap,
+      isOverPartyCapWarning: isOverPartyCapWarning,
+      memberAndInviteCount: memberAndInviteCount,
 
       data: data,
       Group: Group

--- a/website/src/controllers/api-v2/groups.js
+++ b/website/src/controllers/api-v2/groups.js
@@ -693,7 +693,7 @@ api.invite = function(req, res, next){
   if (group.privacy === 'private' && !_.contains(group.members,res.locals.user._id)) {
     return res.json(401, {err: "Only a member can invite new members!"});
   }
-  if (group.memberCount + group.invites.length >= 30) {
+  if (group.isOverPartyCap) {
     return res.json(400, {err: "Over 30 member party cap"});
   } 
 

--- a/website/src/controllers/api-v2/groups.js
+++ b/website/src/controllers/api-v2/groups.js
@@ -693,6 +693,10 @@ api.invite = function(req, res, next){
   if (group.privacy === 'private' && !_.contains(group.members,res.locals.user._id)) {
     return res.json(401, {err: "Only a member can invite new members!"});
   }
+  if (group.memberCount + group.invites.length >= 30) {
+    return res.json(400, {err: "Over 30 member party cap"});
+  } 
+
   if (req.body.uuids) {
     inviteByUUIDs(req.body.uuids, group, req, res, next);
   } else if (req.body.emails) {

--- a/website/src/controllers/api-v2/groups.js
+++ b/website/src/controllers/api-v2/groups.js
@@ -693,7 +693,7 @@ api.invite = function(req, res, next){
   if (group.privacy === 'private' && !_.contains(group.members,res.locals.user._id)) {
     return res.json(401, {err: "Only a member can invite new members!"});
   }
-  if (group.isOverPartyCap) {
+  if (group.type === 'party' && group.isOverPartyCap) {
     return res.json(400, {err: "Over 30 member party cap"});
   } 
 

--- a/website/src/models/group.js
+++ b/website/src/models/group.js
@@ -8,6 +8,8 @@ var logging = require('../libs/logging');
 var Challenge = require('./../models/challenge').model;
 var firebase = require('../libs/firebase');
 
+const PARTY_CAP = 30;
+
 // NOTE any change to groups' members in MongoDB will have to be run through the API
 // changes made directly to the db will cause Firebase to get out of sync
 var GroupSchema = new Schema({
@@ -59,7 +61,20 @@ var GroupSchema = new Schema({
   }
 }, {
   strict: 'throw',
-  minimize: false // So empty objects are returned
+  minimize: false, // So empty objects are returned
+  toObject: {
+    virtuals: true
+  },
+  toJSON: {
+    virtuals: true
+  }
+});
+
+GroupSchema.virtual('partyCap').get(function(){ return PARTY_CAP });
+
+GroupSchema.virtual('isOverPartyCap').get(function(){
+  return this.type === 'party' 
+      && (this.memberCount + this.invites.length >= this.partyCap);
 });
 
 /**
@@ -132,6 +147,7 @@ GroupSchema.methods.toJSON = function(){
 
   return doc;
 }
+
 
 var chatDefaults = module.exports.chatDefaults = function(msg,user){
   var message = {

--- a/website/src/models/group.js
+++ b/website/src/models/group.js
@@ -74,6 +74,7 @@ GroupSchema.virtual('partyCap').get(function(){ return PARTY_CAP });
 
 GroupSchema.virtual('isOverPartyCap').get(function(){
   return this.type === 'party' 
+      && this.invites
       && (this.memberCount + this.invites.length >= this.partyCap);
 });
 

--- a/website/views/options/social/group.jade
+++ b/website/views/options/social/group.jade
@@ -69,7 +69,7 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
         .panel-heading
           h3.panel-title
             =env.t('members')
-            button.pull-right.btn.btn-primary(ng-click="openInviteModal(group)")=env.t("inviteFriends")
+            button.pull-right.btn.btn-primary(ng-if='group.type === "party" && group.memberCount + group.invites.length < 30', ng-click="openInviteModal(group)")=env.t("inviteFriends")
 
         .panel-body.modal-fixed-height
           h4(ng-show='::group.memberCount === 1 && group.type === "party"')=env.t('partyEmpty')

--- a/website/views/options/social/group.jade
+++ b/website/views/options/social/group.jade
@@ -69,7 +69,11 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
         .panel-heading
           h3.panel-title
             =env.t('members')
-            button.pull-right.btn.btn-primary(ng-if='group.type === "party" && group.memberCount + group.invites.length < 30', ng-click="openInviteModal(group)")=env.t("inviteFriends")
+            button.pull-right.btn.btn-primary(
+              ng-if='group.type === "party" && !isOverPartyCap(group)'
+              ng-click="openInviteModal(group)")
+              = env.t("inviteFriends")
+            
 
         .panel-body.modal-fixed-height
           h4(ng-show='::group.memberCount === 1 && group.type === "party"')=env.t('partyEmpty')

--- a/website/views/shared/modals/invite-friends.jade
+++ b/website/views/shared/modals/invite-friends.jade
@@ -56,7 +56,8 @@ script(type='text/ng-template', id='modals/invite-party.html')
       input.form-control#new-group-name.input-medium.option-content(required, type='text', ng-model='group.name')
     p.alert.alert-warning(ng-if="getMemberAndInviteCount(group) > 25") 
       | You are approaching the 30 member party cap!
-      | There are currently {{getMembersAndInvitesCount(group)}} members in your party.
+      | Your party currently has {{getMemberAndInviteCount(group)}} members and
+      | invites.
     tabset
       tab(heading=env.t('inviteByEmail'))
         p.alert.alert-info=env.t('inviteByEmailExplanation')

--- a/website/views/shared/modals/invite-friends.jade
+++ b/website/views/shared/modals/invite-friends.jade
@@ -54,10 +54,8 @@ script(type='text/ng-template', id='modals/invite-party.html')
     div(ng-if='!group._id')
       h4(style='margin-top:0')=env.t('nameYourParty')
       input.form-control#new-group-name.input-medium.option-content(required, type='text', ng-model='group.name')
-    p.alert.alert-warning(ng-if="getMemberAndInviteCount(group) > 25") 
-      | You are approaching the 30 member party cap!
-      | Your party currently has {{getMemberAndInviteCount(group)}} members and
-      | invites.
+    p.alert.alert-warning(ng-if='isOverPartyCapWarning(group)')
+      = env.t('partyCapWarning', {partyCap: '{{group.partyCap}}', memberAndInviteCount: '{{memberAndInviteCount(group)}}'})
     tabset
       tab(heading=env.t('inviteByEmail'))
         p.alert.alert-info=env.t('inviteByEmailExplanation')

--- a/website/views/shared/modals/invite-friends.jade
+++ b/website/views/shared/modals/invite-friends.jade
@@ -54,6 +54,9 @@ script(type='text/ng-template', id='modals/invite-party.html')
     div(ng-if='!group._id')
       h4(style='margin-top:0')=env.t('nameYourParty')
       input.form-control#new-group-name.input-medium.option-content(required, type='text', ng-model='group.name')
+    p.alert.alert-warning(ng-if="getMemberAndInviteCount(group) > 25") 
+      | You are approaching the 30 member party cap!
+      | There are currently {{getMembersAndInvitesCount(group)}} members in your party.
     tabset
       tab(heading=env.t('inviteByEmail'))
         p.alert.alert-info=env.t('inviteByEmailExplanation')


### PR DESCRIPTION
fixes #6756

Not a complete solution but the best I know how to do.  

The trouble is that after giving an invite the group model is not updated to reflect the new invite.  The invite doesn't show up in the invites list and a new invite that puts the group over the 30 member + invite limit does not trigger the invite button to hide.  After a page refresh however the invite button will be hidden.  I also didn't implement any way of preventing a user from accepting an invite if the group is over it's limit but I think that would be a bad idea anyways.  If a user has an invite then let him join regardless. So what if the party goes 1 or 2 users over the limit.  At least the ability to invite more users is taken away.  These changes also don't in any way affect a "grandfathered" party except that they can't invite new users until they get below 30 again.

I also didn't put in any kind of warning but I don't really know people would like that done.  Should we just pop up a regular notification every time they invite someone after they reach 25 users?  Or should it be in the invite modal?  or near the invite button?

**EDIT:**  I figured out how to update the invites list.  I really don't know what I'm doing here so I have no idea whether what I did will cause problems in some way.  Also as before I can't run the tests and I didn't write any tests.  I also created a warning notification.
