### PR TITLE
prevent sync from clearing selected tags

### DIFF
--- a/website/client/js/controllers/filtersCtrl.js
+++ b/website/client/js/controllers/filtersCtrl.js
@@ -25,9 +25,6 @@ habitrpg.controller("FiltersCtrl", ['$scope', '$rootScope', 'User', 'Shared',
     };
 
     $scope.toggleFilter = function(tag) {
-      if (user.filters === undefined) {
-        user.filters = {};
-      }
       if (!user.filters[tag.id]) {
         user.filters[tag.id] = true;
       } else {

--- a/website/client/js/controllers/filtersCtrl.js
+++ b/website/client/js/controllers/filtersCtrl.js
@@ -25,6 +25,9 @@ habitrpg.controller("FiltersCtrl", ['$scope', '$rootScope', 'User', 'Shared',
     };
 
     $scope.toggleFilter = function(tag) {
+      if (user.filters === undefined) {
+        user.filters = {};
+      }
       if (!user.filters[tag.id]) {
         user.filters[tag.id] = true;
       } else {

--- a/website/client/js/services/userServices.js
+++ b/website/client/js/services/userServices.js
@@ -80,6 +80,10 @@ angular.module('habitrpg')
 
           _.extend(user, response.data.data);
 
+          if (!user.filters) {
+            user.filters = {};
+          }
+          
           if (!user._wrapped) {
             // This wraps user with `ops`, which are functions shared both on client and mobile. When performed on client,
             // they update the user in the browser and then send the request to the server, where the same operation is

--- a/website/server/models/user/hooks.js
+++ b/website/server/models/user/hooks.js
@@ -13,7 +13,7 @@ schema.plugin(baseModel, {
   private: ['auth.local.hashed_password', 'auth.local.salt', '_cronSignature'],
   toJSONTransform: function userToJSON (plainObj, originalDoc) {
     plainObj._tmp = originalDoc._tmp; // be sure to send down drop notifs
-    plainObj.filters = undefined;
+    delete plainObj.filters;
 
     return plainObj;
   },

--- a/website/server/models/user/hooks.js
+++ b/website/server/models/user/hooks.js
@@ -13,6 +13,7 @@ schema.plugin(baseModel, {
   private: ['auth.local.hashed_password', 'auth.local.salt', '_cronSignature'],
   toJSONTransform: function userToJSON (plainObj, originalDoc) {
     plainObj._tmp = originalDoc._tmp; // be sure to send down drop notifs
+    plainObj.filters = undefined;
 
     return plainObj;
   },

--- a/website/server/models/user/schema.js
+++ b/website/server/models/user/schema.js
@@ -108,9 +108,9 @@ let schema = new Schema({
 
   balance: {type: Number, default: 0},
   // Not saved on the user right now
-  filters: {type: Schema.Types.Mixed, default: () => {
-    return {};
-  }},
+  // filters: {type: Schema.Types.Mixed, default: () => {
+  //   return {};
+  // }},
 
   purchased: {
     ads: {type: Boolean, default: false},

--- a/website/server/models/user/schema.js
+++ b/website/server/models/user/schema.js
@@ -107,10 +107,6 @@ let schema = new Schema({
   },
 
   balance: {type: Number, default: 0},
-  // Not saved on the user right now
-  // filters: {type: Schema.Types.Mixed, default: () => {
-  //   return {};
-  // }},
 
   purchased: {
     ads: {type: Boolean, default: false},


### PR DESCRIPTION
Fixes #7413
### Changes

These are the changes pointed out by @paglias to fix the unintended clearing of selected tags when a sync occurs, plus one additional change to prevent user.filters from becoming permanently undefined, which breaks tag functionality.

---

UUID: c104a050-7a9a-488f-ad0f-cda73815432b
