### PR TITLE
Buy false takeThis gear

### DIFF
--- a/common/script/content/gear/index.js
+++ b/common/script/content/gear/index.js
@@ -71,7 +71,7 @@ each(GEAR_TYPES, (type) => {
         };
       }
 
-      if (item.mystery) {
+      if (item.mystery || key.indexOf('takeThis') !== -1) {
         item.canOwn = ownsItem(key);
       }
 


### PR DESCRIPTION
### Changes

Adds the Take This items to the generic `canOwn` check so they can be purchased from the Rewards column when set to `false` on the user's gear list.
