### PR TITLE
Active handles logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0-152",
   "main": "./website/src/server.js",
   "dependencies": {
+    "active-handles": "^1.1.0",
     "amazon-payments": "0.0.4",
     "amplitude": "^2.0.3",
     "async": "~0.9.0",

--- a/website/src/server.js
+++ b/website/src/server.js
@@ -163,7 +163,8 @@ if (cores!==0 && cluster.isMaster && (isDev || isProd)) {
 
   module.exports = server;
 
-  var activeHandleInterval = setInterval(logHandles,600000);
+  var logHandlesInterval = +nconf.get('LOG_HANDLES_INTERVAL') || 60000;
+  var activeHandleInterval = setInterval(logHandles, logHandlesInterval);
 
   function logHandles() {
     activeHandles.print();

--- a/website/src/server.js
+++ b/website/src/server.js
@@ -11,6 +11,7 @@ var isDev = nconf.get('NODE_ENV') === 'development';
 var DISABLE_LOGGING = nconf.get('DISABLE_REQUEST_LOGGING');
 var cores = +nconf.get("WEB_CONCURRENCY") || 0;
 var activeHandles = require('active-handles');
+var moment = require('moment');
 
 if (cores!==0 && cluster.isMaster && (isDev || isProd)) {
   // Fork workers. If config.json has CORES=x, use that - otherwise, use all cpus-1 (production)
@@ -167,6 +168,7 @@ if (cores!==0 && cluster.isMaster && (isDev || isProd)) {
   var activeHandleInterval = setInterval(logHandles, logHandlesInterval);
 
   function logHandles() {
+    console.log(moment().format());
     activeHandles.print({highlight:false});
   }
 }

--- a/website/src/server.js
+++ b/website/src/server.js
@@ -164,8 +164,8 @@ if (cores!==0 && cluster.isMaster && (isDev || isProd)) {
 
   module.exports = server;
 
-  var logHandlesInterval = +nconf.get('LOG_HANDLES_INTERVAL') || 60000;
-  var activeHandleInterval = setInterval(logHandles, logHandlesInterval);
+  var logHandlesInterval = +nconf.get('LOG_HANDLES_INTERVAL');
+  if (logHandlesInterval) { var activeHandleInterval = setInterval(logHandles, logHandlesInterval); }
 
   function logHandles() {
     console.log(moment().format());

--- a/website/src/server.js
+++ b/website/src/server.js
@@ -167,6 +167,6 @@ if (cores!==0 && cluster.isMaster && (isDev || isProd)) {
   var activeHandleInterval = setInterval(logHandles, logHandlesInterval);
 
   function logHandles() {
-    activeHandles.print();
+    activeHandles.print({highlight:false});
   }
 }

--- a/website/src/server.js
+++ b/website/src/server.js
@@ -10,6 +10,7 @@ var isProd = nconf.get('NODE_ENV') === 'production';
 var isDev = nconf.get('NODE_ENV') === 'development';
 var DISABLE_LOGGING = nconf.get('DISABLE_REQUEST_LOGGING');
 var cores = +nconf.get("WEB_CONCURRENCY") || 0;
+var activeHandles = require('active-handles');
 
 if (cores!==0 && cluster.isMaster && (isDev || isProd)) {
   // Fork workers. If config.json has CORES=x, use that - otherwise, use all cpus-1 (production)
@@ -161,4 +162,10 @@ if (cores!==0 && cluster.isMaster && (isDev || isProd)) {
   });
 
   module.exports = server;
+
+  var activeHandleInterval = setInterval(logHandles,600000);
+
+  function logHandles() {
+    activeHandles.print();
+  }
 }


### PR DESCRIPTION
Implements the `active-handles` library to help diagnose CPU load issues on the server. If the LOG_HANDLES_INTERVAL environment variable is set (use a time interval, in milliseconds), we will output the active handles to the console. If it is not set, we skip logging.
