### PR TITLE
fix: Cleanup quest progress for non-members when quest starts

### DIFF
--- a/test/api/v3/integration/quests/POST-groups_groupId_quests_accept.test.js
+++ b/test/api/v3/integration/quests/POST-groups_groupId_quests_accept.test.js
@@ -3,6 +3,7 @@ import {
   translate as t,
   generateUser,
 } from '../../../../helpers/api-v3-integration.helper';
+import Bluebird from 'bluebird';
 
 describe('POST /groups/:groupId/quests/accept', () => {
   const PET_QUEST = 'whale';
@@ -114,6 +115,23 @@ describe('POST /groups/:groupId/quests/accept', () => {
 
       await questingGroup.sync();
       expect(questingGroup.quest.active).to.equal(true);
+    });
+
+    it('cleans up user quest data for non-quest members when last member accepts', async () => {
+      let rejectingMember = partyMembers[0];
+
+      await leader.post(`/groups/${questingGroup._id}/quests/invite/${PET_QUEST}`);
+      await rejectingMember.post(`/groups/${questingGroup._id}/quests/reject`);
+      // quest will start after everyone has accepted
+      await partyMembers[1].post(`/groups/${questingGroup._id}/quests/accept`);
+
+      await Bluebird.delay(500);
+
+      await rejectingMember.sync();
+
+      expect(rejectingMember.party.quest.RSVPNeeded).to.eql(false);
+      expect(rejectingMember.party.quest.key).to.not.exist;
+      expect(rejectingMember.party.quest.completed).to.not.exist;
     });
   });
 });

--- a/test/api/v3/integration/quests/POST-groups_groupid_quests_reject.test.js
+++ b/test/api/v3/integration/quests/POST-groups_groupid_quests_reject.test.js
@@ -4,6 +4,7 @@ import {
   generateUser,
 } from '../../../../helpers/api-v3-integration.helper';
 import { v4 as generateUUID } from 'uuid';
+import Bluebird from 'bluebird';
 
 describe('POST /groups/:groupId/quests/reject', () => {
   let questingGroup;
@@ -141,6 +142,27 @@ describe('POST /groups/:groupId/quests/reject', () => {
       await questingGroup.sync();
 
       expect(questingGroup.quest.active).to.be.true;
+    });
+
+    it('cleans up user quest data for non-quest members when last member rejects', async () => {
+      let rejectingMember = partyMembers[1];
+
+      await leader.post(`/groups/${questingGroup._id}/quests/invite/${PET_QUEST}`);
+      await partyMembers[0].post(`/groups/${questingGroup._id}/quests/accept`);
+      // quest will start after everyone has accepted or rejected
+      await rejectingMember.post(`/groups/${questingGroup._id}/quests/reject`);
+
+      await Bluebird.delay(500);
+
+      await questingGroup.sync();
+
+      expect(questingGroup.quest.active).to.be.true;
+
+      await rejectingMember.sync();
+
+      expect(rejectingMember.party.quest.RSVPNeeded).to.eql(false);
+      expect(rejectingMember.party.quest.key).to.not.exist;
+      expect(rejectingMember.party.quest.completed).to.not.exist;
     });
   });
 });

--- a/website/server/controllers/api-v3/quests.js
+++ b/website/server/controllers/api-v3/quests.js
@@ -301,7 +301,7 @@ api.forceStart = {
 };
 
 /**
- * @api {post} /api/v3/groups/:groupId/quests/cancel Cancels a quest
+ * @api {post} /api/v3/groups/:groupId/quests/cancel Cancels a quest that is not active
  * @apiVersion 3.0.0
  * @apiName CancelQuest
  * @apiGroup Group


### PR DESCRIPTION
Fixes #7353

This cleans up the RSVPNeeded property when the quest starts. Since the client does a user sync after any quest action, it should correct the value on the client as well. 
