### PR TITLE
update documentation for marking chat seen

### DIFF
--- a/website/server/controllers/api-v3/chat.js
+++ b/website/server/controllers/api-v3/chat.js
@@ -305,7 +305,7 @@ api.clearChatFlags = {
 };
 
 /**
- * @api {post} /api/v3/groups/:groupId/chat/:chatId/seen Seen a group chat message
+ * @api {post} /api/v3/groups/:groupId/chat/seen Seen a group chat message
  * @apiVersion 3.0.0
  * @apiName SeenChat
  * @apiGroup Chat


### PR DESCRIPTION
Fixes put_issue_url_here
### Changes

Changed documentation for marking group/guild chat as read. The documentation included the chatId in the url, but this is not used by the api and will cause a 404 error.

---

UUID: 9173198f-4777-4a35-9f03-8aea24f51782

Documentation included the chatId in the url, but the api does not use it. Adding the chatId will cause a 404 error. The api marks all chats in the guild as read; not individual chats.
