### PR TITLE
[API v3] updates apidoc URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,6 +163,6 @@
     "name": "habitica",
     "title": "Habitica",
     "version": "3.0.0",
-    "url": "https://habitica-v3.herokuapp.com/api-v3"
+    "url": "https://v3.habitica.com/api-v3"
   }
 }


### PR DESCRIPTION
### Changes

Updates the apidoc URL in package.json. Hopefully fixes this problem:

![screen shot 2016-05-14 at 3 43 55 pm](https://cloud.githubusercontent.com/assets/1495809/15266514/f776fcc6-19ea-11e6-8c74-9698f5e17ac6.png)
