### PR TITLE
Adding ticks back into gifted gems receive message #7540

### DIFF
--- a/common/locales/en/groups.json
+++ b/common/locales/en/groups.json
@@ -105,7 +105,7 @@
     "gemAmountRequired": "A number of gems is required",
     "notAuthorizedToSendMessageToThisUser": "Can't send message to this user.",
     "privateMessageGiftIntro": "Hello <%= receiverName %>, <%= senderName %> has sent you ",
-    "privateMessageGiftGemsMessage": "<%= gemAmount %> gems! ",
+    "privateMessageGiftGemsMessage": "<%= gemAmount %> gems!",
     "privateMessageGiftSubscriptionMessage": "<%= numberOfMonths %> months of subscription! ",
     "cannotSendGemsToYourself": "Cannot send gems to yourself. Try a subscription instead.",
     "badAmountOfGemsToSend": "Amount must be within 1 and your current number of gems.",

--- a/test/api/v3/integration/members/POST-transfer_gems.test.js
+++ b/test/api/v3/integration/members/POST-transfer_gems.test.js
@@ -2,7 +2,6 @@ import {
   generateUser,
   translate as t,
 } from '../../../../helpers/api-v3-integration.helper';
-import _ from 'lodash';
 import { v4 as generateUUID } from 'uuid';
 
 describe('POST /members/transfer-gems', () => {
@@ -130,7 +129,7 @@ describe('POST /members/transfer-gems', () => {
       senderName: userToSendMessage.profile.name,
     });
     messageSentContent += t('privateMessageGiftGemsMessage', {gemAmount});
-    messageSentContent = '`' + _.trim(messageSentContent) + '` ';
+    messageSentContent =  `\`${messageSentContent}\` `;
     messageSentContent += message;
 
     expect(sendersMessageInReceiversInbox).to.exist;
@@ -164,7 +163,7 @@ describe('POST /members/transfer-gems', () => {
       senderName: userToSendMessage.profile.name,
     });
     messageSentContent += t('privateMessageGiftGemsMessage', {gemAmount});
-    messageSentContent = '`' + _.trim(messageSentContent) + '` ';
+    messageSentContent =  `\`${messageSentContent}\` `;
 
     expect(sendersMessageInReceiversInbox).to.exist;
     expect(sendersMessageInReceiversInbox.text).to.equal(messageSentContent);

--- a/test/api/v3/integration/members/POST-transfer_gems.test.js
+++ b/test/api/v3/integration/members/POST-transfer_gems.test.js
@@ -2,6 +2,7 @@ import {
   generateUser,
   translate as t,
 } from '../../../../helpers/api-v3-integration.helper';
+import _ from 'lodash';
 import { v4 as generateUUID } from 'uuid';
 
 describe('POST /members/transfer-gems', () => {
@@ -129,6 +130,7 @@ describe('POST /members/transfer-gems', () => {
       senderName: userToSendMessage.profile.name,
     });
     messageSentContent += t('privateMessageGiftGemsMessage', {gemAmount});
+    messageSentContent = '`' + _.trim(messageSentContent) + '` ';
     messageSentContent += message;
 
     expect(sendersMessageInReceiversInbox).to.exist;
@@ -162,6 +164,7 @@ describe('POST /members/transfer-gems', () => {
       senderName: userToSendMessage.profile.name,
     });
     messageSentContent += t('privateMessageGiftGemsMessage', {gemAmount});
+    messageSentContent = '`' + _.trim(messageSentContent) + '` ';
 
     expect(sendersMessageInReceiversInbox).to.exist;
     expect(sendersMessageInReceiversInbox.text).to.equal(messageSentContent);

--- a/website/server/controllers/api-v3/members.js
+++ b/website/server/controllers/api-v3/members.js
@@ -15,7 +15,6 @@ import {
   getUserInfo,
   sendTxn as sendTxnEmail,
 } from '../../libs/api-v3/email';
-import _ from 'lodash';
 import Bluebird from 'bluebird';
 import sendPushNotification from '../../libs/api-v3/pushNotifications';
 
@@ -357,7 +356,7 @@ api.transferGems = {
       senderName: sender.profile.name,
     });
     message += res.t('privateMessageGiftGemsMessage', {gemAmount});
-    message = '`' + _.trim(message) + '` ';
+    message =  `\`${message}\` `;
 
     if (req.body.message) {
       message += req.body.message;

--- a/website/server/controllers/api-v3/members.js
+++ b/website/server/controllers/api-v3/members.js
@@ -15,6 +15,7 @@ import {
   getUserInfo,
   sendTxn as sendTxnEmail,
 } from '../../libs/api-v3/email';
+import _ from 'lodash';
 import Bluebird from 'bluebird';
 import sendPushNotification from '../../libs/api-v3/pushNotifications';
 
@@ -356,6 +357,7 @@ api.transferGems = {
       senderName: sender.profile.name,
     });
     message += res.t('privateMessageGiftGemsMessage', {gemAmount});
+    message = '`' + _.trim(message) + '` ';
 
     if (req.body.message) {
       message += req.body.message;


### PR DESCRIPTION
#7540
### Changes

Wrapped gem gifted message in back ticks as requested. I did this in code instead of in the translated strings file as I felt this was formatting which should be consistent across languages and shouldn't require touching a large number of files to change.

---

UUID: 2a4d30ee-4833-420e-be7c-ad6a6e261c5f
