### PR TITLE
Removed sync call on load

### DIFF
--- a/website/client/js/services/userServices.js
+++ b/website/client/js/services/userServices.js
@@ -112,7 +112,6 @@ angular.module('habitrpg')
           $rootScope.$emit('userSynced');
         });
       }
-      sync();
 
       var save = function () {
         localStorage.setItem(STORAGE_USER_ID, JSON.stringify(user));


### PR DESCRIPTION
Fixes put_issue_url_here
### Changes

I removed an extra sync call that is called on load of service
When the user service loads, userServices.authenticate and sync is called in there

---

UUID: 
