### PR TITLE
allow "Your password" to be translated in account deletion confirmation

### DIFF
--- a/common/locales/en/settings.json
+++ b/common/locales/en/settings.json
@@ -63,7 +63,7 @@
     "dangerZone": "Danger Zone",
     "resetText1": "WARNING! This resets many parts of your account. This is highly discouraged, but some people find it useful in the beginning after playing with the site for a short time.",
     "resetText2": "You will lose all your levels, gold, and experience points. All your tasks (except those from challenges) will be deleted permanently and you will lose all of their historical data. You will lose all your equipment but you will be able to buy it all back, including all limited edition equipment or subscriber Mystery items that you already own (you will need to be in the correct class to re-buy class-specific gear). You will keep your current class and your pets and mounts. You might prefer to use an Orb of Rebirth instead, which is a much safer option and which will preserve your tasks.",
-    "deleteText": "Are you sure? This will delete your account forever, and it can never be restored! You will need to register a new account to use Habitica again. Banked or spent Gems will not be refunded. If you're absolutely certain, type <strong><%= deleteWord %></strong> into the text box below.",
+    "deleteAccountText": "Are you sure? This will delete your account forever, and it can never be restored! You will need to register a new account to use Habitica again. Banked or spent Gems will not be refunded. If you're absolutely certain, type your password into the text box below.",
     "API": "API",
     "APIv3": "API v3",
     "APIv2": "API v2 - Deprecated",

--- a/common/locales/en/settings.json
+++ b/common/locales/en/settings.json
@@ -63,7 +63,7 @@
     "dangerZone": "Danger Zone",
     "resetText1": "WARNING! This resets many parts of your account. This is highly discouraged, but some people find it useful in the beginning after playing with the site for a short time.",
     "resetText2": "You will lose all your levels, gold, and experience points. All your tasks (except those from challenges) will be deleted permanently and you will lose all of their historical data. You will lose all your equipment but you will be able to buy it all back, including all limited edition equipment or subscriber Mystery items that you already own (you will need to be in the correct class to re-buy class-specific gear). You will keep your current class and your pets and mounts. You might prefer to use an Orb of Rebirth instead, which is a much safer option and which will preserve your tasks.",
-    "deleteAccountText": "Are you sure? This will delete your account forever, and it can never be restored! You will need to register a new account to use Habitica again. Banked or spent Gems will not be refunded. If you're absolutely certain, type your password into the text box below.",
+    "deleteLocalAccountText": "Are you sure? This will delete your account forever, and it can never be restored! You will need to register a new account to use Habitica again. Banked or spent Gems will not be refunded. If you're absolutely certain, type your password into the text box below.",
     "API": "API",
     "APIv3": "API v3",
     "APIv2": "API v2 - Deprecated",

--- a/website/views/shared/modals/settings.jade
+++ b/website/views/shared/modals/settings.jade
@@ -61,7 +61,7 @@ script(type='text/ng-template', id='modals/delete.html')
   .modal-header
     h4=env.t('deleteAccount')
   .modal-body
-    p!=env.t('deleteText', {deleteWord: 'Your password'})
+    p!=env.t('deleteAccountText')
     br
     .row
       .col-md-6

--- a/website/views/shared/modals/settings.jade
+++ b/website/views/shared/modals/settings.jade
@@ -61,7 +61,7 @@ script(type='text/ng-template', id='modals/delete.html')
   .modal-header
     h4=env.t('deleteAccount')
   .modal-body
-    p!=env.t('deleteAccountText')
+    p!=env.t('deleteLocalAccountText')
     br
     .row
       .col-md-6


### PR DESCRIPTION
When you're deleting your account, the confirmation screen instructs you to enter your password, but the phrase "Your password" is untranslatable. Example:

![screenshot from 2016-06-08 21-10-15](https://cloud.githubusercontent.com/assets/1495809/15892591/e5507202-2dbd-11e6-9bea-a249f6fb18bf.png)

This code that does that is left over from before API v3 when you had to type the word "DELETE" into the confirmation box but there's no need for that any more.

This PR removes the special handling for "Your password" and makes it a normal part of the `deleteText` locale string. 

@GitHubSphinx This PR removes the old `deleteText` locale string and adds a new `deleteAccountText` string. They're nearly identical so translators could copy the old translation, but will that still be possible in Transifex when this PR is merged? Should I adjust it to leave the old string in place until later?
