### PR TITLE
fix: Only apply captureStackTrace if it exists on the error object

### DIFF
--- a/common/script/libs/errors.js
+++ b/common/script/libs/errors.js
@@ -5,7 +5,10 @@ import extendableBuiltin from './extendableBuiltin';
 export class CustomError extends extendableBuiltin(Error) {
   constructor () {
     super();
-    Error.captureStackTrace(this, this.constructor);
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
   }
 }
 


### PR DESCRIPTION
Fixes js error in non-Chrome browsers.
