### PR TITLE
Fixing Duplicate tasks showing up after joining a challenge

### DIFF
--- a/website/client-old/js/controllers/challengesCtrl.js
+++ b/website/client-old/js/controllers/challengesCtrl.js
@@ -320,7 +320,7 @@ habitrpg.controller("ChallengesCtrl", ['$rootScope','$scope', 'Shared', 'User', 
     */
 
     $scope.join = function (challenge) {
-      challenge._joiningInProgress = false;
+      challenge._joiningInProgress = true;
       Challenges.joinChallenge(challenge._id)
         .then(function (response) {
           User.user.challenges.push(challenge._id);
@@ -330,8 +330,8 @@ habitrpg.controller("ChallengesCtrl", ['$rootScope','$scope', 'Shared', 'User', 
         .then(function (response) {
           var tasks = response.data.data;
           User.syncUserTasks(tasks);
+          challenge._joiningInProgress = false;
         });
-      challenge._joiningInProgress = true;
     }
 
     $scope.leave = function(keep, challenge) {

--- a/website/client-old/js/controllers/challengesCtrl.js
+++ b/website/client-old/js/controllers/challengesCtrl.js
@@ -320,6 +320,7 @@ habitrpg.controller("ChallengesCtrl", ['$rootScope','$scope', 'Shared', 'User', 
     */
 
     $scope.join = function (challenge) {
+      challenge._joiningInProgress = false;
       Challenges.joinChallenge(challenge._id)
         .then(function (response) {
           User.user.challenges.push(challenge._id);
@@ -330,6 +331,7 @@ habitrpg.controller("ChallengesCtrl", ['$rootScope','$scope', 'Shared', 'User', 
           var tasks = response.data.data;
           User.syncUserTasks(tasks);
         });
+      challenge._joiningInProgress = true;
     }
 
     $scope.leave = function(keep, challenge) {

--- a/website/server/models/challenge.js
+++ b/website/server/models/challenge.js
@@ -79,8 +79,11 @@ schema.methods.syncToUser = async function syncChallengeToUser (user) {
   challenge.shortName = challenge.shortName || challenge.name;
 
   // Add challenge to user.challenges
-  if (!_.contains(user.challenges, challenge._id)) user.challenges.push(challenge._id);
-
+  if (!_.contains(user.challenges, challenge._id)) {
+    // using concat because mongoose's protection against concurrent array modification isn't working as expected.
+    // see https://github.com/HabitRPG/habitrpg/pull/7787#issuecomment-232972394
+    user.challenges = user.challenges.concat([challenge._id]);
+  }
   // Sync tags
   let userTags = user.tags;
   let i = _.findIndex(userTags, {id: challenge._id});

--- a/website/views/options/social/challenges.jade
+++ b/website/views/options/social/challenges.jade
@@ -202,7 +202,7 @@ script(type='text/ng-template', id='partials/options.social.challenges.html')
                   a.btn.btn-sm.btn-danger(ng-show='isUserMemberOf(challenge)', ng-click='clickLeave(challenge, $event)')
                     span.glyphicon.glyphicon-ban-circle
                     =env.t('leave')
-                  a.btn.btn-sm.btn-success(ng-hide='isUserMemberOf(challenge)', ng-click='join(challenge)')
+                  a.btn.btn-sm.btn-success(ng-hide='isUserMemberOf(challenge)', ng-click='join(challenge)', ng-disabled='challenge._joiningInProgress')
                     span.glyphicon.glyphicon-ok
                     =env.t('join')
               a.accordion-toggle(id="{{challenge._id}}" ng-click='toggle(challenge._id)')


### PR DESCRIPTION
Fixes #7730 
### Changes

Double clicking the join button on a challenge will no longer result in the user showing duplicate tasks.

Switched from mongoose's save method to an update method which should prevent the save from using a diff which was the cause of the new item being saved twice.

---

UUID: 2a4d30ee-4833-420e-be7c-ad6a6e261c5f

closes #7730
