### PR TITLE
Fix #6708 - guild message maximizes width in Firefox

### DIFF
--- a/website/client/css/alerts.styl
+++ b/website/client/css/alerts.styl
@@ -14,6 +14,7 @@
   display: inline-block
 
 .wide-popover
+  max-width: -moz-max-content
   max-width: max-content
 
 // Small alerts


### PR DESCRIPTION
Fixes https://github.com/HabitRPG/habitrpg/issues/6708
### Changes

Guild messages, or anything that uses `.wide-popover` class really, won’t stretch to let its contents spread naturally in Firefox, due to the `max-content` value still being experimental in that browser.

This fix adds a `-moz` browser-prefix for that value so it works in Firefox and browsers that support it without a browser-prefix.

Firefox 47.0.1 screenshot:
![screen shot 2016-08-04 at 18 20 56](https://cloud.githubusercontent.com/assets/65468/17420348/41e43998-5a70-11e6-852a-713e4b59179f.png)

---

UUID: ffee6b77-0bf8-422a-a65c-c20de17f2b32
