### PR TITLE
set lastCron at the start of cron instead of the end

### DIFF
--- a/website/server/libs/api-v3/cron.js
+++ b/website/server/libs/api-v3/cron.js
@@ -110,6 +110,7 @@ export async function recoverCron (status, locals) {
 export function cron (options = {}) {
   let {user, tasksByType, analytics, now = new Date(), daysMissed, timezoneOffsetFromUserPrefs} = options;
 
+  user.lastCron = now; // TODO does putting this here help prevent this double-cron bug: https://github.com/HabitRPG/habitrpg/issues/2805#issuecomment-222314260
   user.preferences.timezoneOffsetAtLastCron = timezoneOffsetFromUserPrefs;
   // User is only allowed a certain number of drops a day. This resets the count.
   if (user.items.lastDrop.count > 0) user.items.lastDrop.count = 0;

--- a/website/server/middlewares/api-v3/cron.js
+++ b/website/server/middlewares/api-v3/cron.js
@@ -164,13 +164,13 @@ async function cronAsync (req, res) {
       await Group[`${questType}Quest`](user, progress);
     }
 
-    // Set _cronSignature, lastCron and auth.timestamps.loggedin to signal end of cron
+    // Set _cronSignature and auth.timestamps.loggedin to signal end of cron
     await User.update({
       _id: user._id,
     }, {
       $set: {
         _cronSignature: 'NOT_RUNNING',
-        lastCron: now,
+        // lastCron: now, // TODO does moving this back into cron() help prevent this double-cron bug: https://github.com/HabitRPG/habitrpg/issues/2805#issuecomment-222314260
         'auth.timestamps.loggedin': now,
       },
     }).exec();


### PR DESCRIPTION
possible partial workaround for https://github.com/HabitRPG/habitrpg/issues/2805
### Changes

This sets lastCron when cron starts running (in api.cron()) instead of setting it when cron ends (in middleware cronAsync()) to see if that helps prevent the new double cron bug: https://github.com/HabitRPG/habitrpg/issues/2805#issuecomment-222314260

auth.timestamps.loggedin is still set when cron ends because I'm curious about the difference between the timestamps. I can't see any code that could possibly break from its value being different to lastCron

@paglias what do you think? As with the cron change in getGroup() this shouldn't be necessary but maybe it will make a difference.
