### PR TITLE
send email when admin unflags post

### DIFF
--- a/test/api/v3/unit/libs/email.test.js
+++ b/test/api/v3/unit/libs/email.test.js
@@ -49,23 +49,6 @@ function getUser () {
   };
 }
 
-function getGroup (type) {
-  if (type === 'tavern') {
-    return {
-      _id: TAVERN_ID,
-      type: 'guild',
-    };
-  } else if (type === 'guild') {
-    return {
-      _id: 'random _id',
-      type: 'guild',
-    };
-  } else return {
-    _id: 'random _id',
-    type: 'group',
-  };
-}
-
 describe('emails', () => {
   let pathToEmailLib = '../../../../../website/server/libs/api-v3/email';
 
@@ -157,24 +140,18 @@ describe('emails', () => {
 
   describe('getGroupUrl', () => {
     it('returns correct url if group is the tavern', () => {
-      let attachEmail = requireAgain(pathToEmailLib);
-      let getGroupUrl = attachEmail.getGroupUrl;
-      let group = getGroup('tavern');
-      expect(getGroupUrl(group)).to.eql('/#/options/groups/tavern');
+      let getGroupUrl = require(pathToEmailLib).getGroupUrl;
+      expect(getGroupUrl({_id: TAVERN_ID, type: 'guild'})).to.eql('/#/options/groups/tavern');
     });
 
     it('returns correct url if group is a guild', () => {
-      let attachEmail = requireAgain(pathToEmailLib);
-      let getGroupUrl = attachEmail.getGroupUrl;
-      let group = getGroup('guild');
-      expect(getGroupUrl(group)).to.eql(`/#/options/groups/guilds/${group._id}`);
+      let getGroupUrl = require(pathToEmailLib).getGroupUrl;
+      expect(getGroupUrl({_id: 'random _id', type: 'guild'})).to.eql('/#/options/groups/guilds/random _id');
     });
 
     it('returns correct url if group is a party', () => {
-      let attachEmail = requireAgain(pathToEmailLib);
-      let getGroupUrl = attachEmail.getGroupUrl;
-      let group = getGroup('party');
-      expect(getGroupUrl(group)).to.eql('party');
+      let getGroupUrl = require(pathToEmailLib).getGroupUrl;
+      expect(getGroupUrl({_id: 'random _id', type: 'party'})).to.eql('party');
     });
   });
 

--- a/test/api/v3/unit/libs/email.test.js
+++ b/test/api/v3/unit/libs/email.test.js
@@ -5,6 +5,7 @@ import nodemailer from 'nodemailer';
 import Bluebird from 'bluebird';
 import requireAgain from 'require-again';
 import logger from '../../../../../website/server/libs/api-v3/logger';
+import { TAVERN_ID } from '../../../../../website/server/models/group';
 
 function defer () {
   let resolve;
@@ -45,6 +46,23 @@ function getUser () {
         unsubscribeFromAll: false,
       },
     },
+  };
+}
+
+function getGroup (type) {
+  if (type === 'tavern') {
+    return {
+      _id: TAVERN_ID,
+      type: 'guild',
+    };
+  } else if (type === 'guild') {
+    return {
+      _id: 'random _id',
+      type: 'guild',
+    };
+  } else return {
+    _id: 'random _id',
+    type: 'group',
   };
 }
 
@@ -134,6 +152,29 @@ describe('emails', () => {
       expect(data).not.to.have.property('email');
       expect(data).to.have.property('_id', user._id);
       expect(data).to.have.property('canSend', true);
+    });
+  });
+
+  describe('getGroupUrl', () => {
+    it('returns correct url if group is the tavern', () => {
+      let attachEmail = requireAgain(pathToEmailLib);
+      let getGroupUrl = attachEmail.getGroupUrl;
+      let group = getGroup('tavern');
+      expect(getGroupUrl(group)).to.eql('/#/options/groups/tavern');
+    });
+
+    it('returns correct url if group is a guild', () => {
+      let attachEmail = requireAgain(pathToEmailLib);
+      let getGroupUrl = attachEmail.getGroupUrl;
+      let group = getGroup('guild');
+      expect(getGroupUrl(group)).to.eql(`/#/options/groups/guilds/${group._id}`);
+    });
+
+    it('returns correct url if group is a party', () => {
+      let attachEmail = requireAgain(pathToEmailLib);
+      let getGroupUrl = attachEmail.getGroupUrl;
+      let group = getGroup('party');
+      expect(getGroupUrl(group)).to.eql('party');
     });
   });
 

