### PR TITLE
Don't persist properties of tag filters

### DIFF
--- a/test/spec/controllers/filtersCtrlSpec.js
+++ b/test/spec/controllers/filtersCtrlSpec.js
@@ -27,7 +27,7 @@ describe('Filters Controller', function() {
       scope.toggleFilter(tag);
       expect(userService.user.filters[tag.id]).to.eql(true);
       scope.toggleFilter(tag);
-      expect(userService.user.filters[tag.id]).to.eql(false);
+      expect(userService.user.filters[tag.id]).to.not.eql(true);
     }));
   });
 

--- a/website/client/js/controllers/filtersCtrl.js
+++ b/website/client/js/controllers/filtersCtrl.js
@@ -28,7 +28,7 @@ habitrpg.controller("FiltersCtrl", ['$scope', '$rootScope', 'User', 'Shared',
       if (!user.filters[tag.id]) {
         user.filters[tag.id] = true;
       } else {
-        user.filters[tag.id] = !user.filters[tag.id];
+        delete user.filters[tag.id];
       }
 
       // no longer persisting this, it was causing a lot of confusion - users thought they'd permanently lost tasks


### PR DESCRIPTION
Fixes the first half of #7412. Pull request #7553 fixes the latter half.
### Changes

Because we use the keys of `User.user.filters` to decide what tags to apply to a task by default, we can't turn off tag filters by setting them `false`. We need to remove the object property instead.

---

UUID: meaaaaaaaaaaw
