### PR TITLE
feat: allowing modification of challenge tasks after challenge creation

### DIFF
--- a/test/api/v3/unit/models/challenge.test.js
+++ b/test/api/v3/unit/models/challenge.test.js
@@ -158,6 +158,7 @@ describe('Challenge Model', () => {
       });
     });
   });
+
   context('type specific updates', () => {
     it('updates habit specific field to challenge and challenge members', async () => {
       task = new Tasks.habit(Tasks.Task.sanitize(tasksToTest.habit)); // eslint-disable-line babel/new-cap
@@ -195,7 +196,7 @@ describe('Challenge Model', () => {
     });
 
     it('updates daily specific field to challenge and challenge members', async () => {
-      task = new Tasks.daily(Tasks.Task.sanitize(tasksToTest.todo)); // eslint-disable-line babel/new-cap
+      task = new Tasks.daily(Tasks.Task.sanitize(tasksToTest.daily)); // eslint-disable-line babel/new-cap
       task.challenge.id = challenge._id;
       await task.save();
 

--- a/test/api/v3/unit/models/challenge.test.js
+++ b/test/api/v3/unit/models/challenge.test.js
@@ -158,4 +158,56 @@ describe('Challenge Model', () => {
       });
     });
   });
+  context('type specific updates', () => {
+    it('updates habit specific field to challenge and challenge members', async () => {
+      task = new Tasks.habit(Tasks.Task.sanitize(tasksToTest.habit)); // eslint-disable-line babel/new-cap
+      task.challenge.id = challenge._id;
+      await task.save();
+
+      await challenge.addTasks([task]);
+
+      task.up = true;
+      task.down = false;
+
+      await challenge.updateTask(task);
+
+      let updatedLeader = await User.findOne({_id: leader._id});
+      let updatedUserTask = await Tasks.Task.findById(updatedLeader.tasksOrder.habits[0]);
+
+      expect(updatedUserTask.up).to.equal(true);
+      expect(updatedUserTask.down).to.equal(false);
+    });
+
+    it('updates todo specific field to challenge and challenge members', async () => {
+      task = new Tasks.todo(Tasks.Task.sanitize(tasksToTest.todo)); // eslint-disable-line babel/new-cap
+      task.challenge.id = challenge._id;
+      await task.save();
+
+      await challenge.addTasks([task]);
+
+      task.date = new Date();
+      await challenge.updateTask(task);
+
+      let updatedLeader = await User.findOne({_id: leader._id});
+      let updatedUserTask = await Tasks.Task.findById(updatedLeader.tasksOrder.todos[0]);
+
+      expect(updatedUserTask.date).to.exist;
+    });
+
+    it('updates daily specific field to challenge and challenge members', async () => {
+      task = new Tasks.daily(Tasks.Task.sanitize(tasksToTest.todo)); // eslint-disable-line babel/new-cap
+      task.challenge.id = challenge._id;
+      await task.save();
+
+      await challenge.addTasks([task]);
+
+      task.everyX = 2;
+      await challenge.updateTask(task);
+
+      let updatedLeader = await User.findOne({_id: leader._id});
+      let updatedUserTask = await Tasks.Task.findById(updatedLeader.tasksOrder.dailys[0]);
+
+      expect(updatedUserTask.everyX).to.eql(2);
+    });
+  });
 });

