### PR TITLE
Splitting party and boss damage notifications into two code blocks.

### DIFF
--- a/website/src/models/group.js
+++ b/website/src/models/group.js
@@ -355,7 +355,7 @@ GroupSchema.statics.bossQuest = function(user, progress, cb) {
     var down = progress.down * quest.boss.str; // multiply by boss strength
 
     group.quest.progress.hp -= progress.up;
-    group.sendChat("`" + user.profile.name + " attacks " + quest.boss.name('en') + " for " + (progress.up.toFixed(1)) + " damage, " + quest.boss.name('en') + " attacks party for " + Math.abs(down).toFixed(1) + " damage.`"); //TODO Create a party preferred language option so emits like this can be localized
+    group.sendChat("`" + user.profile.name + " attacks " + quest.boss.name('en') + " for " + (progress.up.toFixed(1)) + " damage.` `" + quest.boss.name('en') + " attacks party for " + Math.abs(down).toFixed(1) + " damage.`"); //TODO Create a party preferred language option so emits like this can be localized
 
     // If boss has Rage, increment Rage as well
     if (quest.boss.rage) {


### PR DESCRIPTION
Fixes https://github.com/HabitRPG/habitrpg/issues/3453
### Changes

```
Splitting party and boss damage notifications into two code blocks.

Splitting the party and boss damage notifications into two code blocks will allow the page to push them to newlines if needed instead of added a scroll bar and making the user scroll to see the entire message.

Related issue: https://github.com/HabitRPG/habitrpg/issues/3453
```

---

UUID: 2a4d30ee-4833-420e-be7c-ad6a6e261c5f
