### PR TITLE
Changed tavern tier 1 text icon

### DIFF
--- a/website/views/options/social/tavern.jade
+++ b/website/views/options/social/tavern.jade
@@ -83,7 +83,7 @@
                 a.label.label-contributor-1(ng-click='toggleUserTier($event)')=env.t('tier') + ' 1 (' + env.t('friend') + ')'
                 div
                   p
-                    span.achievement.achievement-firefox
+                    span.achievement.achievement-boot
                     !=env.t('friendFirst')
             tr
               td


### PR DESCRIPTION
The icon for the text/description of the 1st tier contributor was
incorrect. It should be the boot icon, but the firefox icon was being
displayed.

This issue was reported through the wiki here: http://habitica.wikia.com/wiki/Thread:41876
