### PR TITLE
[v3] Ported sendPrivateMessage route and added initial tests

### DIFF
--- a/common/locales/en/api-v3.json
+++ b/common/locales/en/api-v3.json
@@ -117,5 +117,9 @@
   "missingPetFoodFeed": "\"pet\" and \"food\" are required parameters.",
   "invalidPetName": "Invalid pet name supplied.",
   "missingEggHatchingPotionHatch": "\"egg\" and \"hatchingPotion\" are required parameters.",
-  "invalidTypeEquip": "\"type\" must be one of 'equipped', 'pet', 'mount', 'costume'."
+  "invalidTypeEquip": "\"type\" must be one of 'equipped', 'pet', 'mount', 'costume'.",
+  "cannoyBuyItem": "You can't buy this item",
+  "messageRequired": "A message is required.",
+  "toUserIDRequired": "A toUserId is required",
+  "notAuthorizedToSendMessageToThisUser": "Can't send message to this user."
 }

--- a/common/locales/en/api-v3.json
+++ b/common/locales/en/api-v3.json
@@ -124,5 +124,7 @@
   "notAuthorizedToSendMessageToThisUser": "Can't send message to this user.",
   "privateMessageGiftIntro": "Hello <%= receiverName %>, <%= senderName %> has sent you ",
   "privateMessageGiftGemsMessage": "<%= gemAmount %> gems! ",
-  "privateMessageGiftSubscriptionMessage": "<%= numberOfMonths %> months of subscription! "
+  "privateMessageGiftSubscriptionMessage": "<%= numberOfMonths %> months of subscription! ",
+  "cannotSendGemsToYourself": "Cannot send gems to yourself. Try a subscription instead.",
+  "notEnoughGemsToSend": "Amount must be within 0 and your current number of gems."
 }

--- a/common/locales/en/api-v3.json
+++ b/common/locales/en/api-v3.json
@@ -121,5 +121,8 @@
   "cannoyBuyItem": "You can't buy this item",
   "messageRequired": "A message is required.",
   "toUserIDRequired": "A toUserId is required",
-  "notAuthorizedToSendMessageToThisUser": "Can't send message to this user."
+  "notAuthorizedToSendMessageToThisUser": "Can't send message to this user.",
+  "privateMessageGiftIntro": "Hello <%= receiverName %>, <%= senderName %> has sent you ",
+  "privateMessageGiftGemsMessage": "<%= gemAmount %> gems! ",
+  "privateMessageGiftSubscriptionMessage": "<%= numberOfMonths %> months of subscription! "
 }

--- a/common/script/libs/refPush.js
+++ b/common/script/libs/refPush.js
@@ -7,13 +7,14 @@ import uuid from './uuid';
   no problem. To maintain sorting, we use these helper functions:
  */
 
