### PR TITLE
[API v3] rename buyPotion / buy-potion to buyHealthPotion / buy-health-potion

### DIFF
--- a/common/script/index.js
+++ b/common/script/index.js
@@ -114,7 +114,7 @@ import sleep from './ops/sleep';
 import allocate from './ops/allocate';
 import buy from './ops/buy';
 import buyGear from './ops/buyGear';
-import buyPotion from './ops/buyPotion';
+import buyHealthPotion from './ops/buyHealthPotion';
 import buyArmoire from './ops/buyArmoire';
 import buyMysterySet from './ops/buyMysterySet';
 import buyQuest from './ops/buyQuest';
@@ -155,7 +155,7 @@ api.ops = {
   allocate,
   buy,
   buyGear,
-  buyPotion,
+  buyHealthPotion,
   buyArmoire,
   buyMysterySet,
   buySpecialSpell,
@@ -274,7 +274,7 @@ api.wrap = function wrapUser (user, main = true) {
       releaseMounts: _.partial(importedOps.releaseMounts, user),
       releaseBoth: _.partial(importedOps.releaseBoth, user),
       buy: _.partial(importedOps.buy, user),
-      buyPotion: _.partial(importedOps.buyPotion, user),
+      buyHealthPotion: _.partial(importedOps.buyHealthPotion, user),
       buyArmoire: _.partial(importedOps.buyArmoire, user),
       buyGear: _.partial(importedOps.buyGear, user),
       buyQuest: _.partial(importedOps.buyQuest, user),

--- a/common/script/ops/buy.js
+++ b/common/script/ops/buy.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import {
   BadRequest,
 } from '../libs/errors';
-import buyPotion from './buyPotion';
+import buyHealthPotion from './buyHealthPotion';
 import buyArmoire from './buyArmoire';
 import buyGear from './buyGear';
 
@@ -13,7 +13,7 @@ module.exports = function buy (user, req = {}, analytics) {
 
   let buyRes;
   if (key === 'potion') {
-    buyRes = buyPotion(user, req, analytics);
+    buyRes = buyHealthPotion(user, req, analytics);
   } else if (key === 'armoire') {
     buyRes = buyArmoire(user, req, analytics);
   } else {

--- a/common/script/ops/buyHealthPotion.js
+++ b/common/script/ops/buyHealthPotion.js
@@ -4,7 +4,7 @@ import {
   NotAuthorized,
 } from '../libs/errors';
 
-module.exports = function buyPotion (user, req = {}, analytics) {
+module.exports = function buyHealthPotion (user, req = {}, analytics) {
   let item = content.potion;
 
   if (user.stats.gp < item.value) {

--- a/common/script/ops/index.js
+++ b/common/script/ops/index.js
@@ -31,7 +31,7 @@ import releaseMounts from './releaseMounts';
 import releaseBoth from './releaseBoth';
 import buy from './buy';
 import buyGear from './buyGear';
-import buyPotion from './buyPotion';
+import buyHealthPotion from './buyHealthPotion';
 import buyArmoire from './buyArmoire';
 import buyQuest from './buyQuest';
 import buyMysterySet from './buyMysterySet';
@@ -83,7 +83,7 @@ module.exports = {
   releaseBoth,
   buy,
   buyGear,
-  buyPotion,
+  buyHealthPotion,
   buyArmoire,
   buyQuest,
   buyMysterySet,

--- a/test/api/v3/integration/user/POST-user_buy_armoire.test.js
+++ b/test/api/v3/integration/user/POST-user_buy_armoire.test.js
@@ -18,7 +18,7 @@ describe('POST /user/buy-armoire', () => {
   // More tests in common code unit tests
 
   it('returns an error if user does not have enough gold', async () => {
-    await expect(user.post('/user/buy-potion'))
+    await expect(user.post('/user/buy-health-potion'))
       .to.eventually.be.rejected.and.eql({
         code: 401,
         error: 'NotAuthorized',
@@ -32,7 +32,7 @@ describe('POST /user/buy-armoire', () => {
     });
 
     let potion = content.potion;
-    let res = await user.post('/user/buy-potion');
+    let res = await user.post('/user/buy-health-potion');
     await user.sync();
 
     expect(user.stats.hp).to.equal(50);

--- a/test/api/v3/integration/user/POST-user_buy_health_potion.test.js
+++ b/test/api/v3/integration/user/POST-user_buy_health_potion.test.js
@@ -6,7 +6,7 @@ import shared from '../../../../../common/script';
 
 let content = shared.content;
 
-describe('POST /user/buy-potion', () => {
+describe('POST /user/buy-health-potion', () => {
   let user;
 
   beforeEach(async () => {
@@ -18,7 +18,7 @@ describe('POST /user/buy-potion', () => {
   // More tests in common code unit tests
 
   it('returns an error if user does not have enough gold', async () => {
-    await expect(user.post('/user/buy-potion'))
+    await expect(user.post('/user/buy-health-potion'))
       .to.eventually.be.rejected.and.eql({
         code: 401,
         error: 'NotAuthorized',
@@ -32,7 +32,7 @@ describe('POST /user/buy-potion', () => {
     });
 
     let potion = content.potion;
-    let res = await user.post('/user/buy-potion');
+    let res = await user.post('/user/buy-health-potion');
     await user.sync();
 
     expect(user.stats.hp).to.equal(50);

--- a/test/common/ops/buyHealthPotion.js
+++ b/test/common/ops/buyHealthPotion.js
@@ -2,13 +2,13 @@
 import {
   generateUser,
 } from '../../helpers/common.helper';
-import buyPotion from '../../../common/script/ops/buyPotion';
+import buyHealthPotion from '../../../common/script/ops/buyHealthPotion';
 import {
   NotAuthorized,
 } from '../../../common/script/libs/errors';
 import i18n from '../../../common/script/i18n';
 
-describe('shared.ops.buyPotion', () => {
+describe('shared.ops.buyHealthPotion', () => {
   let user;
 
   beforeEach(() => {
@@ -30,19 +30,19 @@ describe('shared.ops.buyPotion', () => {
   context('Potion', () => {
     it('recovers 15 hp', () => {
       user.stats.hp = 30;
-      buyPotion(user);
+      buyHealthPotion(user);
       expect(user.stats.hp).to.eql(45);
     });
 
     it('does not increase hp above 50', () => {
       user.stats.hp = 45;
-      buyPotion(user);
+      buyHealthPotion(user);
       expect(user.stats.hp).to.eql(50);
     });
 
     it('deducts 25 gp', () => {
       user.stats.hp = 45;
-      buyPotion(user);
+      buyHealthPotion(user);
 
       expect(user.stats.gp).to.eql(175);
     });
@@ -51,7 +51,7 @@ describe('shared.ops.buyPotion', () => {
       user.stats.hp = 45;
       user.stats.gp = 5;
       try {
-        buyPotion(user);
+        buyHealthPotion(user);
       } catch (err) {
         expect(err).to.be.an.instanceof(NotAuthorized);
         expect(err.message).to.equal(i18n.t('messageNotEnoughGold'));

--- a/website/server/controllers/api-v3/user.js
+++ b/website/server/controllers/api-v3/user.js
@@ -577,25 +577,23 @@ api.buyArmoire = {
 };
 
 /**
- * @api {post} /user/buy-potion Buy a potion.
+ * @api {post} /user/buy-health-potion Buy a health potion
  * @apiVersion 3.0.0
  * @apiName UserBuyPotion
  * @apiGroup User
  *
- * @apiParam {string} key The item to buy.
- *
  * @apiSuccess {Object} data user.stats
  * @apiSuccess {string} message Success message
  */
-api.buyPotion = {
+api.buyHealthPotion = {
   method: 'POST',
   middlewares: [authWithHeaders()],
-  url: '/user/buy-potion',
+  url: '/user/buy-health-potion',
   async handler (req, res) {
     let user = res.locals.user;
-    let buyPotionResponse = common.ops.buyPotion(user, req, res.analytics);
+    let buyHealthPotionResponse = common.ops.buyHealthPotion(user, req, res.analytics);
     await user.save();
-    res.respond(200, ...buyPotionResponse);
+    res.respond(200, ...buyHealthPotionResponse);
   },
 };
 


### PR DESCRIPTION
### Changes
- renames buyPotion to buyHealthPotion 
- renames buy-potion to buy-health-potion
- fixes an apidoc error (it listed a param for buy-health-potion)

The renaming is to avoid confusion with other types of potions.

If there's conflicts by the time this is reviewed and accepted, I'm happy to fix them.
