### PR TITLE
fix: shows user correct challenge when showing won challenge modal

### DIFF
--- a/website/client/js/controllers/notificationCtrl.js
+++ b/website/client/js/controllers/notificationCtrl.js
@@ -97,7 +97,9 @@ habitrpg.controller('NotificationCtrl',
             $rootScope.openModal('rebirthEnabled');
             break;
           case 'WON_CHALLENGE':
-            $rootScope.openModal('wonChallenge', {controller: 'UserCtrl', size: 'sm'});
+            User.sync().then( function() {
+              $rootScope.openModal('wonChallenge', {controller: 'UserCtrl', size: 'sm'});
+            });
             break;
           case 'STREAK_ACHIEVEMENT':
             Notification.streak(User.user.achievements.streak);


### PR DESCRIPTION
Fixes #7716 
### Changes

Updating challenge pop up to sync the user object from the database before showing the user the challenge won modal to make sure that the most recent challenge won is the one that is displayed.

---

UUID: 2a4d30ee-4833-420e-be7c-ad6a6e261c5f