--- a/website/client/js/controllers/challengesCtrl.js
+++ b/website/client/js/controllers/challengesCtrl.js
@@ -40,6 +40,18 @@ habitrpg.controller("ChallengesCtrl", ['$rootScope','$scope', 'Shared', 'User', 
       return true;
     }
 
+    $scope.doubleClickTask = function (obj, task) {
+      if (obj._locked) {
+        return false;
+      }
+
+      if (task._editing) {
+        $scope.saveTask(task);
+      } else {
+        $scope.editTask(task);
+      }
+    }
+
     /**
      * Create
      */

--- a/website/client/js/controllers/challengesCtrl.js
+++ b/website/client/js/controllers/challengesCtrl.js
@@ -1,5 +1,5 @@
-habitrpg.controller("ChallengesCtrl", ['$rootScope','$scope', 'Shared', 'User', 'Challenges', 'Notification', '$compile', 'Groups', '$state', '$stateParams', 'Members', 'Tasks', 'TAVERN_ID',
-  function($rootScope, $scope, Shared, User, Challenges, Notification, $compile, Groups, $state, $stateParams, Members, Tasks, TAVERN_ID) {
+habitrpg.controller("ChallengesCtrl", ['$rootScope','$scope', 'Shared', 'User', 'Tasks', 'Challenges', 'Notification', '$compile', 'Groups', '$state', '$stateParams', 'Members', 'Tasks', 'TAVERN_ID',
+  function($rootScope, $scope, Shared, User, Tasks, Challenges, Notification, $compile, Groups, $state, $stateParams, Members, Tasks, TAVERN_ID) {
 
     // Use presence of cid to determine whether to show a list or a single
     // challenge
@@ -35,6 +35,10 @@ habitrpg.controller("ChallengesCtrl", ['$rootScope','$scope', 'Shared', 'User', 
     }
 
     $scope.editTask = Tasks.editTask;
+
+    $scope.canEdit = function(task) {
+      return true;
+    }
 
     /**
      * Create
@@ -274,8 +278,8 @@ habitrpg.controller("ChallengesCtrl", ['$rootScope','$scope', 'Shared', 'User', 
     };
 
     $scope.saveTask = function(task){
+      Tasks.updateTask(task._id, task);
       task._editing = false;
-      // TODO persist
     }
 
     $scope.toggleBulk = function(list) {

--- a/website/client/js/controllers/tasksCtrl.js
+++ b/website/client/js/controllers/tasksCtrl.js
@@ -72,7 +72,7 @@ habitrpg.controller("TasksCtrl", ['$scope', '$rootScope', '$location', 'User','N
 
     $scope.canEdit = function(task) {
       // can't edit challenge tasks
-      return ! task.challenge.id;
+      return !task.challenge.id;
     }
 
     $scope.doubleClickTask = function (obj, task) {

--- a/website/client/js/controllers/tasksCtrl.js
+++ b/website/client/js/controllers/tasksCtrl.js
@@ -75,6 +75,18 @@ habitrpg.controller("TasksCtrl", ['$scope', '$rootScope', '$location', 'User','N
       return ! task.challenge.id;
     }
 
+    $scope.doubleClickTask = function (obj, task) {
+      if (obj._locked) {
+        return false;
+      }
+
+      if (task._editing) {
+        $scope.saveTask(task);
+      } else {
+        $scope.editTask(task);
+      }
+    }
+
     /**
      * Add the new task to the actions log
      */

--- a/website/client/js/controllers/tasksCtrl.js
+++ b/website/client/js/controllers/tasksCtrl.js
@@ -70,6 +70,11 @@ habitrpg.controller("TasksCtrl", ['$scope', '$rootScope', '$location', 'User','N
 
     $scope.editTask = Tasks.editTask;
 
+    $scope.canEdit = function(task) {
+      // can't edit challenge tasks
+      return ! task.challenge.id;
+    }
+
     /**
      * Add the new task to the actions log
      */

--- a/website/server/models/challenge.js
+++ b/website/server/models/challenge.js
@@ -209,20 +209,7 @@ schema.methods.updateTask = async function challengeUpdateTask (task) {
     updateCmd.$set[key] = syncableAttrs[key];
   }
 
-  let taskSchema;
-  switch (task.type) {
-    case 'habit':
-      taskSchema = Tasks.habit;
-      break;
-    case 'todo':
-      taskSchema = Tasks.todo;
-      break;
-    case 'daily':
-      taskSchema = Tasks.daily;
-      break;
-    default:
-      taskSchema = Tasks.Task;
-  }
+  let taskSchema = Tasks[task.type] ? Tasks[task.type] : Tasks.Task;
   // Updating instead of loading and saving for performances, risks becoming a problem if we introduce more complexity in tasks
   await taskSchema.update({
     userId: {$exists: true},

--- a/website/server/models/challenge.js
+++ b/website/server/models/challenge.js
@@ -209,8 +209,22 @@ schema.methods.updateTask = async function challengeUpdateTask (task) {
     updateCmd.$set[key] = syncableAttrs[key];
   }
 
+  let taskSchema;
+  switch (task.type) {
+    case 'habit':
+      taskSchema = Tasks.habit;
+      break;
+    case 'todo':
+      taskSchema = Tasks.todo;
+      break;
+    case 'daily':
+      taskSchema = Tasks.daily;
+      break;
+    default:
+      taskSchema = Tasks.Task;
+  }
   // Updating instead of loading and saving for performances, risks becoming a problem if we introduce more complexity in tasks
-  await Tasks.Task.update({
+  await taskSchema.update({
     userId: {$exists: true},
     'challenge.id': challenge.id,
     'challenge.taskId': task._id,

--- a/website/server/models/challenge.js
+++ b/website/server/models/challenge.js
@@ -209,7 +209,7 @@ schema.methods.updateTask = async function challengeUpdateTask (task) {
     updateCmd.$set[key] = syncableAttrs[key];
   }
 
-  let taskSchema = Tasks[task.type] ? Tasks[task.type] : Tasks.Task;
+  let taskSchema = Tasks[task.type];
   // Updating instead of loading and saving for performances, risks becoming a problem if we introduce more complexity in tasks
   await taskSchema.update({
     userId: {$exists: true},

--- a/website/views/shared/tasks/edit/advanced_options.jade
+++ b/website/views/shared/tasks/edit/advanced_options.jade
@@ -18,13 +18,13 @@ div(ng-if='::task.type!="reward"')
 
         input.form-control(type='text', ng-model='task.startDate',
           datepicker-popup='{{::user.preferences.dateFormat}}', is-open='datepickerOpened',
-          ng-click='datepickerOpened = true', ng-disabled='task.challenge.id')
+          ng-click='datepickerOpened = true', ng-disabled='! canEdit(task)')
 
       hr
 
       .form-group
         legend.option-title=env.t('repeat')
-        select.form-control(ng-model='task.frequency', ng-disabled='task.challenge.id')
+        select.form-control(ng-model='task.frequency', ng-disabled='! canEdit(task)')
           option(value='weekly')=env.t('repeatWeek')
           option(value='daily')=env.t('repeatDays')
 
@@ -39,19 +39,19 @@ div(ng-if='::task.type!="reward"')
     ul.priority-multiplier
       li
         button(type='button', ng-class='{active: task.priority==0.1}',
-          ng-click='task.challenge.id || (task.priority=0.1)')
+          ng-click='! canEdit(task) || (task.priority=0.1)')
           =env.t('trivial')
       li
         button(type='button', ng-class='{active: task.priority==1 || !task.priority}',
-          ng-click='task.challenge.id || (task.priority=1)')
+          ng-click='! canEdit(task) || (task.priority=1)')
           =env.t('easy')
       li
         button(type='button', ng-class='{active: task.priority==1.5}',
-          ng-click='task.challenge.id || (task.priority=1.5)')
+          ng-click='! canEdit(task) || (task.priority=1.5)')
           =env.t('medium')
       li
         button(type='button', ng-class='{active: task.priority==2}',
-          ng-click='task.challenge.id || (task.priority=2)')
+          ng-click='! canEdit(task) || (task.priority=2)')
           =env.t('hard')
 
     span(ng-if='task.type=="daily"')

--- a/website/views/shared/tasks/edit/advanced_options.jade
+++ b/website/views/shared/tasks/edit/advanced_options.jade
@@ -18,13 +18,13 @@ div(ng-if='::task.type!="reward"')
 
         input.form-control(type='text', ng-model='task.startDate',
           datepicker-popup='{{::user.preferences.dateFormat}}', is-open='datepickerOpened',
-          ng-click='datepickerOpened = true', ng-disabled='! canEdit(task)')
+          ng-click='datepickerOpened = true', ng-disabled='!canEdit(task)')
 
       hr
 
       .form-group
         legend.option-title=env.t('repeat')
-        select.form-control(ng-model='task.frequency', ng-disabled='! canEdit(task)')
+        select.form-control(ng-model='task.frequency', ng-disabled='!canEdit(task)')
           option(value='weekly')=env.t('repeatWeek')
           option(value='daily')=env.t('repeatDays')
 
@@ -39,19 +39,19 @@ div(ng-if='::task.type!="reward"')
     ul.priority-multiplier
       li
         button(type='button', ng-class='{active: task.priority==0.1}',
-          ng-click='! canEdit(task) || (task.priority=0.1)')
+          ng-click='!canEdit(task) || (task.priority=0.1)')
           =env.t('trivial')
       li
         button(type='button', ng-class='{active: task.priority==1 || !task.priority}',
-          ng-click='! canEdit(task) || (task.priority=1)')
+          ng-click='!canEdit(task) || (task.priority=1)')
           =env.t('easy')
       li
         button(type='button', ng-class='{active: task.priority==1.5}',
-          ng-click='! canEdit(task) || (task.priority=1.5)')
+          ng-click='!canEdit(task) || (task.priority=1.5)')
           =env.t('medium')
       li
         button(type='button', ng-class='{active: task.priority==2}',
-          ng-click='! canEdit(task) || (task.priority=2)')
+          ng-click='!canEdit(task) || (task.priority=2)')
           =env.t('hard')
 
     span(ng-if='task.type=="daily"')

--- a/website/views/shared/tasks/edit/dailies/repeat_options.jade
+++ b/website/views/shared/tasks/edit/dailies/repeat_options.jade
@@ -3,9 +3,9 @@ legend.option-title
     popover='{{env.t(task.frequency + "RepeatHelpContent")}}')=env.t('repeatEvery')
 
 // If frequency is daily
-ng-form.form-group(name='everyX' ng-if='task.frequency=="daily"')
+ng-form.form-group(name='everyX', ng-if='task.frequency=="daily"')
   .input-group
-    input.form-control(type='number', ng-model='task.everyX', ng-disabled='task.challenge.id', min='0', required)
+    input.form-control(type='number', ng-model='task.everyX', min='0', ng-disabled='! canEdit(task)', required)
     span.input-group-addon {{task.everyX == 1 ? env.t('day') : env.t('days')}}
 
 // If frequency is weekly
@@ -15,7 +15,7 @@ ng-form.form-group(name='everyX' ng-if='task.frequency=="daily"')
     mixin dayOfWeek(day, num)
       li
         button(type='button', ng-class='{active: task.repeat.#{day}}',
-          ng-disabled='task.challenge.id', ng-click='task.repeat.#{day} = !task.repeat.#{day}',
+          ng-disabled='! canEdit(task)', ng-click='task.repeat.#{day} = !task.repeat.#{day}',
           tooltip='{{env.t((task.repeat.#{day}) ? "due" : "notDue")}}')
           | {{::moment.weekdaysMin(#{num})}}
 

--- a/website/views/shared/tasks/edit/dailies/repeat_options.jade
+++ b/website/views/shared/tasks/edit/dailies/repeat_options.jade
@@ -5,7 +5,7 @@ legend.option-title
 // If frequency is daily
 ng-form.form-group(name='everyX', ng-if='task.frequency=="daily"')
   .input-group
-    input.form-control(type='number', ng-model='task.everyX', min='0', ng-disabled='! canEdit(task)', required)
+    input.form-control(type='number', ng-model='task.everyX', min='0', ng-disabled='!canEdit(task)', required)
     span.input-group-addon {{task.everyX == 1 ? env.t('day') : env.t('days')}}
 
 // If frequency is weekly
@@ -15,7 +15,7 @@ ng-form.form-group(name='everyX', ng-if='task.frequency=="daily"')
     mixin dayOfWeek(day, num)
       li
         button(type='button', ng-class='{active: task.repeat.#{day}}',
-          ng-disabled='! canEdit(task)', ng-click='task.repeat.#{day} = !task.repeat.#{day}',
+          ng-disabled='!canEdit(task)', ng-click='task.repeat.#{day} = !task.repeat.#{day}',
           tooltip='{{env.t((task.repeat.#{day}) ? "due" : "notDue")}}')
           | {{::moment.weekdaysMin(#{num})}}
 

--- a/website/views/shared/tasks/edit/habits/plus_minus.jade
+++ b/website/views/shared/tasks/edit/habits/plus_minus.jade
@@ -1,4 +1,4 @@
-fieldset.option-group.plusminus(ng-if='task.type=="habit" && !task.challenge.id')
+fieldset.option-group.plusminus(ng-if='task.type=="habit" && canEdit(task)')
   legend.option-title=env.t('direction/Actions')
   span.task-checker
     input.visuallyhidden.focusable(id='{{obj._id}}_{{task._id}}-option-plus', type='checkbox', ng-model='task.up')

--- a/website/views/shared/tasks/edit/text_notes.jade
+++ b/website/views/shared/tasks/edit/text_notes.jade
@@ -1,6 +1,6 @@
 fieldset.option-group
   label.option-title=env.t('text')
-  input.form-control(type='text', ng-model='task.text', ng-disabled='! canEdit(task)', required)
+  input.form-control(type='text', ng-model='task.text', ng-disabled='!canEdit(task)', required)
 
 fieldset.option-group
   label.option-title=env.t('extraNotes')

--- a/website/views/shared/tasks/edit/text_notes.jade
+++ b/website/views/shared/tasks/edit/text_notes.jade
@@ -1,6 +1,6 @@
 fieldset.option-group
   label.option-title=env.t('text')
-  input.form-control(type='text', ng-model='task.text', required, ng-disabled='task.challenge.id')
+  input.form-control(type='text', ng-model='task.text', ng-disabled='! canEdit(task)', required)
 
 fieldset.option-group
   label.option-title=env.t('extraNotes')

--- a/website/views/shared/tasks/edit/todos/due_date.jade
+++ b/website/views/shared/tasks/edit/todos/due_date.jade
@@ -1,4 +1,4 @@
-fieldset.option-group(ng-if='task.type=="todo" && !task.challenge.id')
+fieldset.option-group(ng-if='task.type=="todo" && canEdit(task)')
   legend.option-title=env.t('dueDate')
   input.option-content.datepicker(type='text', ng-model='task.date',
     datepicker-popup='{{::user.preferences.dateFormat}}', is-open='datepickerOpened',

--- a/website/views/shared/tasks/task_view/index.jade
+++ b/website/views/shared/tasks/task_view/index.jade
@@ -37,7 +37,8 @@
     label(for='box-{{::obj._id}}_{{::task._id}}')
 
 // main content
-.task-text(ng-dblclick='task._editing ? saveTask(task) : editTask(task)')
+// don't allow a double click to edit if the object is locked
+.task-text(ng-dblclick='obj._locked ? {} : task._editing ? saveTask(task) : editTask(task, obj)')
   markdown(text='task.text',target='_blank')
 
   div(ng-if='task.checklist && !$state.includes("options.social.challenges") && !task.collapseChecklist && !task._editing')

--- a/website/views/shared/tasks/task_view/index.jade
+++ b/website/views/shared/tasks/task_view/index.jade
@@ -38,7 +38,7 @@
 
 // main content
 // don't allow a double click to edit if the object is locked
-.task-text(ng-dblclick='obj._locked ? {} : task._editing ? saveTask(task) : editTask(task, obj)')
+.task-text(ng-dblclick='doubleClickTask(obj, task)')
   markdown(text='task.text',target='_blank')
 
   div(ng-if='task.checklist && !$state.includes("options.social.challenges") && !task.collapseChecklist && !task._editing')


### PR DESCRIPTION
Fixes #7320 
### Changes

This change allows challenge owners to modify challenge tasks after the initial creation of the challenge. 

Allowed Changes:
- Edit the title of a task
- Edit the extra notes (NB: the participants can also edit)
- Change the difficulty
- Edit the Habit's negative and positive buttons
- Edit the repeat fields and start date for a Daily
- Edit the due date for a To-Do
- Add and delete tasks

Notes:
- Removing a task from a challenge doesn't remove the task from the user, only results in the user task having a broken challenge link and can be removed that way. This isn't a change in behavior.
- Changes (except for notes) will be propagated to all users of that challenge.
- Changes to the notes of a challenge won't effect anyone who's already in the challenge, only users who join the challenge after the update will have the new notes.
- I've remove the ability to open a task edit window for challenge tasks when just viewing challenges by double clicking. You can replicate this behavior in prod by going to challenges, expanding one, and double clicking a task. This functionality will be removed by this pull request.

---

UUID: 2a4d30ee-4833-420e-be7c-ad6a6e261c5f
