### PR TITLE
[API v3] add CRON_SAFE_MODE

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -9,6 +9,7 @@
     "NODE_DB_URI":"mongodb://localhost/habitrpg",
     "TEST_DB_URI":"mongodb://localhost/habitrpg_test",
     "NODE_ENV":"development",
+    "CRON_SAFE_MODE":"false",
     "SESSION_SECRET":"YOUR SECRET HERE",
     "ADMIN_EMAIL": "you@example.com",
     "SMTP_USER":"user@example.com",

--- a/website/server/libs/api-v3/cron.js
+++ b/website/server/libs/api-v3/cron.js
@@ -70,6 +70,7 @@ function performSleepTasks (user, tasksByType, now) {
     let thatDay = moment(now).subtract({days: 1});
 
     if (shouldDo(thatDay.toDate(), daily, user.preferences) || completed) {
+      // TODO also untick checklists if the Daily was due on previous missed days, if two or more days were missed at once -- https://github.com/HabitRPG/habitrpg/pull/7218#issuecomment-219256016
       daily.checklist.forEach(box => box.completed = false);
     }
 

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -517,7 +517,7 @@ schema.statics.bossQuest = async function bossQuest (user, progress) {
   group.quest.progress.hp -= progress.up;
   // TODO Create a party preferred language option so emits like this can be localized. Suggestion: Always display the English version too. Or, if English is not displayed to the players, at least include it in a new field in the chat object that's visible in the database - essential for admins when troubleshooting quests!
   let playerAttack = `${user.profile.name} attacks ${quest.boss.name('en')} for ${progress.up.toFixed(1)} damage.`;
-  let bossAttack = nconf.get('CRON_SAFE_MODE') ? `${quest.boss.name('en')} did not attack the party because it was asleep while maintenance was happening.` : `${quest.boss.name('en')} attacks party for ${Math.abs(down).toFixed(1)} damage.`;
+  let bossAttack = nconf.get('CRON_SAFE_MODE') === 'true' ? `${quest.boss.name('en')} did not attack the party because it was asleep while maintenance was happening.` : `${quest.boss.name('en')} attacks party for ${Math.abs(down).toFixed(1)} damage.`;
   group.sendChat(`\`${playerAttack}\` \`${bossAttack}\``);
 
   // If boss has Rage, increment Rage as well

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -517,8 +517,8 @@ schema.statics.bossQuest = async function bossQuest (user, progress) {
   group.quest.progress.hp -= progress.up;
   // TODO Create a party preferred language option so emits like this can be localized. Suggestion: Always display the English version too. Or, if English is not displayed to the players, at least include it in a new field in the chat object that's visible in the database - essential for admins when troubleshooting quests!
   let playerAttack = `${user.profile.name} attacks ${quest.boss.name('en')} for ${progress.up.toFixed(1)} damage.`;
-  let bossAttack = (nconf.get('CRON_SAFE_MODE') ? `${quest.boss.name('en')} did not attack the party because it was asleep while maintenance was happening.` : `${quest.boss.name('en')} attacks party for ${Math.abs(down).toFixed(1)} damage.`;
-  group.sendChat('`' + playerAttack + '` `' + bossAttack + '`');
+  let bossAttack = nconf.get('CRON_SAFE_MODE') ? `${quest.boss.name('en')} did not attack the party because it was asleep while maintenance was happening.` : `${quest.boss.name('en')} attacks party for ${Math.abs(down).toFixed(1)} damage.`;
+  group.sendChat(`\`${playerAttack}\` \`${bossAttack}\``);
 
   // If boss has Rage, increment Rage as well
   if (quest.boss.rage) {

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -515,8 +515,10 @@ schema.statics.bossQuest = async function bossQuest (user, progress) {
   let down = progress.down * quest.boss.str; // multiply by boss strength
 
   group.quest.progress.hp -= progress.up;
-  // TODO Create a party preferred language option so emits like this can be localized
-  group.sendChat(`\`${user.profile.name} attacks ${quest.boss.name('en')} for ${progress.up.toFixed(1)} damage.\` \`${quest.boss.name('en')} attacks party for ${Math.abs(down).toFixed(1)} damage.\``);
+  // TODO Create a party preferred language option so emits like this can be localized. Suggestion: Always display the English version too. Or, if English is not displayed to the players, at least include it in a new field in the chat object that's visible in the database - essential for admins when troubleshooting quests!
+  let playerAttack = `${user.profile.name} attacks ${quest.boss.name('en')} for ${progress.up.toFixed(1)} damage.`;
+  let bossAttack = (nconf.get('CRON_SAFE_MODE') ? `${quest.boss.name('en')} did not attack the party because it was asleep while maintenance was happening.` : `${quest.boss.name('en')} attacks party for ${Math.abs(down).toFixed(1)} damage.`;
+  group.sendChat('`' + playerAttack + '` `' + bossAttack + '`');
 
   // If boss has Rage, increment Rage as well
   if (quest.boss.rage) {


### PR DESCRIPTION
Partial work for https://github.com/HabitRPG/habitrpg/issues/7161
### Changes
- Adds "safe mode" for cron.
- Requires a **new environment variable**: `CRON_SAFE_MODE` (set to "false" normally; "true" when we want safe mode).
- Removes an unrelated TODO that's already been done.
- Removes duplicated code (this was causing twice as much mana as appropriate to be gained overnight in API v3 only, so if anyone reports that as a bug, this fixes it).

I suggest reviewing with `w=1` because a bunch of unchanged code is now wrapped in an `else`.

The quest damage and chat message portions still need to be tested (can't start a quest due to an unrelated bug).

I'm writing automated tests for this.
