### PR TITLE
remove userServices.js from karma.conf

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -39,7 +39,6 @@ module.exports = function karmaConfig (config) {
       'website/client/js/env.js',
       'website/client/js/app.js',
       'common/script/public/config.js',
-      'common/script/public/userServices.js',
       'common/script/public/directives.js',
 
       'website/client/js/services/**/*.js',


### PR DESCRIPTION
### Changes

removes userServices.js from karma.conf to prevent this warning:

```
> karma start --single-run

14 05 2016 23:12:48.766:WARN [watcher]: Pattern
"..../common/script/public/userServices.js" does not match any file.
```

I believe userServices.js was moved to website/client/js/services/userServices.js and so it's covered in karma.conf by `website/client/js/services/**/*.js`
