### PR TITLE
Fixing quest naming according to @lemoness #7629

### DIFF
--- a/common/locales/en/questsContent.json
+++ b/common/locales/en/questsContent.json
@@ -86,17 +86,17 @@
   "questVice3DropDragonEgg": "Dragon (Egg)",
   "questVice3DropShadeHatchingPotion": "Shade Hatching Potion",
 
-  "questMoonstone1Text": "The Moonstone Chain, Part 1: The Moonstone Chain",
+  "questMoonstone1Text": "Recidivate, Part 1: The Moonstone Chain",
   "questMoonstone1Notes": "A terrible affliction has struck Habiticans. Bad Habits thought long-dead are rising back up with a vengeance. Dishes lie unwashed, textbooks linger unread, and procrastination runs rampant!<br><br>You track some of your own returning Bad Habits to the Swamps of Stagnation and discover the culprit: the ghostly Necromancer, Recidivate. You rush in, weapons swinging, but they slide through her specter uselessly.<br><br>\"Don’t bother,\" she hisses with a dry rasp. \"Without a chain of moonstones, nothing can harm me – and master jeweler @aurakami scattered all the moonstones across Habitica long ago!\" Panting, you retreat... but you know what you must do.",
   "questMoonstone1CollectMoonstone": "Moonstones",
   "questMoonstone1DropMoonstone2Quest": "The Moonstone Chain Part 2: Recidivate the Necromancer (Scroll)",
 
-  "questMoonstone2Text": "The Moonstone Chain, Part 2: Recidivate The Necromancer",
+  "questMoonstone2Text": "Recidivate, Part 2: Recidivate The Necromancer",
   "questMoonstone2Notes": "The brave weaponsmith @Inventrix helps you fashion the enchanted moonstones into a chain. You’re ready to confront Recidivate at last, but as you enter the Swamps of Stagnation, a terrible chill sweeps over you.<br><br>Rotting breath whispers in your ear. \"Back again? How delightful...\" You spin and lunge, and under the light of the moonstone chain, your weapon strikes solid flesh. \"You may have bound me to the world once more,\" Recidivate snarls, \"but now it is time for you to leave it!\"",
   "questMoonstone2Boss": "The Necromancer",
   "questMoonstone2DropMoonstone3Quest": "The Moonstone Chain Part 3: Recidivate Transformed (Scroll)",
 
-  "questMoonstone3Text": "The Moonstone Chain, Part 3: Recidivate Transformed",
+  "questMoonstone3Text": "Recidivate, Part 3: Recidivate Transformed",
   "questMoonstone3Notes": "Recidivate crumples to the ground, and you strike at her with the moonstone chain. To your horror, Recidivate seizes the gems, eyes burning with triumph.<br><br>\"Foolish creature of flesh!\" she shouts. \"These moonstones will restore me to a physical form, true, but not as you imagined. As the full moon waxes from the dark, so too does my power flourish, and from the shadows I summon the specter of your most feared foe!\"<br><br>A sickly green fog rises from the swamp, and Recidivate’s body writhes and contorts into a shape that fills you with dread – the undead body of Vice, horribly reborn.",
   "questMoonstone3Completion": "Your breath comes hard and sweat stings your eyes as the undead Wyrm collapses. The remains of Recidivate dissipate into a thin grey mist that clears quickly under the onslaught of a refreshing breeze, and you hear the distant, rallying cries of Habiticans defeating their Bad Habits for once and for all.<br><br>@Baconsaur the beast master swoops down on a gryphon. \"I saw the end of your battle from the sky, and I was greatly moved. Please, take this enchanted tunic – your bravery speaks of a noble heart, and I believe you were meant to have it.\"",
   "questMoonstone3Boss": "Necro-Vice",
@@ -106,12 +106,12 @@
   "questGoldenknight1Text": "The Golden Knight, Part 1: A Stern Talking-To",
   "questGoldenknight1Notes": "The Golden Knight has been getting on poor Habiticans' cases. Didn't do all of your Dailies? Checked off a negative Habit? She will use this as a reason to harass you about how you should follow her example. She is the shining example of a perfect Habitican, and you are naught but a failure. Well, that is not nice at all! Everyone makes mistakes. They should not have to be met with such negativity for it. Perhaps it is time you gather some testimonies from hurt Habiticans and give the Golden Knight a stern talking-to!",
   "questGoldenknight1CollectTestimony": "Testimonies",
-  "questGoldenknight1DropGoldenknight2Quest": "The Golden Knight Chain Part 2: Gold Knight (Scroll)",
+  "questGoldenknight1DropGoldenknight2Quest": "The Golden Knight Part 2: Gold Knight (Scroll)",
 
   "questGoldenknight2Text": "The Golden Knight, Part 2: Gold Knight",
   "questGoldenknight2Notes": "Armed with hundreds of Habitican's testimonies, you finally confront the Golden Knight. You begin to recite the Habitcan's complaints to her, one by one. \"And @Pfeffernusse says that your constant bragging-\" The knight raises her hand to silence you and scoffs, \"Please, these people are merely jealous of my success. Instead of complaining, they should simply work as hard as I! Perhaps I shall show you the power you can attain through diligence such as mine!\" She raises her morningstar and prepares to attack you!",
   "questGoldenknight2Boss": "Gold Knight",
-  "questGoldenknight2DropGoldenknight3Quest": "The Golden Knight Chain Part 3: The Iron Knight (Scroll)",
+  "questGoldenknight2DropGoldenknight3Quest": "The Golden Knight Part 3: The Iron Knight (Scroll)",
 
   "questGoldenknight3Text": "The Golden Knight, Part 3: The Iron Knight",
   "questGoldenknight3Notes": "@Jon Arinbjorn cries out to you to get your attention. In the aftermath of your battle, a new figure has appeared. A knight coated in stained-black iron slowly approaches you with sword in hand. The Golden Knight shouts to the figure, \"Father, no!\" but the knight shows no signs of stopping. She turns to you and says, \"I am sorry. I have been a fool, with a head too big to see how cruel I have been. But my father is crueler than I could ever be. If he isn't stopped he'll destroy us all. Here, use my morningstar and halt the Iron Knight!\"",


### PR DESCRIPTION
#7629
### Changes

Fixing naming of the golden knight by removing the word chain and changing the moonstone chain quest name to recidivate.

---

UUID: 2a4d30ee-4833-420e-be7c-ad6a6e261c5f
