### PR TITLE
[API v3] minor improvements to cron code for clarity; fix inaccurate comments; add TODOs

### DIFF
--- a/common/script/ops/scoreTask.js
+++ b/common/script/ops/scoreTask.js
@@ -87,7 +87,6 @@ function _gainMP (user, val) {
   if (user.stats.mp >= user._statsComputed.maxMP) user.stats.mp = user._statsComputed.maxMP;
   if (user.stats.mp < 0) {
     user.stats.mp = 0;
-    return user.stats.mp;
   }
 }
 
@@ -181,10 +180,9 @@ module.exports = function scoreTask (options = {}, req = {}) {
   // the API consumer, then cleared afterwards
   user._tmp = {};
 
-  // If they're trying to purhcase a too-expensive reward, don't allow them to do that.
+  // If they're trying to purchase a too-expensive reward, don't allow them to do that.
   if (task.value > user.stats.gp && task.type === 'reward') throw new NotAuthorized(i18n.t('messageNotEnoughGold', req.language));
 
-  // ===== starting to actually do stuff, most of above was definitions =====
   if (task.type === 'habit') {
     delta += _changeTaskValue(user, task, direction, times, cron);
 

--- a/website/server/libs/api-v3/cron.js
+++ b/website/server/libs/api-v3/cron.js
@@ -37,8 +37,10 @@ function grantEndOfTheMonthPerks (user, now) {
       if (plan.consecutive.gemCapExtra > 25) plan.consecutive.gemCapExtra = 25; // cap it at 50 (hard 25 limit + extra 25)
     }
   }
+}
 
-  // If user cancelled subscription, we give them until 30day's end until it terminates
+function removeTerminatedSubscription (user) {
+  // If subscription's termination date has arrived
   if (plan.dateTerminated && moment(plan.dateTerminated).isBefore(new Date())) {
     _.merge(plan, {
       planId: null,
@@ -71,17 +73,14 @@ function performSleepTasks (user, tasksByType, now) {
   });
 }
 
-// At end of day, add value to all incomplete Daily & Todo tasks (further incentive)
-// For incomplete Dailys, deduct experience
-// Make sure to run this function once in a while as server will not take care of overnight calculations.
-// And you have to run it every time client connects.
+// Perform various beginning-of-day reset actions.
 export function cron (options = {}) {
   let {user, tasksByType, analytics, now = new Date(), daysMissed, timezoneOffsetFromUserPrefs} = options;
 
   user.auth.timestamps.loggedin = now;
   user.lastCron = now;
   user.preferences.timezoneOffsetAtLastCron = timezoneOffsetFromUserPrefs;
-  // Reset the lastDrop count to zero
+  // Allow user to get drops again
   if (user.items.lastDrop.count > 0) user.items.lastDrop.count = 0;
 
   // "Perfect Day" achievement for perfect-days
@@ -89,6 +88,7 @@ export function cron (options = {}) {
 
   if (user.isSubscribed()) {
     grantEndOfTheMonthPerks(user, now);
+    removeTerminatedSubscription(user);
   }
 
   // User is resting at the inn.
@@ -105,7 +105,7 @@ export function cron (options = {}) {
   // Tally each task
   let todoTally = 0;
 
-  tasksByType.todos.forEach(task => { // make uncompleted todos redder
+  tasksByType.todos.forEach(task => { // make uncompleted To-Dos redder (further incentive to complete them)
     scoreTask({
       task,
       user,
@@ -117,8 +117,9 @@ export function cron (options = {}) {
     todoTally += task.value;
   });
 
+  // For incomplete Dailys, add value (further incentive), deduct health, keep records for later decreasing the nightly mana gain
   let dailyChecked = 0; // how many dailies were checked?
-  let dailyDueUnchecked = 0; // how many dailies were cun-hecked?
+  let dailyDueUnchecked = 0; // how many dailies were un-checked?
   if (!user.party.quest.progress.down) user.party.quest.progress.down = 0;
 
   tasksByType.dailys.forEach((task) => {
@@ -186,6 +187,7 @@ export function cron (options = {}) {
     }
   });
 
+//  move singleton Habits towards yellow.
   tasksByType.habits.forEach((task) => { // slowly reset 'onlies' value to 0
     if (task.up === false || task.down === false) {
       task.value = Math.abs(task.value) < 0.1 ? 0 : task.value = task.value / 2;
@@ -206,8 +208,8 @@ export function cron (options = {}) {
   user.history.exp.push({date: now, value: expTally});
 
   // preen user history so that it doesn't become a performance problem
-  // also for subscribed users but differentyly
-  // premium subscribers can keep their full history.
+  // also for subscribed users but differently
+  // TODO also do while resting in the inn. Note that later we'll be allowing the value/color of tasks to change while sleeping (https://github.com/HabitRPG/habitrpg/issues/5232), so the code in performSleepTasks() might be best merged back into here for that. Perhaps wait until then to do preen history for sleeping users.
   preenUserHistory(user, tasksByType, user.preferences.timezoneOffset);
 
   if (perfect) {
@@ -242,7 +244,7 @@ export function cron (options = {}) {
   _.merge(progress, {down: 0, up: 0});
   progress.collect = _.transform(progress.collect, (m, v, k) => m[k] = 0);
 
-  // @TODO: Clean PMs - keep 200 for subscribers and 50 for free users
+  // @TODO: Clean PMs - keep 200 for subscribers and 50 for free users. Should also be done while resting in the inn
   // let numberOfPMs = Object.keys(user.inbox.messages).length;
   // if (numberOfPMs > maxPMs) {
   //   _(user.inbox.messages)
@@ -257,7 +259,7 @@ export function cron (options = {}) {
 
   // Analytics
   user.flags.cronCount++;
-  analytics.track('Cron', {
+  analytics.track('Cron', { // TODO also do while resting in the inn. https://github.com/HabitRPG/habitrpg/issues/7161#issuecomment-218214191
     category: 'behavior',
     gaLabel: 'Cron Count',
     gaValue: user.flags.cronCount,

--- a/website/server/libs/api-v3/cron.js
+++ b/website/server/libs/api-v3/cron.js
@@ -41,6 +41,8 @@ function grantEndOfTheMonthPerks (user, now) {
 
 function removeTerminatedSubscription (user) {
   // If subscription's termination date has arrived
+  let plan = user.purchased.plan;
+
   if (plan.dateTerminated && moment(plan.dateTerminated).isBefore(new Date())) {
     _.merge(plan, {
       planId: null,


### PR DESCRIPTION
### Changes
- Minor code changes for clarity:
  - delete unnecessary `return` from `_gainMP()`
  - move some code from `grantEndOfTheMonthPerks()` to new function `removeTerminatedSubscription()`
- Delete/edit/clarify outdated comments and fix typos in comments
- Add TODOs for cron actions that should be done when resting in the inn:
  - `preenUserHistory()`
  - `analytics.track()`
  - "Clean PMs" (code not going live yet)

@paglias, I'm not sure the preenUserHistory and analytics.track TODOs are urgent, but if you want them done before API v3 goes live, I can do them this weekend. Some players spend weeks or months resting in the inn, so preening/cleaning for them would be helpful.
