### PR TITLE
allow flagging the post of a deleted user

### DIFF
--- a/test/api/v3/integration/chat/POST-chat.flag.test.js
+++ b/test/api/v3/integration/chat/POST-chat.flag.test.js
@@ -30,7 +30,7 @@ describe('POST /chat/:chatId/flag', () => {
   });
 
   it('Returns an error when user tries to flag their own message', async () => {
-    let message = await user.post(`/groups/${group._id}/chat`, { message: TEST_MESSAGE });
+    let message = await user.post(`/groups/${group._id}/chat`, {message: TEST_MESSAGE});
     await expect(user.post(`/groups/${group._id}/chat/${message.message.id}/flag`))
       .to.eventually.be.rejected.and.eql({
         code: 404,
@@ -40,7 +40,7 @@ describe('POST /chat/:chatId/flag', () => {
   });
 
   it('Flags a chat', async () => {
-    let message = await anotherUser.post(`/groups/${group._id}/chat`, { message: TEST_MESSAGE});
+    let message = await anotherUser.post(`/groups/${group._id}/chat`, {message: TEST_MESSAGE});
     message = message.message;
 
     let flagResult = await user.post(`/groups/${group._id}/chat/${message.id}/flag`);
@@ -53,9 +53,9 @@ describe('POST /chat/:chatId/flag', () => {
     expect(messageToCheck.flags[user._id]).to.equal(true);
   });
 
-  it('Flags a chat when the author\'s count was deleted', async () => {
+  it('Flags a chat when the author\'s account was deleted', async () => {
     let deletedUser = await generateUser();
-    let message = await deletedUser.post(`/groups/${group._id}/chat`, { message: TEST_MESSAGE});
+    let message = await deletedUser.post(`/groups/${group._id}/chat`, {message: TEST_MESSAGE});
     message = message.message;
     await deletedUser.del('/user', {
       password: 'password',
@@ -72,7 +72,7 @@ describe('POST /chat/:chatId/flag', () => {
   });
 
   it('Flags a chat with a higher flag acount when an admin flags the message', async () => {
-    let message = await user.post(`/groups/${group._id}/chat`, { message: TEST_MESSAGE});
+    let message = await user.post(`/groups/${group._id}/chat`, {message: TEST_MESSAGE});
     message = message.message;
 
     let flagResult = await admin.post(`/groups/${group._id}/chat/${message.id}/flag`);
@@ -87,7 +87,7 @@ describe('POST /chat/:chatId/flag', () => {
   });
 
   it('Returns an error when user tries to flag a message that is already flagged', async () => {
-    let message = await anotherUser.post(`/groups/${group._id}/chat`, { message: TEST_MESSAGE});
+    let message = await anotherUser.post(`/groups/${group._id}/chat`, {message: TEST_MESSAGE});
     message = message.message;
 
     await user.post(`/groups/${group._id}/chat/${message.id}/flag`);

--- a/test/api/v3/integration/chat/POST-chat.flag.test.js
+++ b/test/api/v3/integration/chat/POST-chat.flag.test.js
@@ -40,8 +40,7 @@ describe('POST /chat/:chatId/flag', () => {
   });
 
   it('Flags a chat', async () => {
-    let message = await anotherUser.post(`/groups/${group._id}/chat`, {message: TEST_MESSAGE});
-    message = message.message;
+    let { message } = await anotherUser.post(`/groups/${group._id}/chat`, {message: TEST_MESSAGE});
 
     let flagResult = await user.post(`/groups/${group._id}/chat/${message.id}/flag`);
     expect(flagResult.flags[user._id]).to.equal(true);
@@ -55,8 +54,7 @@ describe('POST /chat/:chatId/flag', () => {
 
   it('Flags a chat when the author\'s account was deleted', async () => {
     let deletedUser = await generateUser();
-    let message = await deletedUser.post(`/groups/${group._id}/chat`, {message: TEST_MESSAGE});
-    message = message.message;
+    let { message } = await deletedUser.post(`/groups/${group._id}/chat`, {message: TEST_MESSAGE});
     await deletedUser.del('/user', {
       password: 'password',
     });
@@ -72,8 +70,7 @@ describe('POST /chat/:chatId/flag', () => {
   });
 
   it('Flags a chat with a higher flag acount when an admin flags the message', async () => {
-    let message = await user.post(`/groups/${group._id}/chat`, {message: TEST_MESSAGE});
-    message = message.message;
+    let { message } = await user.post(`/groups/${group._id}/chat`, {message: TEST_MESSAGE});
 
     let flagResult = await admin.post(`/groups/${group._id}/chat/${message.id}/flag`);
     expect(flagResult.flags[admin._id]).to.equal(true);
@@ -87,8 +84,7 @@ describe('POST /chat/:chatId/flag', () => {
   });
 
   it('Returns an error when user tries to flag a message that is already flagged', async () => {
-    let message = await anotherUser.post(`/groups/${group._id}/chat`, {message: TEST_MESSAGE});
-    message = message.message;
+    let { message } = await anotherUser.post(`/groups/${group._id}/chat`, {message: TEST_MESSAGE});
 
     await user.post(`/groups/${group._id}/chat/${message.id}/flag`);
 

--- a/test/api/v3/integration/chat/POST-chat.flag.test.js
+++ b/test/api/v3/integration/chat/POST-chat.flag.test.js
@@ -53,6 +53,24 @@ describe('POST /chat/:chatId/flag', () => {
     expect(messageToCheck.flags[user._id]).to.equal(true);
   });
 
+  it('Flags a chat when the author\'s count was deleted', async () => {
+    let deletedUser = await generateUser();
+    let message = await deletedUser.post(`/groups/${group._id}/chat`, { message: TEST_MESSAGE});
+    message = message.message;
+    await deletedUser.del('/user', {
+      password: 'password',
+    });
+
+    let flagResult = await user.post(`/groups/${group._id}/chat/${message.id}/flag`);
+    expect(flagResult.flags[user._id]).to.equal(true);
+    expect(flagResult.flagCount).to.equal(1);
+
+    let groupWithFlags = await admin.get(`/groups/${group._id}`);
+
+    let messageToCheck = find(groupWithFlags.chat, {id: message.id});
+    expect(messageToCheck.flags[user._id]).to.equal(true);
+  });
+
   it('Flags a chat with a higher flag acount when an admin flags the message', async () => {
     let message = await user.post(`/groups/${group._id}/chat`, { message: TEST_MESSAGE});
     message = message.message;

--- a/website/client/js/controllers/chatCtrl.js
+++ b/website/client/js/controllers/chatCtrl.js
@@ -96,20 +96,10 @@ habitrpg.controller('ChatCtrl', ['$scope', 'Groups', 'Chat', 'User', '$http', 'A
         $scope.groupId = groupId;
 
         $scope.isSystemMessage = message.uuid === 'system';
-        if (message.uuid === 'system') {
-            $rootScope.openModal('abuse-flag',{
-              controller:'MemberModalCtrl',
-              scope: $scope
-            });
-        } else {
-          Members.selectMember(message.uuid)
-            .then(function () {
-              $rootScope.openModal('abuse-flag',{
-                controller:'MemberModalCtrl',
-                scope: $scope
-              });
-            });
-        }
+        $rootScope.openModal('abuse-flag',{
+          controller:'MemberModalCtrl',
+          scope: $scope
+        });
       }
     };
 

--- a/website/server/controllers/api-v3/chat.js
+++ b/website/server/controllers/api-v3/chat.js
@@ -217,7 +217,13 @@ api.flagChat = {
 
     let reporterEmailContent = getUserInfo(user, ['email']).email;
 
-    let authorEmailContent = author ? getUserInfo(author, ['email']).email : 'system';
+    let authorEmailContent;
+    if (author) {
+      authorEmailContent = getUserInfo(author, ['email']).email;
+    } else {
+      // if there's no author it's either a system message or a user who deleted their account
+      authorEmailContent = message.uuid === 'system' ? 'system' : 'Author Account Deleted';
+    }
 
     let groupUrl = getGroupUrl(group);
 

--- a/website/server/controllers/api-v3/chat.js
+++ b/website/server/controllers/api-v3/chat.js
@@ -220,9 +220,10 @@ api.flagChat = {
     let authorEmailContent;
     if (author) {
       authorEmailContent = getUserInfo(author, ['email']).email;
+    } else if (message.uuid === 'system') {
+      authorEmailContent = 'system';
     } else {
-      // if there's no author it's either a system message or a user who deleted their account
-      authorEmailContent = message.uuid === 'system' ? 'system' : 'Author Account Deleted';
+      authorEmailContent = 'Author Account Deleted';
     }
 
     let groupUrl = getGroupUrl(group);

--- a/website/views/shared/modals/members.jade
+++ b/website/views/shared/modals/members.jade
@@ -102,7 +102,7 @@ script(type='text/ng-template', id='modals/send-gift.html')
 
 script(type='text/ng-template', id='modals/abuse-flag.html')
   .modal-header
-    h4!=env.t('abuseFlagModalHeading', {name: "<span class='text-danger'>{{isSystemMessage ? env.t('systemMessage') : profile.profile.name}}</span>"})
+    h4!=env.t('abuseFlagModalHeading', {name: "<span class='text-danger'>{{isSystemMessage ? env.t('systemMessage') : abuseObject.user}}</span>"})
   .modal-body
     blockquote
       markdown(text="abuseObject.text")


### PR DESCRIPTION
Fixes #7894 
closes #7894 
### Changes

Allows users to now flag posts from users that have since been deleted. This flag will email admins with all the message information as before but as there is no email for the deleted user the email address will read "Author Account Deleted".
