### PR TITLE
Consolidate EB extensions

### DIFF
--- a/.ebextensions/01-increase-timeout.config
+++ b/.ebextensions/01-increase-timeout.config
@@ -1,7 +1,0 @@
-option_settings:
-  - namespace: aws:elasticbeanstalk:command
-    option_name: Timeout
-    value: 1800
-  - namespace: aws:elb:policies
-    option_name: ConnectionSettingIdleTimeout
-    value: 900

--- a/.ebextensions/deploy.config
+++ b/.ebextensions/deploy.config
@@ -1,3 +1,10 @@
+option_settings:
+  - namespace: aws:elasticbeanstalk:command
+    option_name: Timeout
+    value: 1800
+  - namespace: aws:elb:policies
+    option_name: ConnectionSettingIdleTimeout
+    value: 900
 commands:
   01_sym_node:
     command: "ln -sf $(ls -td /opt/elasticbeanstalk/node-install/node-* | head -1)/bin/node /bin/node"


### PR DESCRIPTION
### Changes

Moves the timeout configuration for deploys to Elastic Beanstalk into the same file as the rest of our specialized deploy steps. Seems to help prevent errors when sending up a new application version.

---

UUID: [Flexible Beanstalk Stretch](https://map.what3words.com/flexible.beanstalk.stretch)
