### PR TITLE
fix training values not resetting at level up

### DIFF
--- a/common/script/fns/autoAllocate.js
+++ b/common/script/fns/autoAllocate.js
@@ -56,11 +56,10 @@ function getStatToAllocate (user) {
     case 'taskbased': {
       suggested = _.invert(statsObj.training)[_.max(statsObj.training)];
 
-      let training = statsObj.training;
-      training.str = 0;
-      training.int = 0;
-      training.con = 0;
-      training.per = 0;
+      user.stats.training.str = 0;
+      user.stats.training.int = 0;
+      user.stats.training.con = 0;
+      user.stats.training.per = 0;
 
       return suggested || 'str';
     }


### PR DESCRIPTION
Fixes #7542
### Changes

I am not sure why the previous code needed to be fixed, or why this is a fix, but in my test environment all values are reset to zero upon level up as expected.

This is curious since at least one value is reset in the current production version, so I can't figure out why the others wouldn't be.

---

UUID: c104a050-7a9a-488f-ad0f-cda73815432b
