### PR TITLE
Fix timezone issue with iOS app

### DIFF
--- a/website/src/models/user.js
+++ b/website/src/models/user.js
@@ -350,7 +350,7 @@ var UserSchema = new Schema({
     hideHeader: {type:Boolean, 'default':false},
     skin: {type:String, 'default':'915533'},
     shirt: {type: String, 'default': 'blue'},
-    timezoneOffset: Number,
+    timezoneOffset: {type: Number, 'default': 0},
     timezoneOffsetAtLastCron: Number,
     sound: {type:String, 'default':'off', enum: ['off', 'danielTheBard', 'gokulTheme', 'luneFoxTheme', 'wattsTheme']},
     language: String,


### PR DESCRIPTION
Fixes put_issue_url_here
### Changes

Changed preferences.timezoneOffset to be set to 0 as default. This fixes an issue with the iOS app not setting the offset, when no initial value exists.

---

UUID: 
