### PR TITLE
Say "Invitation Sent" if only one invitation was sent, and add multiple UUID invites

### DIFF
--- a/common/locales/en/groups.json
+++ b/common/locales/en/groups.json
@@ -136,6 +136,7 @@
     "inviteNewUsers": "Invite New Users",
     "sendInvitations": "Send Invitations",
     "invitationsSent": "Invitations sent!",
+    "invitationSent": "Invitation sent!",
     "inviteAlertInfo2": "Or share this link (copy/paste):",
     "sendGiftHeading": "Send Gift to <%= name %>",
     "sendGiftGemsBalance": "From <%= number %> Gems",

--- a/website/client/js/controllers/inviteToGroupCtrl.js
+++ b/website/client/js/controllers/inviteToGroupCtrl.js
@@ -44,8 +44,13 @@ habitrpg.controller('InviteToGroupCtrl', ['$scope', '$rootScope', 'User', 'Group
 
       Groups.Group.invite($scope.group._id, invitationDetails)
         .then(function() {
-          Notification.text(window.env.t('invitationsSent'));
-          _resetInvitees();
+           if ((inviteMethod === 'email' && invitationDetails.emails.length > 1) || (inviteMethod === 'uuid' && invitationDetails.uuids.length > 1)) { // test if it's inviting more than 1 emails or uuid
+                Notification.text(window.env.t('invitationsSent'));
+            }
+            else {
+                Notification.text(window.env.t('invitationSent'));
+            }
+            _resetInvitees();
 
           if ($scope.group.type === 'party') {
             $rootScope.hardRedirect('/#/options/groups/party');

--- a/website/client/js/controllers/inviteToGroupCtrl.js
+++ b/website/client/js/controllers/inviteToGroupCtrl.js
@@ -43,8 +43,9 @@ habitrpg.controller('InviteToGroupCtrl', ['$scope', '$rootScope', 'User', 'Group
       }
 
       Groups.Group.invite($scope.group._id, invitationDetails)
-        .then(function() {
-           if ((inviteMethod === 'email' && invitationDetails.emails.length > 1) || (inviteMethod === 'uuid' && invitationDetails.uuids.length > 1)) { // test if it's inviting more than 1 emails or uuid
+        .then(function () {
+           var invitesSent = invitationDetails.emails || invitationDetails.uuids;
+           if (invitesSent.length > 1){
                 Notification.text(window.env.t('invitationsSent'));
             }
             else {

--- a/website/views/shared/modals/invite-friends.jade
+++ b/website/views/shared/modals/invite-friends.jade
@@ -12,10 +12,10 @@ script(type='text/ng-template', id='modals/invite-guild.html')
           tr(ng-repeat='user in invitees track by $index')
             td
               input.form-control(type='text', ng-model='user.uuid')
-          tr
+           tr
             td
               a.btn.btn-xs.pull-right(ng-click='addUuid()')
-                i.glyphicon.glyphicon-plus
+               i.glyphicon.glyphicon-plus
           tr
             td
               .col-sm-4.col-sm-offset-8

--- a/website/views/shared/modals/invite-friends.jade
+++ b/website/views/shared/modals/invite-friends.jade
@@ -12,11 +12,10 @@ script(type='text/ng-template', id='modals/invite-guild.html')
           tr(ng-repeat='user in invitees track by $index')
             td
               input.form-control(type='text', ng-model='user.uuid')
-          //- @TODO: Refactor src/controllers/groups api.invite to use promises before implimenting this
-          //- tr
-          //-   td
-          //-     a.btn.btn-xs.pull-right(ng-click='addUuid()')
-          //-       i.glyphicon.glyphicon-plus
+          tr
+            td
+              a.btn.btn-xs.pull-right(ng-click='addUuid()')
+                i.glyphicon.glyphicon-plus
           tr
             td
               .col-sm-4.col-sm-offset-8
@@ -91,11 +90,10 @@ script(type='text/ng-template', id='modals/invite-party.html')
               tr(ng-repeat='user in invitees track by $index')
                 td
                   input.form-control(type='text', ng-model='user.uuid')
-              //- @TODO: Refactor src/controllers/groups api.invite to use promises before implimenting this
-              //- tr
-              //-   td
-              //-     a.btn.btn-xs.pull-right(ng-click='addUuid()')
-              //-       i.glyphicon.glyphicon-plus
+              tr
+                td
+                  a.btn.btn-xs.pull-right(ng-click='addUuid()')
+                   i.glyphicon.glyphicon-plus
               tr
                 td
                   .col-sm-4.col-sm-offset-8


### PR DESCRIPTION
Fixes https://github.com/HabitRPG/habitrpg/issues/7789
### Changes

Added the string "invitationSent": "Invitation sent!" in the groups.json file

In the inviteToGroupCtrl.js file, added a test to check if more than 1 invite is being sent to choose which string will be used in the notification, plural or singular.

In the invite-friends.jade file, removed //- on the already existing code to enable multiple UUID invites for party and guild..

Tested locally using three accounts, worked on the following tests for both party and guild:
Inviting one by UUID;
Inviting two by UUID;
Inviting one by email;
Inviting two by email.

![2016-07-16](https://cloud.githubusercontent.com/assets/20071290/16894509/b2bda4de-4b2e-11e6-8956-d4186afc7fa9.png)

![2016-07-16 1](https://cloud.githubusercontent.com/assets/20071290/16929445/395f30d0-4d0e-11e6-975b-c39517a354ef.png)

![2016-07-18](https://cloud.githubusercontent.com/assets/20071290/16929469/4c10a510-4d0e-11e6-9e32-59c3f256a778.png)

---

UUID: 8389891a-ba52-4580-b08b-2cb706c7e0b4
