### PR TITLE
[v3] Add Party Up / Party On achievements to server in V3

### DIFF
--- a/test/api/v3/integration/groups/POST-groups.test.js
+++ b/test/api/v3/integration/groups/POST-groups.test.js
@@ -189,6 +189,17 @@ describe('POST /group', () => {
       expect(updatedUser.party._id).to.eql(party._id);
     });
 
+    it('does not award Party Up achievement to solo partier', async () => {
+      await user.post('/groups', {
+        name: partyName,
+        type: partyType,
+      });
+
+      let updatedUser = await user.get('/user');
+
+      expect(updatedUser.achievements.partyUp).to.not.eql(true);
+    });
+
     it('prevents user in a party from creating another party', async () => {
       await user.post('/groups', {
         name: partyName,

--- a/website/src/controllers/api-v3/groups.js
+++ b/website/src/controllers/api-v3/groups.js
@@ -295,6 +295,12 @@ api.joinGroup = {
 
     if (group.type === 'party' && inviter) {
       promises.push(User.update({_id: inviter}, {$inc: {'items.quests.basilist': 1}}).exec()); // Reward inviter
+      if (group.memberCount > 1) {
+        promises.push(User.update({$or: [{'party._id': group._id}, {_id: user._id}], 'achievements.partyUp': {$ne: true}}, {$set: {'achievements.partyUp': true}}, {multi: true}).exec());
+      }
+      if (group.memberCount > 3) {
+        promises.push(User.update({$or: [{'party._id': group._id}, {_id: user._id}], 'achievements.partyOn': {$ne: true}}, {$set: {'achievements.partyOn': true}}, {multi: true}).exec());
+      }
     }
 
     await Q.all(promises);


### PR DESCRIPTION
Logic to award the `partyUp` and `partyOn` achievements via the party join route instead of the heavily client-dependent current implementation.

To dos / questions:
- [ ] Remove current modal logic and create an Angular watch to display the achievement
- [x] Fix failing tests. It looks to me like the achievements aren't available on the user model for some reason?
- [x] This first draft logic is inefficient in that it will `$set` the achievement for party members who already have it. But I'm not sure if GETting the whole party's achievements to check them first would be a great move either. Thoughts?
