### PR TITLE
Modal explaining new class gear is now class-agnostic

### DIFF
--- a/common/locales/en/npc.json
+++ b/common/locales/en/npc.json
@@ -36,7 +36,7 @@
     "paymentMethods": "Purchase using",
 
     "classGear": "Class Gear",
-    "classGearText": "First: don't panic! Your old gear is in your inventory, and you're now wearing your apprentice <strong><%= klass %></strong> equipment. Wearing your class's gear grants you a 50% bonus to stats. However, feel free to switch back to your old gear.",
+    "classGearText": "First: don't panic! Your old gear is in your inventory, and you're now wearing the apprentice equipment of your new class. Wearing your class's gear grants you a 50% bonus to stats. However, feel free to switch back to your old gear.",
     "classStats": "These are your class's stats; they affect the game-play. Each time you level up, you get one point to allocate to a particular stat. Hover over each stat for more information.",
     "autoAllocate": "Auto Allocate",
     "autoAllocateText": "If 'automatic allocation' is checked, your avatar gains stats automatically based on your tasks' attributes, which you can find in <strong>TASK > Edit > Advanced > Attributes</strong>. Eg, if you hit the gym often, and your 'Gym' Daily is set to 'Physical', you'll gain Strength automatically.",

--- a/website/public/js/services/guideServices.js
+++ b/website/public/js/services/guideServices.js
@@ -67,7 +67,7 @@ function($rootScope, User, $timeout, $state, Analytics) {
           state: 'options.inventory.equipment',
           element: '.equipment-tab',
           title: window.env.t('classGear'),
-          content: window.env.t('classGearText', {klass: User.user.stats.class})
+          content: window.env.t('classGearText')
         }, {
           state: 'options.profile.stats',
           element: ".allocate-stats",


### PR DESCRIPTION
This PR is regarding Issue #4888.

The `classGearText` string is now class-agnostic and the reference to "klass" has been removed.

![image](https://cloud.githubusercontent.com/assets/5641207/13896433/707bdc4c-ed61-11e5-8a0b-749b4f26a677.png)
