### PR TITLE
Fix preferences typeError

### DIFF
--- a/website/views/shared/tasks/task_view/index.jade
+++ b/website/views/shared/tasks/task_view/index.jade
@@ -37,7 +37,7 @@
     label(for='box-{{::obj._id}}_{{::task._id}}')
 
 // main content
-.task-text(ng-dblclick='task._editing ? saveTask(task) : editTask(task)')
+.task-text(ng-dblclick='task._editing ? saveTask(task) : editTask(task, user)')
   markdown(text='task.text',target='_blank')
 
   div(ng-if='task.checklist && !$state.includes("options.social.challenges") && !task.collapseChecklist && !task._editing')


### PR DESCRIPTION
Fixes an issue where double-clicking a task to edit it would throw `TypeError: Cannot read property 'preferences' of undefined`.
### Changes

In most places where we call `editTask`, we provide the task and the user object. However, in the double-click action for tasks, we only sent the task, which resulted in the function being unable to find the user's editing preferences. Now this bit also provides the user object.
