### PR TITLE
Remove extra 'it' from spec description

### DIFF
--- a/test/spec/controllers/challengesCtrlSpec.js
+++ b/test/spec/controllers/challengesCtrlSpec.js
@@ -149,7 +149,7 @@ describe('Challenges Controller', function() {
         expect(scope.filterChallenges(notOwnNotMem)).to.eql(true);
       });
 
-      it('it filters challenges to a single group when group id filter is set', inject(function($controller) {
+      it('filters challenges to a single group when group id filter is set', inject(function($controller) {
         scope.search = { };
         scope.groups = {
           0: specHelper.newGroup({_id: 'group-one'}),


### PR DESCRIPTION
### Changes

Removed an extra 'it' from a spec description. Was just getting my bearings in the app and saw this typo. Hoping to contribute something real soon!

---

UUID: 4e3123a6-42c2-43b2-9db1-30489072597a
