### PR TITLE
Automatic worker restarts

### DIFF
--- a/website/src/middlewares/domain.js
+++ b/website/src/middlewares/domain.js
@@ -33,6 +33,10 @@ module.exports = function(server,mongoose) {
         throw memoryLeakMessage;
       }
     }, mins*60*1000);
+    // Restart workers on an interval between 60 and 75 minutes
+    setInterval(function () {
+      throw new Error('Automatic restart'); // throwing causes the server to restart properly
+    }, (Math.floor(Math.random() * (16)) + 60) * 60 * 1000);
   }
 
   return domainMiddleware({

--- a/website/src/middlewares/domain.js
+++ b/website/src/middlewares/domain.js
@@ -5,6 +5,8 @@ var os = require('os');
 var request = require('request');
 
 var IS_PROD = nconf.get('NODE_ENV') === 'production';
+var RESTART_INTERVAL_LOW = nconf.get('RESTART_INTERVAL_LOW') || 15;
+var RESTART_INTERVAL_HIGH = nconf.get('RESTART_INTERVAL_HIGH') || 30;
 
 module.exports = function(server,mongoose) {
   if (IS_PROD) {
@@ -33,10 +35,10 @@ module.exports = function(server,mongoose) {
         throw memoryLeakMessage;
       }
     }, mins*60*1000);
-    // Restart workers on an interval between 60 and 75 minutes
+    // Restart workers on an interval based on environment config, default 15-30 minutes
     setInterval(function () {
       throw new Error('Automatic restart'); // throwing causes the server to restart properly
-    }, (Math.floor(Math.random() * (16)) + 60) * 60 * 1000);
+    }, (Math.floor(Math.random() * (RESTART_INTERVAL_HIGH - RESTART_INTERVAL_LOW + 1)) + RESTART_INTERVAL_LOW) * 60 * 1000);
   }
 
   return domainMiddleware({


### PR DESCRIPTION
Stopgap solution to creeping CPU usage. Throws an error every 60-75 minutes to force the worker process for the server to restart. This will allow us to use the same (temporary) fix on both Heroku and AWS instead of e.g. using cron jobs on our load balancer to send restart requests.

Code by @paglias; CC @crookedneighbor 
