### PR TITLE
Allows the flagging of system messages

### DIFF
--- a/common/locales/en/generic.json
+++ b/common/locales/en/generic.json
@@ -180,5 +180,6 @@
     "raisePetShare": "I raised a pet into a mount by completing my real-life tasks!",
     "wonChallengeShare": "I won a challenge in Habitica!",
     "achievementShare": "I earned a new achievement in Habitica!",
-    "orderBy": "Order By <%= item %>"
+    "orderBy": "Order By <%= item %>",
+    "systemMessage": "System Message"
 }

--- a/website/client/js/controllers/chatCtrl.js
+++ b/website/client/js/controllers/chatCtrl.js
@@ -94,13 +94,23 @@ habitrpg.controller('ChatCtrl', ['$scope', 'Groups', 'Chat', 'User', '$http', 'A
       } else {
         $scope.abuseObject = message;
         $scope.groupId = groupId;
-        Members.selectMember(message.uuid)
-          .then(function () {
+
+        if (message.uuid === 'system') {
+            $scope.isSystemMessage = true;
             $rootScope.openModal('abuse-flag',{
               controller:'MemberModalCtrl',
               scope: $scope
             });
-          });
+        } else {
+          $scope.isSystemMessage = false;
+          Members.selectMember(message.uuid)
+            .then(function () {
+              $rootScope.openModal('abuse-flag',{
+                controller:'MemberModalCtrl',
+                scope: $scope
+              });
+            });
+        }
       }
     };
 

--- a/website/client/js/controllers/chatCtrl.js
+++ b/website/client/js/controllers/chatCtrl.js
@@ -95,14 +95,13 @@ habitrpg.controller('ChatCtrl', ['$scope', 'Groups', 'Chat', 'User', '$http', 'A
         $scope.abuseObject = message;
         $scope.groupId = groupId;
 
+        $scope.isSystemMessage = message.uuid === 'system';
         if (message.uuid === 'system') {
-            $scope.isSystemMessage = true;
             $rootScope.openModal('abuse-flag',{
               controller:'MemberModalCtrl',
               scope: $scope
             });
         } else {
-          $scope.isSystemMessage = false;
           Members.selectMember(message.uuid)
             .then(function () {
               $rootScope.openModal('abuse-flag',{

--- a/website/server/controllers/api-v3/chat.js
+++ b/website/server/controllers/api-v3/chat.js
@@ -217,7 +217,7 @@ api.flagChat = {
 
     let reporterEmailContent = getUserInfo(user, ['email']).email;
 
-    let authorEmailContent = getUserInfo(author, ['email']).email;
+    let authorEmailContent = author ? getUserInfo(author, ['email']).email : 'system';
 
     let groupUrl = getGroupUrl(group);
 

--- a/website/views/options/social/chat-message.jade
+++ b/website/views/options/social/chat-message.jade
@@ -31,7 +31,7 @@ mixin chatMessages(inbox)
         span(ng-if='#{inbox ? "true" : ":: user.contributor.admin || message.uuid == user.id"}') &nbsp; &nbsp;
           a(ng-click='#{inbox? "User.deletePM({params:{id:message.$key}})" : "deleteChatMessage(group, message)"}')
             span.glyphicon.glyphicon-trash(tooltip=env.t('delete'))
-        span(ng-if=':: user.contributor.admin || (!message.sent && user.flags.communityGuidelinesAccepted && message.uuid != user.id && message.uuid != "system")') &nbsp; &nbsp;
+        span(ng-if=':: user.contributor.admin || (!message.sent && user.flags.communityGuidelinesAccepted && message.uuid != user.id)') &nbsp; &nbsp;
           a(ng-click="flagChatMessage(group._id, message)")
             span.glyphicon.glyphicon-flag(tooltip="{{message.flags[user._id] ? env.t('abuseAlreadyReported') : env.t('abuseFlag')}}" ng-class='message.flags[user._id] ? "text-danger" : ""')
         span &nbsp; &nbsp;

--- a/website/views/shared/modals/members.jade
+++ b/website/views/shared/modals/members.jade
@@ -102,7 +102,7 @@ script(type='text/ng-template', id='modals/send-gift.html')
 
 script(type='text/ng-template', id='modals/abuse-flag.html')
   .modal-header
-    h4!=env.t('abuseFlagModalHeading', {name: "<span class='text-danger'>{{profile.profile.name}}</span>"})
+    h4!=env.t('abuseFlagModalHeading', {name: "<span class='text-danger'>{{isSystemMessage? env.t('systemMessage') : profile.profile.name}}</span>"})
   .modal-body
     blockquote
       markdown(text="abuseObject.text")

--- a/website/views/shared/modals/members.jade
+++ b/website/views/shared/modals/members.jade
@@ -102,7 +102,7 @@ script(type='text/ng-template', id='modals/send-gift.html')
 
 script(type='text/ng-template', id='modals/abuse-flag.html')
   .modal-header
-    h4!=env.t('abuseFlagModalHeading', {name: "<span class='text-danger'>{{isSystemMessage? env.t('systemMessage') : profile.profile.name}}</span>"})
+    h4!=env.t('abuseFlagModalHeading', {name: "<span class='text-danger'>{{isSystemMessage ? env.t('systemMessage') : profile.profile.name}}</span>"})
   .modal-body
     blockquote
       markdown(text="abuseObject.text")


### PR DESCRIPTION
Fixes #7767 
### Changes

Allows the flagging of system messages.

Reporting a system message:
![report system](https://cloud.githubusercontent.com/assets/17734753/16716365/5516e0c6-46af-11e6-8b24-fd99a5040b0f.png)

System message reported:
![flagged system message](https://cloud.githubusercontent.com/assets/17734753/16716367/571f8e86-46af-11e6-824d-3627cff3e237.png)

---

UUID: 2a4d30ee-4833-420e-be7c-ad6a6e261c5f
