### PR TITLE
Adding tests to prove expected behavior around force starting a quest

### DIFF
--- a/test/api/v3/integration/quests/POST-groups_groupId_quests_force-start.test.js
+++ b/test/api/v3/integration/quests/POST-groups_groupId_quests_force-start.test.js
@@ -149,5 +149,64 @@ describe('POST /groups/:groupId/quests/force-start', () => {
       expect(partyMemberThatIgnores.party.quest.key).to.not.exist;
       expect(partyMemberThatIgnores.party.quest.completed).to.not.exist;
     });
+
+    it('removes users who have not accepted the quest from quest.members', async () => {
+      let partyMemberThatRejects = partyMembers[1];
+      let partyMemberThatIgnores = partyMembers[2];
+
+      await leader.post(`/groups/${questingGroup._id}/quests/invite/${PET_QUEST}`);
+      await partyMembers[0].post(`/groups/${questingGroup._id}/quests/accept`);
+      await partyMemberThatRejects.post(`/groups/${questingGroup._id}/quests/reject`);
+
+      await leader.post(`/groups/${questingGroup._id}/quests/force-start`);
+
+      await Bluebird.delay(500);
+
+      await questingGroup.sync();
+
+      expect(questingGroup.quest.members[partyMemberThatRejects._id]).to.not.exist;
+      expect(questingGroup.quest.members[partyMemberThatIgnores._id]).to.not.exist;
+      expect(questingGroup.quest.members[partyMembers[0]._id]).to.exist;
+      expect(questingGroup.quest.members[leader._id]).to.exist;
+    });
+
+    it('removes users who are not in the party from quest.members', async () => {
+      await leader.post(`/groups/${questingGroup._id}/quests/invite/${PET_QUEST}`);
+
+      let notInPartyUser = await generateUser();
+      questingGroup.quest.members[notInPartyUser._id] = true;
+
+      expect(questingGroup.quest.members[notInPartyUser._id]).to.eql(true);
+
+      await leader.post(`/groups/${questingGroup._id}/quests/force-start`);
+
+      await Bluebird.delay(500);
+
+      await questingGroup.sync();
+
+      expect(questingGroup.quest.members[notInPartyUser._id]).to.not.exist;
+    });
+
+    it('removes users who don\'t have true value in quest.members from quest.members', async () => {
+      let partyMemberThatRejects = partyMembers[1];
+      let partyMemberThatIgnores = partyMembers[2];
+
+      await leader.post(`/groups/${questingGroup._id}/quests/invite/${PET_QUEST}`);
+      await partyMembers[0].post(`/groups/${questingGroup._id}/quests/accept`);
+
+      questingGroup.quest.members[partyMemberThatRejects._id] = false;
+      questingGroup.quest.members[partyMemberThatIgnores._id] = null;
+
+      await leader.post(`/groups/${questingGroup._id}/quests/force-start`);
+
+      await Bluebird.delay(500);
+
+      await questingGroup.sync();
+
+      expect(questingGroup.quest.members[partyMemberThatRejects._id]).to.not.exist;
+      expect(questingGroup.quest.members[partyMemberThatIgnores._id]).to.not.exist;
+      expect(questingGroup.quest.members[partyMembers[0]._id]).to.exist;
+      expect(questingGroup.quest.members[leader._id]).to.exist;
+    });
   });
 });

