### PR TITLE
moved broadcast to task page. changed up key press binding

### DIFF
--- a/website/public/js/controllers/rootCtrl.js
+++ b/website/public/js/controllers/rootCtrl.js
@@ -330,19 +330,5 @@ habitrpg.controller("RootCtrl", ['$scope', '$rootScope', '$location', 'User', '$
       });
       // error will be handled via $http interceptor
     }
-
-    // Global Keyevents
-    var ctrlKeys = [17, 224, 91];
-    $scope.$on("habit:keydown", function (e, keyEvent) {
-      if (ctrlKeys.indexOf(keyEvent.keyCode) !== -1) {
-        $scope.ctrlPressed = true;
-      }
-    });
-
-    $scope.$on("habit:keyup", function (e, keyEvent) {
-      if (ctrlKeys.indexOf(keyEvent.keyCode) !== -1) {
-        $scope.ctrlPressed = false;
-      }
-    });
   }
 ]);

--- a/website/public/js/controllers/tasksCtrl.js
+++ b/website/public/js/controllers/tasksCtrl.js
@@ -258,4 +258,26 @@ habitrpg.controller("TasksCtrl", ['$scope', '$rootScope', '$location', 'User','N
         $rootScope.playSound('Reward');
       }
     }
+
+    var ctrlKeys = [17, 224, 91];
+    $scope.hoverIn = function () {
+      $(document).keydown(function (keyEvent) {
+        if (ctrlKeys.indexOf(keyEvent.keyCode) !== -1) {
+                $scope.ctrlPressed = true;
+                $scope.$apply();
+              }
+      });
+      $(document).keyup(function (keyEvent) {
+        console.log('blah');
+        if (ctrlKeys.indexOf(keyEvent.keyCode) !== -1) {
+          $scope.ctrlPressed = false;
+          $scope.$apply();
+        }
+      });
+    }
+    $scope.hoverout = function () {
+      $(document).unbind('keydown');
+      $(document).unbind('keyup');
+      $scope.ctrlPressed = false;
+    }
   }]);

--- a/website/views/index.jade
+++ b/website/views/index.jade
@@ -1,6 +1,6 @@
 doctype html
 //html(ng-app="habitrpg", ng-controller="RootCtrl", ng-class='{"applying-action":applyingAction}', ui-keypress="{27:'castCancel()'}")
-html(ng-app="habitrpg", ng-controller="RootCtrl", ng-class='{"applying-action":applyingAction}', ui-keyup="{27:'castCancel()'}", ng-keydown="$broadcast('habit:keydown', $event)", ng-keyup="$broadcast('habit:keyup', $event)")
+html(ng-app="habitrpg", ng-controller="RootCtrl", ng-class='{"applying-action":applyingAction}', ui-keyup="{27:'castCancel()'}")
   head
     title(ng-bind="env.t('habitica') + ' | ' + $root.pageTitle")
     // ?v=1 needed to force refresh

--- a/website/views/main/index.jade
+++ b/website/views/main/index.jade
@@ -1,4 +1,4 @@
 script(id='partials/main.html', type="text/ng-template")
   include ./filters
-  div(ng-controller='TasksCtrl')
+  div(ng-controller='TasksCtrl', ng-mouseenter="hoverIn()", ng-mouseleave="hoverout()")
     habitrpg-tasks(main='true', obj='user')


### PR DESCRIPTION
#6462
### Changes

Removed 
`, ng-keydown="$broadcast('habit:keydown', $event)", ng-keyup="$broadcast('habit:keyup', $event)"`
from html element and placed on task div. Had to use mouseover and mouseout to find key down and key up due to ng-keypress not being able to work on a div. The biggest change of how this would work is someone would have to have there mouse over the task area vs the whole page being able to detect the keypress event. 

That being said chat seems to be way faster :0) So need someone to review and see what they think.. if we are good i will do the same for inventory. if not i will need some other ideas :0)

---

UUID: 
