### PR TITLE
Fix tag removal functionality

### DIFF
--- a/website/client/js/controllers/tasksCtrl.js
+++ b/website/client/js/controllers/tasksCtrl.js
@@ -305,7 +305,7 @@ habitrpg.controller("TasksCtrl", ['$scope', '$rootScope', '$location', 'User','N
         task.tags.push(tagId);
       } else {
         Tasks.removeTagFromTask(task._id, tagId);
-        task.tags.splice(tagIndex, 0);
+        task.tags.splice(tagIndex, 1);
       }
     }
   }]);


### PR DESCRIPTION
Fixes #7412
### Changes

Changing second argument for splice from `0` to `1` sufficed.

---

UUID: 8ac1be04-4201-4eed-a2a4-436eada5c0e9

Tag removal functionality was broken. Turns out the issue was simply
that we weren't removing the tag from the local `task` object, so the
tag was removed, but readded upon sync/pressing save.

Closes #7412
