### PR TITLE
Clear invites from user when the request fails because the invite is invalid

### DIFF
--- a/test/api/v3/integration/quests/POST-groups_groupId_quests_accept.test.js
+++ b/test/api/v3/integration/quests/POST-groups_groupId_quests_accept.test.js
@@ -74,6 +74,21 @@ describe('POST /groups/:groupId/quests/accept', () => {
       });
     });
 
+    it('clears the invalid invite from the user when the request fails', async () => {
+      await leader.post(`/groups/${questingGroup._id}/quests/invite/${PET_QUEST}`);
+      await partyMembers[0].post(`/groups/${questingGroup._id}/quests/accept`);
+
+      await expect(partyMembers[0].post(`/groups/${questingGroup._id}/quests/accept`))
+      .to.eventually.be.rejected.and.eql({
+        code: 400,
+        error: 'BadRequest',
+        message: t('questAlreadyAccepted'),
+      });
+
+      await partyMembers[0].sync();
+      expect(partyMembers[0].party.quest.RSVPNeeded).to.be.false;
+    });
+
     it('does not accept invite for a quest already underway', async () => {
       await leader.post(`/groups/${questingGroup._id}/quests/invite/${PET_QUEST}`);
       await partyMembers[0].post(`/groups/${questingGroup._id}/quests/accept`);

--- a/test/api/v3/integration/quests/POST-groups_groupid_quests_reject.test.js
+++ b/test/api/v3/integration/quests/POST-groups_groupid_quests_reject.test.js
@@ -83,6 +83,21 @@ describe('POST /groups/:groupId/quests/reject', () => {
       });
     });
 
+    it('clears the user rsvp needed if the request fails because the request is invalid', async () => {
+      await leader.post(`/groups/${questingGroup._id}/quests/invite/${PET_QUEST}`);
+      await partyMembers[0].post(`/groups/${questingGroup._id}/quests/reject`);
+
+      await expect(partyMembers[0].post(`/groups/${questingGroup._id}/quests/reject`))
+      .to.eventually.be.rejected.and.eql({
+        code: 400,
+        error: 'BadRequest',
+        message: t('questAlreadyRejected'),
+      });
+
+      await partyMembers[0].sync();
+      expect(partyMembers[0].party.quest.RSVPNeeded).to.be.false;
+    });
+
     it('return an error when a user rejects an invite already accepted', async () => {
       await leader.post(`/groups/${questingGroup._id}/quests/invite/${PET_QUEST}`);
       await partyMembers[0].post(`/groups/${questingGroup._id}/quests/accept`);

--- a/website/server/controllers/api-v3/quests.js
+++ b/website/server/controllers/api-v3/quests.js
@@ -162,7 +162,7 @@ api.acceptQuest = {
     if (validationErrors) throw validationErrors;
 
     user.party.quest.RSVPNeeded = false;
-    user.save();
+    await user.save();
 
     let group = await Group.getGroup({user, groupId: req.params.groupId, fields: 'type quest'});
 

--- a/website/server/controllers/api-v3/quests.js
+++ b/website/server/controllers/api-v3/quests.js
@@ -161,6 +161,9 @@ api.acceptQuest = {
     let validationErrors = req.validationErrors();
     if (validationErrors) throw validationErrors;
 
+    user.party.quest.RSVPNeeded = false;
+    user.save();
+
     let group = await Group.getGroup({user, groupId: req.params.groupId, fields: 'type quest'});
 
     if (!group) throw new NotFound(res.t('groupNotFound'));
@@ -171,16 +174,12 @@ api.acceptQuest = {
 
     group.markModified('quest');
     group.quest.members[user._id] = true;
-    user.party.quest.RSVPNeeded = false;
 
     if (canStartQuestAutomatically(group)) {
       await group.startQuest(user);
     }
 
-    let [savedGroup] = await Bluebird.all([
-      group.save(),
-      user.save(),
-    ]);
+    let savedGroup = await group.save();
 
     res.respond(200, savedGroup.quest);
 
@@ -218,6 +217,10 @@ api.rejectQuest = {
     let validationErrors = req.validationErrors();
     if (validationErrors) throw validationErrors;
 
+    user.party.quest = Group.cleanQuestProgress();
+    user.markModified('party.quest');
+    await user.save();
+
     let group = await Group.getGroup({user, groupId: req.params.groupId, fields: 'type quest'});
     if (!group) throw new NotFound(res.t('groupNotFound'));
     if (group.type !== 'party') throw new NotAuthorized(res.t('guildQuestsNotSupported'));
@@ -229,17 +232,11 @@ api.rejectQuest = {
     group.quest.members[user._id] = false;
     group.markModified('quest.members');
 
-    user.party.quest = Group.cleanQuestProgress();
-    user.markModified('party.quest');
-
     if (canStartQuestAutomatically(group)) {
       await group.startQuest(user);
     }
 
-    let [savedGroup] = await Bluebird.all([
-      group.save(),
-      user.save(),
-    ]);
+    let savedGroup = await group.save();
 
     res.respond(200, savedGroup.quest);
 


### PR DESCRIPTION
part of #7653 
### Changes

This should clear a user invite to a quest when the user tries to accept or decline the quest when the invite has gotten into a bad or invalid state. Should help prevent the need for admin intervention.

---

UUID: 2a4d30ee-4833-420e-be7c-ad6a6e261c5f
