### PR TITLE
add dateCreated to all tasks; add empty challenge object to tasks tha…

### DIFF
--- a/website/server/models/task.js
+++ b/website/server/models/task.js
@@ -134,12 +134,16 @@ TaskSchema.methods.toJSONV2 = function toJSONV2 () {
     toJSON.id = toJSON._id;
   }
 
+  if (!toJSON.challenge) toJSON.challenge = {};
+
   let v3Tags = this.tags;
 
   toJSON.tags = {};
   v3Tags.forEach(tag => {
     toJSON.tags[tag] = true;
   });
+
+  toJSON.dateCreated = this.createdAt;
 
   return toJSON;
 };


### PR DESCRIPTION
### Changes

adjusts API v2:
- put dateCreated back into all tasks
- add an empty challenge object to any tasks that don't have a challenge object (I don't know of any integrations that require this, but it can't hurt)
