### PR TITLE
fix inconsistencies in apidoc for member routes

### DIFF
--- a/website/server/controllers/api-v3/members.js
+++ b/website/server/controllers/api-v3/members.js
@@ -208,8 +208,8 @@ api.getMembersForChallenge = {
 /**
  * @api {get} /api/v3/challenges/:challengeId/members/:memberId Get a challenge member progress
  * @apiVersion 3.0.0
- * @apiName GetChallenge
- * @apiGroup Challenge
+ * @apiName GetChallengeMemberProgress
+ * @apiGroup Member
  *
  * @apiParam {UUID} challengeId The challenge _id
  * @apiParam {UUID} member The member _id
@@ -262,7 +262,7 @@ api.getChallengeMemberProgress = {
  * @api {posts} /api/v3/members/send-private-message Send a private message to a member
  * @apiVersion 3.0.0
  * @apiName SendPrivateMessage
- * @apiGroup Members
+ * @apiGroup Member
  *
  * @apiParam {String} message Body parameter - The message
  * @apiParam {UUID} toUserId Body parameter - The user to contact
@@ -311,7 +311,7 @@ api.sendPrivateMessage = {
  * @api {posts} /api/v3/members/transfer-gems Send a gem gift to a member
  * @apiVersion 3.0.0
  * @apiName TransferGems
- * @apiGroup Members
+ * @apiGroup Member
  *
  * @apiParam {String} message Body parameter The message
  * @apiParam {UUID} toUserId Body parameter The toUser _id


### PR DESCRIPTION
### Changes

Adjusts the comments for the apidocs to remove things that look inconsistent. I think the things I changed were mistakes but check this in case there's some reason for it to be the way it was.
- Fixes the name for `GetChallengeMemberProgress`
- Makes members/member consistent:

![members](https://cloud.githubusercontent.com/assets/1495809/16148512/61cabe1c-34cd-11e6-94e8-2736a52e5ce5.png)
