### PR TITLE
fix: Remove unnecessary flags.contributor property from user

### DIFF
--- a/test/api/v3/integration/hall/PUT-hall_heores_heroId.test.js
+++ b/test/api/v3/integration/hall/PUT-hall_heores_heroId.test.js
@@ -66,7 +66,6 @@ describe('PUT /heroes/:heroId', () => {
     await hero.sync();
     expect(hero.balance).to.equal(3 + 0.75); // 3+0.75 for first contrib level
     expect(hero.contributor.level).to.equal(1);
-    expect(hero.flags.contributor).to.equal(true);
     expect(hero.purchased.ads).to.equal(true);
     expect(hero.auth.blocked).to.equal(true);
   });
@@ -95,7 +94,6 @@ describe('PUT /heroes/:heroId', () => {
     await hero.sync();
     expect(hero.balance).to.equal(1); // 0+1 for sixth contrib level
     expect(hero.contributor.level).to.equal(6);
-    expect(hero.flags.contributor).to.equal(true);
     expect(hero.items.pets['Dragon-Hydra']).to.equal(5);
   });
 

--- a/website/client/js/controllers/notificationCtrl.js
+++ b/website/client/js/controllers/notificationCtrl.js
@@ -106,8 +106,8 @@ habitrpg.controller('NotificationCtrl',
       $rootScope.openModal('achievements/rebirth', {controller:'UserCtrl', size: 'sm'});
     });
 
-    $rootScope.$watch('user.flags.contributor', function(after, before){
-      if (after === before || after !== true) return;
+    $rootScope.$watch('user.contributor.level', function(after, before){
+      if (after === before || after < before || after == null) return;
       $rootScope.openModal('achievements/contributor',{controller:'UserCtrl'});
     });
 

--- a/website/server/models/user.js
+++ b/website/server/models/user.js
@@ -201,7 +201,6 @@ export let schema = new Schema({
     itemsEnabled: {type: Boolean, default: false},
     newStuff: {type: Boolean, default: false},
     rewrite: {type: Boolean, default: true},
-    contributor: Boolean,
     classSelected: {type: Boolean, default: false},
     mathUpdates: Boolean,
     rebirthEnabled: {type: Boolean, default: false},

--- a/website/views/shared/modals/achievements.jade
+++ b/website/views/shared/modals/achievements.jade
@@ -106,7 +106,6 @@ script(id='modals/achievements/triadBingo.html', type='text/ng-template')
     +achievementFooter
 
 // Contributor
-// activated by user.flags.contributor
 script(id='modals/achievements/contributor.html', type='text/ng-template')
   .modal-content(style='min-width:28em')
     .modal-body.text-center
@@ -115,7 +114,7 @@ script(id='modals/achievements/contributor.html', type='text/ng-template')
       !=env.t('contribModal', {name: "{{user.profile.name}}", level: "{{user.contributor.level}}"}) + ' '
       a(href='http://habitica.wikia.com/wiki/Contributor_Rewards' target='_blank')=env.t('contribLink')
       br
-      button.btn.btn-primary(style='margin-top:1em' ng-click='set({"flags.contributor":false}); $close()')=env.t('huzzah')
+      button.btn.btn-primary(style='margin-top:1em' ng-click='$close()')=env.t('huzzah')
     +achievementFooter
 
 //Rebirth


### PR DESCRIPTION
Closes #7550

The flags.contributor property was only used on the client to pop up the contributor modal. However, that can easily be done by checking the level property itself. 
