### PR TITLE
Disabling Frost and Stealth when all dailies are already effected  [merged in b97d7cc]

### DIFF
--- a/common/locales/en/spells.json
+++ b/common/locales/en/spells.json
@@ -10,6 +10,8 @@
 
   "spellWizardFrostText": "Chilling Frost",
   "spellWizardFrostNotes": "Ice covers your tasks. None of your streaks will reset to zero tomorrow! (One cast affects all streaks.)",
+  "spellWizardFrostAlreadyCast": " You have already cast this today. Your streaks are frozen, and there's no need to cast this again.",
+
 
   "spellWarriorSmashText": "Brutal Smash",
   "spellWarriorSmashNotes": "You hit a task with all of your might. It gets more blue/less red, and you deal extra damage to Bosses! Click on a task to cast. (Based on: STR)",
@@ -34,6 +36,8 @@
 
   "spellRogueStealthText": "Stealth",
   "spellRogueStealthNotes": "You are too sneaky to spot. Some of your undone Dailies will not cause damage tonight, and their streaks/color will not change. (Cast multiple times to affect more Dailies)",
+  "spellRogueStealthDaliesAvoided": " Number of dailies avoided: <%= number %>.",
+  "spellRogueStealthMaxedOut": " You have already avoided all your dailies, there's no need to cast this again.",
 
   "spellHealerHealText": "Healing Light",
   "spellHealerHealNotes": "Light covers your body, healing your wounds. You regain health! (Based on: CON and INT)",

--- a/website/public/js/controllers/tasksCtrl.js
+++ b/website/public/js/controllers/tasksCtrl.js
@@ -258,4 +258,23 @@ habitrpg.controller("TasksCtrl", ['$scope', '$rootScope', '$location', 'User','N
         $rootScope.playSound('Reward');
       }
     }
+
+    /*
+     ------------------------
+     Disabling Spells
+     ------------------------
+     */
+
+    $scope.isSpellDisabled = function(user, skill) {
+      if ( skill == "frost" && user.stats.buffs.streaks )
+      {
+        return false;
+      }
+      else if ( skill == "stealth" && user.stats.buffs.stealth >= user.dailys.length)
+      {
+        return true;
+      }
+      return false;
+    }
+
   }]);

--- a/website/views/shared/tasks/task_view/skills.jade
+++ b/website/views/shared/tasks/task_view/skills.jade
@@ -7,27 +7,21 @@ ul.items.rewards
       +specialSkill(dispel,skill)
 
 // Class Skills
+- var frostNoAdditionalBenefitText = '{{k=="frost" && user.stats.buffs.streaks ? env.t("spellWizardFrostAlreadyCast") : ""}}'
+- var stealthNumberOfCastsText = '{{k=="stealth" ? env.t("spellRogueStealthDaliesAvoided", { number: user.stats.buffs.stealth }) : ""}}'
+- var stealthNoAdditionalBenefitText = '{{k=="stealth" && user.stats.buffs.stealth >= user.dailys.length ? env.t("spellRogueStealthMaxedOut") : ""}}'
 ul.items(ng-if='main && list.type=="reward" && user.stats.class && !user.preferences.disableClasses')
   li.task.reward-item.list-group-item(ng-repeat='(k,skill) in Content.spells[user.stats.class]', ng-if='user.stats.lvl >= skill.lvl',popover-trigger='mouseenter', popover-placement='top',
-  popover='{{skill.notes()}}{{k=="frost" && user.stats.buffs.streaks ? " You have already cast this today. Your streaks are frozen, and there\'s no need to cast this again." : ""}}}{{k=="stealth" ? " Number of dailies avoided: " + user.stats.buffs.stealth + "." : ""}}{{k=="stealth" && user.stats.buffs.stealth >= user.dailys.length ? " You have already avoided all your dailies, there\'s no need to cast this again." : ""}}')
+  popover='{{skill.notes()}}#{frostNoAdditionalBenefitText}#{stealthNumberOfCastsText}#{stealthNoAdditionalBenefitText}')
     .task-meta-controls
       span.task-notes
         span.glyphicon.glyphicon-comment
     //left-hand size commands
     .task-controls.task-primary
