### PR TITLE
WIP: Monthlies

### DIFF
--- a/common/script/cron.js
+++ b/common/script/cron.js
@@ -5,6 +5,7 @@
   ------------------------------------------------------
  */
 import _ from 'lodash';
+import reverse from 'lodash.reverse';
 import moment from 'moment';
 
 export const DAY_MAPPING = {
@@ -88,17 +89,17 @@ export function daysSince (yesterday, options = {}) {
   Should the user do this task on this date, given the task's repeat options and user.preferences.dayStart?
  */
 
-function _lastCompletedCheck (dailyHistory) {
-  _.reverse(dailyHistory); // Work in reverse chronological order
+function _missedLastDueCheck (dailyHistory) {
+  reverse(dailyHistory); // Work in reverse chronological order
   let nextIndex = 1;
   for (let entry of dailyHistory) {
     if (!dailyHistory[nextIndex]) {
-      return false; // History is empty or value static throughout; Daily was never completed or failed
+      return true; // History is empty or value static throughout; Daily was never completed or failed
     }
     if (entry.value < dailyHistory[nextIndex].value) {
-      return false; // We've found a value lower than the next older one in dailyHistory; Daily was failed
+      return true; // We've found a value lower than the next older one in dailyHistory; Daily was failed
     } else if (entry.value > dailyHistory[nextIndex].value) {
-      return true; // We've found a value higher than the next older one in dailyHistory; Daily was completed
+      return false; // We've found a value higher than the next older one in dailyHistory; Daily was completed
     } else nextIndex++; // Values are equal; Daily was skipped that day. Keep looking
   }
 }
@@ -132,7 +133,7 @@ export function shouldDo (day, dailyTask, options = {}) {
     if (intervalsSinceTaskStart % dailyTask.everyX === 0) {
       return true;
     } else if (activeUntilCompleted) {
-      return _lastCompletedCheck(dailyTask.history);
+      return _missedLastDueCheck(dailyTask.history);
     } else {
       return false;
     }

--- a/common/script/cron.js
+++ b/common/script/cron.js
@@ -88,6 +88,21 @@ export function daysSince (yesterday, options = {}) {
   Should the user do this task on this date, given the task's repeat options and user.preferences.dayStart?
  */
 
+function _lastCompletedCheck (dailyHistory) {
+  _.reverse(dailyHistory); // Work in reverse chronological order
+  let nextIndex = 1;
+  for (let entry of dailyHistory) {
+    if (!dailyHistory[nextIndex]) {
+      return false; // History is empty or value static throughout; Daily was never completed or failed
+    }
+    if (entry.value < dailyHistory[nextIndex].value) {
+      return false; // We've found a value lower than the next older one in dailyHistory; Daily was failed
+    } else if (entry.value > dailyHistory[nextIndex].value) {
+      return true; // We've found a value higher than the next older one in dailyHistory; Daily was completed
+    } else nextIndex++; // Values are equal; Daily was skipped that day. Keep looking
+  }
+}
+
 export function shouldDo (day, dailyTask, options = {}) {
   if (dailyTask.type !== 'daily') {
     return false;
@@ -104,14 +119,26 @@ export function shouldDo (day, dailyTask, options = {}) {
   if (taskStartDate > startOfDayWithCDSTime.startOf('day')) {
     return false; // Daily starts in the future
   }
-  if (dailyTask.frequency === 'daily') { // "Every X Days"
+  let frequency = dailyTask.frequency;
+  let activeUntilCompleted = dailyTask.activeUntilCompleted || false;
+
+  if (frequency === 'daily') { // "Every X Intervals"
     if (!dailyTask.everyX) {
       return false; // error condition
     }
-    let daysSinceTaskStart = startOfDayWithCDSTime.startOf('day').diff(taskStartDate, 'days');
+    let intervalUnit = dailyTask.intervalUnit || 'days';
+    let intervalsSinceTaskStart = startOfDayWithCDSTime.startOf('day').diff(taskStartDate, intervalUnit);
 
-    return daysSinceTaskStart % dailyTask.everyX === 0;
-  } else if (dailyTask.frequency === 'weekly') { // "On Certain Days of the Week"
+    if (intervalsSinceTaskStart % dailyTask.everyX === 0) {
+      return true;
+    } else if (activeUntilCompleted) {
+      return _lastCompletedCheck(dailyTask.history);
+    } else {
+      return false;
+    }
+  /* } else if (frequency === 'sinceCompletion') {
+  } else if (frequency === 'timesInInterval') { */
+  } else if (frequency === 'weekly') { // "On Certain Days of the Week"
     if (!dailyTask.repeat) {
       return false; // error condition
     }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "jade": "~1.11.0",
     "js2xmlparser": "~1.0.0",
     "lodash": "^3.10.1",
+    "lodash.reverse": "^4.0.1",
     "lodash.setwith": "^4.2.0",
     "markdown-it": "^6.0.1",
     "merge-stream": "^1.0.0",

--- a/website/server/models/task.js
+++ b/website/server/models/task.js
@@ -243,13 +243,18 @@ export let HabitSchema = new Schema(_.defaults({
 export let habit = Task.discriminator('habit', HabitSchema);
 
 export let DailySchema = new Schema(_.defaults({
-  frequency: {type: String, default: 'weekly', enum: ['daily', 'weekly']},
+  frequency: {type: String, default: 'weekly', enum: ['daily', 'weekly', 'sinceCompletion', 'timesInInterval']}, // 'Every X Interval', 'Certain Days of the Week', 'Every X Interval Since Completion', 'Y Times in X Interval'
   everyX: {type: Number, default: 1}, // e.g. once every X weeks
+  completionTarget: {type: Number, default: 1}, // the Y in 'Y Times in X Interval'. How many successes are needed in the timeframe
+  intervalUnit: {type: String, default: 'days', enum: ['days', 'weeks', 'months', 'years'], // The 'Interval' in most frequencies
   startDate: {
     type: Date,
     default () {
       return moment().startOf('day').toDate();
     },
+  },
+  schedule: {type: Schema.Types.Mixed, default: () => {
+    return {};
   },
   repeat: { // used only for 'weekly' frequency,
     m: {type: Boolean, default: true},
@@ -260,6 +265,7 @@ export let DailySchema = new Schema(_.defaults({
     s: {type: Boolean, default: true},
     su: {type: Boolean, default: true},
   },
+  activeUntilCompleted: {type: Boolean, default: false},
   streak: {type: Number, default: 0},
 }, habitDailySchema(), dailyTodoSchema()), subDiscriminatorOptions);
 export let daily = Task.discriminator('daily', DailySchema);

--- a/website/server/models/task.js
+++ b/website/server/models/task.js
@@ -255,7 +255,7 @@ export let DailySchema = new Schema(_.defaults({
   },
   schedule: {type: Schema.Types.Mixed, default: () => {
     return {};
-  },
+  }},
   repeat: { // used only for 'weekly' frequency,
     m: {type: Boolean, default: true},
     t: {type: Boolean, default: true},

--- a/website/server/models/task.js
+++ b/website/server/models/task.js
@@ -246,7 +246,7 @@ export let DailySchema = new Schema(_.defaults({
   frequency: {type: String, default: 'weekly', enum: ['daily', 'weekly', 'sinceCompletion', 'timesInInterval']}, // 'Every X Interval', 'Certain Days of the Week', 'Every X Interval Since Completion', 'Y Times in X Interval'
   everyX: {type: Number, default: 1}, // e.g. once every X weeks
   completionTarget: {type: Number, default: 1}, // the Y in 'Y Times in X Interval'. How many successes are needed in the timeframe
-  intervalUnit: {type: String, default: 'days', enum: ['days', 'weeks', 'months', 'years'], // The 'Interval' in most frequencies
+  intervalUnit: {type: String, default: 'days', enum: ['days', 'weeks', 'months', 'years']}, // The 'Interval' in most frequencies
   startDate: {
     type: Date,
     default () {

--- a/website/server/models/task.js
+++ b/website/server/models/task.js
@@ -244,8 +244,8 @@ export let habit = Task.discriminator('habit', HabitSchema);
 
 export let DailySchema = new Schema(_.defaults({
   frequency: {
-    type: String, 
-    default: 'weekly', 
+    type: String,
+    default: 'weekly',
     enum: [
       'daily', // Every X Interval
       'weekly', // Certain Days of the Week
@@ -256,12 +256,12 @@ export let DailySchema = new Schema(_.defaults({
   everyX: {type: Number, default: 1}, // e.g. once every X weeks
   completionTarget: {type: Number, default: 1}, // the Y in 'Y Times in X Interval'. How many successes are needed in the timeframe
   intervalUnit: { // The 'Interval' in most frequencies
-    type: String, 
-    default: 'days', 
+    type: String,
+    default: 'days',
     enum: [
-      'days', 
-      'weeks', 
-      'months', 
+      'days',
+      'weeks',
+      'months',
       'years',
     ],
   },

--- a/website/server/models/task.js
+++ b/website/server/models/task.js
@@ -243,10 +243,28 @@ export let HabitSchema = new Schema(_.defaults({
 export let habit = Task.discriminator('habit', HabitSchema);
 
 export let DailySchema = new Schema(_.defaults({
-  frequency: {type: String, default: 'weekly', enum: ['daily', 'weekly', 'sinceCompletion', 'timesInInterval']}, // 'Every X Interval', 'Certain Days of the Week', 'Every X Interval Since Completion', 'Y Times in X Interval'
+  frequency: {
+    type: String, 
+    default: 'weekly', 
+    enum: [
+      'daily', // Every X Interval
+      'weekly', // Certain Days of the Week
+      'sinceCompletion', // Every X Interval Since Completion
+      'timesInInterval', // Y Times in X Interval
+    ],
+  },
   everyX: {type: Number, default: 1}, // e.g. once every X weeks
   completionTarget: {type: Number, default: 1}, // the Y in 'Y Times in X Interval'. How many successes are needed in the timeframe
-  intervalUnit: {type: String, default: 'days', enum: ['days', 'weeks', 'months', 'years']}, // The 'Interval' in most frequencies
+  intervalUnit: { // The 'Interval' in most frequencies
+    type: String, 
+    default: 'days', 
+    enum: [
+      'days', 
+      'weeks', 
+      'months', 
+      'years',
+    ],
+  },
   startDate: {
     type: Date,
     default () {

--- a/website/server/models/task.js
+++ b/website/server/models/task.js
@@ -247,10 +247,10 @@ export let DailySchema = new Schema(_.defaults({
     type: String,
     default: 'weekly',
     enum: [
-      'daily', // Every X Interval
+      'daily', // Every X Intervals
       'weekly', // Certain Days of the Week
       'sinceCompletion', // Every X Interval Since Completion
-      'timesInInterval', // Y Times in X Interval
+      'timesInInterval', // Y Times in X Intervals
     ],
   },
   everyX: {type: Number, default: 1}, // e.g. once every X weeks
@@ -271,9 +271,12 @@ export let DailySchema = new Schema(_.defaults({
       return moment().startOf('day').toDate();
     },
   },
-  schedule: {type: Schema.Types.Mixed, default: () => {
-    return {};
-  }},
+  nextActive: {
+    type: Date,
+    default () {
+      return moment().startOf('day').toDate();
+    },
+  },
   repeat: { // used only for 'weekly' frequency,
     m: {type: Boolean, default: true},
     t: {type: Boolean, default: true},

--- a/website/views/shared/tasks/edit/dailies/repeat_options.jade
+++ b/website/views/shared/tasks/edit/dailies/repeat_options.jade
@@ -26,3 +26,7 @@ ng-form.form-group(name='everyX' ng-if='task.frequency=="daily"')
     +dayOfWeek('th', 4)
     +dayOfWeek('f', 5)
     +dayOfWeek('s', 6)
+
+label.checkbox
+  input(type='checkbox', ng-model='task.activeUntilCompleted', ng-click='saveTask(task, true, false)')
+  p Active until completed 


### PR DESCRIPTION
### Changes

Implementation of much more sophisticated scheduling for when Dailies are active. (more thorough description coming soon)
### To Do
- [ ] Save off Dailies schedule in `_createTasks` of website/server/controllers/api-v3/tasks.js
- [ ] Cap non-subscribers' evaluation period for "Y times in X interval" at 30 days / 4 weeks / 1 month
- [ ] Check new schedule logic in `shouldDo` of common/script/cron.js

---

UUID: [Daily Monthly Yearly](https://map.what3words.com/daily.monthly.yearly)
