### PR TITLE
prevent getGroup from running cron - possible partial fix for double cron bug

### DIFF
--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -117,6 +117,7 @@ api.getGroups = {
 api.getGroup = {
   method: 'GET',
   url: '/groups/:groupId',
+  runCron: false, // TODO Decide if this is needed. Ref: https://github.com/HabitRPG/habitrpg/compare/v3.3.3...v3.4.0?w=1#diff-b950a7c557b35ea58bc2685532c46170L120 and https://github.com/HabitRPG/habitrpg/issues/2805#issuecomment-222314260
   middlewares: [authWithHeaders()],
   async handler (req, res) {
     let user = res.locals.user;

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -508,7 +508,7 @@ schema.statics.collectQuest = async function collectQuest (user, progress) {
 };
 
 schema.statics.bossQuest = async function bossQuest (user, progress) {
-  let group = await this.getGroup({user, groupId: 'party'});
+  let group = await this.getGroup({user, groupId: 'party'}); // TODO Is the new form of double cron sneaking in here? getGroup() runs cron and bossQuest() runs within cron. Example of bug: https://github.com/HabitRPG/habitrpg/issues/2805#issuecomment-222314260
   if (!_isOnQuest(user, progress, group)) return;
 
   let quest = shared.content.quests[group.quest.key];


### PR DESCRIPTION
This changes the getGroup() function to prevent it running cron. This new code was also being used before v3.4.0 so removing it might have been a cause of the new form of double cron bug we're getting.

Also, in API v2, at least some of the groups routes did not trigger cron. E.g.,  you could use the API to talk to your party to find out if a boss quest had finished, before logging in to the website and killing your party. ;)  So maybe removing that "feature" has contributed to the double cron bug?

@paglias what do you think?  I know the _cronSignature code should prevent this bug, and I can't see anything at all wrong with it, but we're definitely still getting cron running a second time too soon.
