### PR TITLE
Challenges: Assigning Location as Tavern only sets prize to 1 if 0 or empty

### DIFF
--- a/website/client/js/controllers/challengesCtrl.js
+++ b/website/client/js/controllers/challengesCtrl.js
@@ -358,7 +358,7 @@ habitrpg.controller("ChallengesCtrl", ['$rootScope','$scope', 'Shared', 'User', 
 
       _calculateMaxPrize(gid);
 
-      if (gid == TAVERN_ID) {
+      if (gid == TAVERN_ID && !($scope.newChallenge.prize > 0)) {
         $scope.newChallenge.prize = 1;
       }
     })


### PR DESCRIPTION
Fixes https://github.com/HabitRPG/habitrpg/issues/3998
### Changes

Added a test to check the current value of `$scope.newChallenge.prize` so it doesn't always change to 1 when you choose tavern as location for the challenge. 
Now changing the location to Tavern will only change `$scope.newChallenge.prize` to 1 if the current value is `null`, `undefined`, 0, or negative.

Tests:
![2016-08-01 2](https://cloud.githubusercontent.com/assets/20071290/17312583/0eec93d4-582a-11e6-8967-69d4c197233b.png)

---

UUID: 8389891a-ba52-4580-b08b-2cb706c7e0b4
