### PR TITLE
Changing level up attribute allocation division from collapsable to ng-show

### DIFF
--- a/website/views/shared/modals/level-up.jade
+++ b/website/views/shared/modals/level-up.jade
@@ -17,11 +17,11 @@ script(type='text/ng-template', id='modals/levelUp.html')
       p=env.t('fullyHealed')
       br
       div(ng-if='user.flags.classSelected && !user.preferences.disableClasses && !user.preferences.automaticAllocation')
-        a.btn.btn-default(ng-click='statsAllocationBoxIsOpen = !statsAllocationBoxIsOpen',
-          data-toggle='collapse', data-target='#stat-allocation', aria-expanded=false, aria-controls='stat-allocation')
+        a.btn.btn-default(ng-click='statsAllocationBoxIsOpen = !statsAllocationBoxIsOpen', 
+          aria-expanded=false, aria-controls='stat-allocation')
           | {{statsAllocationBoxIsOpen  ? env.t('hideQuickAllocation') : env.t('showQuickAllocation')}}
         p &nbsp;
-        .collapse#stat-allocation
+        stat-allocation(ng-show='statsAllocationBoxIsOpen')
           table.table.text-left
             tr
               td


### PR DESCRIPTION
Fixes https://github.com/HabitRPG/habitrpg/issues/6961
### Changes

Changing level up attribute allocation division from collapsable to ng-show

Changing this dialog from a collapsible element to one that uses ng-show takes care of this issue. The only change in functionality from the user perspective (outside of fixing the bug) is it no longer has a slow open effect where the table slides down to be displayed. Now it just appears.

Example:
Old Collapse Style - http://i.imgur.com/iKqar66.gif
New ng-show style - http://i.stack.imgur.com/z94GJ.gif

---

UUID: 2a4d30ee-4833-420e-be7c-ad6a6e261c5f
