### PR TITLE
Fix #7388 - Invert tag collapse when adding tasks

### DIFF
--- a/common/script/ops/addTask.js
+++ b/common/script/ops/addTask.js
@@ -11,7 +11,7 @@ module.exports = function addTask (user, req = {body: {}}) {
     task._editing = true;
   }
 
-  if (user.preferences.tagsCollapsed) {
+  if (!user.preferences.tagsCollapsed) {
     task._tags = true;
   }
 


### PR DESCRIPTION
Fixes #7388 
### Changes

This fixes addTask so that it follows `user.preferences.tagsCollapsed` (see https://github.com/HabitRPG/habitrpg/blob/develop/website/client/js/services/taskServices.js#L154 for what it looks like when editing a task)

---

UUID: 95f16006-1504-4a9f-95b6-0c7314dbd7ee
