### PR TITLE
Fix mystery set award to new subscribers

### DIFF
--- a/test/api/v3/unit/libs/payments.test.js
+++ b/test/api/v3/unit/libs/payments.test.js
@@ -9,8 +9,17 @@ describe('payments/index', () => {
   let user;
 
   describe('#createSubscription', () => {
+    const MYSTERY_AWARD_COUNT = 2;
+    const MYSTERY_AWARD_UNIX_TIME = 1464725113000;
+    let fakeClock;
+
     beforeEach(async () => {
       user = new User();
+      fakeClock = sinon.useFakeTimers(MYSTERY_AWARD_UNIX_TIME);
+    });
+
+    afterEach(() => {
+      fakeClock.restore();
     });
 
     it('succeeds', async () => {
@@ -18,6 +27,12 @@ describe('payments/index', () => {
       expect(user.purchased.plan.planId).to.not.exist;
       await api.createSubscription(data);
       expect(user.purchased.plan.planId).to.exist;
+    });
+
+    it('awards mystery items', async () => {
+      data = { user, sub: { key: 'basic_3mo' } };
+      await api.createSubscription(data);
+      expect(user.purchased.plan.mysteryItems.length).to.eql(MYSTERY_AWARD_COUNT);
     });
   });
 

--- a/website/server/libs/api-v3/payments.js
+++ b/website/server/libs/api-v3/payments.js
@@ -20,7 +20,7 @@ function revealMysteryItems (user) {
         moment().isAfter(shared.content.mystery[item.mystery].start) &&
         moment().isBefore(shared.content.mystery[item.mystery].end) &&
         !user.items.gear.owned[item.key] &&
-        user.purchased.plan.mysteryItems.indexOf(item.key) !== -1
+        user.purchased.plan.mysteryItems.indexOf(item.key) === -1
       ) {
       user.purchased.plan.mysteryItems.push(item.key);
     }


### PR DESCRIPTION
Fixes https://github.com/HabitRPG/habitrpg/issues/7552
### Changes

A sign error in code for awarding mystery set items to new subscribers caused items to be awarded only when the user already had the item in their mystery box. Fixified!

---

UUID: wryyyyy
