### PR TITLE
Fixing the quest name in the previous quests scroll drop for recidivate

### DIFF
--- a/common/locales/en/questsContent.json
+++ b/common/locales/en/questsContent.json
@@ -89,9 +89,9 @@
   "questMoonstone1Text": "Recidivate, Part 1: The Moonstone Chain",
   "questMoonstone1Notes": "A terrible affliction has struck Habiticans. Bad Habits thought long-dead are rising back up with a vengeance. Dishes lie unwashed, textbooks linger unread, and procrastination runs rampant!<br><br>You track some of your own returning Bad Habits to the Swamps of Stagnation and discover the culprit: the ghostly Necromancer, Recidivate. You rush in, weapons swinging, but they slide through her specter uselessly.<br><br>\"Don’t bother,\" she hisses with a dry rasp. \"Without a chain of moonstones, nothing can harm me – and master jeweler @aurakami scattered all the moonstones across Habitica long ago!\" Panting, you retreat... but you know what you must do.",
   "questMoonstone1CollectMoonstone": "Moonstones",
-  "questMoonstone1DropMoonstone2Quest": "Recidivate, Part 2: Recidivate The Necromancer (Scroll)",
+  "questMoonstone1DropMoonstone2Quest": "Recidivate, Part 2: Recidivate the Necromancer (Scroll)",
 
-  "questMoonstone2Text": "Recidivate, Part 2: Recidivate The Necromancer",
+  "questMoonstone2Text": "Recidivate, Part 2: Recidivate the Necromancer",
   "questMoonstone2Notes": "The brave weaponsmith @Inventrix helps you fashion the enchanted moonstones into a chain. You’re ready to confront Recidivate at last, but as you enter the Swamps of Stagnation, a terrible chill sweeps over you.<br><br>Rotting breath whispers in your ear. \"Back again? How delightful...\" You spin and lunge, and under the light of the moonstone chain, your weapon strikes solid flesh. \"You may have bound me to the world once more,\" Recidivate snarls, \"but now it is time for you to leave it!\"",
   "questMoonstone2Boss": "The Necromancer",
   "questMoonstone2DropMoonstone3Quest": "Recidivate, Part 3: Recidivate Transformed (Scroll)",

--- a/common/locales/en/questsContent.json
+++ b/common/locales/en/questsContent.json
@@ -89,12 +89,12 @@
   "questMoonstone1Text": "Recidivate, Part 1: The Moonstone Chain",
   "questMoonstone1Notes": "A terrible affliction has struck Habiticans. Bad Habits thought long-dead are rising back up with a vengeance. Dishes lie unwashed, textbooks linger unread, and procrastination runs rampant!<br><br>You track some of your own returning Bad Habits to the Swamps of Stagnation and discover the culprit: the ghostly Necromancer, Recidivate. You rush in, weapons swinging, but they slide through her specter uselessly.<br><br>\"Don’t bother,\" she hisses with a dry rasp. \"Without a chain of moonstones, nothing can harm me – and master jeweler @aurakami scattered all the moonstones across Habitica long ago!\" Panting, you retreat... but you know what you must do.",
   "questMoonstone1CollectMoonstone": "Moonstones",
-  "questMoonstone1DropMoonstone2Quest": "The Moonstone Chain Part 2: Recidivate the Necromancer (Scroll)",
+  "questMoonstone1DropMoonstone2Quest": "Recidivate, Part 2: Recidivate The Necromancer (Scroll)",
 
   "questMoonstone2Text": "Recidivate, Part 2: Recidivate The Necromancer",
   "questMoonstone2Notes": "The brave weaponsmith @Inventrix helps you fashion the enchanted moonstones into a chain. You’re ready to confront Recidivate at last, but as you enter the Swamps of Stagnation, a terrible chill sweeps over you.<br><br>Rotting breath whispers in your ear. \"Back again? How delightful...\" You spin and lunge, and under the light of the moonstone chain, your weapon strikes solid flesh. \"You may have bound me to the world once more,\" Recidivate snarls, \"but now it is time for you to leave it!\"",
   "questMoonstone2Boss": "The Necromancer",
-  "questMoonstone2DropMoonstone3Quest": "The Moonstone Chain Part 3: Recidivate Transformed (Scroll)",
+  "questMoonstone2DropMoonstone3Quest": "Recidivate, Part 3: Recidivate Transformed (Scroll)",
 
   "questMoonstone3Text": "Recidivate, Part 3: Recidivate Transformed",
   "questMoonstone3Notes": "Recidivate crumples to the ground, and you strike at her with the moonstone chain. To your horror, Recidivate seizes the gems, eyes burning with triumph.<br><br>\"Foolish creature of flesh!\" she shouts. \"These moonstones will restore me to a physical form, true, but not as you imagined. As the full moon waxes from the dark, so too does my power flourish, and from the shadows I summon the specter of your most feared foe!\"<br><br>A sickly green fog rises from the swamp, and Recidivate’s body writhes and contorts into a shape that fills you with dread – the undead body of Vice, horribly reborn.",


### PR DESCRIPTION
### Changes

The recidivate quests were renamed to recidivate from the moonstone chain. When this rename happened, the quest scrolls dropped by these quests weren't updated to the new names. This updates the dropped quest scroll text to the new quest names.

---

UUID: 2a4d30ee-4833-420e-be7c-ad6a6e261c5f
