### PR TITLE
Enable guild challenge prize to use guild bank gems

### DIFF
--- a/test/api/v3/integration/challenges/GET-challenges_challengeId.test.js
+++ b/test/api/v3/integration/challenges/GET-challenges_challengeId.test.js
@@ -46,7 +46,14 @@ describe('GET /challenges/:challengeId', () => {
         id: groupLeader._id,
         profile: {name: groupLeader.profile.name},
       });
-      expect(chal.group).to.eql(_.pick(group, ['_id', 'id', 'name', 'type', 'privacy']));
+      expect(chal.group).to.eql({
+        _id: group._id,
+        id: group.id,
+        name: group.name,
+        type: group.type,
+        privacy: group.privacy,
+        leader: groupLeader.id,
+      });
     });
   });
 
@@ -91,7 +98,14 @@ describe('GET /challenges/:challengeId', () => {
         id: groupLeader._id,
         profile: {name: groupLeader.profile.name},
       });
-      expect(chal.group).to.eql(_.pick(group, ['_id', 'id', 'name', 'type', 'privacy']));
+      expect(chal.group).to.eql({
+        _id: group._id,
+        id: group.id,
+        name: group.name,
+        type: group.type,
+        privacy: group.privacy,
+        leader: groupLeader.id,
+      });
     });
   });
 
@@ -136,7 +150,14 @@ describe('GET /challenges/:challengeId', () => {
         id: groupLeader.id,
         profile: {name: groupLeader.profile.name},
       });
-      expect(chal.group).to.eql(_.pick(group, ['_id', 'id', 'name', 'type', 'privacy']));
+      expect(chal.group).to.eql({
+        _id: group._id,
+        id: group.id,
+        name: group.name,
+        type: group.type,
+        privacy: group.privacy,
+        leader: groupLeader.id,
+      });
     });
   });
 });

--- a/test/api/v3/integration/challenges/GET-challenges_user.test.js
+++ b/test/api/v3/integration/challenges/GET-challenges_user.test.js
@@ -45,6 +45,7 @@ describe('GET challenges/user', () => {
         type: publicGuild.type,
         privacy: publicGuild.privacy,
         name: publicGuild.name,
+        leader: publicGuild.leader._id,
       });
     });
 
@@ -64,6 +65,7 @@ describe('GET challenges/user', () => {
         type: publicGuild.type,
         privacy: publicGuild.privacy,
         name: publicGuild.name,
+        leader: publicGuild.leader._id,
       });
       let foundChallenge2 = _.find(challenges, { _id: challenge2._id });
       expect(foundChallenge2).to.exist;
@@ -78,6 +80,7 @@ describe('GET challenges/user', () => {
         type: publicGuild.type,
         privacy: publicGuild.privacy,
         name: publicGuild.name,
+        leader: publicGuild.leader._id,
       });
     });
 
@@ -97,6 +100,7 @@ describe('GET challenges/user', () => {
         type: publicGuild.type,
         privacy: publicGuild.privacy,
         name: publicGuild.name,
+        leader: publicGuild.leader._id,
       });
       let foundChallenge2 = _.find(challenges, { _id: challenge2._id });
       expect(foundChallenge2).to.exist;
@@ -111,6 +115,7 @@ describe('GET challenges/user', () => {
         type: publicGuild.type,
         privacy: publicGuild.privacy,
         name: publicGuild.name,
+        leader: publicGuild.leader._id,
       });
     });
 

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -95,7 +95,7 @@ schema.statics.sanitizeUpdate = function sanitizeUpdate (updateObj) {
 };
 
 // Basic fields to fetch for populating a group info
-export let basicFields = 'name type privacy';
+export let basicFields = 'name type privacy leader';
 
 schema.pre('remove', true, async function preRemoveGroup (next, done) {
   next();


### PR DESCRIPTION
Fixes https://github.com/HabitRPG/habitrpg/issues/7361
### Changes

The problem here was that on the function [_calculateAvailableGroupBalance(gid)](https://github.com/HabitRPG/habitrpg/blob/develop/website/client/js/controllers/challengesCtrl.js#L431) the `if (group && group.balance && group.leader === User.user._id)` is never true because `group.leader` is an unidentified object. So I tried to find the root of the problem. The object group comes from $scope.groups, which comes from Groups.Group.getGroups which is not returning the leader property from the query.

So I went to [`schema.statics.getGroups`](https://github.com/HabitRPG/habitrpg/blob/develop/website/server/models/group.js#L167) on group.js to see what I could do. I saw `populateLeader = false` and changed it to `true` but it didn't fix the problem. So I went to `basicFields` and added 'leader' and that made the query return the leader property so that `if (group && group.balance && group.leader === User.user._id)` could work properly again. I think that change shouldn't affect somewhere else in a bad way, but if it does plz let me know!

Here are some tests:

Guild leader creating a challenge with the sum of his gems plus guild gems:
![test1](https://cloud.githubusercontent.com/assets/20071290/17195298/528842c8-5433-11e6-875b-9b81702fe73a.png)

Guild leader creating a challenge only with guild gems:
![test2](https://cloud.githubusercontent.com/assets/20071290/17195300/54193890-5433-11e6-80c3-02fb2e488a23.png)

Guild member (not leader) creating a challenge:
![test3](https://cloud.githubusercontent.com/assets/20071290/17195302/5610fcbe-5433-11e6-9526-a467da77ffc7.png)

---

UUID: 8389891a-ba52-4580-b08b-2cb706c7e0b4