--- a/test/api/v3/integration/quests/POST-groups_groupId_quests_force-start.test.js
+++ b/test/api/v3/integration/quests/POST-groups_groupId_quests_force-start.test.js
@@ -172,9 +172,12 @@ describe('POST /groups/:groupId/quests/force-start', () => {
 
     it('removes users who are not in the party from quest.members', async () => {
       await leader.post(`/groups/${questingGroup._id}/quests/invite/${PET_QUEST}`);
-
       let notInPartyUser = await generateUser();
-      questingGroup.quest.members[notInPartyUser._id] = true;
+
+      await questingGroup.update({
+        [`quest.members.${notInPartyUser._id}`]: true,
+      });
+      questingGroup.sync();
 
       expect(questingGroup.quest.members[notInPartyUser._id]).to.eql(true);
 
@@ -194,8 +197,10 @@ describe('POST /groups/:groupId/quests/force-start', () => {
       await leader.post(`/groups/${questingGroup._id}/quests/invite/${PET_QUEST}`);
       await partyMembers[0].post(`/groups/${questingGroup._id}/quests/accept`);
 
-      questingGroup.quest.members[partyMemberThatRejects._id] = false;
-      questingGroup.quest.members[partyMemberThatIgnores._id] = null;
+      await questingGroup.update({
+        [`quest.members.${partyMemberThatRejects._id}`]: false,
+        [`quest.members.${partyMemberThatIgnores._id}`]: null,
+      });
 
       await leader.post(`/groups/${questingGroup._id}/quests/force-start`);
 

--- a/test/api/v3/integration/quests/POST-groups_groupId_quests_force-start.test.js
+++ b/test/api/v3/integration/quests/POST-groups_groupId_quests_force-start.test.js
@@ -153,9 +153,10 @@ describe('POST /groups/:groupId/quests/force-start', () => {
     it('removes users who have not accepted the quest from quest.members', async () => {
       let partyMemberThatRejects = partyMembers[1];
       let partyMemberThatIgnores = partyMembers[2];
+      let partyMemberThatAccepts = partyMembers[0];
 
       await leader.post(`/groups/${questingGroup._id}/quests/invite/${PET_QUEST}`);
-      await partyMembers[0].post(`/groups/${questingGroup._id}/quests/accept`);
+      await partyMemberThatAccepts.post(`/groups/${questingGroup._id}/quests/accept`);
       await partyMemberThatRejects.post(`/groups/${questingGroup._id}/quests/reject`);
 
       await leader.post(`/groups/${questingGroup._id}/quests/force-start`);
@@ -166,7 +167,7 @@ describe('POST /groups/:groupId/quests/force-start', () => {
 
       expect(questingGroup.quest.members[partyMemberThatRejects._id]).to.not.exist;
       expect(questingGroup.quest.members[partyMemberThatIgnores._id]).to.not.exist;
-      expect(questingGroup.quest.members[partyMembers[0]._id]).to.exist;
+      expect(questingGroup.quest.members[partyMemberThatAccepts._id]).to.exist;
       expect(questingGroup.quest.members[leader._id]).to.exist;
     });
 
@@ -177,7 +178,7 @@ describe('POST /groups/:groupId/quests/force-start', () => {
       await questingGroup.update({
         [`quest.members.${notInPartyUser._id}`]: true,
       });
-      questingGroup.sync();
+      await questingGroup.sync();
 
       expect(questingGroup.quest.members[notInPartyUser._id]).to.eql(true);
 

--- a/test/api/v3/integration/quests/POST-groups_groupId_quests_force-start.test.js
+++ b/test/api/v3/integration/quests/POST-groups_groupId_quests_force-start.test.js
@@ -190,6 +190,23 @@ describe('POST /groups/:groupId/quests/force-start', () => {
       expect(questingGroup.quest.members[notInPartyUser._id]).to.not.exist;
     });
 
+    it('removes users who have been deleted from quest.members', async () => {
+      await leader.post(`/groups/${questingGroup._id}/quests/invite/${PET_QUEST}`);
+      await partyMembers[0].post(`/groups/${questingGroup._id}/quests/accept`);
+
+      await partyMembers[0].del('/user', {
+        password: 'password',
+      });
+
+      await leader.post(`/groups/${questingGroup._id}/quests/force-start`);
+
+      await Bluebird.delay(500);
+
+      await questingGroup.sync();
+
+      expect(questingGroup.quest.members[partyMembers[0]._id]).to.not.exist;
+    });
+
     it('removes users who don\'t have true value in quest.members from quest.members', async () => {
       let partyMemberThatRejects = partyMembers[1];
       let partyMemberThatIgnores = partyMembers[2];

--- a/website/server/controllers/api-v3/quests.js
+++ b/website/server/controllers/api-v3/quests.js
@@ -287,13 +287,6 @@ api.forceStart = {
 
     group.markModified('quest');
 
-    // removes any users who haven't accepted the invitiation
-    _.forEach(group.quest.members, function(member){
-
-    });
-
-    // removes any users who aren't in the party
-    
     await group.startQuest(user);
 
     let [savedGroup] = await Bluebird.all([

--- a/website/server/controllers/api-v3/quests.js
+++ b/website/server/controllers/api-v3/quests.js
@@ -287,6 +287,13 @@ api.forceStart = {
 
     group.markModified('quest');
 
+    // removes any users who haven't accepted the invitiation
+    _.forEach(group.quest.members, function(member){
+
+    });
+
+    // removes any users who aren't in the party
+    
     await group.startQuest(user);
 
     let [savedGroup] = await Bluebird.all([

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -370,9 +370,9 @@ schema.methods.startQuest = async function startQuest (user) {
   let partyId = this._id;
   let questMembers = this.quest.members;
   await Bluebird.map(Object.keys(this.quest.members), async (memberId) => {
-    let member = await User.findById(memberId, 'party._id').exec();
+    let member = await User.findOne({_id: memberId, 'party._id': partyId});
 
-    if (member.party._id !== partyId) {
+    if (!member) {
       delete questMembers[memberId];
     }
   });

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -370,7 +370,7 @@ schema.methods.startQuest = async function startQuest (user) {
   let partyId = this._id;
   let questMembers = this.quest.members;
   await Bluebird.map(Object.keys(this.quest.members), async (memberId) => {
-    let member = await User.findOne({_id: memberId, 'party._id': partyId});
+    let member = await User.findOne({_id: memberId, 'party._id': partyId}).select('_id').lean();
 
     if (!member) {
       delete questMembers[memberId];

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -366,6 +366,17 @@ schema.methods.startQuest = async function startQuest (user) {
   let nonUserQuestMembers = _.keys(this.quest.members);
   removeFromArray(nonUserQuestMembers, user._id);
 
+  // remove any users from quest.members who aren't in the party
+  let partyId = this._id;
+  let questMembers = this.quest.members;
+  await Bluebird.map(Object.keys(this.quest.members), async (memberId) => {
+    let member = await User.findById(memberId, 'party._id').exec();
+
+    if (member.party._id !== partyId) {
+      delete questMembers[memberId];
+    }
+  });
+
   if (userIsParticipating) {
     user.party.quest.key = this.quest.key;
     user.party.quest.progress.down = 0;


### PR DESCRIPTION
part of #7653 
### Changes

Added tests to prove the following occurs as it is the expected behavior:
- check that the code for force-starting a quest removes any players from quest.members that don't have a true value
- check that the code for force-starting a quest removes any players from quest.members that aren't in the party

---

UUID: 2a4d30ee-4833-420e-be7c-ad6a6e261c5f
