### PR TITLE
Improvements to the display of the experience, todo and task charts

### DIFF
--- a/website/client-old/css/tasks.styl
+++ b/website/client-old/css/tasks.styl
@@ -705,3 +705,7 @@ form
     background-color:inherit !important
   .task-checker label:hover:after
     content: ''
+
+// Add padding to exp-chart
+.exp-chart
+  padding-bottom: 10px

--- a/website/client-old/js/controllers/rootCtrl.js
+++ b/website/client-old/js/controllers/rootCtrl.js
@@ -187,7 +187,13 @@ habitrpg.controller("RootCtrl", ['$scope', '$rootScope', '$location', 'User', '$
 
     $rootScope.charts = {};
     $rootScope.toggleChart = function(id, task) {
-      var history = [], matrix, data, chart, options;
+      if($rootScope.charts[id] === undefined) {
+        $(window).resize(function() { 
+          $rootScope.drawChart(id, data);
+        });
+      }
+
+      var history = [], matrix, data, options, container;
       switch (id) {
         case 'exp':
           history = User.user.history.exp;
@@ -202,23 +208,62 @@ habitrpg.controller("RootCtrl", ['$scope', '$rootScope', '$location', 'User', '$
           $rootScope.charts[id] = (history.length == 0) ? false : !$rootScope.charts[id];
           if (task && task._editing) task._editing = false;
       }
+
       matrix = [[env.t('date'), env.t('score')]];
       _.each(history, function(obj) {
         matrix.push([moment(obj.date).format(User.user.preferences.dateFormat.toUpperCase().replace('YYYY','YY') ), obj.value]);
       });
       data = google.visualization.arrayToDataTable(matrix);
+
+      $rootScope.drawChart(id, data);
+    };
+
+    $rootScope.drawChart = function(id, data, options) {
+      var chart, width;
+
+      switch(id) {
+        case 'exp':
+          width = $(".row").width() - 5;
+          break;
+        case 'todos':
+          width = $(".task-column.todos").width() - 5;
+          break;
+        default:
+          width = $(".task-text").width() - 5;
+          break;
+      }
+
       options = {
         title: window.env.t('history'),
         backgroundColor: {
           fill: 'transparent'
         },
-        hAxis: {slantedText:true, slantedTextAngle: 90},
-        height:270,
-        width:300
+        hAxis: {
+          slantedText: true, 
+          slantedTextAngle: 90,
+          textStyle: {
+            fontSize: 12
+          }
+        },
+        vAxis: {
+          format: 'short',
+          textStyle: {
+            fontSize: 12
+          }
+        },
+        width: width,
+        height: 270,      
+        chartArea: {
+          left: 50,
+          top: 30,  
+          right: 65,
+          bottom: 65
+        }
       };
+
       chart = new google.visualization.LineChart($("." + id + "-chart")[0]);
       chart.draw(data, options);
-    };
+    }
 
     $rootScope.getGearArray = function(set){
       var flatGearArray = _.toArray(Content.gear.flat);

--- a/website/client-old/js/controllers/rootCtrl.js
+++ b/website/client-old/js/controllers/rootCtrl.js
@@ -225,16 +225,12 @@ habitrpg.controller("RootCtrl", ['$scope', '$rootScope', '$location', 'User', '$
     function drawChart(id, data, options) {
       var chart, width;
 
-      switch(id) {
-        case 'exp':
-          width = $(".row").width() - 20;
-          break;
-        case 'todos':
-          width = $(".task-column.todos").width();
-          break;
-        default:
-          width = $(".task-text").width() - 15;
-          break;
+      if(id === "exp") {
+        width = $(".row").width() - 20;
+      } else if(id === "todos") {
+        width = $(".task-column.todos").width();
+      } else {
+        width = $(".task-text").width() - 15;
       }
 
       options = {

--- a/website/client-old/js/controllers/rootCtrl.js
+++ b/website/client-old/js/controllers/rootCtrl.js
@@ -223,13 +223,13 @@ habitrpg.controller("RootCtrl", ['$scope', '$rootScope', '$location', 'User', '$
 
       switch(id) {
         case 'exp':
-          width = $(".row").width() - 5;
+          width = $(".row").width() - 20;
           break;
         case 'todos':
-          width = $(".task-column.todos").width() - 5;
+          width = $(".task-column.todos").width();
           break;
         default:
-          width = $(".task-text").width() - 5;
+          width = $(".task-text").width() - 15;
           break;
       }
 
@@ -256,8 +256,11 @@ habitrpg.controller("RootCtrl", ['$scope', '$rootScope', '$location', 'User', '$
         chartArea: {
           left: 50,
           top: 30,  
-          right: 65,
+          right: 20,
           bottom: 65
+        },
+        legend: {
+          position: 'none'
         }
       };
 

--- a/website/client-old/js/controllers/rootCtrl.js
+++ b/website/client-old/js/controllers/rootCtrl.js
@@ -207,7 +207,6 @@ habitrpg.controller("RootCtrl", ['$scope', '$rootScope', '$location', 'User', '$
       if($rootScope.charts[id]) {
         var handleResize = _.debounce(function() {
           drawChart(id, data);
-          console.log("triggered");
         }, 300);
 
         $rootScope.resizeCharts[id] = $rootScope.resizeCharts[id] || _.once(function() { $(window).resize(handleResize) });

--- a/website/client-old/js/controllers/rootCtrl.js
+++ b/website/client-old/js/controllers/rootCtrl.js
@@ -187,12 +187,6 @@ habitrpg.controller("RootCtrl", ['$scope', '$rootScope', '$location', 'User', '$
 
     $rootScope.charts = {};
     $rootScope.toggleChart = function(id, task) {
-      if($rootScope.charts[id] === undefined) {
-        $(window).resize(function() { 
-          $rootScope.drawChart(id, data);
-        });
-      }
-
       var history = [], matrix, data, options, container;
       switch (id) {
         case 'exp':
@@ -209,16 +203,24 @@ habitrpg.controller("RootCtrl", ['$scope', '$rootScope', '$location', 'User', '$
           if (task && task._editing) task._editing = false;
       }
 
+      if($rootScope.charts[id]) {
+        var handleResize = _.debounce(function() {
+          drawChart(id, data);
+        }, 300);
+
+        $(window).resize(handleResize);
+      }
+
       matrix = [[env.t('date'), env.t('score')]];
       _.each(history, function(obj) {
         matrix.push([moment(obj.date).format(User.user.preferences.dateFormat.toUpperCase().replace('YYYY','YY') ), obj.value]);
       });
       data = google.visualization.arrayToDataTable(matrix);
 
-      $rootScope.drawChart(id, data);
+      drawChart(id, data);
     };
 
-    $rootScope.drawChart = function(id, data, options) {
+    function drawChart(id, data, options) {
       var chart, width;
 
       switch(id) {

--- a/website/client-old/js/controllers/rootCtrl.js
+++ b/website/client-old/js/controllers/rootCtrl.js
@@ -186,6 +186,7 @@ habitrpg.controller("RootCtrl", ['$scope', '$rootScope', '$location', 'User', '$
     }
 
     $rootScope.charts = {};
+    $rootScope.resizeCharts = {};
     $rootScope.toggleChart = function(id, task) {
       var history = [], matrix, data, options, container;
       switch (id) {
@@ -206,9 +207,11 @@ habitrpg.controller("RootCtrl", ['$scope', '$rootScope', '$location', 'User', '$
       if($rootScope.charts[id]) {
         var handleResize = _.debounce(function() {
           drawChart(id, data);
+          console.log("triggered");
         }, 300);
 
-        $(window).resize(handleResize);
+        $rootScope.resizeCharts[id] = $rootScope.resizeCharts[id] || _.once(function() { $(window).resize(handleResize) });
+        $rootScope.resizeCharts[id]();
       }
 
       matrix = [[env.t('date'), env.t('score')]];
@@ -241,7 +244,7 @@ habitrpg.controller("RootCtrl", ['$scope', '$rootScope', '$location', 'User', '$
           fill: 'transparent'
         },
         hAxis: {
-          slantedText: true, 
+          slantedText: true,
           slantedTextAngle: 90,
           textStyle: {
             fontSize: 12
@@ -254,10 +257,10 @@ habitrpg.controller("RootCtrl", ['$scope', '$rootScope', '$location', 'User', '$
           }
         },
         width: width,
-        height: 270,      
+        height: 270,
         chartArea: {
           left: 50,
-          top: 30,  
+          top: 30,
           right: 20,
           bottom: 65
         },

--- a/website/views/shared/tasks/task_view/index.jade
+++ b/website/views/shared/tasks/task_view/index.jade
@@ -40,6 +40,8 @@
 .task-text(ng-dblclick='doubleClickTask(obj, task)')
   markdown(text='task._editing ? task._edit.text : task.text',target='_blank')
 
+  div(class='{{obj._id}}{{task.id}}-chart', ng-show='charts[obj._id+task.id]')
+
   div(ng-if='task.checklist && !$state.includes("options.social.challenges") && !task.collapseChecklist && !task._editing')
     fieldset.option-group.task-checklist
       label.checkbox(ng-repeat='item in task.checklist')


### PR DESCRIPTION
1) Fixes issue #6679, which referred to the EXP chart getting cropped.
2) Added some bottom padding to the EXP chart so that the tags are
further apart from the chart itself (requires rebuilding stylus)
3) Added event handlers for the dynamic resizing of the charts. The
event handlers use the same data every time and are only created when a
chart is first toggled, as to reduce overhead.
4) Moved the location of the tasks chart into the .task-text, so that
the habit +/- buttons are now fully triggerable.

I’ll add more details on the implementation below soon.
