### PR TITLE
Added initial delete challenge tasks tests

### DIFF
--- a/test/api/v3/integration/tasks/challenges/DELETE-tasks_id_challenge_challengeId.test.js
+++ b/test/api/v3/integration/tasks/challenges/DELETE-tasks_id_challenge_challengeId.test.js
@@ -1,0 +1,55 @@
+import {
+  generateUser,
+  generateGroup,
+  generateChallenge,
+  translate as t,
+} from '../../../../../helpers/api-integration/v3';
+import { v4 as generateUUID } from 'uuid';
+
+describe('DELETE /tasks/:id', () => {
+  let user;
+  let guild;
+  let challenge;
+  let task;
+
+  before(async () => {
+    user = await generateUser();
+    guild = await generateGroup(user);
+    challenge = await generateChallenge(user, guild);
+  });
+
+  beforeEach(async () => {
+    task = await user.post(`/tasks/challenge/${challenge._id}`, {
+      text: 'test habit',
+      type: 'habit',
+    });
+  });
+
+  it('cannot delete a non-existant task', async () => {
+    await expect(user.del(`/tasks/${generateUUID()}`)).to.eventually.be.rejected.and.eql({
+      code: 404,
+      error: 'NotFound',
+      message: t('taskNotFound'),
+    });
+  });
+
+  it('returns error when user is not leader of the challenge', async () => {
+    let anotherUser = await generateUser();
+
+    await expect(anotherUser.del(`/tasks/${task._id}`)).to.eventually.be.rejected.and.eql({
+      code: 401,
+      error: 'NotAuthorized',
+      message: t('onlyChalLeaderEditTasks'),
+    });
+  });
+
+  it('deletes a user\'s task', async () => {
+    await user.del(`/tasks/${task._id}`);
+
+    await expect(user.get(`/tasks/${task._id}`)).to.eventually.be.rejected.and.eql({
+      code: 404,
+      error: 'NotFound',
+      message: t('taskNotFound'),
+    });
+  });
+});

--- a/website/src/controllers/api-v3/tasks.js
+++ b/website/src/controllers/api-v3/tasks.js
@@ -914,7 +914,7 @@ api.deleteTask = {
       if (challenge.leader !== user._id) throw new NotAuthorized(res.t('onlyChalLeaderEditTasks'));
     } else if (task.userId !== user._id) { // If the task is owned by an user make it's the current one
       throw new NotFound(res.t('taskNotFound'));
-    } else if (task.userId && task.challenge.id) {
+    } else if (task.userId && task.challenge.id && !task.challenge.broken) {
       throw new NotAuthorized(res.t('cantDeleteChallengeTasks'));
     }
 

--- a/website/src/controllers/api-v3/tasks.js
+++ b/website/src/controllers/api-v3/tasks.js
@@ -909,7 +909,7 @@ api.deleteTask = {
     if (!task) {
       throw new NotFound(res.t('taskNotFound'));
     } else if (!task.userId) { // If the task belongs to a challenge make sure the user has rights
-      challenge = await Challenge.find().selec({_id: task.challenge.id}).select('leader').exec();
+      challenge = await Challenge.findOne({_id: task.challenge.id}).exec();
       if (!challenge) throw new NotFound(res.t('challengeNotFound'));
       if (challenge.leader !== user._id) throw new NotAuthorized(res.t('onlyChalLeaderEditTasks'));
     } else if (task.userId !== user._id) { // If the task is owned by an user make it's the current one


### PR DESCRIPTION
These are for the "tests for routes used to manage tasks for challenges" item in #6776 .

@paglias I saw this in a TODO: "cannot delete active challenge tasks". Is this still a functionality we want? If so, I think this PR is a good place to add it. Just let me know, and I'll add the code. 
