### PR TITLE
Align guild gems box with other page elements

### DIFF
--- a/website/client/css/inventory.styl
+++ b/website/client/css/inventory.styl
@@ -1,6 +1,7 @@
 .gem-wallet
   cursor: pointer
-  padding-top: 10px;
+  padding-right: 15px
+  margin-right: 5px
   .tile
     background-color: darken($neutral, 10%)
   .add-gems-btn

--- a/website/client/css/inventory.styl
+++ b/website/client/css/inventory.styl
@@ -1,7 +1,7 @@
 .gem-wallet
   cursor: pointer
-  padding-right: 15px
-  margin-right: 5px
+  &.pull-right
+    margin-right: 20px
   .tile
     background-color: darken($neutral, 10%)
   .add-gems-btn
@@ -12,6 +12,9 @@
       background-color: $good
     .tile
       opacity: 1
+    text-decoration: none
+.buy-gems .gem-wallet
+  margin-right: 0px
 
 .modal-header .gem-wallet
   padding-top: 0px

--- a/website/client/css/inventory.styl
+++ b/website/client/css/inventory.styl
@@ -4,14 +4,21 @@
     margin-right: 20px
   .tile
     background-color: darken($neutral, 10%)
-  .add-gems-btn
-    opacity: 0
+    &.add-gems-btn
+      opacity: 0
   &:hover, &:focus
-    .add-gems-btn
-      opacity: 1
-      background-color: $good
     .tile
       opacity: 1
+      &.has-add-gems
+        border-top-left-radius: 0px
+        border-bottom-left-radius: 0px
+      &.add-gems-btn
+        opacity: 1
+        background-color: $good
+        border-right: 0
+        border-radius: 0px
+        border-top-left-radius: 4px
+        border-bottom-left-radius: 4px
     text-decoration: none
 .buy-gems .gem-wallet
   margin-right: 0px

--- a/website/client/css/tasks.styl
+++ b/website/client/css/tasks.styl
@@ -517,6 +517,8 @@ form
   border-radius: 4px
   display: inline-flex
   align-items: center // vertically align text
+  .Gems
+    margin-top: 0px
 
 .task-options
   .task-action-btn.tile

--- a/website/client/css/tasks.styl
+++ b/website/client/css/tasks.styl
@@ -509,13 +509,15 @@ form
   background-color: lighten($best, 20%)
   &:hover, &:focus
     background-color: lighten($best, 40%)
+// this affects the guild gems box, maybe other stuff?
 .tile.flush
   margin-left: 0
   border: 1px solid rgba(0,0,0,0.2)
   outline: 0
   line-height: 2em
-  &:first-child
-    border-right: 0
+  border-radius: 4px
+  display: flex
+  align-items: center // vertically align text
 
 .task-options
   .task-action-btn.tile

--- a/website/client/css/tasks.styl
+++ b/website/client/css/tasks.styl
@@ -516,7 +516,7 @@ form
   outline: 0
   line-height: 2em
   border-radius: 4px
-  display: flex
+  display: inline-flex
   align-items: center // vertically align text
 
 .task-options

--- a/website/client/css/tasks.styl
+++ b/website/client/css/tasks.styl
@@ -509,7 +509,6 @@ form
   background-color: lighten($best, 20%)
   &:hover, &:focus
     background-color: lighten($best, 40%)
-// this affects the guild gems box, maybe other stuff?
 .tile.flush
   margin-left: 0
   border: 1px solid rgba(0,0,0,0.2)

--- a/website/views/shared/mixins.jade
+++ b/website/views/shared/mixins.jade
@@ -2,7 +2,7 @@ mixin gemButton(isGemsModal)
   a.pull-right.gem-wallet(ng-click=( isGemsModal ? '' : 'openModal("buyGems",{track:"Gems > Wallet"})'), popover-trigger='mouseenter', popover-title=env.t('gemsPopoverTitle'), popover=env.t('gemsWhatFor'), popover-placement='bottom')
     if !isGemsModal
       span.task-action-btn.tile.flush.bright.add-gems-btn ＋
-    span.task-action-btn.tile.flush.neutral
+    span.task-action-btn.tile.flush.neutral(class={"has-add-gems": !isGemsModal})
       .Pet_Currency_Gem2x.Gems
       =env.t('gemButton', {number: '{{user.balance * 4 | number:0}}'})
 


### PR DESCRIPTION
Fixes #7796
### Changes

Aligns right side with speech bubble below, and aligns top with description box to the left. Also centres text and gem icon.

Old:

![image](https://cloud.githubusercontent.com/assets/9433472/17119614/e6f548d2-52be-11e6-968c-c17dc05428a4.png)

New:

![image](https://cloud.githubusercontent.com/assets/9433472/17119648/1946b442-52bf-11e6-98f7-bd405e914229.png)

One side-effect of these changes is that the 'guild gems' text is now underlined on hover. Hopefully that doesn't matter? I've no idea why it happens.

I still need to work on this to fix issues created by this change in other places, like the Fortify modal - applying `display: flex` to align the text vertically causes the green plus box visible on hover to be misplaced on top of the gem count, rather than to the side [solution - `display: inline-flex`]. Also, the '+' icon is underlined, which is a problem [fixed with inline-flex].

---

UUID: `0e1d15f7-f36b-4f15-a9e1-0c31b732dac9`
