### PR TITLE
fix: allows user to leave party/guild that doesn't exist

### DIFF
--- a/test/api/v3/integration/groups/POST-groups_groupId_leave.js
+++ b/test/api/v3/integration/groups/POST-groups_groupId_leave.js
@@ -6,6 +6,7 @@ import {
   generateUser,
   translate as t,
 } from '../../../../helpers/api-v3-integration.helper';
+import { v4 as generateUUID } from 'uuid';
 import {
   each,
 } from 'lodash';
@@ -171,6 +172,19 @@ describe('POST /groups/:groupId/leave', () => {
 
         expect(userWithoutInvitation.invitations.guilds).to.not.be.empty;
       });
+
+      it('deletes non existant guild from user when user tries to leave', async () => {
+        let nonExistentGuildId = generateUUID();
+        let userWithNonExistentGuild = await generateUser({guilds: [nonExistentGuildId]});
+        expect(userWithNonExistentGuild.guilds).to.contain(nonExistentGuildId);
+
+        await expect(userWithNonExistentGuild.post(`/groups/${nonExistentGuildId}/leave`))
+          .to.eventually.be.rejected;
+
+        await userWithNonExistentGuild.sync();
+
+        expect(userWithNonExistentGuild.guilds).to.not.contain(nonExistentGuildId);
+      });
     });
 
     context('party', () => {
@@ -205,6 +219,19 @@ describe('POST /groups/:groupId/leave', () => {
 
         expect(userWithoutInvitation.invitations.party).to.be.empty;
       });
+    });
+
+    it('deletes non existant party from user when user tries to leave', async () => {
+      let nonExistentPartyId = generateUUID();
+      let userWithNonExistentParty = await generateUser({'party._id': nonExistentPartyId});
+      expect(userWithNonExistentParty.party._id).to.be.eql(nonExistentPartyId);
+
+      await expect(userWithNonExistentParty.post(`/groups/${nonExistentPartyId}/leave`))
+        .to.eventually.be.rejected;
+
+      await userWithNonExistentParty.sync();
+
+      expect(userWithNonExistentParty.guilds).to.not.eql(nonExistentPartyId);
     });
   });
 });

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -348,7 +348,13 @@ api.leaveGroup = {
     if (validationErrors) throw validationErrors;
 
     let group = await Group.getGroup({user, groupId: req.params.groupId, fields: '-chat', requireMembership: true});
-    if (!group) throw new NotFound(res.t('groupNotFound'));
+    if (!group) {
+      delete user.party._id;
+      removeFromArray(user.guilds, req.params.groupId);
+      await user.save();
+
+      throw new NotFound(res.t('groupNotFound'));
+    }
 
     // During quests, checke wheter user can leave
     if (group.type === 'party') {

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -347,10 +347,14 @@ api.leaveGroup = {
     let validationErrors = req.validationErrors();
     if (validationErrors) throw validationErrors;
 
-    let group = await Group.getGroup({user, groupId: req.params.groupId, fields: '-chat', requireMembership: true});
+    let groupId = req.params.groupId;
+    let group = await Group.getGroup({user, groupId, fields: '-chat', requireMembership: true});
     if (!group) {
-      delete user.party._id;
-      removeFromArray(user.guilds, req.params.groupId);
+      if (groupId === user.party._id) {
+        delete user.party._id;
+      } else {
+        removeFromArray(user.guilds, groupId);
+      }
       await user.save();
 
       throw new NotFound(res.t('groupNotFound'));


### PR DESCRIPTION
Fixes #7724 
### Changes

This change allows a user to leave a party or group that doesn't exist to avoid the poison pill situation that currently exists.

---

UUID: 2a4d30ee-4833-420e-be7c-ad6a6e261c5f
