### PR TITLE
Add licensing info to readme & fix small grammar mistakes in licensing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,8 +2,9 @@
 This Source Code is subject to the terms of the GNU General Public License, v. 3.0.
 If a copy of the GPL was not distributed with this file, You can obtain one at http://www.gnu.org/licenses/gpl-3.0.txt
 
-* Assets and content designed for Mozilla BrowserQuest is licensed under CC-BY-SA 3.0:
+* Assets and content designed for Mozilla BrowserQuest are licensed under CC-BY-SA 3.0:
 http://creativecommons.org/licenses/by-sa/3.0/
 
-* Assets and content designed for HabitRPG is licensed under CC-BY-NC-SA 3.0:
+* Assets and content designed for HabitRPG are licensed under CC-BY-NC-SA 3.0:
 http://creativecommons.org/licenses/by-nc-sa/3.0/
+

--- a/README.md
+++ b/README.md
@@ -28,3 +28,8 @@ node debug-scripts/name-of-script.js
 ```
 
 If there are more arguments required to make the script work, it will print out the usage and an explanation of what the script does.
+
+## Licensing
+* The source code of Habitica is available under the [GPLv3 license](http://www.gnu.org/licenses/gpl-3.0.txt), see `LICENSE` for more information.
+* The included assets and content designed for Mozilla BrowserQuest are available under the [CC-BY-SA 3.0 license](http://creativecommons.org/licenses/by-sa/3.0/).
+* The included assets and content designed for HabitRPG are available under the [CC-BY-NC-SA 3.0 license](http://creativecommons.org/licenses/by-nc-sa/3.0/).


### PR DESCRIPTION
### Changes

Adds information on the licensing of the contents of the repo to the `README.md` file, as that information is currently only held within the `LICENSE` file which is generally used to contain the full contents of the license of a project, rather than the general licensing information. This makes it easier for contributors to see what license the project is under.

Also fixes some small grammar mistakes in the `LICENSE` file.

---

UUID: dea0a1fd-6cc3-4511-bf6f-9957c233e792
