### PR TITLE
Inserting split into boss attacks to separate boss attacks and user attacks on two different lines.

### DIFF
--- a/website/src/models/group.js
+++ b/website/src/models/group.js
@@ -355,7 +355,7 @@ GroupSchema.statics.bossQuest = function(user, progress, cb) {
     var down = progress.down * quest.boss.str; // multiply by boss strength
 
     group.quest.progress.hp -= progress.up;
-    group.sendChat("`" + user.profile.name + " attacks " + quest.boss.name('en') + " for " + (progress.up.toFixed(1)) + " damage, " + quest.boss.name('en') + " attacks party for " + Math.abs(down).toFixed(1) + " damage.`"); //TODO Create a party preferred language option so emits like this can be localized
+    group.sendChat("`" + user.profile.name + " attacks " + quest.boss.name('en') + " for " + (progress.up.toFixed(1)) + " damage.` `" + quest.boss.name('en') + " attacks party for " + Math.abs(down).toFixed(1) + " damage.`"); //TODO Create a party preferred language option so emits like this can be localized
 
     // If boss has Rage, increment Rage as well
     if (quest.boss.rage) {

--- a/website/src/models/group.js
+++ b/website/src/models/group.js
@@ -355,7 +355,7 @@ GroupSchema.statics.bossQuest = function(user, progress, cb) {
     var down = progress.down * quest.boss.str; // multiply by boss strength
 
     group.quest.progress.hp -= progress.up;
-    group.sendChat("`" + user.profile.name + " attacks " + quest.boss.name('en') + " for " + (progress.up.toFixed(1)) + " damage, " + quest.boss.name('en') + " attacks party for " + Math.abs(down).toFixed(1) + " damage.`"); //TODO Create a party preferred language option so emits like this can be localized
+    group.sendChat("`" + user.profile.name + " attacks " + quest.boss.name('en') + " for " + (progress.up.toFixed(1)) + " damage.`  \n`" + quest.boss.name('en') + " attacks party for " + Math.abs(down).toFixed(1) + " damage.`"); //TODO Create a party preferred language option so emits like this can be localized
 
     // If boss has Rage, increment Rage as well
     if (quest.boss.rage) {


### PR DESCRIPTION
fixes #3453 
### Changes

Splits the markdown text notification to the party into two code tags split by a newline instead of one code tag. The code tag prevents wrap-text css styles from being applied which was the cause of the scrolling.

The newline can be removed so that it only splits into two lines if needed by the browser size which might be slightly more ideal as Markdown doesn't recommend counting on line break escapes. This would be easy to change by simply updating the '  \n' to a comma or semicolon but the newline seem to be the preferred solution in the issue.

---

UUID: 2a4d30ee-4833-420e-be7c-ad6a6e261c5f

Related issue: https://github.com/HabitRPG/habitrpg/issues/3453
