### PR TITLE
Legacy Id for v2

### DIFF
--- a/common/script/ops/scoreTask.js
+++ b/common/script/ops/scoreTask.js
@@ -194,6 +194,7 @@ module.exports = function scoreTask (options = {}, req = {}) {
     }
     _gainMP(user, _.max([0.25, 0.0025 * user._statsComputed.maxMP]) * (direction === 'down' ? -1 : 1));
 
+    task.history = task.history || [];
     // Add history entry, even more than 1 per day
     task.history.push({
       date: Number(new Date()),

--- a/migrations/api_v3/challenges.js
+++ b/migrations/api_v3/challenges.js
@@ -129,16 +129,16 @@ function processChallenges (afterId) {
 
       oldTasks.forEach(function (oldTask) {
         oldTask._id = uuid.v4();
-        oldTask.legacyId = oldTask.id; // store the old task id
+        oldTask._legacyId = oldTask.id; // store the old task id
         delete oldTask.id;
 
         oldTask.challenge = oldTask.challenge || {};
         oldTask.challenge.id = newChallenge._id;
 
-        if (newTasksIds[oldTask.legacyId + '-' + newChallenge._id]) {
+        if (newTasksIds[oldTask._legacyId + '-' + newChallenge._id]) {
           throw new Error('duplicate :(');
         } else {
-          newTasksIds[oldTask.legacyId + '-' + newChallenge._id] = oldTask._id;
+          newTasksIds[oldTask._legacyId + '-' + newChallenge._id] = oldTask._id;
         }
 
         oldTask.tags = _.map(oldTask.tags || {}, function (tagPresent, tagId) {

--- a/migrations/api_v3/users.js
+++ b/migrations/api_v3/users.js
@@ -131,20 +131,20 @@ function processUsers (afterId) {
       oldTasks.forEach(function (oldTask) {
         oldTask._id = uuid.v4(); // create a new unique uuid
         oldTask.userId = newUser._id;
-        oldTask.legacyId = oldTask.id; // store the old task id
+        oldTask._legacyId = oldTask.id; // store the old task id
         delete oldTask.id;
 
         oldTask.challenge = oldTask.challenge || {};
         if (oldTask.challenge.id) {
           if (oldTask.challenge.broken) {
-            oldTask.challenge.taskId = oldTask.legacyId;
+            oldTask.challenge.taskId = oldTask._legacyId;
           } else {
-            var newId = newTasksIds[oldTask.legacyId + '-' + oldTask.challenge.id];
+            var newId = newTasksIds[oldTask._legacyId + '-' + oldTask.challenge.id];
 
             // Challenges' tasks ids changed
             if (!newId && !oldTask.challenge.broken) {
               challengeTaskNoMatchingId++;
-              oldTask.challenge.taskId = oldTask.legacyId;
+              oldTask.challenge.taskId = oldTask._legacyId;
               oldTask.challenge.broken = 'CHALLENGE_TASK_NOT_FOUND';
             } else {
               challengeTaskWithMatchingId++;
@@ -173,7 +173,7 @@ function processUsers (afterId) {
           newUser.tasksOrder[`${oldTask.type}s`].push(oldTask._id);
         }
 
-        var allTasksFields = ['_id', 'type', 'text', 'notes', 'tags', 'value', 'priority', 'attribute', 'challenge', 'reminders', 'userId', 'legacyId', 'createdAt'];
+        var allTasksFields = ['_id', 'type', 'text', 'notes', 'tags', 'value', 'priority', 'attribute', 'challenge', 'reminders', 'userId', '_legacyId', 'createdAt'];
         // using mongoose models is too slow
         if (oldTask.type === 'habit') {
           oldTask = _.pick(oldTask, allTasksFields.concat(['history', 'up', 'down']));

--- a/website/server/controllers/api-v2/user.js
+++ b/website/server/controllers/api-v2/user.js
@@ -110,8 +110,8 @@ api.score = function(req, res, next) {
       // Defaults. Other defaults are handled in user.ops.addTask()
       task = new Tasks.Task({
         _id: id, // TODO this might easily lead to conflicts as ids are now unique db-wide
-        type: body.type,
-        text: body.text,
+        type: body.type || 'habit',
+        text: body.text || id,
         userId: user._id,
         notes: body.notes || "This task was created by a third-party service. Feel free to edit, it won't harm the connection to that service. Additionally, multiple services may piggy-back off this task." // TODO translate
       });

--- a/website/server/models/task.js
+++ b/website/server/models/task.js
@@ -17,6 +17,7 @@ export let tasksTypes = ['habit', 'daily', 'todo', 'reward'];
 // Important
 // When something changes here remember to update the client side model at common/script/libs/taskDefaults
 export let TaskSchema = new Schema({
+  _legacyId: String, // TODO Remove when v2 is deprecated
   type: {type: String, enum: tasksTypes, required: true, default: tasksTypes[0]},
   text: {type: String, required: true},
   notes: {type: String, default: ''},
@@ -119,7 +120,11 @@ TaskSchema.methods.scoreChallengeTask = async function scoreChallengeTask (delta
 // toJSON for API v2
 TaskSchema.methods.toJSONV2 = function toJSONV2 () {
   let toJSON = this.toJSON();
-  toJSON.id = toJSON._id;
+  if (toJSON._legacyId) {
+    toJSON.id = toJSON._legacyId;
+  } else {
+    toJSON.id = toJSON._id;
+  }
 
   let v3Tags = this.tags;
 


### PR DESCRIPTION
First pass at supporting _legacyId in v2 routes.

If we want to keep `_legacyId` as `legacyId`, we should remove it from the object when `toJSON` is called. 
