### PR TITLE
Xp bar overfilled clarification

### DIFF
--- a/common/locales/en/character.json
+++ b/common/locales/en/character.json
@@ -104,6 +104,7 @@
     "characterBuild": "Character Build",
     "class": "Class",
     "experience": "Experience",
+    "canLevelUp": "Complete a Task to Level Up!",
     "warrior": "Warrior",
     "healer": "Healer",
     "rogue": "Rogue",

--- a/test/spec/services/statServicesSpec.js
+++ b/test/spec/services/statServicesSpec.js
@@ -139,22 +139,23 @@ describe('Stats Service', function() {
   });
 
   describe('canLevelUp', function() {
-  	it('returns true if a user has enough exp to level up', function() {
-  		user.stats.exp = 150;
-  		user.stats.lvl = 1;
-  		var canLevelUp = statCalc.canLevelUp(user);
+    it('returns true if a user has enough exp to level up', function() {
+      user.stats.exp = 150;
+      user.stats.lvl = 1;
+      var canLevelUp = statCalc.canLevelUp(user);
 
-  		expect(canLevelUp).to.eql(true);
-  	});
+      expect(canLevelUp).to.eql(true);
+    });
 
-  	it('returns false if a user doesn\'t have enough exp to level up', function() {
-  		user.stats.exp = 149;
-  		user.stats.lvl = 1;
-  		var canLevelUp = statCalc.canLevelUp(user);
+    it('returns false if a user doesn\'t have enough exp to level up', function() {
+      user.stats.exp = 149;
+      user.stats.lvl = 1;
+      var canLevelUp = statCalc.canLevelUp(user);
 
-  		expect(canLevelUp).to.eql(false);
-  	});
+      expect(canLevelUp).to.eql(false);
+    });
   });
