### PR TITLE
Mark private messages as read when entering the inbox and syncing whi…

### DIFF
--- a/website/client/js/controllers/rootCtrl.js
+++ b/website/client/js/controllers/rootCtrl.js
@@ -22,8 +22,8 @@ habitrpg.controller("RootCtrl", ['$scope', '$rootScope', '$location', 'User', '$
         $rootScope.pageTitle = $state.current.title;
 
         if (!!fromState.name) Analytics.track({'hitType':'pageview','eventCategory':'navigation','eventAction':'navigate','page':'/#/'+toState.name});
-        // clear inbox when entering or exiting inbox tab
-        if (fromState.name=='options.social.inbox' || toState.name=='options.social.inbox') {
+        // clear inbox when entering inbox tab
+        if (toState.name=='options.social.inbox') {
           User.clearNewMessages();
         }
       });

--- a/website/client/js/services/userServices.js
+++ b/website/client/js/services/userServices.js
@@ -106,6 +106,9 @@ angular.module('habitrpg')
         .then(function (response) {
           var tasks = response.data.data;
           syncUserTasks(tasks);
+          if ($rootScope.$state && $rootScope.$state.current.name=='options.social.inbox') {
+            userServices.clearNewMessages();
+          }
           $rootScope.$emit('userSynced');
           $rootScope.appLoaded = true;
           $rootScope.$emit('userUpdated', user);


### PR DESCRIPTION
#7689
### Changes

Updating the behavior of marking private messages as read to the following:
- mark them as read when entering the inbox (already done; no change needed)
- mark them as read when a sync occurs while viewing the inbox
- do NOT mark them as read when leaving the inbox

---

UUID: 2a4d30ee-4833-420e-be7c-ad6a6e261c5f

closes #7689
