### PR TITLE
Fix #7869 - highlight current audio theme in dropdown

### DIFF
--- a/website/views/shared/header/menu.jade
+++ b/website/views/shared/header/menu.jade
@@ -225,7 +225,7 @@ nav.toolbar(ng-controller='MenuCtrl')
               // Using [{k,v}] instead of {k:v,k:v} to maintain order ('off' at top)
               for theme in ['off', 'danielTheBard', 'gokulTheme', 'luneFoxTheme', 'wattsTheme', 'rosstavoTheme', 'dewinTheme']
                 li
-                  a(ng-class="{'bg-primary':user.preferences.sound === '# {theme}'}", ng-click="set({'preferences.sound':'#{theme}'})")=env.t('audioTheme_'+theme)
+                  a(ng-class="{'bg-info':user.preferences.sound === '#{theme}'}", ng-click="set({'preferences.sound':'#{theme}'})")=env.t('audioTheme_'+theme)
           ul.toolbar-controls
             li.toolbar-controls-button
               a(data-close-menu)=env.t('close')


### PR DESCRIPTION
Fixes https://github.com/HabitRPG/habitrpg/issues/7869
### Changes

This fixes a typo in `menu.jade` that would have highlighted the current audio theme being used. This change fixes the typo in the comparator and changes the Bootstrap colour used to something less garish…

![screen shot 2016-08-04 at 18 52 13](https://cloud.githubusercontent.com/assets/65468/17421081/fec6a98e-5a74-11e6-8f7b-ed2f78ba0684.png)

---

UUID: ffee6b77-0bf8-422a-a65c-c20de17f2b32
