### PR TITLE
Vagrantfile and scripts changes for API v3

### DIFF
--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -6,7 +6,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider "virtualbox" do |v|
-    v.memory = 768
+    v.memory = 4096
     v.cpus = 1
     v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/vagrant", "1"]
   end

--- a/vagrant_scripts/install_node.sh
+++ b/vagrant_scripts/install_node.sh
@@ -16,7 +16,7 @@ nvm use
 nvm alias default current
 
 echo Update npm...
-npm install -g npm@2
+npm install -g npm@3
 
 echo Installing global modules...
 npm install -g gulp bower grunt-cli mocha


### PR DESCRIPTION
Fixes https://github.com/HabitRPG/habitrpg/issues/7456
### Changes

I have a new vagrant install running for API v3 after a very minor change (npm 2 to npm 3) and the local website is running.

There are some quirks with npm 3 and links, as reported [here](https://github.com/npm/npm/issues/10800) and [here](https://github.com/npm/npm/issues/10343). I've yet to be able to complete the npm install process in a single run of the command. Packages will go missing during the install process causing errors.

Here are the logs:

[Vagrant up](https://gist.github.com/velezsarain/65a923f7d66f9ae9c610c504e0533154)
[First run of npm install](https://gist.github.com/velezsarain/f9fb6e269b10d22c44d326153d1564e9)
[Second run of npm install with cache cleared](https://gist.github.com/velezsarain/0389cd7f854e67ec6a42787a48d0aeaf)
[npm start](https://gist.github.com/velezsarain/86f8dc35ff727c8c0f83db40b0d2cf03)

However I can't run any of the tests as I end up with weird errors. I've tried fixing them but was unable to (mostly because I can't find the files that are causing these errors). This should be looked into.

Here are the [test errors](https://gist.github.com/velezsarain/1299e4c0f94fcf6ba5738091da9f1123). No debug log is created for the npm test command. Here is the [debug log for npm run lint](https://gist.github.com/velezsarain/d2c94e52ebb1a423be0b6e144c432511). Error is the same (eslint .) in both cases. npm run test:karma causes another error, this time karma not found.

I would also ask how much RAM would be acceptable as the default for the future example file. I've set it to 4GB, but maybe more is necessary.

---

UUID: c104a050-7a9a-488f-ad0f-cda73815432b
