### PR TITLE
[API v3] fix bug in a test for Rebirth, add new tests, adjust apidocs

### DIFF
--- a/test/api/v3/integration/user/POST-user_rebirth.test.js
+++ b/test/api/v3/integration/user/POST-user_rebirth.test.js
@@ -31,6 +31,7 @@ describe('POST /user/rebirth', () => {
     let daily = await generateDaily({
       text: 'test habit',
       type: 'daily',
+      value: 1,
       streak: 1,
       userId: user._id,
     });

--- a/test/common/ops/rebirth.js
+++ b/test/common/ops/rebirth.js
@@ -3,7 +3,9 @@ import i18n from '../../../common/script/i18n';
 import { MAX_LEVEL } from '../../../common/script/constants';
 import {
   generateUser,
+  generateHabit,
   generateDaily,
+  generateTodo,
   generateReward,
 } from '../../helpers/common.helper';
 import {
@@ -19,7 +21,7 @@ describe('shared.ops.rebirth', () => {
   beforeEach(() => {
     user = generateUser();
     user.balance = 2;
-    tasks = [generateDaily(), generateReward()];
+    tasks = [generateHabit(), generateDaily(), generateTodo(), generateReward()];
   });
 
   it('returns an error when user balance is too low and user is less than max level', (done) => {
@@ -49,22 +51,35 @@ describe('shared.ops.rebirth', () => {
     expect(message).to.equal(i18n.t('rebirthComplete'));
   });
 
-  it('resets user\'s taks values except for rewards to 0', () => {
+  it('rebirths a user with not enough gems but more than max level', () => {
+    user.balance = 0;
+    user.stats.lvl = MAX_LEVEL + 1;
+
+    let [, message] = rebirth(user);
+
+    expect(message).to.equal(i18n.t('rebirthComplete'));
+  });
+
+  it('resets user\'s tasks values except for rewards to 0', () => {
     tasks[0].value = 1;
     tasks[1].value = 1;
+    tasks[2].value = 1;
+    tasks[3].value = 1; // Reward
 
     rebirth(user, tasks);
 
     expect(tasks[0].value).to.equal(0);
-    expect(tasks[1].value).to.equal(1);
+    expect(tasks[1].value).to.equal(0);
+    expect(tasks[2].value).to.equal(0);
+    expect(tasks[3].value).to.equal(1); // Reward
   });
 
   it('resets user\'s daily streaks to 0', () => {
-    tasks[0].streak = 1;
+    tasks[1].streak = 1; // Daily
 
     rebirth(user, tasks);
 
-    expect(tasks[0].streak).to.equal(0);
+    expect(tasks[1].streak).to.equal(0);
   });
 
   it('resets a user\'s buffs', () => {
@@ -156,7 +171,7 @@ describe('shared.ops.rebirth', () => {
     expect(user.flags.dropsEnabled).to.be.false;
     expect(user.flags.classSelected).to.be.false;
     expect(user.flags.rebirthEnabled).to.be.false;
-    expect(user.flags.levelDrops).to.be.emtpy;
+    expect(user.flags.levelDrops).to.be.empty;
   });
 
   it('does not reset rebirthEnabled if user has beastMaster', () => {
@@ -175,7 +190,7 @@ describe('shared.ops.rebirth', () => {
     expect(user.achievements.rebirthLevel).to.equal(user.stats.lvl);
   });
 
-  it('increments rebirth achievemnts', () => {
+  it('increments rebirth achievements', () => {
     user.stats.lvl = 2;
     user.achievements.rebirths = 1;
     user.achievements.rebirthLevel = 1;
@@ -184,5 +199,38 @@ describe('shared.ops.rebirth', () => {
 
     expect(user.achievements.rebirths).to.equal(2);
     expect(user.achievements.rebirthLevel).to.equal(2);
+  });
+
+  it('does not increment rebirth achievements when level is lower than previous', () => {
+    user.stats.lvl = 2;
+    user.achievements.rebirths = 1;
+    user.achievements.rebirthLevel = 3;
+
+    rebirth(user);
+
+    expect(user.achievements.rebirths).to.equal(1);
+    expect(user.achievements.rebirthLevel).to.equal(3);
+  });
+
+  it('always increments rebirth achievements when level is MAX_LEVEL', () => {
+    user.stats.lvl = MAX_LEVEL;
+    user.achievements.rebirths = 1;
+    user.achievements.rebirthLevel = MAX_LEVEL + 1; // this value is not actually possible (actually capped at MAX_LEVEL) but makes a good test
+
+    rebirth(user);
+
+    expect(user.achievements.rebirths).to.equal(2);
+    expect(user.achievements.rebirthLevel).to.equal(MAX_LEVEL);
+  });
+
+  it('always increments rebirth achievements when level is greater than MAX_LEVEL', () => {
+    user.stats.lvl = MAX_LEVEL + 1;
+    user.achievements.rebirths = 1;
+    user.achievements.rebirthLevel = MAX_LEVEL + 2; // this value is not actually possible (actually capped at MAX_LEVEL) but makes a good test
+
+    rebirth(user);
+
+    expect(user.achievements.rebirths).to.equal(2);
+    expect(user.achievements.rebirthLevel).to.equal(MAX_LEVEL);
   });
 });

--- a/website/server/controllers/api-v3/user.js
+++ b/website/server/controllers/api-v3/user.js
@@ -1091,12 +1091,12 @@ api.userRevive = {
 };
 
 /*
-* @api {post} /api/v3/user/rebirth Resets a user.
+* @api {post} /api/v3/user/rebirth Use Orb of Rebirth on user
 * @apiVersion 3.0.0
 * @apiName UserRebirth
 * @apiGroup User
 *
-* @apiSuccess {Object} data.userr
+* @apiSuccess {Object} data.user
 * @apiSuccess {array} data.tasks User's modified tasks (no rewards)
 * @apiSuccess {string} message Success message
 */


### PR DESCRIPTION
### Changes
- Fix minor bug in Rebirth test (changed to.be.emtpy to to.be.empty) - that typo didn't seem to have any effect on the success of the test though in previous builds (see below from previous build https://travis-ci.org/HabitRPG/habitrpg/builds/130502946 line 3393) - maybe we should look into that?
- Add more tests for Rebirth
- Adjust apidocs for Rebirth to remove typos and use normal terminology ("rebirth" not "reset")

```
  shared.ops.rebirth
    ✓ returns an error when user balance is too low and user is less than max level
    ✓ rebirths a user with enough gems
    ✓ rebirths a user with not enough gems but max level
    ✓ resets user's taks values except for rewards to 0
    ✓ resets user's daily streaks to 0
    ✓ resets a user's buffs
    ✓ resets a user's health points
    ✓ resets a user's class
    ✓ resets a user's stats
    ✓ resets a user's gear
    ✓ resets a user's gear owned
    ✓ resets a user's current pet
    ✓ resets a user's current mount
    ✓ resets a user's flags
    ✓ does not reset rebirthEnabled if user has beastMaster
    ✓ sets rebirth achievement
    ✓ increments rebirth achievemnts
```
