### PR TITLE
feat: Add eb extension to increase deploy timeout to 30 minutes

### DIFF
--- a/.ebextensions/01-increase-timeout.config
+++ b/.ebextensions/01-increase-timeout.config
@@ -1,0 +1,4 @@
+option_settings:
+    - namespace: aws:elasticbeanstalk:command
+      option_name: Timeout
+      value: 1800


### PR DESCRIPTION
This _should_ prevent the EB CLI from timing out. 

Pinging @SabreCat
