### PR TITLE
Correctly award 3-month benefits

### DIFF
--- a/test/api/v3/unit/libs/cron.test.js
+++ b/test/api/v3/unit/libs/cron.test.js
@@ -80,21 +80,25 @@ describe('cron', () => {
     });
 
     it('decrements plan.consecutive.offset when offset is greater than 0', () => {
-      user.purchased.plan.consecutive.offset = 1;
+      user.purchased.plan.consecutive.offset = 2;
       cron({user, tasksByType, daysMissed, analytics});
-      expect(user.purchased.plan.consecutive.offset).to.equal(0);
+      expect(user.purchased.plan.consecutive.offset).to.equal(1);
     });
 
     it('increments plan.consecutive.trinkets when user has reached a month that is a multiple of 3', () => {
       user.purchased.plan.consecutive.count = 5;
+      user.purchased.plan.consecutive.offset = 1;
       cron({user, tasksByType, daysMissed, analytics});
       expect(user.purchased.plan.consecutive.trinkets).to.equal(1);
+      expect(user.purchased.plan.consecutive.offset).to.equal(0);
     });
 
     it('increments plan.consecutive.gemCapExtra when user has reached a month that is a multiple of 3', () => {
       user.purchased.plan.consecutive.count = 5;
+      user.purchased.plan.consecutive.offset = 1;
       cron({user, tasksByType, daysMissed, analytics});
       expect(user.purchased.plan.consecutive.gemCapExtra).to.equal(5);
+      expect(user.purchased.plan.consecutive.offset).to.equal(0);
     });
 
     it('does not increment plan.consecutive.gemCapExtra when user has reached the gemCap limit', () => {

--- a/website/server/libs/api-v3/cron.js
+++ b/website/server/libs/api-v3/cron.js
@@ -57,9 +57,10 @@ function grantEndOfTheMonthPerks (user, now) {
 
     plan.consecutive.count++;
 
-    if (plan.consecutive.offset > 0) {
+    if (plan.consecutive.offset > 1) {
       plan.consecutive.offset--;
     } else if (plan.consecutive.count % 3 === 0) { // every 3 months
+      if (plan.consecutive.offset === 1) plan.consecutive.offset--;
       plan.consecutive.trinkets++;
       plan.consecutive.gemCapExtra += 5;
       if (plan.consecutive.gemCapExtra > 25) plan.consecutive.gemCapExtra = 25; // cap it at 50 (hard 25 limit + extra 25)


### PR DESCRIPTION
Fixes #4819.
### Changes

Previously, the check for whether or not to award 3-, 6-, or 12-month subscribers their new Mystic Hourglass and Gem-to-Gold cap increase would be skipped when their `purchased.plan.consecutive.offset` value was anything above 0 when their subscription was updated. This meant that the first time they should get their benefits--i.e., when the `offset` was 1 then fell to 0--they would receive nothing.

Now, the perk award code handles the case of an `offset` of 1 correctly, by reducing it to 0 then proceeding to give out the Hourglass and Gem cap increase.

---

UUID: [Subtle Toaster Model](https://map.what3words.com/subtle.toaster.model)
