### PR TITLE
Add two unit tests for CRON_SAFE_MODE

### DIFF
--- a/test/api/v3/unit/libs/cron.test.js
+++ b/test/api/v3/unit/libs/cron.test.js
@@ -2,6 +2,7 @@
 import moment from 'moment';
 import nconf from 'nconf';
 import Bluebird from 'bluebird';
+import requireAgain from 'require-again';
 import { recoverCron, cron } from '../../../../../website/server/libs/api-v3/cron';
 import { model as User } from '../../../../../website/server/models/user';
 import * as Tasks from '../../../../../website/server/models/task';
@@ -9,6 +10,8 @@ import { clone } from 'lodash';
 import common from '../../../../../common';
 
 // const scoreTask = common.ops.scoreTask;
+
+let pathToCronLib = '../../../../../website/server/libs/api-v3/cron';
 
 describe('cron', () => {
   let user;
@@ -321,7 +324,9 @@ describe('cron', () => {
     });
 
     it('should not do damage for missing a daily when CRON_SAFE_MODE is set', () => {
-      sandbox.stub(nconf, 'get').withArgs('CRON_SAFE_MODE').returns(true);
+      sandbox.stub(nconf, 'get').withArgs('CRON_SAFE_MODE').returns('true');
+      let cron = requireAgain(pathToCronLib).cron;
+
       daysMissed = 1;
       let hpBefore = user.stats.hp;
       tasksByType.dailys[0].startDate = moment(new Date()).subtract({days: 1});
@@ -456,7 +461,8 @@ describe('cron', () => {
     });
 
     it('still grants a perfect day when CRON_SAFE_MODE is set', () => {
-      sandbox.stub(nconf, 'get').withArgs('CRON_SAFE_MODE').returns(true);
+      sandbox.stub(nconf, 'get').withArgs('CRON_SAFE_MODE').returns('true');
+      let cron = requireAgain(pathToCronLib).cron;
       daysMissed = 1;
       tasksByType.dailys[0].completed = false;
       tasksByType.dailys[0].startDate = moment(new Date()).subtract({days: 1});

--- a/test/api/v3/unit/libs/cron.test.js
+++ b/test/api/v3/unit/libs/cron.test.js
@@ -325,13 +325,13 @@ describe('cron', () => {
 
     it('should not do damage for missing a daily when CRON_SAFE_MODE is set', () => {
       sandbox.stub(nconf, 'get').withArgs('CRON_SAFE_MODE').returns('true');
-      let cron = requireAgain(pathToCronLib).cron;
+      let cronOverride = requireAgain(pathToCronLib).cron;
 
       daysMissed = 1;
       let hpBefore = user.stats.hp;
       tasksByType.dailys[0].startDate = moment(new Date()).subtract({days: 1});
 
-      cron({user, tasksByType, daysMissed, analytics});
+      cronOverride({user, tasksByType, daysMissed, analytics});
 
       expect(user.stats.hp).to.equal(hpBefore);
     });
@@ -462,14 +462,14 @@ describe('cron', () => {
 
     it('still grants a perfect day when CRON_SAFE_MODE is set', () => {
       sandbox.stub(nconf, 'get').withArgs('CRON_SAFE_MODE').returns('true');
-      let cron = requireAgain(pathToCronLib).cron;
+      let cronOverride = requireAgain(pathToCronLib).cron;
       daysMissed = 1;
       tasksByType.dailys[0].completed = false;
       tasksByType.dailys[0].startDate = moment(new Date()).subtract({days: 1});
 
       let previousBuffs = clone(user.stats.buffs);
 
-      cron({user, tasksByType, daysMissed, analytics});
+      cronOverride({user, tasksByType, daysMissed, analytics});
 
       expect(user.stats.buffs.str).to.be.greaterThan(previousBuffs.str);
       expect(user.stats.buffs.int).to.be.greaterThan(previousBuffs.int);


### PR DESCRIPTION
Fixes #7464
### Changes

This introduces two simple unit tests for `CRON_SAFE_MODE`. It's my first PR so I wanted to keep it small. I copied the style of this test from `email.test.js`, but this style of reloading strikes me as hacky, so I also wanted to clear that with a maintainer before pushing forward. If this gets through, I'll do another pass and add more than two tests :D

Tests are green.

---

UUID: 859e77a3-cb68-4cf0-8cc2-b84c9adf18ce
