### PR TITLE
[API v3] fix incorrect Armoire test; remove incorrect data from apidoc; disambiguate health potion

### DIFF
--- a/common/script/ops/buy.js
+++ b/common/script/ops/buy.js
@@ -12,7 +12,7 @@ module.exports = function buy (user, req = {}, analytics) {
   if (!key) throw new BadRequest(i18n.t('missingKeyParam', req.language));
 
   let buyRes;
-  if (key === 'potion') {
+  if (key === 'potion') { // health potion
     buyRes = buyPotion(user, req, analytics);
   } else if (key === 'armoire') {
     buyRes = buyArmoire(user, req, analytics);

--- a/common/script/ops/buyPotion.js
+++ b/common/script/ops/buyPotion.js
@@ -4,7 +4,7 @@ import {
   NotAuthorized,
 } from '../libs/errors';
 
-module.exports = function buyPotion (user, req = {}, analytics) {
+module.exports = function buyPotion (user, req = {}, analytics) { // health potion
   let item = content.potion;
 
   if (user.stats.gp < item.value) {

--- a/test/api/v3/integration/user/POST-user_buy_armoire.test.js
+++ b/test/api/v3/integration/user/POST-user_buy_armoire.test.js
@@ -2,23 +2,23 @@ import {
   generateUser,
   translate as t,
 } from '../../../../helpers/api-integration/v3';
-import shared from '../../../../../common/script';
-
-let content = shared.content;
 
 describe('POST /user/buy-armoire', () => {
   let user;
 
   beforeEach(async () => {
     user = await generateUser({
-      'stats.hp': 40,
+      'stats.gp': 400,
     });
   });
 
   // More tests in common code unit tests
 
   it('returns an error if user does not have enough gold', async () => {
-    await expect(user.post('/user/buy-potion'))
+    await user.update({
+      'stats.gp': 5,
+    });
+    await expect(user.post('/user/buy-armoire'))
       .to.eventually.be.rejected.and.eql({
         code: 401,
         error: 'NotAuthorized',
@@ -26,19 +26,14 @@ describe('POST /user/buy-armoire', () => {
       });
   });
 
-  xit('buys a piece of armoire', async () => {
-    await user.update({
-      'stats.gp': 400,
-    });
-
-    let potion = content.potion;
-    let res = await user.post('/user/buy-potion');
+  it('reduces gold when buying from the armoire', async () => {
+    await user.post('/user/buy-armoire');
     await user.sync();
 
-    expect(user.stats.hp).to.equal(50);
-    expect(res.data).to.eql({
-      stats: user.stats,
-    });
-    expect(res.message).to.equal(t('messageBought', {itemText: potion.text()}));
+    expect(user.stats.gp).to.equal(300);
+  });
+
+  xit('buys a piece of armoire', async () => {
+    // Skipped because can't stub predictableRandom correctly
   });
 });

--- a/website/server/controllers/api-v3/user.js
+++ b/website/server/controllers/api-v3/user.js
@@ -557,8 +557,6 @@ api.buyGear = {
  * @apiName UserBuyArmoire
  * @apiGroup User
  *
- * @apiParam {string} key The item to buy.
- *
  * @apiSuccess {object} data.items user.items
  * @apiSuccess {object} data.flags user.flags
  * @apiSuccess {object} data.armoire Extra item given by the armoire
@@ -577,12 +575,10 @@ api.buyArmoire = {
 };
 
 /**
- * @api {post} /user/buy-potion Buy a potion.
+ * @api {post} /user/buy-potion Buy a health potion
  * @apiVersion 3.0.0
  * @apiName UserBuyPotion
  * @apiGroup User
- *
- * @apiParam {string} key The item to buy.
  *
  * @apiSuccess {Object} data user.stats
  * @apiSuccess {string} message Success message


### PR DESCRIPTION
### Changes
- Fixes `POST-user_buy_armoire.test.js` which had contained code for buying health potions instead of buying the armoire
- Removes incorrect (I think!) @apiParam from apidocs for buying the armoire and buying health potions (no parameters are needed as far as I can tell)
- Disambiguates "potion" by adding comments and adjusting apidocs to explain that it's the health potion.

Is it too late to change all instances of `buy-potion` and `buyPotion` to `buy-health-potion` and `buyHealthPotion`? It would avoid any possible confusion with hatching potions and fortify potions (and any future types of potion we might add). I'm willing to do this asap if you think it's okay.
