### PR TITLE
Correct GA unsub info

### DIFF
--- a/website/server/libs/api-v3/analyticsService.js
+++ b/website/server/libs/api-v3/analyticsService.js
@@ -144,7 +144,7 @@ let _generateValueForGoogleAnalytics = (data) => {
 
 let _sendDataToGoogle = (eventType, data) => {
   let eventData = {
-    ec: data.category || data.gaCategory || 'behavior',
+    ec: data.gaCategory || data.category || 'behavior',
     ea: eventType,
   };
 

--- a/website/server/libs/api-v3/analyticsService.js
+++ b/website/server/libs/api-v3/analyticsService.js
@@ -116,20 +116,6 @@ let _sendDataToAmplitude = (eventType, data) => {
   });
 };
 
-let _generateCategoryForGoogleAnalytics = (data) => {
-  let category;
-
-  if (data.category) {
-    category = data.category;
-  } else if (data.gaCategory) {
-    category = data.gaCategory;
-  } else {
-    category = 'behavior';
-  }
-
-  return category;
-};
-
 let _generateLabelForGoogleAnalytics = (data) => {
   let label;
 
@@ -158,7 +144,7 @@ let _generateValueForGoogleAnalytics = (data) => {
 
 let _sendDataToGoogle = (eventType, data) => {
   let eventData = {
-    ec: _generateCategoryForGoogleAnalytics(data);
+    ec: data.category || data.gaCategory || 'behavior',
     ea: eventType,
   };
 

--- a/website/server/libs/api-v3/analyticsService.js
+++ b/website/server/libs/api-v3/analyticsService.js
@@ -116,6 +116,20 @@ let _sendDataToAmplitude = (eventType, data) => {
   });
 };
 
+let _generateCategoryForGoogleAnalytics = (data) => {
+  let category;
+
+  if (data.category) {
+    category = data.category;
+  } else if (data.gaCategory) {
+    category = data.gaCategory;
+  } else {
+    category = 'behavior';
+  }
+
+  return category;
+};
+
 let _generateLabelForGoogleAnalytics = (data) => {
   let label;
 
@@ -144,7 +158,7 @@ let _generateValueForGoogleAnalytics = (data) => {
 
 let _sendDataToGoogle = (eventType, data) => {
   let eventData = {
-    ec: data.category,
+    ec: _generateCategoryForGoogleAnalytics(data);
     ea: eventType,
   };
 


### PR DESCRIPTION
Fixes an issue spotted in server error logs (trimmed):

> Error: Please provide at least an event category (ec) and an event action (ea)
>    at Object.Visitor._handleError (/var/app/current/node_modules/universal-analytics/lib/index.js:391:24)
>  in libs/api-v3/payments.js
### Changes

We were passing `gaCategory` in the `data` of an analytics service call, when the expected property name was simply `category`. This led to us trying to send Google Analytics information without required fields. This commit corrects the error.

---

UUID: [Money Label Error](https://map.what3words.com/money.label.error)
