### PR TITLE
fix: Correct purchase call to use purchaseType, not identifier

### DIFF
--- a/common/script/ops/purchase.js
+++ b/common/script/ops/purchase.js
@@ -60,11 +60,10 @@ module.exports = function purchase (user, req = {}, analytics) {
     ];
   }
 
-  let acceptedTypes = ['eggs', 'hatchingPotions', 'premiumHatchingPotions', 'food', 'quests', 'gear'];
+  let acceptedTypes = ['eggs', 'hatchingPotions', 'food', 'quests', 'gear'];
   if (acceptedTypes.indexOf(type) === -1) {
     throw new NotFound(i18n.t('notAccteptedType', req.language));
   }
-  if (type === 'premiumHatchingPotions') type = 'hatchingPotions';
 
   if (type === 'gear') {
     item = content.gear.flat[key];

--- a/website/views/options/inventory/drops.jade
+++ b/website/views/options/inventory/drops.jade
@@ -119,7 +119,7 @@
                 popover='{{item.notes}}', popover-append-to-body='true',
                 popover-title!='{{item.text}}',
                 popover-trigger='mouseenter', popover-placement='top',
-                ng-click='purchase(category.identifier, item)')
+                ng-click='purchase(item.purchaseType, item)')
               p {{item.value}}&nbsp;
                 span.Pet_Currency_Gem1x.inline-gems(ng-if='item.currency === "gems"')
                 span(class='shop_gold', ng-if='item.currency === "gold"')


### PR DESCRIPTION
The view for purchasing things in the market was using the category identifier instead of the item's purchaseType to make the purchase. This fixes that and removes the logic to accept premiumHatchingPotions since the purchase type for those is just hatchingPotions.

Since we just added the premiumHatchingPotions check and didn't document in the api docs that premiumHatchingPotions are an accepted type, I don't consider this a breaking change.

@SabreCat 

@vIiRuS sanity check. The mobile apps don't use the category identifier to make the purchase, right? They use purchaseType?
