### PR TITLE
Removing accepted guild invitations from the local copy of the user o…

### DIFF
--- a/website/client/js/controllers/guildsCtrl.js
+++ b/website/client/js/controllers/guildsCtrl.js
@@ -65,6 +65,8 @@ habitrpg.controller("GuildsCtrl", ['$scope', 'Groups', 'User', 'Challenges', '$r
               Analytics.track({'hitType':'event', 'eventCategory':'behavior', 'eventAction':'join group', 'owner':false, 'groupType':'guild','privacy': joinedGroup.privacy})
             }
 
+            _.pull(User.user.invitations.guilds, group);
+
             $location.path('/options/groups/guilds/' + joinedGroup._id);
           });
       }


### PR DESCRIPTION
closes #7600 
### Changes

Removed the accepted guild request from the pending invitations for a user so the notification goes away without having to refresh.

---

UUID: 2a4d30ee-4833-420e-be7c-ad6a6e261c5f
