### PR TITLE
api: expose user's inbox.optOut for `api/v3/members/:memberId` #7798

### DIFF
--- a/test/api/v3/integration/groups/GET-groups_groupId_members.test.js
+++ b/test/api/v3/integration/groups/GET-groups_groupId_members.test.js
@@ -79,7 +79,7 @@ describe('GET /groups/:groupId/members', () => {
 
     expect(memberRes).to.have.all.keys([ // works as: object has all and only these keys
       '_id', 'id', 'preferences', 'profile', 'stats', 'achievements', 'party',
-      'backer', 'contributor', 'auth', 'items',
+      'backer', 'contributor', 'auth', 'items', 'inbox',
     ]);
     expect(Object.keys(memberRes.auth)).to.eql(['timestamps']);
     expect(Object.keys(memberRes.preferences).sort()).to.eql(['size', 'hair', 'skin', 'shirt',
@@ -88,6 +88,8 @@ describe('GET /groups/:groupId/members', () => {
     expect(memberRes.stats.maxMP).to.exists;
     expect(memberRes.stats.maxHealth).to.equal(common.maxHealth);
     expect(memberRes.stats.toNextLevel).to.equal(common.tnl(memberRes.stats.lvl));
+    expect(memberRes.inbox.optOut).to.exist;
+    expect(memberRes.inbox.messages).to.not.exist;
   });
 
   it('returns only first 30 members', async () => {

--- a/test/api/v3/integration/groups/GET-groups_groupId_members.test.js
+++ b/test/api/v3/integration/groups/GET-groups_groupId_members.test.js
@@ -85,7 +85,7 @@ describe('GET /groups/:groupId/members', () => {
     expect(Object.keys(memberRes.preferences).sort()).to.eql(['size', 'hair', 'skin', 'shirt',
       'chair', 'costume', 'sleep', 'background'].sort());
 
-    expect(memberRes.stats.maxMP).to.exists;
+    expect(memberRes.stats.maxMP).to.exist;
     expect(memberRes.stats.maxHealth).to.equal(common.maxHealth);
     expect(memberRes.stats.toNextLevel).to.equal(common.tnl(memberRes.stats.lvl));
     expect(memberRes.inbox.optOut).to.exist;

--- a/test/api/v3/integration/members/GET-members_id.test.js
+++ b/test/api/v3/integration/members/GET-members_id.test.js
@@ -38,7 +38,7 @@ describe('GET /members/:memberId', () => {
     expect(Object.keys(memberRes.preferences).sort()).to.eql(['size', 'hair', 'skin', 'shirt',
       'chair', 'costume', 'sleep', 'background'].sort());
 
-    expect(memberRes.stats.maxMP).to.exists;
+    expect(memberRes.stats.maxMP).to.exist;
     expect(memberRes.stats.maxHealth).to.equal(common.maxHealth);
     expect(memberRes.stats.toNextLevel).to.equal(common.tnl(memberRes.stats.lvl));
     expect(memberRes.inbox.optOut).to.exist;

--- a/test/api/v3/integration/members/GET-members_id.test.js
+++ b/test/api/v3/integration/members/GET-members_id.test.js
@@ -32,7 +32,7 @@ describe('GET /members/:memberId', () => {
     let memberRes = await user.get(`/members/${member._id}`);
     expect(memberRes).to.have.all.keys([ // works as: object has all and only these keys
       '_id', 'id', 'preferences', 'profile', 'stats', 'achievements', 'party',
-      'backer', 'contributor', 'auth', 'items',
+      'backer', 'contributor', 'auth', 'items', 'inbox',
     ]);
     expect(Object.keys(memberRes.auth)).to.eql(['timestamps']);
     expect(Object.keys(memberRes.preferences).sort()).to.eql(['size', 'hair', 'skin', 'shirt',
@@ -41,6 +41,8 @@ describe('GET /members/:memberId', () => {
     expect(memberRes.stats.maxMP).to.exists;
     expect(memberRes.stats.maxHealth).to.equal(common.maxHealth);
     expect(memberRes.stats.toNextLevel).to.equal(common.tnl(memberRes.stats.lvl));
+    expect(memberRes.inbox.optOut).to.exist;
+    expect(memberRes.inbox.messages).to.not.exist;
   });
 
   it('handles non-existing members', async () => {

--- a/test/api/v3/integration/user/GET-user.test.js
+++ b/test/api/v3/integration/user/GET-user.test.js
@@ -14,7 +14,7 @@ describe('GET /user', () => {
     let returnedUser = await user.get('/user');
     expect(returnedUser._id).to.equal(user._id);
 
-    expect(returnedUser.stats.maxMP).to.exists;
+    expect(returnedUser.stats.maxMP).to.exist;
     expect(returnedUser.stats.maxHealth).to.equal(common.maxHealth);
     expect(returnedUser.stats.toNextLevel).to.equal(common.tnl(returnedUser.stats.lvl));
   });

--- a/test/api/v3/integration/user/POST-user_class_cast_spellId.test.js
+++ b/test/api/v3/integration/user/POST-user_class_cast_spellId.test.js
@@ -156,7 +156,7 @@ describe('POST /user/class/cast/:spellId', () => {
     await groupLeader.post('/user/class/cast/earth');
     await sleep(1);
     await group.sync();
-    expect(group.chat[0]).to.exists;
+    expect(group.chat[0]).to.exist;
     expect(group.chat[0].uuid).to.equal('system');
   });
 

--- a/test/api/v3/unit/models/user.test.js
+++ b/test/api/v3/unit/models/user.test.js
@@ -36,13 +36,13 @@ describe('User Model', () => {
     let user = new User();
     let userToJSON = user.toJSON();
 
-    expect(userToJSON.stats.maxMP).to.not.exists;
-    expect(userToJSON.stats.maxHealth).to.not.exists;
-    expect(userToJSON.stats.toNextLevel).to.not.exists;
+    expect(userToJSON.stats.maxMP).to.not.exist;
+    expect(userToJSON.stats.maxHealth).to.not.exist;
+    expect(userToJSON.stats.toNextLevel).to.not.exist;
 
     user.addComputedStatsToJSONObj(userToJSON);
 
-    expect(userToJSON.stats.maxMP).to.exists;
+    expect(userToJSON.stats.maxMP).to.exist;
     expect(userToJSON.stats.maxHealth).to.equal(common.maxHealth);
     expect(userToJSON.stats.toNextLevel).to.equal(common.tnl(user.stats.lvl));
   });

--- a/test/common/ops/addTask.js
+++ b/test/common/ops/addTask.js
@@ -32,7 +32,7 @@ describe('shared.ops.addTask', () => {
     expect(habit.up).to.equal(true);
     expect(habit.down).to.equal(false);
     expect(habit.history).to.eql([]);
-    expect(habit.checklist).to.not.exists;
+    expect(habit.checklist).to.not.exist;
   });
 
   it('adds an habtit when type is invalid', () => {
@@ -53,7 +53,7 @@ describe('shared.ops.addTask', () => {
     expect(habit.up).to.equal(true);
     expect(habit.down).to.equal(false);
     expect(habit.history).to.eql([]);
-    expect(habit.checklist).to.not.exists;
+    expect(habit.checklist).to.not.exist;
   });
 
   it('adds a daily', () => {
@@ -73,7 +73,7 @@ describe('shared.ops.addTask', () => {
     expect(daily.history).to.eql([]);
     expect(daily.checklist).to.eql([]);
     expect(daily.completed).to.be.false;
-    expect(daily.up).to.not.exists;
+    expect(daily.up).to.not.exist;
   });
 
   it('adds a todo', () => {
@@ -92,7 +92,7 @@ describe('shared.ops.addTask', () => {
     expect(todo.text).to.equal('todo');
     expect(todo.checklist).to.eql([]);
     expect(todo.completed).to.be.false;
-    expect(todo.up).to.not.exists;
+    expect(todo.up).to.not.exist;
   });
 
   it('adds a reward', () => {
@@ -110,7 +110,7 @@ describe('shared.ops.addTask', () => {
     expect(reward.type).to.equal('reward');
     expect(reward.text).to.equal('reward');
     expect(reward.value).to.equal(10);
-    expect(reward.up).to.not.exists;
+    expect(reward.up).to.not.exist;
   });
 
   context('user preferences', () => {

--- a/test/common/ops/equip.js
+++ b/test/common/ops/equip.js
@@ -38,19 +38,19 @@ describe('shared.ops.equip', () => {
 
       // one-handed to one-handed
       let [, message] = equip(user, {params: {key: 'weapon_warrior_2'}});
-      expect(message).to.not.exists;
+      expect(message).to.not.exist;
 
       // one-handed to two-handed
       [, message] = equip(user, {params: {key: 'weapon_wizard_1'}});
-      expect(message).to.not.exists;
+      expect(message).to.not.exist;
 
       // two-handed to two-handed
       [, message] = equip(user, {params: {key: 'weapon_wizard_2'}});
-      expect(message).to.not.exists;
+      expect(message).to.not.exist;
 
       // two-handed to one-handed
       [, message] = equip(user, {params: {key: 'weapon_warrior_2'}});
-      expect(message).to.not.exists;
+      expect(message).to.not.exist;
     });
 
     it('should send messages if equipping a two-hander causes the off-hander to be unequipped', () => {

--- a/test/common/ops/unlock.js
+++ b/test/common/ops/unlock.js
@@ -67,19 +67,19 @@ describe('shared.ops.unlock', () => {
   });
 
   it('equips an item already owned', () => {
-    expect(user.purchased.background.giant_florals).to.not.exists;
+    expect(user.purchased.background.giant_florals).to.not.exist;
 
     unlock(user, {query: {path: backgroundUnlockPath}});
     let afterBalance = user.balance;
     let response = unlock(user, {query: {path: backgroundUnlockPath}});
     expect(user.balance).to.equal(afterBalance); // do not bill twice
 
-    expect(response.message).to.not.exists;
+    expect(response.message).to.not.exist;
     expect(user.preferences.background).to.equal('giant_florals');
   });
 
   it('un-equips an item already equipped', () => {
-    expect(user.purchased.background.giant_florals).to.not.exists;
+    expect(user.purchased.background.giant_florals).to.not.exist;
 
     unlock(user, {query: {path: backgroundUnlockPath}}); // unlock
     let afterBalance = user.balance;
@@ -87,7 +87,7 @@ describe('shared.ops.unlock', () => {
     let response = unlock(user, {query: {path: backgroundUnlockPath}});
     expect(user.balance).to.equal(afterBalance); // do not bill twice
 
-    expect(response.message).to.not.exists;
+    expect(response.message).to.not.exist;
     expect(user.preferences.background).to.equal('');
   });
 

--- a/website/server/controllers/api-v3/members.js
+++ b/website/server/controllers/api-v3/members.js
@@ -162,7 +162,7 @@ function _getMembersForItem (type) {
  *
  * @apiParam {UUID} groupId The group id
  * @apiParam {UUID} lastId Query parameter to specify the last member returned in a previous request to this route and get the next batch of results
- * @apiParam {boolean} includeAllPublicFields Query parameter available only when fetching a party. If === `true` then all public fields for members will be returned (liek when making a request for a single member)
+ * @apiParam {boolean} includeAllPublicFields Query parameter available only when fetching a party. If === `true` then all public fields for members will be returned (like when making a request for a single member)
  *
  * @apiSuccess {array} data An array of members, sorted by _id
  */

--- a/website/server/models/user/index.js
+++ b/website/server/models/user/index.js
@@ -8,7 +8,7 @@ require('./methods');
 // A list of publicly accessible fields (not everything from preferences because there are also a lot of settings tha should remain private)
 export let publicFields = `preferences.size preferences.hair preferences.skin preferences.shirt
   preferences.chair preferences.costume preferences.sleep preferences.background profile stats
-  achievements party backer contributor auth.timestamps items`;
+  achievements party backer contributor auth.timestamps items inbox.optOut`;
 
 // The minimum amount of data needed when populating multiple users
 export let nameFields = 'profile.name';


### PR DESCRIPTION
Trivial change that should fix the request from #7798 . The publicFields are used only in this api call, so extending here rather than altering the mongoose select call is nicer.

Fixes #7798

---

UUID: 10c530d0-a796-476b-8a31-6f048c6e8a8c
