### PR TITLE
Add tests for timezoneOffsetToUtc filter

### DIFF
--- a/test/spec/filters/timezoneOffsetToUtcSpec.js
+++ b/test/spec/filters/timezoneOffsetToUtcSpec.js
@@ -1,0 +1,20 @@
+describe('timezoneOffsetToUtc', function() {
+
+  beforeEach(module('habitrpg'));
+
+  it('formats the timezone offset with a - sign if the offset is positive', inject(function(timezoneOffsetToUtcFilter) {
+    expect(timezoneOffsetToUtcFilter(90)).to.eql('UTC-1:30');
+  }));
+
+  it('formats the timezone offset with a + sign if the offset is negative', inject(function(timezoneOffsetToUtcFilter) {
+    expect(timezoneOffsetToUtcFilter(-525)).to.eql('UTC+8:45');
+  }));
+
+  it('prepends the minutes with a 0 if the minute the offset is less than 10', inject(function(timezoneOffsetToUtcFilter) {
+    expect(timezoneOffsetToUtcFilter(60)).to.eql('UTC-1:00');
+  }));
+
+  it('returns the string UTC+0:00 if the offset is 0', inject(function(timezoneOffsetToUtcFilter) {
+    expect(timezoneOffsetToUtcFilter(0)).to.eql('UTC+0:00');
+  }));
+});


### PR DESCRIPTION
Hey! I wanted to get started contributing tests to this project and I noticed the `timezoneOffsetToUtc` filter had a little logic to it and was [not already covered by tests](https://coveralls.io/builds/6838596/source?filename=website%2Fclient%2Fjs%2Ffilters%2FtimezoneOffsetToUtc.js) so I thought I'd take a swag at adding some. Let me know if you think these are useful.
### Changes

Add unit tests for the [timezoneOffsetToUtcSpec.js](https://github.com/HabitRPG/habitrpg/blob/develop/website/client/js/filters/timezoneOffsetToUtc.js) file.

---

UUID: 9e0d1dc5-3954-4ca0-9c8f-442ea3de1edc
