### PR TITLE
Apidoc Adjustments

### DIFF
--- a/apidoc.json
+++ b/apidoc.json
@@ -1,5 +1,8 @@
 {
   "name": "Habitica V3 API Documentation",
   "title": "Habitica",
-  "url": "https://habitica.com"
+  "url": "https://habitica.com",
+  "template": {
+    "withCompare": false
+  }
 }

--- a/apidoc.json
+++ b/apidoc.json
@@ -1,0 +1,5 @@
+{
+  "name": "Habitica V3 API Documentation",
+  "title": "Habitica",
+  "url": "https://habitica.com"
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "habitica",
   "description": "A habit tracker app which treats your goals like a Role Playing Game.",
-  "version": "3.0.0",
+  "version": "3.2.0",
   "main": "./website/server/index.js",
   "dependencies": {
     "accepts": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -160,11 +160,5 @@
     "vinyl-source-stream": "^1.0.0",
     "vinyl-transform": "^1.0.0",
     "xml2js": "^0.4.16"
-  },
-  "apidoc": {
-    "name": "habitica",
-    "title": "Habitica",
-    "version": "3.0.0",
-    "url": "https://habitica.com"
   }
 }


### PR DESCRIPTION
- Sets package.json to correct version number (I'll update our deploy documentation to bump the package.json version when releasing)
- Move apidoc config to separate file
- Turn off [apidoc versioning](http://apidocjs.com/#param-api-version)

To do versioning correctly, we'd need to copy the different API documentation for the previous versions to a separate file, which seems like a lot of work for only a little payoff (especially since we don't have a versioned api).

Open to other opinions though. 

@SabreCat @paglias @Alys 
