### PR TITLE
Fix day for end of maintenance

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -75,5 +75,5 @@
         "ENABLED": "false"
     },
     "MAINTENANCE_START": "Sat May 21 2016 20:00:00 UTC",
-    "MAINTENANCE_END": "Sat May 22 2016 5:00:00 UTC"
+    "MAINTENANCE_END": "Sun May 22 2016 5:00:00 UTC"
 }


### PR DESCRIPTION
### Changes

End of maintenance changed to Sunday morning (from Saturday) – assuming typo, as maintenance runs from Saturday 21st 8pm to Sunday 22nd 5am UTC but ends on the Saturday (at 10pm) Pacific Time.

---

UUID: 0e1d15f7-f36b-4f15-a9e1-0c31b732dac9