-module.exports = function(reflist, item, prune) {
-  if (prune == null) {
-    prune = 0;
-  }
+module.exports = function refPush (reflist, item) {
   item.sort = _.isEmpty(reflist) ? 0 : _.max(reflist, 'sort').sort + 1;
+
   if (!(item.id && !reflist[item.id])) {
     item.id = uuid();
   }
-  return reflist[item.id] = item;
+
+  reflist[item.id] = item;
+
+  return reflist[item.id];
 };

--- a/tasks/gulp-eslint.js
+++ b/tasks/gulp-eslint.js
@@ -69,7 +69,6 @@ const COMMON_FILES = [
   '!./common/script/libs/planGemLimits.js',
   '!./common/script/libs/preenHistory.js',
   '!./common/script/libs/preenTodos.js',
-  '!./common/script/libs/refPush.js',
   '!./common/script/libs/removeWhitespace.js',
   '!./common/script/libs/silver.js',
   '!./common/script/libs/splitWhitespace.js',

--- a/test/api/v3/integration/members/POST-send_private_message.test.js
+++ b/test/api/v3/integration/members/POST-send_private_message.test.js
@@ -1,0 +1,171 @@
+import {
+  generateUser,
+  translate as t,
+} from '../../../../helpers/api-v3-integration.helper';
+import { v4 as generateUUID } from 'uuid';
+
+describe('POST /send-private-message', () => {
+  let userToSendMessage;
+  let messageToSend = { message: 'Test Private Message' };
+
+  beforeEach(async () => {
+    userToSendMessage = await generateUser();
+  });
+
+  it('returns error when message is not provided', async () => {
+    await expect(userToSendMessage.post('/send-private-message'))
+      .to.eventually.be.rejected.and.eql({
+        code: 400,
+        error: 'BadRequest',
+        message: 'Invalid request parameters.',
+      });
+  });
+
+  it('returns error when toUserId is not provided', async () => {
+    await expect(userToSendMessage.post('/send-private-message', {
+      message: messageToSend,
+    })).to.eventually.be.rejected.and.eql({
+      code: 400,
+      error: 'BadRequest',
+      message: 'Invalid request parameters.',
+    });
+  });
+
+  it('returns error when to user is not found', async () => {
+    await expect(userToSendMessage.post('/send-private-message', {
+      message: messageToSend,
+      toUserId: generateUUID(),
+    })).to.eventually.be.rejected.and.eql({
+      code: 404,
+      error: 'NotFound',
+      message: t('userNotFound'),
+    });
+  });
+
+  it('returns error when to user has blocked the sender', async () => {
+    let receiver = await generateUser({'inbox.blocks': [userToSendMessage._id]});
+
+    await expect(userToSendMessage.post('/send-private-message', {
+      message: messageToSend,
+      toUserId: receiver._id,
+    })).to.eventually.be.rejected.and.eql({
+      code: 401,
+      error: 'NotAuthorized',
+      message: t('notAuthorizedToSendMessageToThisUser'),
+    });
+  });
+
+  it('returns error when sender has blocked to user', async () => {
+    let receiver = await generateUser();
+    let sender = await generateUser({'inbox.blocks': [receiver._id]});
+
+    await expect(sender.post('/send-private-message', {
+      message: messageToSend,
+      toUserId: receiver._id,
+    })).to.eventually.be.rejected.and.eql({
+      code: 401,
+      error: 'NotAuthorized',
+      message: t('notAuthorizedToSendMessageToThisUser'),
+    });
+  });
+
+  it('returns error when to user has opted out of messaging', async () => {
+    let receiver = await generateUser({'inbox.optOut': true});
+
+    await expect(userToSendMessage.post('/send-private-message', {
+      message: messageToSend,
+      toUserId: receiver._id,
+    })).to.eventually.be.rejected.and.eql({
+      code: 401,
+      error: 'NotAuthorized',
+      message: t('notAuthorizedToSendMessageToThisUser'),
+    });
+  });
+
+  it('sends a private message to a user', async () => {
+    let receiver = await generateUser();
+
+    await userToSendMessage.post('/send-private-message', {
+      message: messageToSend,
+      toUserId: receiver._id,
+    });
+
+    let updatedReceiver = await receiver.get('/user');
+    let updatedSender = await userToSendMessage.get('/user');
+
+    let sendersMessageInReceiversInbox = _.find(updatedReceiver.inbox.messages, (message) => {
+      return message.uuid === userToSendMessage._id && message.text === messageToSend.message;
+    });
+
+    let sendersMessageInSendersInbox = _.find(updatedSender.inbox.messages, (message) => {
+      return message.uuid === receiver._id && message.text === messageToSend.message;
+    });
+
+    expect(sendersMessageInReceiversInbox).to.exist;
+    expect(sendersMessageInSendersInbox).to.exist;
+  });
+
+  it('sends a private message about gems to a user', async () => {
+    let receiver = await generateUser();
+    let messageAboutGemsToSend = {
+      type: 'gems',
+      gems: {
+        amount: 2,
+      },
+      message: 'Test Message About Gems',
+    };
+
+    await userToSendMessage.post('/send-private-message', {
+      message: messageAboutGemsToSend,
+      toUserId: receiver._id,
+    });
+
+    let updatedReceiver = await receiver.get('/user');
+    let updatedSender = await userToSendMessage.get('/user');
+
+    let sendersMessageInReceiversInbox = _.find(updatedReceiver.inbox.messages, (message) => {
+      return message.uuid === userToSendMessage._id;
+    });
+
+    let sendersMessageInSendersInbox = _.find(updatedSender.inbox.messages, (message) => {
+      return message.uuid === receiver._id;
+    });
+
+    expect(sendersMessageInReceiversInbox).to.exist;
+    expect(sendersMessageInReceiversInbox.text).to.equal(`Hello ${receiver.profile.name}, ${userToSendMessage.profile.name} has sent you ${messageAboutGemsToSend.gems.amount} gems! ${messageAboutGemsToSend.message}`);
+    expect(sendersMessageInSendersInbox).to.exist;
+    expect(sendersMessageInSendersInbox.text).to.equal(`Hello ${receiver.profile.name}, ${userToSendMessage.profile.name} has sent you ${messageAboutGemsToSend.gems.amount} gems! ${messageAboutGemsToSend.message}`);
+  });
+
+  it('sends a private message about subscriptions to a user', async () => {
+    let receiver = await generateUser();
+    let messageAboutSubscriptionToSend = {
+      type: 'subscription',
+      subscription: {
+        key: 'basic_12mo',
+      },
+      message: 'Test Message About Subscription',
+    };
+
+    await userToSendMessage.post('/send-private-message', {
+      message: messageAboutSubscriptionToSend,
+      toUserId: receiver._id,
+    });
+
+    let updatedReceiver = await receiver.get('/user');
+    let updatedSender = await userToSendMessage.get('/user');
+
+    let sendersMessageInReceiversInbox = _.find(updatedReceiver.inbox.messages, (message) => {
+      return message.uuid === userToSendMessage._id;
+    });
+
+    let sendersMessageInSendersInbox = _.find(updatedSender.inbox.messages, (message) => {
+      return message.uuid === receiver._id;
+    });
+
+    expect(sendersMessageInReceiversInbox).to.exist;
+    expect(sendersMessageInReceiversInbox.text).to.equal(`Hello ${receiver.profile.name}, ${userToSendMessage.profile.name} has sent you 12 months of subscription! ${messageAboutSubscriptionToSend.message}`);
+    expect(sendersMessageInSendersInbox).to.exist;
+    expect(sendersMessageInSendersInbox.text).to.equal(`Hello ${receiver.profile.name}, ${userToSendMessage.profile.name} has sent you 12 months of subscription! ${messageAboutSubscriptionToSend.message}`);
+  });
+});

--- a/test/api/v3/integration/members/POST-send_private_message.test.js
+++ b/test/api/v3/integration/members/POST-send_private_message.test.js
@@ -6,7 +6,7 @@ import { v4 as generateUUID } from 'uuid';
 
 describe('POST /members/send-private-message', () => {
   let userToSendMessage;
-  let messageToSend = { message: 'Test Private Message' };
+  let messageToSend = 'Test Private Message';
 
   beforeEach(async () => {
     userToSendMessage = await generateUser();
@@ -94,92 +94,14 @@ describe('POST /members/send-private-message', () => {
     let updatedSender = await userToSendMessage.get('/user');
 
     let sendersMessageInReceiversInbox = _.find(updatedReceiver.inbox.messages, (message) => {
-      return message.uuid === userToSendMessage._id && message.text === messageToSend.message;
+      return message.uuid === userToSendMessage._id && message.text === messageToSend;
     });
 
     let sendersMessageInSendersInbox = _.find(updatedSender.inbox.messages, (message) => {
-      return message.uuid === receiver._id && message.text === messageToSend.message;
+      return message.uuid === receiver._id && message.text === messageToSend;
     });
 
     expect(sendersMessageInReceiversInbox).to.exist;
     expect(sendersMessageInSendersInbox).to.exist;
-  });
-
-  it('sends a private message about gems to a user', async () => {
-    let receiver = await generateUser();
-    let messageAboutGemsToSend = {
-      type: 'gems',
-      gems: {
-        amount: 2,
-      },
-      message: 'Test Message About Gems',
-    };
-
-    await userToSendMessage.post('/members/send-private-message', {
-      message: messageAboutGemsToSend,
-      toUserId: receiver._id,
-    });
-
-    let updatedReceiver = await receiver.get('/user');
-    let updatedSender = await userToSendMessage.get('/user');
-
-    let sendersMessageInReceiversInbox = _.find(updatedReceiver.inbox.messages, (message) => {
-      return message.uuid === userToSendMessage._id;
-    });
-
-    let sendersMessageInSendersInbox = _.find(updatedSender.inbox.messages, (message) => {
-      return message.uuid === receiver._id;
-    });
-
-    let messageSentContent = t('privateMessageGiftIntro', {
-      receiverName: receiver.profile.name,
-      senderName: userToSendMessage.profile.name,
-    });
-    messageSentContent += t('privateMessageGiftGemsMessage', {gemAmount: messageAboutGemsToSend.gems.amount});
-    messageSentContent += messageAboutGemsToSend.message;
-
-    expect(sendersMessageInReceiversInbox).to.exist;
-    expect(sendersMessageInReceiversInbox.text).to.equal(messageSentContent);
-    expect(sendersMessageInSendersInbox).to.exist;
-    expect(sendersMessageInSendersInbox.text).to.equal(messageSentContent);
-  });
-
-  it('sends a private message about subscriptions to a user', async () => {
-    let receiver = await generateUser();
-    let messageAboutSubscriptionToSend = {
-      type: 'subscription',
-      subscription: {
-        key: 'basic_12mo',
-      },
-      message: 'Test Message About Subscription',
-    };
-
-    await userToSendMessage.post('/members/send-private-message', {
-      message: messageAboutSubscriptionToSend,
-      toUserId: receiver._id,
-    });
-
-    let updatedReceiver = await receiver.get('/user');
-    let updatedSender = await userToSendMessage.get('/user');
-
-    let sendersMessageInReceiversInbox = _.find(updatedReceiver.inbox.messages, (message) => {
-      return message.uuid === userToSendMessage._id;
-    });
-
-    let sendersMessageInSendersInbox = _.find(updatedSender.inbox.messages, (message) => {
-      return message.uuid === receiver._id;
-    });
-
-    let messageSentContent = t('privateMessageGiftIntro', {
-      receiverName: receiver.profile.name,
-      senderName: userToSendMessage.profile.name,
-    });
-    messageSentContent += t('privateMessageGiftSubscriptionMessage', {numberOfMonths: 12});
-    messageSentContent += messageAboutSubscriptionToSend.message;
-
-    expect(sendersMessageInReceiversInbox).to.exist;
-    expect(sendersMessageInReceiversInbox.text).to.equal(messageSentContent);
-    expect(sendersMessageInSendersInbox).to.exist;
-    expect(sendersMessageInSendersInbox.text).to.equal(messageSentContent);
   });
 });

--- a/test/api/v3/integration/members/POST-transfer_gems.test.js
+++ b/test/api/v3/integration/members/POST-transfer_gems.test.js
@@ -1,0 +1,146 @@
+import {
+  generateUser,
+  translate as t,
+} from '../../../../helpers/api-v3-integration.helper';
+import { v4 as generateUUID } from 'uuid';
+
+describe('POST /members/transfer-gems', () => {
+  let userToSendMessage;
+  let receiver;
+  let message = 'Test Private Message';
+  let gemAmount = 20;
+  let giftType = 'gems';
+
+  beforeEach(async () => {
+    userToSendMessage = await generateUser({balance: 5});
+    receiver = await generateUser();
+  });
+
+  it('returns error when giftType is not provided', async () => {
+    await expect(userToSendMessage.post('/members/transfer-gems'))
+      .to.eventually.be.rejected.and.eql({
+        code: 400,
+        error: 'BadRequest',
+        message: 'Invalid request parameters.',
+      });
+  });
+
+  it('returns error when message is not provided', async () => {
+    await expect(userToSendMessage.post('/members/transfer-gems'), {
+      giftType,
+      message,
+    }).to.eventually.be.rejected.and.eql({
+      code: 400,
+      error: 'BadRequest',
+      message: 'Invalid request parameters.',
+    });
+  });
+
+  it('returns error when toUserId is not provided', async () => {
+    await expect(userToSendMessage.post('/members/transfer-gems', {
+      giftType,
+      message,
+    })).to.eventually.be.rejected.and.eql({
+      code: 400,
+      error: 'BadRequest',
+      message: 'Invalid request parameters.',
+    });
+  });
+
+  it('returns error when to user is not found', async () => {
+    await expect(userToSendMessage.post('/members/transfer-gems', {
+      giftType,
+      message,
+      toUserId: generateUUID(),
+    })).to.eventually.be.rejected.and.eql({
+      code: 404,
+      error: 'NotFound',
+      message: t('userNotFound'),
+    });
+  });
+
+  it('returns error when to user attempts to send gems to themselves', async () => {
+    await expect(userToSendMessage.post('/members/transfer-gems', {
+      giftType,
+      message,
+      toUserId: userToSendMessage._id,
+    })).to.eventually.be.rejected.and.eql({
+      code: 401,
+      error: 'NotAuthorized',
+      message: t('cannotSendGemsToYourself'),
+    });
+  });
+
+  it('returns error when there is no amount', async () => {
+    await expect(userToSendMessage.post('/members/transfer-gems', {
+      giftType,
+      message,
+      toUserId: receiver._id,
+    })).to.eventually.be.rejected.and.eql({
+      code: 401,
+      error: 'NotAuthorized',
+      message: t('notEnoughGemsToSend'),
+    });
+  });
+
+  it('returns error when gemAmount is negative', async () => {
+    await expect(userToSendMessage.post('/members/transfer-gems', {
+      giftType,
+      message,
+      gemAmount: -5,
+      toUserId: receiver._id,
+    })).to.eventually.be.rejected.and.eql({
+      code: 401,
+      error: 'NotAuthorized',
+      message: t('notEnoughGemsToSend'),
+    });
+  });
+
+  it('returns error when gemAmount is more than the sender\'s balance', async () => {
+    await expect(userToSendMessage.post('/members/transfer-gems', {
+      giftType,
+      message,
+      gemAmount: gemAmount + 4,
+      toUserId: receiver._id,
+    })).to.eventually.be.rejected.and.eql({
+      code: 401,
+      error: 'NotAuthorized',
+      message: t('notEnoughGemsToSend'),
+    });
+  });
+
+  it('sends a private message about gems to a user', async () => {
+    await userToSendMessage.post('/members/transfer-gems', {
+      giftType,
+      message,
+      gemAmount,
+      toUserId: receiver._id,
+    });
+
+    let updatedReceiver = await receiver.get('/user');
+    let updatedSender = await userToSendMessage.get('/user');
+
+    let sendersMessageInReceiversInbox = _.find(updatedReceiver.inbox.messages, (inboxMessage) => {
+      return inboxMessage.uuid === userToSendMessage._id;
+    });
+
+    let sendersMessageInSendersInbox = _.find(updatedSender.inbox.messages, (inboxMessage) => {
+      return inboxMessage.uuid === receiver._id;
+    });
+
+    let messageSentContent = t('privateMessageGiftIntro', {
+      receiverName: receiver.profile.name,
+      senderName: userToSendMessage.profile.name,
+    });
+    messageSentContent += t('privateMessageGiftGemsMessage', {gemAmount});
+    messageSentContent += message;
+
+    expect(sendersMessageInReceiversInbox).to.exist;
+    expect(sendersMessageInReceiversInbox.text).to.equal(messageSentContent);
+    expect(updatedReceiver.balance).to.equal(gemAmount / 4);
+
+    expect(sendersMessageInSendersInbox).to.exist;
+    expect(sendersMessageInSendersInbox.text).to.equal(messageSentContent);
+    expect(updatedSender.balance).to.equal(0);
+  });
+});

--- a/test/common/libs/refPush.js
+++ b/test/common/libs/refPush.js
@@ -1,0 +1,53 @@
+import shared from '../../../common';
+import { v4 as generateUUID } from 'uuid';
+
+describe('refPush', () => {
+  it('it hashes one object into another by its id', () => {
+    let referenceObject = {};
+    let objectToHash = {
+      a: 1,
+      id: generateUUID(),
+    };
+
+    shared.refPush(referenceObject, objectToHash);
+
+    expect(referenceObject[objectToHash.id].a).to.equal(objectToHash.a);
+    expect(referenceObject[objectToHash.id].id).to.equal(objectToHash.id);
+    expect(referenceObject[objectToHash.id].sort).to.equal(0);
+  });
+
+  it('it hashes one object into another by a uuid when object does not have an id', () => {
+    let referenceObject = {};
+    let objectToHash = {
+      a: 1,
+    };
+
+    shared.refPush(referenceObject, objectToHash);
+
+    let hashedObject = _.find(referenceObject, (hashedItem) => {
+      return objectToHash.a === hashedItem.a;
+    });
+
+    expect(hashedObject.a).to.equal(objectToHash.a);
+    expect(hashedObject.id).to.equal(objectToHash.id);
+    expect(hashedObject.sort).to.equal(0);
+  });
+
+  it('it hashes one object into another by a id and gives it the highest sort value', () => {
+    let referenceObject = {};
+    referenceObject[generateUUID()] = { b: 2, sort: 1 };
+    let objectToHash = {
+      a: 1,
+    };
+
+    shared.refPush(referenceObject, objectToHash);
+
+    let hashedObject = _.find(referenceObject, (hashedItem) => {
+      return objectToHash.a === hashedItem.a;
+    });
+
+    expect(hashedObject.a).to.equal(objectToHash.a);
+    expect(hashedObject.id).to.equal(objectToHash.id);
+    expect(hashedObject.sort).to.equal(2);
+  });
+});

--- a/website/src/controllers/api-v3/members.js
+++ b/website/src/controllers/api-v3/members.js
@@ -237,7 +237,7 @@ api.getChallengeMemberProgress = {
 };
 
 /**
- * @api {posts} /send-private-message Get a challenge member progress
+ * @api {posts} /members/send-private-message Get a challenge member progress
  * @apiVersion 3.0.0
  * @apiName SendPrivateMessage
  * @apiGroup Members
@@ -249,7 +249,7 @@ api.getChallengeMemberProgress = {
  */
 api.sendPrivateMessage = {
   method: 'POST',
-  url: '/send-private-message',
+  url: '/members/send-private-message',
   middlewares: [authWithHeaders(), cron],
   async handler (req, res) {
     req.checkBody('message', res.t('messageRequired')).notEmpty();

--- a/website/src/models/user.js
+++ b/website/src/models/user.js
@@ -715,8 +715,17 @@ schema.methods.sendMessage = async function sendMessage (userToReceiveMessage, m
   if (!messageData.type) {
     msg = messageData.message;
   } else {
-    msg = `Hello ${userToReceiveMessage.profile.name }, ${sender.profile.name} has sent you `;
-    msg += messageData.type === 'gems' ?  `${messageData.gems.amount} gems! ` : `${shared.content.subscriptionBlocks[messageData.subscription.key].months} months of subscription! `;
+    msg = shared.i18n.t('privateMessageGiftIntro', {
+      receiverName: userToReceiveMessage.profile.name,
+      senderName: sender.profile.name,
+    });
+
+    if (messageData.type === 'gems') {
+      msg += shared.i18n.t('privateMessageGiftGemsMessage', {gemAmount: messageData.gems.amount});
+    } else {
+      msg += shared.i18n.t('privateMessageGiftSubscriptionMessage', {numberOfMonths: shared.content.subscriptionBlocks[messageData.subscription.key].months});
+    }
+
     msg += messageData.message;
   }
 

--- a/website/src/models/user.js
+++ b/website/src/models/user.js
@@ -708,33 +708,15 @@ schema.methods.getGroups = function getUserGroups () {
   return userGroups;
 };
 
-schema.methods.sendMessage = async function sendMessage (userToReceiveMessage, messageData) {
-  let msg;
+schema.methods.sendMessage = async function sendMessage (userToReceiveMessage, message) {
   let sender = this;
 
-  if (!messageData.type) {
-    msg = messageData.message;
-  } else {
-    msg = shared.i18n.t('privateMessageGiftIntro', {
-      receiverName: userToReceiveMessage.profile.name,
-      senderName: sender.profile.name,
-    });
-
-    if (messageData.type === 'gems') {
-      msg += shared.i18n.t('privateMessageGiftGemsMessage', {gemAmount: messageData.gems.amount});
-    } else {
-      msg += shared.i18n.t('privateMessageGiftSubscriptionMessage', {numberOfMonths: shared.content.subscriptionBlocks[messageData.subscription.key].months});
-    }
-
-    msg += messageData.message;
-  }
-
-  shared.refPush(userToReceiveMessage.inbox.messages, chatDefaults(msg, sender));
+  shared.refPush(userToReceiveMessage.inbox.messages, chatDefaults(message, sender));
   userToReceiveMessage.inbox.newMessages++;
   userToReceiveMessage._v++;
   userToReceiveMessage.markModified('inbox.messages');
 
-  shared.refPush(sender.inbox.messages, defaults({sent: true}, chatDefaults(msg, userToReceiveMessage)));
+  shared.refPush(sender.inbox.messages, defaults({sent: true}, chatDefaults(message, userToReceiveMessage)));
   sender.markModified('inbox.messages');
 
   let promises = [userToReceiveMessage.save(), sender.save()];


### PR DESCRIPTION
These are for the "sendPrivateMessage and sendMessage" items in #6776.

It was recommended to place this in the inbox routes, but I am unsure of where those are currently located. I think adding these to the user routes might be a good option. one last option would be to separate out and generalize chat.
