### PR TITLE
[API v3] completed To-Dos: return the 30 most recent instead of 30 oldest

### DIFF
--- a/test/api/v3/integration/tasks/GET-tasks_user.test.js
+++ b/test/api/v3/integration/tasks/GET-tasks_user.test.js
@@ -22,7 +22,7 @@ describe('GET /tasks/user', () => {
     expect(tasks[0]._id).to.equal(createdTasks[0]._id);
   });
 
-  it('returns completed todos sorted by completion date if req.query.type === "completeTodos"', async () => {
+  it('returns completed todos sorted by reverse completion date if req.query.type === "completeTodos"', async () => {
     let todo1 = await user.post('/tasks/user', {text: 'todo to complete 1', type: 'todo'});
     let todo2 = await user.post('/tasks/user', {text: 'todo to complete 2', type: 'todo'});
 
@@ -37,6 +37,6 @@ describe('GET /tasks/user', () => {
 
     let completedTodos = await user.get('/tasks/user?type=completedTodos');
     expect(completedTodos.length).to.equal(2);
-    expect(completedTodos[completedTodos.length - 1].text).to.equal('todo to complete 1'); // last is the todo that was completed later
+    expect(completedTodos[completedTodos.length - 1].text).to.equal('todo to complete 2'); // last is the todo that was completed most recently
   });
 });

--- a/website/server/controllers/api-v3/tasks.js
+++ b/website/server/controllers/api-v3/tasks.js
@@ -127,7 +127,7 @@ async function _getTasks (req, res, user, challenge) {
         type: 'todo',
         completed: true,
       }).limit(30).sort({ // TODO add ability to pick more than 30 completed todos
-        dateCompleted: 1,
+        dateCompleted: -1,
       });
     } else {
       query.type = type.slice(0, -1); // removing the final "s"


### PR DESCRIPTION
### Changes

Adjusts the API route for returning 30 completed To-Dos so that the most recently completed ones are returned, instead of the oldest completed ones.
