### PR TITLE
Deduping completed tasks on load. closes #7708

### DIFF
--- a/website/client/js/controllers/tasksCtrl.js
+++ b/website/client/js/controllers/tasksCtrl.js
@@ -156,11 +156,15 @@ habitrpg.controller("TasksCtrl", ['$scope', '$rootScope', '$location', 'User','N
     $scope._today = moment().add({days: 1});
 
     $scope.loadedCompletedTodos = function () {
-      if (Tasks.loadedCompletedTodos === true) return;
+      if (Tasks.loadedCompletedTodos === true) {
+        return;
+      }
+
+      User.user.todos = _.reject(User.user.todos, 'completed')
 
       Tasks.getUserTasks(true)
         .then(function (response) {
-          User.user.todos = _.uniq(User.user.todos.concat(response.data.data), 'id');
+          User.user.todos = User.user.todos.concat(response.data.data);
           Tasks.loadedCompletedTodos = true;
         });
     }

--- a/website/client/js/controllers/tasksCtrl.js
+++ b/website/client/js/controllers/tasksCtrl.js
@@ -160,7 +160,7 @@ habitrpg.controller("TasksCtrl", ['$scope', '$rootScope', '$location', 'User','N
 
       Tasks.getUserTasks(true)
         .then(function (response) {
-          User.user.todos = User.user.todos.concat(response.data.data);
+          User.user.todos = _.uniq(User.user.todos.concat(response.data.data), 'id');
           Tasks.loadedCompletedTodos = true;
         });
     }


### PR DESCRIPTION
#7708
### Changes

This will prevent the user from seeing duplicate completed tasks. This would happen if the user completed tasks locally before loading the completed tasks tab.

---

UUID: 2a4d30ee-4833-420e-be7c-ad6a6e261c5f
