### PR TITLE
Added new user flag when user registers with facebook

### DIFF
--- a/test/api/v3/integration/user/auth/POST-login-local.test.js
+++ b/test/api/v3/integration/user/auth/POST-login-local.test.js
@@ -13,6 +13,7 @@ describe('POST /user/auth/local/login', () => {
     api = requester();
     user = await generateUser();
   });
+
   it('success with username', async () => {
     let response = await api.post(endpoint, {
       username: user.auth.local.username,
@@ -20,6 +21,7 @@ describe('POST /user/auth/local/login', () => {
     });
     expect(response.apiToken).to.eql(user.apiToken);
   });
+
   it('success with email', async () => {
     let response = await api.post(endpoint, {
       username: user.auth.local.email,
@@ -27,6 +29,7 @@ describe('POST /user/auth/local/login', () => {
     });
     expect(response.apiToken).to.eql(user.apiToken);
   });
+
   it('user is blocked', async () => {
     await user.update({ 'auth.blocked': 1 });
     await expect(api.post(endpoint, {
@@ -38,6 +41,7 @@ describe('POST /user/auth/local/login', () => {
       message: t('accountSuspended', { userId: user._id }),
     });
   });
+
   it('wrong password', async () => {
     await expect(api.post(endpoint, {
       username: user.auth.local.username,
@@ -48,6 +52,7 @@ describe('POST /user/auth/local/login', () => {
       message: t('invalidLoginCredentialsLong'),
     });
   });
+
   it('missing username', async () => {
     await expect(api.post(endpoint, {
       password: 'wrong-password',
@@ -57,6 +62,7 @@ describe('POST /user/auth/local/login', () => {
       message: t('invalidReqParams'),
     });
   });
+
   it('missing password', async () => {
     await expect(api.post(endpoint, {
       username: user.auth.local.username,

--- a/test/api/v3/integration/user/auth/POST-user_auth_social.test.js
+++ b/test/api/v3/integration/user/auth/POST-user_auth_social.test.js
@@ -24,7 +24,7 @@ describe('POST /user/auth/social', () => {
 
   it('fails if network is not facebook', async () => {
     await expect(api.post(endpoint, {
-      authResponse: {access_token: randomAccessToken},
+      authResponse: {access_token: randomAccessToken}, // eslint-disable-line camelcase
       network: 'NotFacebook',
     })).to.eventually.be.rejected.and.eql({
       code: 401,
@@ -35,7 +35,7 @@ describe('POST /user/auth/social', () => {
 
   it('registers a new user', async () => {
     let response = await api.post(endpoint, {
-      authResponse: {access_token: randomAccessToken},
+      authResponse: {access_token: randomAccessToken}, // eslint-disable-line camelcase
       network,
     });
 
@@ -48,7 +48,7 @@ describe('POST /user/auth/social', () => {
     await user.update({ 'auth.facebook.id': facebookId });
 
     let response = await api.post(endpoint, {
-      authResponse: {access_token: randomAccessToken},
+      authResponse: {access_token: randomAccessToken}, // eslint-disable-line camelcase
       network,
     });
 

--- a/test/api/v3/integration/user/auth/POST-user_auth_social.test.js
+++ b/test/api/v3/integration/user/auth/POST-user_auth_social.test.js
@@ -1,0 +1,59 @@
+import {
+  generateUser,
+  requester,
+  translate as t,
+} from '../../../../../helpers/api-integration/v3';
+import passport from 'passport';
+
+describe('POST /user/auth/social', () => {
+  let api;
+  let user;
+  let endpoint = '/user/auth/social';
+  let randomAccessToken = '123456';
+  let facebookId = 'facebookId';
+  let network = 'facebook';
+
+  before(async () => {
+    api = requester();
+    user = await generateUser();
+
+    let expectedResult = {id: facebookId};
+    let passportFacebookProfile = sinon.stub(passport._strategies.facebook, 'userProfile');
+    passportFacebookProfile.yields(null, expectedResult);
+  });
+
+  it('fails if network is not facebook', async () => {
+    await expect(api.post(endpoint, {
+      authResponse: {access_token: randomAccessToken},
+      network: 'NotFacebook',
+    })).to.eventually.be.rejected.and.eql({
+      code: 401,
+      error: 'NotAuthorized',
+      message: t('onlyFbSupported'),
+    });
+  });
+
+  it('registers a new user', async () => {
+    let response = await api.post(endpoint, {
+      authResponse: {access_token: randomAccessToken},
+      network,
+    });
+
+    expect(response.apiToken).to.exist;
+    expect(response.id).to.exist;
+    expect(response.newUser).to.be.true;
+  });
+
+  it('logs an existing user in', async () => {
+    await user.update({ 'auth.facebook.id': facebookId });
+
+    let response = await api.post(endpoint, {
+      authResponse: {access_token: randomAccessToken},
+      network,
+    });
+
+    expect(response.apiToken).to.eql(user.apiToken);
+    expect(response.id).to.eql(user._id);
+    expect(response.newUser).to.be.false;
+  });
+});

--- a/website/server/controllers/api-v3/auth.js
+++ b/website/server/controllers/api-v3/auth.js
@@ -162,10 +162,8 @@ api.registerLocal = {
 };
 
 function _loginRes (user, req, res) {
-  var newUser = false;
-  if (user.newUser) newUser = true;
   if (user.auth.blocked) throw new NotAuthorized(res.t('accountSuspended', {userId: user._id}));
-  return res.respond(200, {id: user._id, apiToken: user.apiToken, newUser});
+  return res.respond(200, {id: user._id, apiToken: user.apiToken, newUser: user.newUser || false});
 }
 
 /**

--- a/website/server/controllers/api-v3/auth.js
+++ b/website/server/controllers/api-v3/auth.js
@@ -162,8 +162,10 @@ api.registerLocal = {
 };
 
 function _loginRes (user, req, res) {
+  var newUser = false;
+  if (user.newUser) newUser = true;
   if (user.auth.blocked) throw new NotAuthorized(res.t('accountSuspended', {userId: user._id}));
-  return res.respond(200, {id: user._id, apiToken: user.apiToken});
+  return res.respond(200, {id: user._id, apiToken: user.apiToken, newUser});
 }
 
 /**
@@ -260,6 +262,7 @@ api.loginSocial = {
 
       let savedUser = await user.save();
 
+      user.newUser = true;
       _loginRes(user, ...arguments);
 
       // Clean previous email preferences


### PR DESCRIPTION
Fixes put_issue_url_here
### Changes

When a new user registers with Facebook, the api will not return a newUser value of true. This is used in the app to tell when a user is registering or logging in via social media. 

---

UUID: 
