### PR TITLE
fix: removing party invitations

### DIFF
--- a/test/api/v3/integration/groups/POST-groups_id_removeMember.test.js
+++ b/test/api/v3/integration/groups/POST-groups_id_removeMember.test.js
@@ -120,11 +120,13 @@ describe('POST /groups/:groupId/removeMember/:memberId', () => {
     });
 
     it('can remove other invites', async () => {
+      expect(partyInvitedUser.invitations.party).to.not.be.empty;
+
       await partyleader.post(`/groups/${party._id}/removeMember/${partyInvitedUser._id}`);
 
       let invitedUserWithoutInvite = await partyInvitedUser.get('/user');
 
-      expect(_.findIndex(invitedUserWithoutInvite.invitations.party, {id: party._id})).eql(-1);
+      expect(invitedUserWithoutInvite.invitations.party).to.be.empty;
     });
   });
 });

--- a/test/helpers/api-integration/v3/object-generators.js
+++ b/test/helpers/api-integration/v3/object-generators.js
@@ -128,9 +128,7 @@ export async function createAndPopulateGroup (settings = {}) {
 
   await Bluebird.all(invitationPromises);
 
-  await Bluebird.all(invitees.map((invitee) => {
-    return invitee.sync();
-  }));
+  await Bluebird.map(invitees, (invitee) => invitee.sync());
 
   return {
     groupLeader,

--- a/test/helpers/api-integration/v3/object-generators.js
+++ b/test/helpers/api-integration/v3/object-generators.js
@@ -128,6 +128,10 @@ export async function createAndPopulateGroup (settings = {}) {
 
   await Bluebird.all(invitationPromises);
 
+  await Bluebird.all(invitees.map((invitee) => {
+    return invitee.sync();
+  }));
+
   return {
     groupLeader,
     group,

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -466,8 +466,8 @@ api.removeGroupMember = {
         removeFromArray(member.invitations.guilds, { id: group._id });
       }
       if (isInvited === 'party') {
-        user.invitations.party = {};
-        user.markModified('invitations.party');
+        member.invitations.party = {};
+        member.markModified('invitations.party');
       }
     } else {
       throw new NotFound(res.t('groupMemberNotFound'));
@@ -514,6 +514,7 @@ async function _inviteByUUID (uuid, group, inviter, req, res) {
     }
 
     userToInvite.invitations.party = {id: group._id, name: group.name, inviter: inviter._id};
+    return userToInvite.save();
   }
 
   let groupLabel = group.type === 'guild' ? 'Guild' : 'Party';

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -514,7 +514,6 @@ async function _inviteByUUID (uuid, group, inviter, req, res) {
     }
 
     userToInvite.invitations.party = {id: group._id, name: group.name, inviter: inviter._id};
-    return userToInvite.save();
   }
 
   let groupLabel = group.type === 'guild' ? 'Guild' : 'Party';


### PR DESCRIPTION
closes #7793 
### Changes

Fixed mistake party invitation removal code. Also fixed bug in object generator that prevented the invitees of a group from being correctly populated. 

Also did some test driven development to figure out why the existing test didn't catch this behavior before. It looks like the test was expecting the party invitations to be an array instead of an object.

In looking in the invite groups method in groups of the server controllers, I noticed that the post request awaits the return value of _inviteToGroup but it wasn't returning anything before so I fixed that as well.

---

UUID: 2a4d30ee-4833-420e-be7c-ad6a6e261c5f
