### PR TITLE
refactor common/script/ops/scoreTask.js

### DIFF
--- a/common/script/ops/scoreTask.js
+++ b/common/script/ops/scoreTask.js
@@ -106,45 +106,34 @@ function _gainMP (user, val) {
   }
 }
 
-// HP modifier
-// ===== CONSTITUTION =====
-// TODO Decreases HP loss from bad habits / missed dailies by 0.5% per point.
 function _subtractPoints (user, task, stats, delta) {
-  let conBonus = 1 - user._statsComputed.con / 250;
+  let conBonus = 1 - user._statsComputed.con / 250; // CON decreases HP loss
   if (conBonus < 0.1) conBonus = 0.1;
 
   let hpMod = delta * conBonus * task.priority * 2; // constant 2 multiplier for better results
-  stats.hp += Math.round(hpMod * 10) / 10; // round to 1dp
+  stats.hp += Math.round(hpMod * 10) / 10;
   return stats.hp;
 }
 
 function _addPoints (user, task, stats, direction, delta) {
-  // ===== CRITICAL HITS =====
   // allow critical hit only when checking off a task, not when unchecking it:
-  let _crit = delta > 0 ? crit(user) : 1;
+  let _crit = direction === 'up' ? crit(user) : 1;
   // if there was a crit, alert the user via notification
   if (_crit > 1) user._tmp.crit = _crit;
 
-  // Exp Modifier
-  // ===== Intelligence =====
-  // TODO Increases Experience gain by .2% per point.
-  let intBonus = 1 + user._statsComputed.int * 0.025;
+  let intBonus = 1 + user._statsComputed.int * 0.025; // INT increases XP gain
   stats.exp += Math.round(delta * intBonus * task.priority * _crit * 6);
 
-  // GP modifier
-  // ===== PERCEPTION =====
-  // TODO Increases Gold gained from tasks by .3% per point.
-  let perBonus = 1 + user._statsComputed.per * 0.02;
+  let perBonus = 1 + user._statsComputed.per * 0.02; // PER increases GP gain
   let gpMod = delta * task.priority * _crit * perBonus;
 
-  if (task.streak) {
+  if (task.streak) {  // streak increases GP gain
     let currStreak = direction === 'down' ? task.streak - 1 : task.streak;
     let streakBonus = currStreak / 100 + 1; // eg, 1-day streak is 1.01, 2-day is 1.02, etc
     let afterStreak = gpMod * streakBonus;
     if (currStreak > 0 && gpMod > 0) {
       user._tmp.streakBonus = afterStreak - gpMod; // keep this on-hand for later, so we can notify streak-bonus
     }
-
     stats.gp += afterStreak;
   } else {
     stats.gp += gpMod;

--- a/common/script/ops/scoreTask.js
+++ b/common/script/ops/scoreTask.js
@@ -178,9 +178,9 @@ function _changeTaskValue (user, task, direction, times, cron) {
     // TODO reverse this on 'down' https://github.com/HabitRPG/habitrpg/issues/5648
 
     if (task.type === 'todo' || task.type === 'daily') {
-      user.party.quest.progress.up += nextDelta * (1 + user._statsComputed.str / 200);
+      user.party.quest.progress.up += addToDelta * (1 + user._statsComputed.str / 200);
     } else if (task.type === 'habit') {
-      user.party.quest.progress.up += nextDelta * (0.5 + user._statsComputed.str / 400);
+      user.party.quest.progress.up += addToDelta * (0.5 + user._statsComputed.str / 400);
     }
   }
 
@@ -219,7 +219,6 @@ module.exports = function scoreTask (options = {}, req = {}) {
       date: Number(new Date()),
       value: task.value,
     });
-
   } else if (task.type === 'daily') {
     if (cron) {
       _subtractPoints(user, task, stats, delta);
@@ -241,7 +240,6 @@ module.exports = function scoreTask (options = {}, req = {}) {
         task.completed = false;
       }
     }
-
   } else if (task.type === 'todo' && !cron) { // don't touch stats on cron
     if (direction === 'up') {
       task.dateCompleted = new Date();
@@ -253,7 +251,6 @@ module.exports = function scoreTask (options = {}, req = {}) {
 
     if (direction === 'down') delta = _calculateDelta(task, direction, cron); // recalculate delta for unchecking so the gp and exp come out correctly
     _addPoints(user, task, stats, direction, delta);
-
   } else if (task.type === 'reward') {
     // Don't adjust values for rewards
     // If they're trying to purchase a too-expensive reward, don't allow them to do that.


### PR DESCRIPTION
### Changes

Refactors `common/script/ops/scoreTask.js` because when I was doing https://github.com/HabitRPG/habitrpg/pull/7370 I found the code very hard to follow.

If you want to review this in detail, it might be easiest to do it one commit at a time because I tried to commit in a logical fashion. The commit comments are also supposed to help with reviewing.

To ensure that no behaviour has changed, we'd need to have tests that looked for precise numbers in user and task stats, but I notice that that's not usually done in the test files. Is that just because it's not been done yet, or is there another reason? I think it would make sense to do it for the `test/common/ops/scoreTask.test.js` tests.
- [ ] Note to myself: must test for the effect of checklists on To-Dos.
