### PR TITLE
Add z-index to notes textarea

### DIFF
--- a/website/public/css/tasks.styl
+++ b/website/public/css/tasks.styl
@@ -407,6 +407,10 @@ for $stage in $stages
 form
   margin-bottom: 0 // stupid bootstrap override
 
+textarea.form-control
+  position: relative
+  z-index: 50
+
 [class$="-options"]
   padding: 1em 1em 0
   color: #333


### PR DESCRIPTION
Fixes https://github.com/habitrpg/HabitRPG/issues/6967
### Changes
- Changes textarea for notes to `position: relative`
- Adds `z-index: 50` to the notes textarea

---

UUID: 95f16006-1504-4a9f-95b6-0c7314dbd7ee
