### PR TITLE
fix(client): Prevent group from freezing up when sending a chat message

### DIFF
--- a/website/client/js/controllers/chatCtrl.js
+++ b/website/client/js/controllers/chatCtrl.js
@@ -34,7 +34,11 @@ habitrpg.controller('ChatCtrl', ['$scope', 'Groups', 'Chat', 'User', '$http', 'A
         .then(function(response) {
           var message = response.data.data.message;
 
-          group.chat.unshift(message);
+          if (message) {
+            group.chat.unshift(message);
+          } else {
+            group.chat = response.data.data.chat;
+          }
 
           $scope.message.content = '';
           $scope._sending = false;


### PR DESCRIPTION
The client is unable to send messages if there are new messages that haven't been loaded yet.

May fix #7407

To replicate:

1) log in to two accounts on different browsers/incognito
2) In both go to a group page
3) In one, post a message
4) In the other, without fetching new messages, post a message
5) Be sad forever