--- a/website/server/controllers/api-v3/chat.js
+++ b/website/server/controllers/api-v3/chat.js
@@ -10,6 +10,7 @@ import {
 } from '../../libs/api-v3/errors';
 import _ from 'lodash';
 import { removeFromArray } from '../../libs/api-v3/collectionManipulators';
+import { getUserInfo } from '../../libs/api-v3/email';
 import { sendTxn } from '../../libs/api-v3/email';
 import nconf from 'nconf';
 import Bluebird from 'bluebird';
@@ -209,19 +210,9 @@ api.flagChat = {
       update
     );
 
-    let reporterEmailContent;
-    if (user.auth.local) {
-      reporterEmailContent = user.auth.local.email;
-    } else if (user.auth.facebook && user.auth.facebook.emails && user.auth.facebook.emails[0]) {
-      reporterEmailContent = user.auth.facebook.emails[0].value;
-    }
+    let reporterEmailContent = getUserInfo(user, ['email']).email;
 
-    let authorEmailContent;
-    if (author.auth.local) {
-      authorEmailContent = author.auth.local.email;
-    } else if (author.auth.facebook && author.auth.facebook.emails && author.auth.facebook.emails[0]) {
-      authorEmailContent = author.auth.facebook.emails[0].value;
-    }
+    let authorEmailContent = getUserInfo(author, ['email']).email;
 
     let groupUrl;
     if (group._id === TAVERN_ID) {
@@ -300,21 +291,11 @@ api.clearChatFlags = {
       {$set: {'chat.$.flagCount': message.flagCount}}
     );
 
-    let adminEmailContent;
-    if (user.auth.local) {
-      adminEmailContent = user.auth.local.email;
-    } else if (user.auth.facebook && user.auth.facebook.emails && user.auth.facebook.emails[0]) {
-      adminEmailContent = user.auth.facebook.emails[0].value;
-    }
+    let adminEmailContent = getUserInfo(user, ['email']).email;
 
     let author = await User.findOne({_id: message.uuid}, {auth: 1});
 
-    let authorEmailContent;
-    if (author.auth.local) {
-      authorEmailContent = author.auth.local.email;
-    } else if (author.auth.facebook && author.auth.facebook.emails && author.auth.facebook.emails[0]) {
-      authorEmailContent = author.auth.facebook.emails[0].value;
-    }
+    let authorEmailContent = getUserInfo(author, ['email']).email;
 
     let groupUrl;
     if (group._id === TAVERN_ID) {
@@ -325,8 +306,7 @@ api.clearChatFlags = {
       groupUrl = 'party';
     }
 
-    sendTxn(FLAG_REPORT_EMAILS, 'flag-report-to-mods', [
-      {name: 'STATUS', content: 'UNFLAGGED BY ADMIN'},
+    sendTxn(FLAG_REPORT_EMAILS, 'unflag-report-to-mods', [
       {name: 'MESSAGE_TIME', content: (new Date(message.timestamp)).toString()},
       {name: 'MESSAGE_TEXT', content: message.text},
 

--- a/website/server/controllers/api-v3/chat.js
+++ b/website/server/controllers/api-v3/chat.js
@@ -1,8 +1,5 @@
 import { authWithHeaders } from '../../middlewares/api-v3/auth';
-import {
-  model as Group,
-  TAVERN_ID,
-} from '../../models/group';
+import { model as Group } from '../../models/group';
 import { model as User } from '../../models/user';
 import {
   NotFound,
@@ -10,8 +7,7 @@ import {
 } from '../../libs/api-v3/errors';
 import _ from 'lodash';
 import { removeFromArray } from '../../libs/api-v3/collectionManipulators';
-import { getUserInfo } from '../../libs/api-v3/email';
-import { sendTxn } from '../../libs/api-v3/email';
+import { getUserInfo, getGroupUrl, sendTxn } from '../../libs/api-v3/email';
 import nconf from 'nconf';
 import Bluebird from 'bluebird';
 
@@ -214,14 +210,7 @@ api.flagChat = {
 
     let authorEmailContent = getUserInfo(author, ['email']).email;
 
-    let groupUrl;
-    if (group._id === TAVERN_ID) {
-      groupUrl = '/#/options/groups/tavern';
-    } else if (group.type === 'guild') {
-      groupUrl = `/#/options/groups/guilds/${group._id}`;
-    } else {
-      groupUrl = 'party';
-    }
+    let groupUrl = getGroupUrl(group);
 
     sendTxn(FLAG_REPORT_EMAILS, 'flag-report-to-mods', [
       {name: 'MESSAGE_TIME', content: (new Date(message.timestamp)).toString()},
@@ -297,14 +286,7 @@ api.clearChatFlags = {
 
     let authorEmailContent = getUserInfo(author, ['email']).email;
 
-    let groupUrl;
-    if (group._id === TAVERN_ID) {
-      groupUrl = '/#/options/groups/tavern';
-    } else if (group.type === 'guild') {
-      groupUrl = `/#/options/groups/guilds/${group._id}`;
-    } else {
-      groupUrl = 'party';
-    }
+    let groupUrl = getGroupUrl(group);
 
     sendTxn(FLAG_REPORT_EMAILS, 'unflag-report-to-mods', [
       {name: 'MESSAGE_TIME', content: (new Date(message.timestamp)).toString()},

--- a/website/server/libs/api-v3/email.js
+++ b/website/server/libs/api-v3/email.js
@@ -1,5 +1,6 @@
 import { createTransport } from 'nodemailer';
 import nconf from 'nconf';
+import { TAVERN_ID } from '../../models/group';
 import { encrypt } from './encryption';
 import request from 'request';
 import logger from './logger';
@@ -62,6 +63,19 @@ export function getUserInfo (user, fields = []) {
   }
 
   return info;
+}
+
+export function getGroupUrl (group) {
+  let groupUrl;
+  if (group._id === TAVERN_ID) {
+    groupUrl = '/#/options/groups/tavern';
+  } else if (group.type === 'guild') {
+    groupUrl = `/#/options/groups/guilds/${group._id}`;
+  } else {
+    groupUrl = 'party';
+  }
+
+  return groupUrl;
 }
 
 // Send a transactional email using Mandrill through the external email server

--- a/website/server/libs/api-v3/email.js
+++ b/website/server/libs/api-v3/email.js
@@ -71,7 +71,7 @@ export function getGroupUrl (group) {
     groupUrl = '/#/options/groups/tavern';
   } else if (group.type === 'guild') {
     groupUrl = `/#/options/groups/guilds/${group._id}`;
-  } else {
+  } else if (group.type === 'party') {
     groupUrl = 'party';
   }
 


### PR DESCRIPTION
Implements #7535
### Changes

New block at the en of the unflag API call that hopefully sends an email to admins to notify them an admin has unflagged a post. 

However since apparently the email service does not work in a dev environment I was unable to test my code. I am unsure if it is the correct syntax for sendTxn or not.

The mail recipients and title _should_ be the same. The mail would begin by a 'Unflagged by admin' text. This one is hardcoded, as I am not sure where to put the string in the locale directory (I'm thinking front.json for now) The details of the admin who performed the action are also sent.

---

UUID: c104a050-7a9a-488f-ad0f-cda73815432b
