### PR TITLE
Make wheelchairs public

### DIFF
--- a/test/api/v3/integration/members/GET-members_id.test.js
+++ b/test/api/v3/integration/members/GET-members_id.test.js
@@ -35,7 +35,7 @@ describe('GET /members/:memberId', () => {
     ]);
     expect(Object.keys(memberRes.auth)).to.eql(['timestamps']);
     expect(Object.keys(memberRes.preferences).sort()).to.eql(['size', 'hair', 'skin', 'shirt',
-      'costume', 'sleep', 'background'].sort());
+      'chair', 'costume', 'sleep', 'background'].sort());
   });
 
   it('handles non-existing members', async () => {

--- a/test/api/v3/integration/members/GET-members_id.test.js
+++ b/test/api/v3/integration/members/GET-members_id.test.js
@@ -34,7 +34,7 @@ describe('GET /members/:memberId', () => {
       'backer', 'contributor', 'auth', 'items',
     ]);
     expect(Object.keys(memberRes.auth)).to.eql(['timestamps']);
-    expect(Object.keys(memberRes.preferences).sort()).to.eql(['size', 'hair', 'skin', 'shirt',
+    expect(Object.keys(memberRes.preferences)).to.eql(['size', 'hair', 'skin', 'shirt',
       'chair', 'costume', 'sleep', 'background'].sort());
   });
 

--- a/website/server/models/user.js
+++ b/website/server/models/user.js
@@ -539,8 +539,8 @@ schema.plugin(baseModel, {
 
 // A list of publicly accessible fields (not everything from preferences because there are also a lot of settings tha should remain private)
 export let publicFields = `preferences.size preferences.hair preferences.skin preferences.shirt
-  preferences.costume preferences.sleep preferences.background profile stats achievements party
-  backer contributor auth.timestamps items`;
+  preferences.chair preferences.costume preferences.sleep preferences.background profile stats
+  achievements party backer contributor auth.timestamps items`;
 
 // The minimum amount of data needed when populating multiple users
 export let nameFields = 'profile.name';


### PR DESCRIPTION
Fixes an issue reported by Shine Augustine in the Report a Bug guild.
### Changes

Previously, `preferences.chair` was not considered public data, so it was not returned using the GET members/:memberId route. That led in turn to wheelchairs not appearing outside of one's own profile. Now the `preferences.chair` path is marked as public, so it is visible across the site.

---

UUID: [Bulky Platypus Hive](https://map.what3words.com/bulky.platypus.hive)
