### PR TITLE
fix: Change from moment.zone to moment.utcOffset to fix warnings

### DIFF
--- a/common/script/cron.js
+++ b/common/script/cron.js
@@ -27,7 +27,7 @@ function sanitizeOptions (o) {
   let dayStart = !_.isNaN(ref) && ref >= 0 && ref <= 24 ? ref : 0;
 
   let timezoneOffset;
-  let timezoneOffsetDefault = Number(moment().zone());
+  let timezoneOffsetDefault = Number(moment().utcOffset());
   if (_.isFinite(o.timezoneOffsetOverride)) {
     timezoneOffset = Number(o.timezoneOffsetOverride);
   } else if (_.isFinite(o.timezoneOffset)) {
@@ -40,7 +40,7 @@ function sanitizeOptions (o) {
     timezoneOffset = timezoneOffsetDefault;
   }
 
-  let now = o.now ? moment(o.now).zone(timezoneOffset) : moment().zone(timezoneOffset);
+  let now = o.now ? moment(o.now).utcOffset(timezoneOffset) : moment().utcOffset(timezoneOffset);
 
   // return a new object, we don't want to add "now" to user object
   return {
@@ -97,7 +97,7 @@ export function shouldDo (day, dailyTask, options = {}) {
   // The time portion of the Start Date is never visible to or modifiable by the user so we must ignore it.
   // Therefore, we must also ignore the time portion of the user's day start (startOfDayWithCDSTime), otherwise the date comparison will be wrong for some times.
   // NB: The user's day start date has already been converted to the PREVIOUS day's date if the time portion was before CDS.
-  let taskStartDate = moment(dailyTask.startDate).zone(o.timezoneOffset);
+  let taskStartDate = moment(dailyTask.startDate).utcOffset(o.timezoneOffset);
 
   taskStartDate = moment(taskStartDate).startOf('day');
   if (taskStartDate > startOfDayWithCDSTime.startOf('day')) {

--- a/common/script/public/userServices.js
+++ b/common/script/public/userServices.js
@@ -109,7 +109,7 @@ angular.module('habitrpg')
                         if (MOBILE_APP) Notification.push({type:'text',text:message});
                         else Notification.text(message);
                         // In the case of 200s, they're friendly alert messages like "Your pet has hatched!" - still send the op
-                        if ((err.code && err.code >= 400) || !err.code) return; 
+                        if ((err.code && err.code >= 400) || !err.code) return;
                       }
                       userServices.log({op:k, params: req.params, query:req.query, body:req.body});
                     });
@@ -170,7 +170,7 @@ angular.module('habitrpg')
 
         authenticate: function (uuid, token, cb) {
           if (!!uuid && !!token) {
-            var offset = moment().zone(); // eg, 240 - this will be converted on server as -(offset/60)
+            var offset = moment().utcOffset(); // eg, 240 - this will be converted on server as -(offset/60)
             $http.defaults.headers.common['x-api-user'] = uuid;
             $http.defaults.headers.common['x-api-key'] = token;
             $http.defaults.headers.common['x-user-timezoneOffset'] = offset;

--- a/test/common/algos.mocha.js
+++ b/test/common/algos.mocha.js
@@ -52,7 +52,7 @@ let beforeAfter = (options = {}) => {
   if (options.dayStart) {
     before.preferences.dayStart = after.preferences.dayStart = options.dayStart;
   }
-  before.preferences.timezoneOffset = after.preferences.timezoneOffset = options.timezoneOffset || moment().zone();
+  before.preferences.timezoneOffset = after.preferences.timezoneOffset = options.timezoneOffset || moment().utcOffset();
   before.preferences.timezoneOffsetAtLastCron = after.preferences.timezoneOffsetAtLastCron = before.preferences.timezoneOffset;
   if (options.limitOne) {
     before[`${options.limitOne}s`] = [before[`${options.limitOne}s`][0]];
@@ -154,7 +154,7 @@ let repeatWithoutLastWeekday = () => {
     s: true,
   };
 
-  if (startOfWeek(moment().zone(0)).isoWeekday() === 1) {
+  if (startOfWeek(moment().utcOffset(0)).isoWeekday() === 1) {
     repeat.su = false;
   } else {
     repeat.s = false;
@@ -1464,7 +1464,7 @@ describe('Helper', () => {
   it('calculates the start of the day', () => {
     let fstr = 'YYYY-MM-DD HH: mm: ss';
     let today = '2013-01-01 00: 00: 00';
-    let zone = moment(today).zone();
+    let zone = moment(today).utcOffset();
 
     expect(startOfDay({
       now: new Date(2013, 0, 1, 0),

--- a/test/common/dailies.js
+++ b/test/common/dailies.js
@@ -20,7 +20,7 @@ let repeatWithoutLastWeekday = () => { // eslint-disable-line no-unused-vars
     s: true,
   };
 
-  if (startOfWeek(moment().zone(0)).isoWeekday() === 1) {
+  if (startOfWeek(moment().utcOffset(0)).isoWeekday() === 1) {
     repeat.su = false;
   } else {
     repeat.s = false;


### PR DESCRIPTION
### Problem

Moment deprecated the use of `moment().zone` in favor of `moment().utcOffset`. So we're getting deprecation warnings on the server and client. HOWEVER, it is not just a rename. See this note from the `utcOffset` docs:

> **NOTE:** Unlike `moment.fn.zone` this function returns the real offset from UTC, not the reverse offset (as returned by `Date.prototype.getTimezoneOffset`).

So we may need to test and make some adjustments before merging this in. 

@Alys @SabreCat @paglias 
