### PR TITLE
Fix getTasks?type=todos

### DIFF
--- a/website/server/controllers/api-v3/tasks.js
+++ b/website/server/controllers/api-v3/tasks.js
@@ -121,6 +121,7 @@ async function _getTasks (req, res, user, challenge) {
   if (type) {
     if (type === 'todos') {
       query.completed = false; // Exclude completed todos
+      query.type = 'todo';
     } else if (type === 'completedTodos') {
       query = Tasks.Task.find({
         userId: user._id,


### PR DESCRIPTION
The get tasks route, scoped to todos, was getting all tasks that were uncompleted (including dailys).

This adds the type to the query and expands test coverage to catch this case.
