### PR TITLE
Remove BrowserQuest dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,6 @@
   ],
   "dependencies": {
     "Angular-At-Directive": "snicker/Angular-At-Directive#c27bae207aa06d1e",
-    "BrowserQuest": "browserquest/BrowserQuest#c3a960b03031dad5d",
     "angular": "1.3.9",
     "angular-bootstrap": "0.13.0",
     "angular-filter": "0.5.1",


### PR DESCRIPTION
Fixes an issue reported by **sustained** in the Aspiring Coders guild.
### Changes

Previously, [Mozilla's BrowserQuest game](http://browserquest.mozilla.org/) was included as a `bower` dependency for Habitica. The dependency is no longer necessary; early in Habitica's history, we used Creative Commons-licensed BrowserQuest assets directly, but those assets are now stored in `common/img/spritesmith` folders. BrowserQuest is still credited in [the LICENSE file](https://github.com/HabitRPG/habitrpg/blob/develop/LICENSE) for our use of the images.

This commit removes the dependency from `bower.json`, which should speed up build times particularly when BrowserQuest is not yet cached.

---

UUID: [Tree Fairy Barber](https://map.what3words.com/tree.fairy.barber)
