### PR TITLE
prevents damage to quest participants with false or null values - #7653

### DIFF
--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -522,7 +522,7 @@ schema.methods._processBossQuest = async function processBossQuest (options) {
 
   // Everyone takes damage
   await User.update({
-    _id: {$in: _.keys(group.quest.members)},
+    _id: {$in: _.keys(_.pick(group.quest.members, _.identity))},
   }, {
     $inc: {'stats.hp': down},
   }, {multi: true}).exec();


### PR DESCRIPTION
Partial fix for #7653 - addresses this part: "adjust the code that allocates quest damage so that it doesn't affect people who don't have a true value in quest.members."
### Changes

Makes _processBossQuest() not apply damage to quest participants who have a `false` or `null` value, which can happen if a bug prevents them from leaving a quest correctly.

Also adds a test that does fail against the current `develop` code but passes with this PR.
