### PR TITLE
implement cron semi-safe mode - cron behaves as normal except boss does no damage

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -10,6 +10,7 @@
     "TEST_DB_URI":"mongodb://localhost/habitrpg_test",
     "NODE_ENV":"development",
     "CRON_SAFE_MODE":"false",
+    "CRON_SEMI_SAFE_MODE":"false",
     "MAINTENANCE_MODE": "false",
     "SESSION_SECRET":"YOUR SECRET HERE",
     "ADMIN_EMAIL": "you@example.com",

--- a/website/server/libs/api-v3/cron.js
+++ b/website/server/libs/api-v3/cron.js
@@ -5,6 +5,7 @@ import _ from 'lodash';
 import nconf from 'nconf';
 
 const CRON_SAFE_MODE = nconf.get('CRON_SAFE_MODE') === 'true';
+const CRON_SEMI_SAFE_MODE = nconf.get('CRON_SEMI_SAFE_MODE') === 'true';
 const shouldDo = common.shouldDo;
 const scoreTask = common.ops.scoreTask;
 // const maxPMs = 200;
@@ -175,13 +176,15 @@ export function cron (options = {}) {
             cron: true,
           });
 
-          // Apply damage from a boss, less damage for Trivial priority (difficulty)
-          user.party.quest.progress.down += delta * (task.priority < 1 ? task.priority : 1);
-          // NB: Medium and Hard priorities do not increase damage from boss. This was by accident
-          // initially, and when we realised, we could not fix it because users are used to
-          // their Medium and Hard Dailies doing an Easy amount of damage from boss.
-          // Easy is task.priority = 1. Anything < 1 will be Trivial (0.1) or any future
-          // setting between Trivial and Easy.
+          if (!CRON_SEMI_SAFE_MODE) {
+            // Apply damage from a boss, less damage for Trivial priority (difficulty)
+            user.party.quest.progress.down += delta * (task.priority < 1 ? task.priority : 1);
+            // NB: Medium and Hard priorities do not increase damage from boss. This was by accident
+            // initially, and when we realised, we could not fix it because users are used to
+            // their Medium and Hard Dailies doing an Easy amount of damage from boss.
+            // Easy is task.priority = 1. Anything < 1 will be Trivial (0.1) or any future
+            // setting between Trivial and Easy.
+          }
         }
       }
     }

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -517,7 +517,8 @@ schema.statics.bossQuest = async function bossQuest (user, progress) {
   group.quest.progress.hp -= progress.up;
   // TODO Create a party preferred language option so emits like this can be localized. Suggestion: Always display the English version too. Or, if English is not displayed to the players, at least include it in a new field in the chat object that's visible in the database - essential for admins when troubleshooting quests!
   let playerAttack = `${user.profile.name} attacks ${quest.boss.name('en')} for ${progress.up.toFixed(1)} damage.`;
-  let bossAttack = nconf.get('CRON_SAFE_MODE') === 'true' ? `${quest.boss.name('en')} did not attack the party because it was asleep while maintenance was happening.` : `${quest.boss.name('en')} attacks party for ${Math.abs(down).toFixed(1)} damage.`;
+  let bossAttack = nconf.get('CRON_SAFE_MODE') === 'true' || nconf.get('CRON_SEMI_SAFE_MODE') === 'true' ? `${quest.boss.name('en')} does not attack, because it respects the fact that there are some bugs\` \`post-maintenance and it doesn't want to hurt anyone unfairly. It will continue its rampage soon!` : `${quest.boss.name('en')} attacks party for ${Math.abs(down).toFixed(1)} damage.`;
+  // TODO Consider putting the safe mode boss attack message in an ENV var
   group.sendChat(`\`${playerAttack}\` \`${bossAttack}\``);
 
   // If boss has Rage, increment Rage as well


### PR DESCRIPTION
As requested by Lemoness, this introduces a "semi-safe" mode for cron. Cron behaves as it normally does in all ways except:
- a quest boss does not cause damage
- the message in party chat when you attack the quest boss explains that the boss has not caused damage
