### PR TITLE
cron timezone fix (stage 1): cron records current timezone in preferences.timezoneOffsetAtLastCron

### DIFF
--- a/common/script/fns/cron.js
+++ b/common/script/fns/cron.js
@@ -36,6 +36,9 @@ module.exports = function(user, options) {
   }
   user.auth.timestamps.loggedin = new Date();
   user.lastCron = now;
+  if (_.isFinite(+user.preferences.timezoneOffset)) {
+    user.preferences.timezoneOffsetAtLastCron = user.preferences.timezoneOffset;
+  }
   if (user.items.lastDrop.count > 0) {
     user.items.lastDrop.count = 0;
   }

--- a/test/common/algos.mocha.js
+++ b/test/common/algos.mocha.js
@@ -53,6 +53,7 @@ let beforeAfter = (options = {}) => {
     before.preferences.dayStart = after.preferences.dayStart = options.dayStart;
   }
   before.preferences.timezoneOffset = after.preferences.timezoneOffset = options.timezoneOffset || moment().zone();
+  before.preferences.timezoneOffsetAtLastCron = after.preferences.timezoneOffsetAtLastCron = before.preferences.timezoneOffset;
   if (options.limitOne) {
     before[`${options.limitOne}s`] = [before[`${options.limitOne}s`][0]];
     after[`${options.limitOne}s`] = [after[`${options.limitOne}s`][0]];

--- a/website/src/models/user.js
+++ b/website/src/models/user.js
@@ -350,6 +350,7 @@ var UserSchema = new Schema({
     skin: {type:String, 'default':'915533'},
     shirt: {type: String, 'default': 'blue'},
     timezoneOffset: Number,
+    timezoneOffsetAtLastCron: Number,
     sound: {type:String, 'default':'off', enum: ['off', 'danielTheBard', 'gokulTheme', 'luneFoxTheme', 'wattsTheme']},
     language: String,
     automaticAllocation: Boolean,


### PR DESCRIPTION
First stage in a fix for https://github.com/HabitRPG/habitrpg/issues/3806
### Changes
- Adds a new preference to the user model: `preferences.timezoneOffsetAtLastCron`
- Adjusts cron so that when the daily reset happens, `timezoneOffsetAtLastCron` is set to the user's current timezone.
- Adds `timezoneOffsetAtLastCron` to test/common/algos.mocha.js but only enough to stop the current tests failing (proper test coming soon).

This is being pushed now so that `timezoneOffsetAtLastCron` can be populated for active players before cron code that uses it is introduced. Any players that don't pick up the new setting in advance won't have anything bad happen to them; they just won't benefit from a new cron feature.