+
   describe('equipmentStatBonus', function() {
     it('tallies up stats from equipment that is equipped', function() {
       var equippedGear = {

--- a/test/spec/services/statServicesSpec.js
+++ b/test/spec/services/statServicesSpec.js
@@ -138,6 +138,23 @@ describe('Stats Service', function() {
     });
   });
 
+  describe('canLevelUp', function() {
+  	it('returns true if a user has enough exp to level up', function() {
+  		user.stats.exp = 150;
+  		user.stats.lvl = 1;
+  		var canLevelUp = statCalc.canLevelUp(user);
+
+  		expect(canLevelUp).to.eql(true);
+  	});
+
+  	it('returns false if a user doesn\'t have enough exp to level up', function() {
+  		user.stats.exp = 149;
+  		user.stats.lvl = 1;
+  		var canLevelUp = statCalc.canLevelUp(user);
+
+  		expect(canLevelUp).to.eql(false);
+  	});
+  });
   describe('equipmentStatBonus', function() {
     it('tallies up stats from equipment that is equipped', function() {
       var equippedGear = {

--- a/website/client/js/services/statServices.js
+++ b/website/client/js/services/statServices.js
@@ -131,6 +131,6 @@
       mountMasterProgress: mountMasterProgress,
       mpDisplay: mpDisplay,
       totalCount: totalCount
-    }
+    };
   }
 }());

--- a/website/client/js/services/statServices.js
+++ b/website/client/js/services/statServices.js
@@ -61,6 +61,13 @@
       return display;
     }
 
+    function canLevelUp(user) {
+      var exp = Math.floor(user.stats.exp);
+      var toNextLevel = Shared.tnl(user.stats.lvl);
+
+      return (exp - toNextLevel) >= 0;
+    }
+
     function goldDisplay(gold) {
       var display = Math.floor(gold);
       return display;
@@ -117,6 +124,7 @@
       classBonus: classBonus,
       equipmentStatBonus: equipmentStatBonus,
       expDisplay: expDisplay,
+      canLevelUp: canLevelUp,
       goldDisplay: goldDisplay,
       hpDisplay: hpDisplay,
       levelBonus: levelBonus,

--- a/website/views/shared/header/header.jade
+++ b/website/views/shared/header/header.jade
@@ -23,7 +23,6 @@
             a(ng-click='toggleChart("exp")').glyphicon.glyphicon-signal
           span
           | {{statCalc.expDisplay(user)}}
-      span(ng-show='statCalc.canLevelUp(user)' class="visible-xs pull-right")=env.t('canLevelUp')
       .meter-label(tooltip=env.t('mana'), ng-if='user.flags.classSelected && !user.preferences.disableClasses')
         span.glyphicon.glyphicon-fire
       .meter.mana(ng-if='user.flags.classSelected && !user.preferences.disableClasses', tooltip='{{Math.round(user.stats.mp * 100) / 100}}')
@@ -31,6 +30,7 @@
         span.meter-text.value
           span
           | {{statCalc.mpDisplay(user)}}
+      span(ng-show='statCalc.canLevelUp(user)' class="visible-xs pull-right")=env.t('canLevelUp')
     // party
     .party(ng-controller='PartyCtrl')
       button.party-invite.btn.btn-primary(ng-click="inviteOrStartParty(party)",

--- a/website/views/shared/header/header.jade
+++ b/website/views/shared/header/header.jade
@@ -1,9 +1,9 @@
 .header-wrap(ng-controller='HeaderCtrl')
   a.label.label-default.undo-button(x-bind='click:undo', ng-show='_undo')=env.t('undo')
 
-  header.site-header(ng-hide='user.preferences.hideHeader', role='banner', data-partysize='{{party.members.length>1 ? truarr(party.members.length) : 0}}')
+  header.site-header(ng-controller='UserCtrl', ng-hide='user.preferences.hideHeader', role='banner', data-partysize='{{party.members.length>1 ? truarr(party.members.length) : 0}}')
     // avatar
-    .herobox-wrap.main-herobox(ng-controller='UserCtrl')
+    .herobox-wrap.main-herobox
       +herobox({main:1})
     // stat bars
     .hero-stats
@@ -12,23 +12,25 @@
       .meter.health(tooltip='{{Math.round(user.stats.hp * 100) / 100}}')
         .bar(ng-style='{"width": Shared.percent(user.stats.hp, Shared.maxHealth)+"%"}')
         span.meter-text.value
-          | {{Math.ceil(user.stats.hp)}} / {{::Shared.maxHealth}}
+          | {{statCalc.hpDisplay(user.stats.hp)}}
       .meter-label(tooltip=env.t('experience'))
         span.glyphicon.glyphicon-star
       .meter.experience(tooltip='{{Math.round(user.stats.exp * 100) / 100}}')
         .bar(ng-style='{"width": Shared.percent(user.stats.exp,Shared.tnl(user.stats.lvl))+"%"}')
         span.meter-text.value
+          span(ng-show='statCalc.canLevelUp(user)' class="hidden-xs") Complete a Task to Level Up!
           span(ng-show='user.history.exp', tooltip=env.t('progress'))
             a(ng-click='toggleChart("exp")').glyphicon.glyphicon-signal
           span
-          | {{Math.floor(user.stats.exp) | number:0}} / {{Shared.tnl(user.stats.lvl) | number:0}}
+          | {{statCalc.expDisplay(user)}}
+      span(ng-show='statCalc.canLevelUp(user)' class="visible-xs pull-right") Complete a Task to Level Up!
       .meter-label(tooltip=env.t('mana'), ng-if='user.flags.classSelected && !user.preferences.disableClasses')
         span.glyphicon.glyphicon-fire
       .meter.mana(ng-if='user.flags.classSelected && !user.preferences.disableClasses', tooltip='{{Math.round(user.stats.mp * 100) / 100}}')
         .bar(ng-style='{"width": (user.stats.mp / user.fns.statsComputed().maxMP * 100) + "%"}')
         span.meter-text.value
           span
-          | {{Math.floor(user.stats.mp)}} / {{user.fns.statsComputed().maxMP}}
+          | {{statCalc.mpDisplay(user)}}
     // party
     .party(ng-controller='PartyCtrl')
       button.party-invite.btn.btn-primary(ng-click="inviteOrStartParty(party)",

--- a/website/views/shared/header/header.jade
+++ b/website/views/shared/header/header.jade
@@ -18,12 +18,12 @@
       .meter.experience(tooltip='{{Math.round(user.stats.exp * 100) / 100}}')
         .bar(ng-style='{"width": Shared.percent(user.stats.exp,Shared.tnl(user.stats.lvl))+"%"}')
         span.meter-text.value
-          span(ng-show='statCalc.canLevelUp(user)' class="hidden-xs") Complete a Task to Level Up!
+          span(ng-show='statCalc.canLevelUp(user)' class="hidden-xs")=env.t('canLevelUp')
           span(ng-show='user.history.exp', tooltip=env.t('progress'))
             a(ng-click='toggleChart("exp")').glyphicon.glyphicon-signal
           span
           | {{statCalc.expDisplay(user)}}
-      span(ng-show='statCalc.canLevelUp(user)' class="visible-xs pull-right") Complete a Task to Level Up!
+      span(ng-show='statCalc.canLevelUp(user)' class="visible-xs pull-right")=env.t('canLevelUp')
       .meter-label(tooltip=env.t('mana'), ng-if='user.flags.classSelected && !user.preferences.disableClasses')
         span.glyphicon.glyphicon-fire
       .meter.mana(ng-if='user.flags.classSelected && !user.preferences.disableClasses', tooltip='{{Math.round(user.stats.mp * 100) / 100}}')


### PR DESCRIPTION
Fixes #2433 
### Changes

Adds a text label to exp bar informing user to complete a task to level up when they have enough exp to level.

Media queries for xs screens used to move label below exp bar so it is not cut off.

Refactored jade template to allow the UserCtrl to apply to the .hero-stats div as well, they are all logically contained in the same unit of displaying user info.

The refactor allowed me to replace some of the jade math in the template for displaying HP, EXP, and MP to use the built in functions in statServices service. The benefit is code is being reused rather than having multiple implementations, so refactoring is easier if changes need to be made and lesser chance bugs are introduced. Furthermore it reduces the number of watchers on the header.jade section. Finally, the functions have tests against them and cover additional edge cases for displaying hp, mp and exp.
#### >XS Screen Sizes

![Media Query Example](http://imgur.com/Lzdwdfn.jpg)
#### <=XS Screen Size

![Media Query Example](http://imgur.com/EOPQxKm.jpg)

---

UUID: 236e74bc-986d-41ad-9fa1-d4842ad72334
