### PR TITLE
fix tag sorting

### DIFF
--- a/website/client/js/services/userServices.js
+++ b/website/client/js/services/userServices.js
@@ -319,7 +319,7 @@ angular.module('habitrpg')
         },
 
         sortTag: function (data) {
-          let fromId = user.tags[data.query.from].id;
+          var fromId = user.tags[data.query.from].id;
           user.ops.sortTag(data);
           Tags.sortTag(fromId, data.query.to);
         },

--- a/website/client/js/services/userServices.js
+++ b/website/client/js/services/userServices.js
@@ -319,8 +319,9 @@ angular.module('habitrpg')
         },
 
         sortTag: function (data) {
+          let fromId = user.tags[data.query.from].id;
           user.ops.sortTag(data);
-          Tags.sortTag(user.tags[data.query.from].id, data.query.to);
+          Tags.sortTag(fromId, data.query.to);
         },
 
         deleteTag: function(data) {


### PR DESCRIPTION
Fixes #7541
### Changes

A sneaky bug, frustratingly hard to find.
The call to user.ops.sortTag causes the client side tag data to be sorted before the call to the API to update the database. The call to the API then receives the ID of the tag that occupied the slot of the intended tag to be sorted.

Since the tag id cannot be pulled from ui.item.data, I've instead added a variable to the code to store the id if the tag to be sorted.

There is no karma coverage for sorting tags, and I don't know how to write karma tests (maybe I should learn to do so). However, this bug would not have been detected by a karma test either.

---

UUID: c104a050-7a9a-488f-ad0f-cda73815432b
