### PR TITLE
Added force sync param to party and tavern requests

### DIFF
--- a/test/spec/controllers/partyCtrlSpec.js
+++ b/test/spec/controllers/partyCtrlSpec.js
@@ -48,12 +48,15 @@ describe("Party Controller", function() {
       inject(function(_$state_) {
         var state = _$state_;
         sandbox.stub(state, 'is').returns(true);
+
         var syncParty = sinon.stub(groups.Group, 'syncParty')
         syncParty.returns(Promise.resolve(groupResponse));
+
+        var froceSyncParty = sinon.stub(groups, 'party')
+        froceSyncParty.returns(Promise.resolve(groupResponse));
+
         $controller('PartyCtrl', { $scope: scope, $state: state, User: User });
-        // @TODO: I have update the party ctrl to sync the user whenever it is called rather than only on the party page
-        // Since I have cached the promise, this should not be a performance issue, but let's keep this test here in case anything breaks.
-        // expect(state.is).to.be.calledOnce; // ensure initialization worked as desired
+        expect(state.is).to.be.calledOnce;
       });
     };
 

--- a/website/client/js/controllers/partyCtrl.js
+++ b/website/client/js/controllers/partyCtrl.js
@@ -11,13 +11,20 @@ habitrpg.controller("PartyCtrl", ['$rootScope','$scope','Groups','Chat','User','
       $scope.inviteOrStartParty = Groups.inviteOrStartParty;
       $scope.loadWidgets = Social.loadWidgets;
 
-      Groups.Group.syncParty()
-        .then(function successCallback(group) {
-          $rootScope.party = $scope.group = group;
-          checkForNotifications();
-        }, function errorCallback(response) {
-          $rootScope.party = $scope.group = $scope.newGroup = { type: 'party' };
-        });
+      function handlePartyResponse (group) {
+        $rootScope.party = $scope.group = group;
+        checkForNotifications();
+      }
+
+      function handlePartyError (response) {
+        $rootScope.party = $scope.group = $scope.newGroup = { type: 'party' };
+      }
+
+      if ($state.is('options.social.party')) {
+        Groups.party(true).then(handlePartyResponse, handlePartyError);
+      } else {
+        Groups.Group.syncParty().then(handlePartyResponse, handlePartyError);
+      }
 
       function checkForNotifications () {
         // Checks if user's party has reached 2 players for the first time.

--- a/website/client/js/controllers/tavernCtrl.js
+++ b/website/client/js/controllers/tavernCtrl.js
@@ -2,7 +2,7 @@
 
 habitrpg.controller("TavernCtrl", ['$scope', 'Groups', 'User', 'Challenges',
     function($scope, Groups, User, Challenges) {
-      Groups.tavern()
+      Groups.tavern(true)
         .then(function (tavern) {
           $scope.group = tavern;
           Challenges.getGroupChallenges($scope.group._id)


### PR DESCRIPTION
Fixes #7407
### Changes

I have forced the sync every time you are on the party/tavern page. This should help update chat and prevent the need for reloads.

---

UUID: 