-      a.money.btn-buy.item-btn(ng-click='castStart(skill)', ng-if='!( k=="frost" || k=="stealth" )')
-        span.reward-cost
-          strong {{::skill.mana}}
-          =env.t('mp')
-      a.btn.money.btn-buy.item-btn(ng-click='castStart(skill)', ng-class='{"disabled": user.stats.buffs.streaks}', ng-if='k=="frost"')
-        span.reward-cost
-          strong {{::skill.mana}}
-          =env.t('mp')
-      a.btn.money.btn-buy.item-btn(ng-click='castStart(skill)', ng-class='{"disabled": user.stats.buffs.stealth >= user.dailys.length}', ng-if='k=="stealth"')
+      a.btn.money.btn-buy.item-btn(ng-click='castStart(skill)', ng-class='{"disabled": isSpellDisabled(user, k)}')
         span.reward-cost
           strong {{::skill.mana}}
           =env.t('mp')
     // main content
     span(ng-class='{"shop_{{::skill.key}} shop-sprite item-img": true}').reward-img
     p.task-text {{::skill.text()}}
-    

--- a/website/views/shared/tasks/task_view/skills.jade
+++ b/website/views/shared/tasks/task_view/skills.jade
@@ -8,16 +8,26 @@ ul.items.rewards
 
 // Class Skills
 ul.items(ng-if='main && list.type=="reward" && user.stats.class && !user.preferences.disableClasses')
-  li.task.reward-item(ng-repeat='(k,skill) in Content.spells[user.stats.class]', ng-if='user.stats.lvl >= skill.lvl',popover-trigger='mouseenter', popover-placement='top', popover='{{skill.notes()}}')
+  li.task.reward-item.list-group-item(ng-repeat='(k,skill) in Content.spells[user.stats.class]', ng-if='user.stats.lvl >= skill.lvl',popover-trigger='mouseenter', popover-placement='top',
+  popover='{{skill.notes()}}{{k=="frost" && user.stats.buffs.streaks ? " You have already cast this today. Your streaks are frozen, and there\'s no need to cast this again." : ""}}}{{k=="stealth" ? " Number of dailies avoided: " + user.stats.buffs.stealth + "." : ""}}{{k=="stealth" && user.stats.buffs.stealth >= user.dailys.length ? " You have already avoided all your dailies, there\'s no need to cast this again." : ""}}')
     .task-meta-controls
       span.task-notes
         span.glyphicon.glyphicon-comment
     //left-hand size commands
     .task-controls.task-primary
-      a.money.btn-buy.item-btn(ng-click='castStart(skill)', ng-class='{active: skill.key == spell.key}')
+      a.money.btn-buy.item-btn(ng-click='castStart(skill)', ng-if='!( k=="frost" || k=="stealth" )')
+        span.reward-cost
+          strong {{::skill.mana}}
+          =env.t('mp')
+      a.btn.money.btn-buy.item-btn(ng-click='castStart(skill)', ng-class='{"disabled": user.stats.buffs.streaks}', ng-if='k=="frost"')
+        span.reward-cost
+          strong {{::skill.mana}}
+          =env.t('mp')
+      a.btn.money.btn-buy.item-btn(ng-click='castStart(skill)', ng-class='{"disabled": user.stats.buffs.stealth >= user.dailys.length}', ng-if='k=="stealth"')
         span.reward-cost
           strong {{::skill.mana}}
           =env.t('mp')
     // main content
     span(ng-class='{"shop_{{::skill.key}} shop-sprite item-img": true}').reward-img
     p.task-text {{::skill.text()}}
+    


### PR DESCRIPTION
Fixes https://github.com/HabitRPG/habitrpg/issues/6867
### Changes

This enables new functionality for the stealth and frost skills. It updates the skill to disable it when the benefit of the skill has already been gained and there's no additional benefit to casting it again. 

This change was limited to the jade file in order to not interfere with the api v3 changes that are currently going on. Pictures of the changes are in the issue linked here.

---

UUID: 2a4d30ee-4833-420e-be7c-ad6a6e261c5f
