### PR TITLE
add CRON_SLIGHTLY_SAFE_MODE to prevent damage from an offset double cron

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -12,6 +12,7 @@
     "ENABLE_CONSOLE_LOGS_IN_TEST": false,
     "CRON_SAFE_MODE":"false",
     "CRON_SEMI_SAFE_MODE":"false",
+    "CRON_SLIGHTLY_SAFE_MODE":"false",
     "MAINTENANCE_MODE": "false",
     "SESSION_SECRET":"YOUR SECRET HERE",
     "ADMIN_EMAIL": "you@example.com",

--- a/website/server/libs/api-v3/cron.js
+++ b/website/server/libs/api-v3/cron.js
@@ -8,6 +8,7 @@ import nconf from 'nconf';
 
 const CRON_SAFE_MODE = nconf.get('CRON_SAFE_MODE') === 'true';
 const CRON_SEMI_SAFE_MODE = nconf.get('CRON_SEMI_SAFE_MODE') === 'true';
+const CRON_SLIGHTLY_SAFE_MODE = nconf.get('CRON_SLIGHTLY_SAFE_MODE') === 'true';
 const shouldDo = common.shouldDo;
 const scoreTask = common.ops.scoreTask;
 // const maxPMs = 200;
@@ -20,6 +21,7 @@ let CLEAR_BUFFS = {
   stealth: 0,
   streaks: false,
 };
+let MIN_PROGRESS_UP = 2; // if damage to boss is not more than this, assume duplicate cron, when running in CRON_SLIGHTLY_SAFE_MODE https://github.com/HabitRPG/habitrpg/issues/2805#issuecomment-222336424
 
 function grantEndOfTheMonthPerks (user, now) {
   let plan = user.purchased.plan;
@@ -133,6 +135,10 @@ export function cron (options = {}) {
   // If the user does not log in for two or more days, cron (mostly) acts as if it were only one day.
   // When site-wide difficulty settings are introduced, this can be a user preference option.
 
+  // If running in CRON_SLIGHTLY_SAFE_MODE, assume that small damage to a boss means this is a double cron
+  let progress = user.party.quest.progress;
+  let progressUpIsTiny = CRON_SLIGHTLY_SAFE_MODE && progress.up <= MIN_PROGRESS_UP;
+
   // Tally each task
   let todoTally = 0;
 
@@ -201,7 +207,8 @@ export function cron (options = {}) {
             cron: true,
           });
 
-          if (!CRON_SEMI_SAFE_MODE) {
+
+          if (!CRON_SEMI_SAFE_MODE && !progressIsTiny) {
             // Apply damage from a boss, less damage for Trivial priority (difficulty)
             user.party.quest.progress.down += delta * (task.priority < 1 ? task.priority : 1);
             // NB: Medium and Hard priorities do not increase damage from boss. This was by accident
@@ -273,8 +280,7 @@ export function cron (options = {}) {
   user.stats.mp += _.max([10, 0.1 * user._statsComputed.maxMP]) * dailyChecked / (dailyDueUnchecked + dailyChecked);
   if (user.stats.mp > user._statsComputed.maxMP) user.stats.mp = user._statsComputed.maxMP;
 
-  // After all is said and done, progress up user's effect on quest, return those values & reset the user's
-  let progress = user.party.quest.progress;
+  // Progress up user's effect on quest, return those values & reset the user's
   let _progress = _.cloneDeep(progress);
   _.merge(progress, {down: 0, up: 0});
   progress.collect = _.transform(progress.collect, (m, v, k) => m[k] = 0);

--- a/website/server/middlewares/api-v3/cron.js
+++ b/website/server/middlewares/api-v3/cron.js
@@ -103,7 +103,7 @@ async function cronAsync (req, res) {
 
     let _cronSignature = uuid();
 
-    // To avoid double cron we first set _cronSignature to now and then check that it's not changed while processing
+    // To avoid double cron we first set _cronSignature and then check that it's not changed while processing
     let userUpdateResult = await User.update({
       _id: user._id,
       _cronSignature: 'NOT_RUNNING', // Check that in the meantime another cron has not started


### PR DESCRIPTION
Partial workaround for https://github.com/HabitRPG/habitrpg/issues/2805 - see https://github.com/HabitRPG/habitrpg/issues/2805#issuecomment-222336424

**WIP! DO NOT MERGE!** Submitting now in case anyone wants to review my approach. This needs more code and manual testing, and automatic tests that will be included before this is merged.
### Changes
- Adds a new environment variable, CRON_SLIGHTLY_SAFE_MODE (feel free to suggest a new name).
- If that variable is true and if the user's damage to the boss is very small, then we assume that the current cron is an incorrect duplicate which has occurred after a real cron (i.e., the real cron has already unticked all the user's Dailies and has applied the user's real damage to the boss). In that case:
  - prevents any damage being done to the party by the boss
  - prints a special message to party chat

Still to be done:
- prevent personal damage to the player from their own Dailies
- prevent streak loss
- maybe other things
- tests
