### PR TITLE
fix(crit): notify from server response

### DIFF
--- a/website/client/js/controllers/notificationCtrl.js
+++ b/website/client/js/controllers/notificationCtrl.js
@@ -82,14 +82,6 @@ habitrpg.controller('NotificationCtrl',
       }
     });
 
-    $rootScope.$watch('user._tmp.crit', function(after, before){
-       if (after == before || !after) return;
-       var amount = User.user._tmp.crit * 100 - 100;
-       // reset the crit counter
-       User.user._tmp.crit = undefined;
-       Notification.crit(amount);
-    });
-
     $rootScope.$watch('user._tmp.drop', function(after, before){
       // won't work when getting the same item twice?
       if (_.isEqual(after, before) || !after) return;

--- a/website/client/js/services/userServices.js
+++ b/website/client/js/services/userServices.js
@@ -224,8 +224,13 @@ angular.module('habitrpg')
 
           Tasks.scoreTask(data.params.task._id, data.params.direction).then(function (res) {
             var tmp = res.data.data._tmp || {}; // used to notify drops, critical hits and other bonuses
+            var crit = tmp.crit;
             var drop = tmp.drop;
 
+            if (crit) {
+              var critBonus = crit * 100 - 100;
+              Notification.crit(critBonus);
+            }
             if (drop) user._tmp.drop = drop;
           });
         },


### PR DESCRIPTION
Fixes https://github.com/HabitRPG/habitrpg/issues/3166 and https://github.com/HabitRPG/habitrpg/issues/3048
### Changes

Removes notification for critical hits from a `$watch` in the notification controller, and instead displays it based on the data returned from the server.

We may also be able to deal with streak bonuses and drops in similar fashion, but those will require a bit more refactoring because the logic in the notification controller is more tangled.

---

UUID: meh
