### PR TITLE
"allCompletedTodos" option in API for returning all completed To-Dos for when 30 isn't enough

### DIFF
--- a/test/api/v3/integration/tasks/GET-tasks_user.test.js
+++ b/test/api/v3/integration/tasks/GET-tasks_user.test.js
@@ -82,7 +82,7 @@ describe('GET /tasks/user', () => {
     expect(completedTodos[completedTodos.length - 1].text).to.equal('todo to complete 2'); // last is the todo that was completed most recently
   });
 
-  it('returns completed todos sorted by reverse completion date if req.query.type is "allCompletedTodos"', async () => {
+  it('returns completed todos sorted by reverse completion date if req.query.type is "_allCompletedTodos"', async () => {
     let todo1 = await user.post('/tasks/user', {text: 'todo to complete 1', type: 'todo'});
     let todo2 = await user.post('/tasks/user', {text: 'todo to complete 2', type: 'todo'});
 
@@ -95,12 +95,12 @@ describe('GET /tasks/user', () => {
 
     expect(user.tasksOrder.todos.length).to.equal(initialTodoCount - 2);
 
-    let allCompletedTodos = await user.get('/tasks/user?type=allCompletedTodos');
+    let allCompletedTodos = await user.get('/tasks/user?type=_allCompletedTodos');
     expect(allCompletedTodos.length).to.equal(2);
     expect(allCompletedTodos[allCompletedTodos.length - 1].text).to.equal('todo to complete 2');
   });
 
-  it('returns only some completed todos if req.query.type is "completedTodos" or "allCompletedTodos"', async () => {
+  it('returns only some completed todos if req.query.type is "completedTodos" or "_allCompletedTodos"', async () => {
     const LIMIT = 30;
     let numberOfTodos = LIMIT + 1;
     let todosInput = [];
@@ -124,7 +124,7 @@ describe('GET /tasks/user', () => {
     let completedTodos = await user.get('/tasks/user?type=completedTodos');
     expect(completedTodos.length).to.equal(LIMIT);
 
-    let allCompletedTodos = await user.get('/tasks/user?type=allCompletedTodos');
+    let allCompletedTodos = await user.get('/tasks/user?type=_allCompletedTodos');
     expect(allCompletedTodos.length).to.equal(numberOfTodos);
   });
 });

--- a/test/api/v3/integration/tasks/GET-tasks_user.test.js
+++ b/test/api/v3/integration/tasks/GET-tasks_user.test.js
@@ -115,7 +115,7 @@ describe('GET /tasks/user', () => {
     for (let i = 0; i < numberOfTodos; i++) {
       let id = todos[i]._id;
 
-      await user.post(`/tasks/${id}/score/up`);
+      await user.post(`/tasks/${id}/score/up`); // eslint-disable-line babel/no-await-in-loop
     }
     await user.sync();
 

--- a/website/server/controllers/api-v3/tasks.js
+++ b/website/server/controllers/api-v3/tasks.js
@@ -208,8 +208,7 @@ api.getUserTasks = {
   middlewares: [authWithHeaders()],
   async handler (req, res) {
     let types = Tasks.tasksTypes.map(type => `${type}s`);
-    types.push('completedTodos');
-    types.push('allCompletedTodos');
+    types.push('completedTodos', 'allCompletedTodos');
     req.checkQuery('type', res.t('invalidTaskType')).optional().isIn(types);
 
     let validationErrors = req.validationErrors();

--- a/website/server/controllers/api-v3/tasks.js
+++ b/website/server/controllers/api-v3/tasks.js
@@ -143,12 +143,17 @@ async function _getTasks (req, res, user, challenge) {
     if (type === 'todos') {
       query.completed = false; // Exclude completed todos
       query.type = 'todo';
-    } else if (type === 'completedTodos') {
+    } else if (type === 'completedTodos' || type === 'allCompletedTodos') {
+      let limit = 30;
+
+      if (type === 'allCompletedTodos') {
+        limit = 0; // no limit
+      }
       query = Tasks.Task.find({
         userId: user._id,
         type: 'todo',
         completed: true,
-      }).limit(30).sort({ // TODO add ability to pick more than 30 completed todos
+      }).limit(limit).sort({
         dateCompleted: -1,
       });
     } else {
@@ -164,7 +169,7 @@ async function _getTasks (req, res, user, challenge) {
   let tasks = await Tasks.Task.find(query).exec();
 
   // Order tasks based on tasksOrder
-  if (type && type !== 'completedTodos') {
+  if (type && type !== 'completedTodos' && type !== 'allCompletedTodos') {
     let order = (challenge || user).tasksOrder[type];
     let orderedTasks = new Array(tasks.length);
     let unorderedTasks = []; // what we want to add later
@@ -193,7 +198,7 @@ async function _getTasks (req, res, user, challenge) {
  * @apiName GetUserTasks
  * @apiGroup Task
  *
- * @apiParam {string="habits","dailys","todos","rewards","completedTodos"} type Optional query parameter to return just a type of tasks. By default all types will be returned except completed todos that must be requested separately.
+ * @apiParam {string="habits","dailys","todos","rewards","completedTodos","allCompletedTodos"} type Optional query parameter to return just a type of tasks. By default all types will be returned except completed todos that must be requested separately. The "completedTodos" type returns only the 30 most recently completed (best for performance if you don't need them all).
  *
  * @apiSuccess {Array} data An array of tasks
  */
@@ -204,6 +209,7 @@ api.getUserTasks = {
   async handler (req, res) {
     let types = Tasks.tasksTypes.map(type => `${type}s`);
     types.push('completedTodos');
+    types.push('allCompletedTodos');
     req.checkQuery('type', res.t('invalidTaskType')).optional().isIn(types);
 
     let validationErrors = req.validationErrors();

--- a/website/server/controllers/api-v3/tasks.js
+++ b/website/server/controllers/api-v3/tasks.js
@@ -143,10 +143,10 @@ async function _getTasks (req, res, user, challenge) {
     if (type === 'todos') {
       query.completed = false; // Exclude completed todos
       query.type = 'todo';
-    } else if (type === 'completedTodos' || type === 'allCompletedTodos') {
+    } else if (type === 'completedTodos' || type === '_allCompletedTodos') { // _allCompletedTodos is currently in BETA and is likely to be removed in future
       let limit = 30;
 
-      if (type === 'allCompletedTodos') {
+      if (type === '_allCompletedTodos') {
         limit = 0; // no limit
       }
       query = Tasks.Task.find({
@@ -169,7 +169,7 @@ async function _getTasks (req, res, user, challenge) {
   let tasks = await Tasks.Task.find(query).exec();
 
   // Order tasks based on tasksOrder
-  if (type && type !== 'completedTodos' && type !== 'allCompletedTodos') {
+  if (type && type !== 'completedTodos' && type !== '_allCompletedTodos') {
     let order = (challenge || user).tasksOrder[type];
     let orderedTasks = new Array(tasks.length);
     let unorderedTasks = []; // what we want to add later
@@ -198,7 +198,7 @@ async function _getTasks (req, res, user, challenge) {
  * @apiName GetUserTasks
  * @apiGroup Task
  *
- * @apiParam {string="habits","dailys","todos","rewards","completedTodos","allCompletedTodos"} type Optional query parameter to return just a type of tasks. By default all types will be returned except completed todos that must be requested separately. The "completedTodos" type returns only the 30 most recently completed (best for performance if you don't need them all).
+ * @apiParam {string="habits","dailys","todos","rewards","completedTodos"} type Optional query parameter to return just a type of tasks. By default all types will be returned except completed todos that must be requested separately. The "completedTodos" type returns only the 30 most recently completed.
  *
  * @apiSuccess {Array} data An array of tasks
  */
@@ -208,7 +208,7 @@ api.getUserTasks = {
   middlewares: [authWithHeaders()],
   async handler (req, res) {
     let types = Tasks.tasksTypes.map(type => `${type}s`);
-    types.push('completedTodos', 'allCompletedTodos');
+    types.push('completedTodos', '_allCompletedTodos'); // _allCompletedTodos is currently in BETA and is likely to be removed in future
     req.checkQuery('type', res.t('invalidTaskType')).optional().isIn(types);
 
     let validationErrors = req.validationErrors();


### PR DESCRIPTION
**EDIT:   An important note for anyone thinking of using this new feature: We will be changing how it works in a few days. The `_allCompletedTodos` option will be removed. It will be replaced by a different method of specifying that you want to return all completed To-Dos at once. It is recommended that you do NOT use `_allCompletedTodos`**

Fixes https://github.com/HabitRPG/habitrpg/issues/7301
### Changes

Adds a new option to the `tasks/user` route to allow returning all completed To-Dos at once, as suggested by paglias at https://github.com/HabitRPG/habitrpg/issues/7301#issuecomment-223800764

This is NOT ready for merging. There's a lint error in the test at `await user.post(`/tasks/${id}/score/up`);` because it's in a loop and I suspect you'll want the final test `it('returns only some completed todos if req.query.type is "completedTodos" or "allCompletedTodos"'` broken up into two, one for each option. However I want to see if the basic approach is okay before I finish off the details.
