### PR TITLE
Update tasks.js

### DIFF
--- a/website/server/controllers/api-v3/tasks.js
+++ b/website/server/controllers/api-v3/tasks.js
@@ -228,7 +228,7 @@ api.getChallengeTasks = {
 };
 
 /**
- * @api {get} /api/v3/task/:taskId Get a task
+ * @api {get} /api/v3/tasks/:taskId Get a task
  * @apiVersion 3.0.0
  * @apiName GetTask
  * @apiGroup Task


### PR DESCRIPTION
Typo in v3 API Documentation for getting a single task. Correct url is /v3/tasks/:taskId; not /v3/task/:taskID
### Changes

Simply change 'task' to 'tasks'
- @api {get} /api/v3/tasks/:taskId Get a task

---

UUID: 9173198f-4777-4a35-9f03-8aea24f51782

Typo in code: url for getting a single task is  \* @api {get} /api/v3/tasks/:taskId Get a task; not /api/v3/task/:taskId
