### PR TITLE
fix: Display beastmaster count even if member route returned no items

### DIFF
--- a/common/script/count.js
+++ b/common/script/count.js
@@ -8,7 +8,7 @@ import content from './content/index';
 
 const DROP_ANIMALS = keys(content.pets);
 
-function beastMasterProgress (pets) {
+function beastMasterProgress (pets = {}) {
   let count = 0;
 
   each(DROP_ANIMALS, (animal) => {
@@ -19,7 +19,7 @@ function beastMasterProgress (pets) {
   return count;
 }
 
-function dropPetsCurrentlyOwned (pets) {
+function dropPetsCurrentlyOwned (pets = {}) {
   let count = 0;
 
   each(DROP_ANIMALS, (animal) => {
@@ -30,7 +30,7 @@ function dropPetsCurrentlyOwned (pets) {
   return count;
 }
 
-function mountMasterProgress (mounts) {
+function mountMasterProgress (mounts = {}) {
   let count = 0;
 
   each(DROP_ANIMALS, (animal) => {
@@ -41,7 +41,7 @@ function mountMasterProgress (mounts) {
   return count;
 }
 
-function remainingGearInSet (userGear, set) {
+function remainingGearInSet (userGear = {}, set) {
   let gear = filter(content.gear.flat, (item) => {
     let setMatches = item.klass === set;
     let hasItem = userGear[item.key];
@@ -54,7 +54,7 @@ function remainingGearInSet (userGear, set) {
   return count;
 }
 
-function questsOfCategory (userQuests, category) {
+function questsOfCategory (userQuests = {}, category) {
   let quests = filter(content.quests, (quest) => {
     let categoryMatches = quest.category === category;
     let hasQuest = userQuests[quest.key];


### PR DESCRIPTION
Closes #7460

Because of this line:
https://github.com/HabitRPG/habitrpg/blob/f1286762a813186cb4f1093dc33a52b117ab2827/website/server/controllers/api-v3/members.js#L53

We minimize any empty objects, which causes the statCalc methods to fail
