### PR TITLE
Fix #7493 - prevent duplicate items when editing checklists

### DIFF
--- a/website/client/js/controllers/tasksCtrl.js
+++ b/website/client/js/controllers/tasksCtrl.js
@@ -193,10 +193,7 @@ habitrpg.controller("TasksCtrl", ['$scope', '$rootScope', '$location', 'User','N
         // Don't allow creation of an empty checklist item
         // TODO Provide UI feedback that this item is still blank
       } else if ($index == task.checklist.length - 1) {
-        Tasks.addChecklistItem(task._id, task.checklist[$index])
-          .then(function (response) {
-            task.checklist[$index] = response.data.data.checklist[$index];
-          });
+        $scope.saveTask(task, true);
         task.checklist.push({completed:false, text:''});
         focusChecklist(task, task.checklist.length - 1);
       } else {

--- a/website/client/js/controllers/tasksCtrl.js
+++ b/website/client/js/controllers/tasksCtrl.js
@@ -189,16 +189,13 @@ habitrpg.controller("TasksCtrl", ['$scope', '$rootScope', '$location', 'User','N
     }
 
     $scope.addChecklistItem = function(task, $event, $index) {
-      if (!task.checklist[$index].text) {
-        // Don't allow creation of an empty checklist item
-        // TODO Provide UI feedback that this item is still blank
-      } else if ($index == task.checklist.length - 1) {
+      if (task.checklist[$index].text) {
         $scope.saveTask(task, true);
-        task.checklist.push({completed:false, text:''});
-        focusChecklist(task, task.checklist.length - 1);
-      } else {
-        $scope.saveTask(task, true);
+        if ($index == task.checklist.length - 1)
+          task.checklist.push({ completed: false, text: '' });
         focusChecklist(task, $index + 1);
+      } else {
+        // TODO Provide UI feedback that this item is still blank
       }
     }
 


### PR DESCRIPTION
Fixes #7493
### Changes

This PR has two commits.
1. The first commit closes issue #7493. This was done by changing the API call to `addChecklistItem` for a call to `saveTask`. The problem arose from the fact that, when an existing checklist was being edited, the first time the user pressed enter, the very last item would be re-added. This would cause the locally displayed checklist to be rewritten when the API response was received, and the newly added item's name was updated. An alternative fix, though doubtful, would be removing the sync. This seemed to work on my tests, but it would still effectively duplicate the checklist item upon pressing enter on the server-side. Alternatively, adding an extra textbox at the very end of the list upon entering edit mode started spawning even more bugs that I could initially foresee. I finally settled for `saveTask`.
2. The second commit cleans up the function, as the logic of the last two conditionals became virtually the same. I moved the `TODO` to an else statement, although I think it would be interesting to reevaluate whether or not UI feedback for that action is justified, and if so, what it would consist of (e.g.: nor a modal nor a popover seems right to me personally... perhaps changing the outline to red of the textbox to red?).

---

UUID: 8ac1be04-4201-4eed-a2a4-436eada5c0e9
