### PR TITLE
prevent a double cron when timezone decreases (timezoneOffset increases)

### DIFF
--- a/common/script/cron.js
+++ b/common/script/cron.js
@@ -25,7 +25,11 @@ export const DAY_MAPPING = {
 function sanitizeOptions (o) {
   let ref = Number(o.dayStart || 0);
   let dayStart = !_.isNaN(ref) && ref >= 0 && ref <= 24 ? ref : 0;
-  let timezoneOffset = _.isFinite(o.timezoneOffsetOverride) ?  o.timezoneOffsetOverride : _.isFinite(o.timezoneOffset) ? o.timezoneOffset : Number(moment().zone()); // XXX check that Number() is not needed around the ? ... parts
+  let timezoneOffset = _.isFinite(o.timezoneOffsetOverride) ?  o.timezoneOffsetOverride : _.isFinite(o.timezoneOffset) ? o.timezoneOffset : Number(moment().zone());
+  // timezones range from -12 to +14 (offset +720 to -840)
+  if (timezoneOffset > 720 || timezoneOffset < -840) {
+    timezoneOffset = Number(moment().zone());
+  }
   let now = o.now ? moment(o.now).zone(timezoneOffset) : moment().zone(timezoneOffset);
 
   // return a new object, we don't want to add "now" to user object

--- a/common/script/cron.js
+++ b/common/script/cron.js
@@ -25,21 +25,7 @@ export const DAY_MAPPING = {
 function sanitizeOptions (o) {
   let ref = Number(o.dayStart || 0);
   let dayStart = !_.isNaN(ref) && ref >= 0 && ref <= 24 ? ref : 0;
-  let timezoneOffset;
-  if (_.isFinite(o.timezoneOffsetOverride)) { // XXX check 0 passes and - numbers. Check okay when not specified
-	timezoneOffset = o.timezoneOffsetOverride; // XXX check that Number() is not needed here and below
-	console.log("using o.timezoneOffsetOverride"); // TST
-  }
-  else if (_.isFinite(o.timezoneOffset)) { // XXX check 0 passes and -numbers
-    timezoneOffset = o.timezoneOffset;
-	console.log("using o.timezoneOffset"); // TST
-  }
-  else {
-    timezoneOffset = Number(moment().zone());
-	console.log("using server zone"); // TST
-  }
-  // TODO: check and clean timezoneOffset as for dayStart (e.g., might not be a number)
-
+  let timezoneOffset = _.isFinite(o.timezoneOffsetOverride) ?  o.timezoneOffsetOverride : _.isFinite(o.timezoneOffset) ? o.timezoneOffset : Number(moment().zone()); // XXX check that Number() is not needed around the ? ... parts
   let now = o.now ? moment(o.now).zone(timezoneOffset) : moment().zone(timezoneOffset);
 
   // return a new object, we don't want to add "now" to user object

--- a/common/script/cron.js
+++ b/common/script/cron.js
@@ -25,8 +25,21 @@ export const DAY_MAPPING = {
 function sanitizeOptions (o) {
   let ref = Number(o.dayStart || 0);
   let dayStart = !_.isNaN(ref) && ref >= 0 && ref <= 24 ? ref : 0;
-  let timezoneOffset = o.timezoneOffset ? Number(o.timezoneOffset) : Number(moment().zone());
+  let timezoneOffset;
+  if (_.isFinite(o.timezoneOffsetOverride)) { // XXX check 0 passes and - numbers. Check okay when not specified
+	timezoneOffset = o.timezoneOffsetOverride; // XXX check that Number() is not needed here and below
+	console.log("using o.timezoneOffsetOverride"); // TST
+  }
+  else if (_.isFinite(o.timezoneOffset)) { // XXX check 0 passes and -numbers
+    timezoneOffset = o.timezoneOffset;
+	console.log("using o.timezoneOffset"); // TST
+  }
+  else {
+    timezoneOffset = Number(moment().zone());
+	console.log("using server zone"); // TST
+  }
   // TODO: check and clean timezoneOffset as for dayStart (e.g., might not be a number)
+
   let now = o.now ? moment(o.now).zone(timezoneOffset) : moment().zone(timezoneOffset);
 
   // return a new object, we don't want to add "now" to user object

--- a/common/script/cron.js
+++ b/common/script/cron.js
@@ -25,11 +25,21 @@ export const DAY_MAPPING = {
 function sanitizeOptions (o) {
   let ref = Number(o.dayStart || 0);
   let dayStart = !_.isNaN(ref) && ref >= 0 && ref <= 24 ? ref : 0;
-  let timezoneOffset = _.isFinite(o.timezoneOffsetOverride) ?  o.timezoneOffsetOverride : _.isFinite(o.timezoneOffset) ? o.timezoneOffset : Number(moment().zone());
-  // timezones range from -12 to +14 (offset +720 to -840)
-  if (timezoneOffset > 720 || timezoneOffset < -840) {
-    timezoneOffset = Number(moment().zone());
+
+  let timezoneOffset;
+  let timezoneOffsetDefault = Number(moment().zone());
+  if (_.isFinite(o.timezoneOffsetOverride)) {
+    timezoneOffset = Number(o.timezoneOffsetOverride);
+  } else if (_.isFinite(o.timezoneOffset)) {
+    timezoneOffset = Number(o.timezoneOffset);
+  } else {
+    timezoneOffset = timezoneOffsetDefault;
   }
+  if (timezoneOffset > 720 || timezoneOffset < -840) {
+    // timezones range from -12 (offset +720) to +14 (offset -840)
+    timezoneOffset = timezoneOffsetDefault;
+  }
+
   let now = o.now ? moment(o.now).zone(timezoneOffset) : moment().zone(timezoneOffset);
 
   // return a new object, we don't want to add "now" to user object

--- a/common/script/fns/cron.js
+++ b/common/script/fns/cron.js
@@ -14,6 +14,7 @@ import {
   ------------------------------------------------------
  */
 
+// XXX shouldDo relies on timezoneOffset - must adjust for case of two zones
 /*
   At end of day, add value to all incomplete Daily & Todo tasks (further incentive)
   For incomplete Dailys, deduct experience
@@ -58,34 +59,129 @@ module.exports = function(user, options) {
   }, user.preferences));
   console.log("daysMissed CURRENT (NEW) zone: " + daysMissed);
 
-  if (timezoneOffsetFromUserPrefs !== timezoneOffsetAtLastCron) {
-    // User's timezone has changed since cron last ran.
+  if (timezoneOffsetAtLastCron != timezoneOffsetFromUserPrefs) {
+    console.log("TIMEZONE HAS CHANGED")
+    // Since cron last ran, user's timezone has changed.
     // How many days have we missed using the old timezone:
-    console.log("zone has changed")
     let daysMissedNewZone = daysMissed;
     let daysMissedOldZone = daysSince(user.lastCron, _.defaults({
       now: now,
       timezoneOffsetOverride: timezoneOffsetAtLastCron,
     }, user.preferences));
-	// XXX UPTOHERE for testing
     console.log("  daysMissedOldZone: " + daysMissedOldZone);
     console.log("  daysMissedNewZone: " + daysMissedNewZone);
 
-    if (daysMissedOldZone > 0 && daysMissedNewZone > 0) {
-      // Both old and new timezones indicate that we SHOULD run cron, so
-      // it is safe to do so. // actually bullshit
-      daysMissed = Math.min(daysMissedOldZone, daysMissedNewZone);
-      // use minimum value to be nice to user
-      console.log("zone has changed - both zones say to run cron");
+// XXX we need to keep track of the old zone until cron runs in case the new zone changes again before cron runs - CONFIRM THAT
+
+    if (timezoneOffsetAtLastCron < timezoneOffsetFromUserPrefs) {
+      console.log("DANGEROUS zone change")
+      // The timezone change was in the unsafe direction. // XXX relevant?
+      // E.g., timezone changes from UTC+1 (offset -60) to UTC+0 (offset 0).
+      //    or timezone changes from UTC-4 (offset 240) to UTC-5 (offset 300).
+
+      if (daysMissedOldZone > 0 && daysMissedNewZone > 0) {
+        // Both old and new timezones indicate that we SHOULD run cron, so
+        // it is safe to do so immediately.
+        daysMissed = Math.min(daysMissedOldZone, daysMissedNewZone);
+        // use minimum value to be nice to user
+        console.log("zone has changed - both zones say to run cron now");
+      }
+      else if (daysMissedOldZone > 0) {
+        // The old timezone says that cron should run; the new timezone does not.
+        // We can expect cron to run correctly in future in the new timezone.
+        // We don't run it now in case the user is not ready for it.
+        daysMissed = 0; // prevent cron running now
+        //// DO NOT WANT?  user.preferences.timezoneOffsetAtLastCron = timezoneOffsetFromUserPrefs; // from now on we ignore the old timezone (this preference value is now a white lie)
+        console.log("zone has changed - old zone says run cron, NEW zone says no - stop cron now only");
+      }
+      else if (daysMissedNewZone > 0) {
+        // It's not possible to get to this situation (the new zone says to run cron but the old zone does not, when the old zone offset is less than the new one).
+        daysMissed = 0; // Prevent cron anyway in case I'm wrong about that.
+        console.log("NOT POSSIBLE TO GET HERE - zone has changed - NEW zone says run cron, old zone says no"); // XXX CHECK THAT
+        daysMissed = 666; // TST
+        // // The old timezone says that cron should NOT run -- i.e., cron has
+        // // already run today, from the old timezone's point of view.
+        // // The new timezone says that cron should run, but in most cases this
+        // // will be incorrect.
+        // daysMissed = 0; // prevent cron running now
+        // user.lastCron = now; // prevent cron running later today (lastCron is now a white lie)
+        // user.preferences.timezoneOffsetAtLastCron = timezoneOffsetFromUserPrefs; // from now on we ignore the old timezone
+        // // user.auth.timestamps.loggedin is not modified -- leave it set to the
+      // // last time cron really ran to help with troubleshooting if the user
+      // // reports an error.
+        // console.log("zone has changed - NEW zone says run cron, old zone says no - adjust lastCron");
+      }
+      else {
+        // Both old and new timezones indicate that cron should
+        // NOT run.
+        daysMissed = 0; // don't run cron
+        //
+        // XXX WTF below
+        // // If we persist in looking at two zones in the future, it
+        // // will be very difficult to work out whether cron should or should not
+        // // run because it depends too much on the user's exact circumstances.
+        // // So we do not run cron now but we change the last cron time to the
+        // // time it would have occurred if the user's timezone then had been
+        // // what it is now.
+        // // XXX do that
+        // user.preferences.timezoneOffsetAtLastCron = timezoneOffsetFromUserPrefs; // from now on we ignore the old timezone (this preference value is now a white lie)
+        console.log("zone has changed - both zones say don't run cron - keep both zones on record until both agree to run cron -- is this right????");
+      }
     }
-    else {
-      // Either one of the timezones (or both) indicates that cron should
-      // NOT run. It's difficult to tell which zone should be believed
-      // because it depends too much on the user's exact circumstances.
-      // We do not run cron until both zones agree.
-      daysMissed = 0;
-      console.log("zone has changed - at least one zone says don't run cron");
+    else if (timezoneOffsetAtLastCron > timezoneOffsetFromUserPrefs) {
+      console.log("SAFE zone change")
+      // XXX if you use Habitica within the one hour after CDS,
+      // cron will run one hour later than you think it should.
+
+      if (daysMissedOldZone > 0 && daysMissedNewZone > 0) {
+        // Both old and new timezones indicate that we SHOULD run cron, so
+        // it is safe to do so immediately.
+        daysMissed = Math.min(daysMissedOldZone, daysMissedNewZone);
+        // use minimum value to be nice to user
+        console.log("zone has changed - both zones say to run cron now");
+      }
+      else if (daysMissedOldZone > 0) {
+        // It's not possible to get to this situation (the old zone says to run cron but the new zone does not, when the old zone offset is greater than the new one).
+        daysMissed = 0; // Prevent cron anyway in case I'm wrong about that.
+        console.log("NOT POSSIBLE TO GET HERE - zone has changed - old zone says run cron, NEW zone says no"); // XXX CHECK THAT
+        daysMissed = 666; // TST
+        // // We can expect cron to run correctly in future in the new timezone.
+        // daysMissed = 0; // prevent cron running now
+        // user.preferences.timezoneOffsetAtLastCron = timezoneOffsetFromUserPrefs; // from now on we ignore the old timezone (this preference value is now a white lie)
+        // console.log("zone has changed - old zone says run cron, NEW zone says no");
+      }
+      else if (daysMissedNewZone > 0) {
+        // The old timezone says that cron should NOT run -- i.e., cron has
+        // already run today, from the old timezone's point of view.
+        // The new timezone says that cron should run, but this might be too
+        // early for the user.
+        daysMissed = 0; // prevent cron running now
+        // We do not overwrite timezoneOffsetAtLastCron because we want to keep
+        // paying attention to the old timezone until it agrees with the new one
+        // that cron should run.
+        console.log("zone has changed - NEW zone says run cron, old zone says no - keep checking with both zones until both agree to run cron");
+      }
+      else {
+      // XXX probably don't do anything here.
+        // Both old and new timezones indicate that cron should
+        // NOT run.
+        daysMissed = 0; // don't run cron
+        //
+        // XXX WTF below
+        // // If we persist in looking at two zones in the future, it
+        // // will be very difficult to work out whether cron should or should not
+        // // run because it depends too much on the user's exact circumstances.
+        // // So we do not run cron now but we change the last cron time to the
+        // // time it would have occurred if the user's timezone then had been
+        // // what it is now.
+        // // XXX do that
+        // user.preferences.timezoneOffsetAtLastCron = timezoneOffsetFromUserPrefs; // from now on we ignore the old timezone (this preference value is now a white lie)
+        console.log("zone has changed - both zones say don't run cron - keep both zones on record until both agree to run cron -- is this right????");
+      }
     }
+  }
+  else {
+      console.log("WOOT! Timezone has not changed.");
   }
 
   if (!(daysMissed > 0)) {

--- a/common/script/fns/cron.js
+++ b/common/script/fns/cron.js
@@ -105,6 +105,7 @@ module.exports = function(user, options) {
     }
     else if (timezoneOffsetAtLastCron > timezoneOffsetFromUserPrefs) {
       daysMissed = daysMissedNewZone;
+      // TODO: Either confirm that there is nothing that could possibly go wrong here and remove the need for this else branch, or fix stuff. There are probably situations where the Dailies do not reset early enough for a user who was expecting the zone change and wants to use all their Dailies immediately in the new zone; if so, we should provide an option for easy reset of Dailies (can't be automatic because there will be other situations where the user was not prepared).
     }
   }
 

--- a/common/script/fns/cron.js
+++ b/common/script/fns/cron.js
@@ -36,8 +36,8 @@ module.exports = function(user, options) {
   // cron can be triggered twice in one day, so we check for that and use
   // both timezones to work out if cron should run.
 
-  timezoneOffsetFromUserPrefs = +user.preferences.timezoneOffset || 0;
-  timezoneOffsetAtLastCron = (_.isFinite(+user.preferences.timezoneOffsetAtLastCron)) ? +user.preferences.timezoneOffsetAtLastCron : timezoneOffsetFromUserPrefs;
+  timezoneOffsetFromUserPrefs = user.preferences.timezoneOffset || 0;
+  timezoneOffsetAtLastCron = (_.isFinite(user.preferences.timezoneOffsetAtLastCron)) ? user.preferences.timezoneOffsetAtLastCron : timezoneOffsetFromUserPrefs;
   timezoneOffsetFromBrowser = (_.isFinite(+options.timezoneOffset)) ? +options.timezoneOffset : timezoneOffsetFromUserPrefs;
   // NB: all timezone offsets can be 0, so can't use `... || ...` to apply non-zero defaults
 

--- a/common/script/public/userServices.js
+++ b/common/script/public/userServices.js
@@ -170,8 +170,10 @@ angular.module('habitrpg')
 
         authenticate: function (uuid, token, cb) {
           if (!!uuid && !!token) {
+            var offset = moment().zone(); // eg, 240 - this will be converted on server as -(offset/60)
             $http.defaults.headers.common['x-api-user'] = uuid;
             $http.defaults.headers.common['x-api-key'] = token;
+            $http.defaults.headers.common['x-user-timezoneOffset'] = offset;
             authenticated = true;
             settings.auth.apiId = uuid;
             settings.auth.apiToken = token;
@@ -179,7 +181,6 @@ angular.module('habitrpg')
             if (user && user._v) user._v--; // shortcut to always fetch new updates on page reload
             userServices.log({}, function(){
               // If they don't have timezone, set it
-              var offset = moment().zone(); // eg, 240 - this will be converted on server as -(offset/60)
               if (user.preferences.timezoneOffset !== offset)
                 userServices.set({'preferences.timezoneOffset': offset});
               cb && cb();

--- a/website/src/controllers/api-v2/user.js
+++ b/website/src/controllers/api-v2/user.js
@@ -373,7 +373,6 @@ api.update = (req, res, next) => {
 
 api.cron = function(req, res, next) {
   var user = res.locals.user,
-    progress = user.fns.cron({analytics:utils.analytics}),
     progress = user.fns.cron({analytics:utils.analytics, timezoneOffset:req.headers['x-user-timezoneoffset']}),
     ranCron = user.isModified(),
     quest = shared.content.quests[user.party.quest.key];

--- a/website/src/controllers/api-v2/user.js
+++ b/website/src/controllers/api-v2/user.js
@@ -374,6 +374,7 @@ api.update = (req, res, next) => {
 api.cron = function(req, res, next) {
   var user = res.locals.user,
     progress = user.fns.cron({analytics:utils.analytics}),
+    progress = user.fns.cron({analytics:utils.analytics, timezoneOffset:req.headers['x-user-timezoneoffset']}),
     ranCron = user.isModified(),
     quest = shared.content.quests[user.party.quest.key];
 


### PR DESCRIPTION
Partial fix for https://github.com/HabitRPG/habitrpg/issues/3806
### Changes

See also https://github.com/HabitRPG/habitrpg/pull/6981 which created `preferences.timezoneOffsetAtLastCron`

Changes cron to detect when the user's timezone has changed since the previous cron. 

If the change is in the "dangerous" direction (e.g., timezone changes from UTC+1 (offset -60) to UTC+0 (offset 0)), it prevents a second cron in at least some situations. This should protect people for the case where the timezone has changed due to the end of daylight savings time.

The code is more verbose than it could be because I find this hard to wrap my head around each time I come back to it and so I want lots of comments to help the next time I have to look at it. There's still improvements that could be made for cases that this PR doesn't cover.

I'll merge this in a couple of hours if no complaints. **REMEMBER TO SQUASH COMMITS BEFORE MERGING.** :)
