### PR TITLE
Use npm 3 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get clean
 RUN rm -rf /var/lib/apt/lists/*
 
 # Install global packages
-RUN npm install -g gulp grunt-cli bower
+RUN npm install -g gulp grunt-cli bower npm@3
 
 # Clone Habitica repo and install dependencies
 WORKDIR /habitrpg


### PR DESCRIPTION
Fixes #7525. [Gist of `docker-compose up -d` output](https://gist.github.com/hairlessbear/674026813231c6eecec796672acd3c2b). I shut down `habitrpg_web` and restarted it with `docker start -a habitrpg_web_1` to capture [the output of `npm start`](https://gist.github.com/hairlessbear/6d223f83e849a65465e1038ba3386c5c). Tested creating a new user, logging in, and creating new to-dos to ensure it installed properly.

Surprisingly, the only change that was needed was updating to npm3.

Maybe worth mentioning: I had some errors initially due to severely outdated cookies stored in my browser from when I last worked on Habitica (~1 year ago). Might be worth adding instructions to the wiki to tell people to delete any localhost cookies they have if they experience certain errors.
