### PR TITLE
Updated shortname validation to support multiple browsers

### DIFF
--- a/common/locales/en/challenge.json
+++ b/common/locales/en/challenge.json
@@ -78,5 +78,6 @@
     "userTasksNoChallengeId": "When \"tasksOwner\" is \"user\" \"challengeId\" can't be passed.",
     "onlyChalLeaderEditTasks": "Tasks belonging to a challenge can only be edited by the leader.",
     "userAlreadyInChallenge": "User is already participating in this challenge.",
-    "cantOnlyUnlinkChalTask": "Only broken challenges tasks can be unlinked."
+    "cantOnlyUnlinkChalTask": "Only broken challenges tasks can be unlinked.",
+    "shortNameTooShort": "Short Name must have at least 3 characters."
 }

--- a/test/spec/controllers/challengesCtrlSpec.js
+++ b/test/spec/controllers/challengesCtrlSpec.js
@@ -344,6 +344,7 @@ describe('Challenges Controller', function() {
       it("opens an alert box if challenge.group is not specified", function() {
         var challenge = specHelper.newChallenge({
           name: 'Challenge without a group',
+          shortName: 'chal without group',
           group: null
         });
 
@@ -356,6 +357,7 @@ describe('Challenges Controller', function() {
       it("opens an alert box if isNew and user does not have enough gems", function() {
         var challenge = specHelper.newChallenge({
           name: 'Challenge without enough gems',
+          shortName: 'chal without gem',
           prize: 5
         });
 
@@ -372,6 +374,7 @@ describe('Challenges Controller', function() {
         var challenge = specHelper.newChallenge({
           _id: 'challenge-has-id-so-its-not-new',
           name: 'Challenge without enough gems',
+          shortName: 'chal without gem',
           prize: 5,
         });
 
@@ -385,6 +388,7 @@ describe('Challenges Controller', function() {
       it("saves the challenge if user has enough gems and challenge is new", function() {
         var challenge = specHelper.newChallenge({
           name: 'Challenge without enough gems',
+          shortName: 'chal without gem',
           prize: 5,
         });
 
@@ -400,6 +404,7 @@ describe('Challenges Controller', function() {
 
         var challenge = specHelper.newChallenge({
           name: 'Challenge',
+          shortName: 'chal',
         });
 
         setTimeout(function() {
@@ -419,6 +424,7 @@ describe('Challenges Controller', function() {
 
       it('saves new challenge and syncs User', function(done) {
         var challenge = specHelper.newChallenge();
+        challenge.shortName = 'chal';
 
         setTimeout(function() {
           expect(User.sync).to.be.calledOnce;
@@ -432,6 +438,7 @@ describe('Challenges Controller', function() {
         sinon.stub(notification, 'text');
 
         var challenge = specHelper.newChallenge();
+        challenge.shortName = 'chal';
 
         setTimeout(function() {
           expect(notification.text).to.be.calledOnce;

--- a/website/client/js/controllers/challengesCtrl.js
+++ b/website/client/js/controllers/challengesCtrl.js
@@ -120,6 +120,8 @@ habitrpg.controller("ChallengesCtrl", ['$rootScope','$scope', 'Shared', 'User', 
     $scope.save = function(challenge) {
       if (!challenge.group) return alert(window.env.t('selectGroup'));
 
+      if (!challenge.shortName || challenge.shortName.length < 3) return alert(window.env.t('shortNameTooShort'));
+
       var isNew = !challenge._id;
 
       if(isNew && challenge.prize > $scope.maxPrize) {

--- a/website/views/options/social/challenges.jade
+++ b/website/views/options/social/challenges.jade
@@ -145,7 +145,7 @@ script(type='text/ng-template', id='partials/options.social.challenges.html')
 
               .row
                 .form-group.col-md-6.col-sm-12
-                  input.form-control(type='text', minlength="3",
+                  input.form-control(type='text',
                     ng-model='newChallenge.shortName', placeholder=env.t('challengeTag'), required
                     ng-disabled='insufficientGemsForTavernChallenge()')
                   |&nbsp;


### PR DESCRIPTION
Fixes #7382
### Changes

minLength is not supported in many browsers, so I added an alert message
I completely removed minlength because ng-model does not play well with it even when the browser does not support the attribute.

---

UUID: 
