### PR TITLE
Update email check exist

### DIFF
--- a/common/locales/en/front.json
+++ b/common/locales/en/front.json
@@ -252,5 +252,6 @@
     "onlySocialAttachLocal": "Local authentication can be added to only a social account.",
     "invalidReqParams": "Invalid request parameters.",
     "memberIdRequired": "\"member\" must be a valid UUID.",
-    "heroIdRequired": "\"heroId\" must be a valid UUID."
+    "heroIdRequired": "\"heroId\" must be a valid UUID.",
+    "cannotFulfillReq":"Your request cannot be fulfilled.  Email admin@habitica.com if this error persists"
 }

--- a/common/locales/en/front.json
+++ b/common/locales/en/front.json
@@ -253,5 +253,5 @@
     "invalidReqParams": "Invalid request parameters.",
     "memberIdRequired": "\"member\" must be a valid UUID.",
     "heroIdRequired": "\"heroId\" must be a valid UUID.",
-    "cannotFulfillReq":"Your request cannot be fulfilled.  Email admin@habitica.com if this error persists"
+    "cannotFulfillReq":"Your request cannot be fulfilled.  Email admin@habitica.com if this error persists."
 }

--- a/test/api/v3/integration/user/auth/PUT-user_update_email.test.js
+++ b/test/api/v3/integration/user/auth/PUT-user_update_email.test.js
@@ -55,6 +55,17 @@ describe('PUT /user/auth/update-email', () => {
       await user.sync();
       expect(user.auth.local.email).to.eql(newEmail);
     });
+
+    it('rejects if email is already taken', async () => {
+      await expect(user.put(ENDPOINT, {
+        newEmail: user.auth.local.email,
+        password: oldPassword
+      })).to.eventually.be.rejected.and.eql({
+        code: 401,
+        error: 'NotAuthorized',
+        message: t('cannotFulfillReq'),
+      });
+    });
   });
 
   context('Social Login User', async () => {

--- a/test/api/v3/integration/user/auth/PUT-user_update_email.test.js
+++ b/test/api/v3/integration/user/auth/PUT-user_update_email.test.js
@@ -59,7 +59,7 @@ describe('PUT /user/auth/update-email', () => {
     it('rejects if email is already taken', async () => {
       await expect(user.put(ENDPOINT, {
         newEmail: user.auth.local.email,
-        password: oldPassword
+        password: oldPassword,
       })).to.eventually.be.rejected.and.eql({
         code: 401,
         error: 'NotAuthorized',

--- a/website/server/controllers/api-v3/auth.js
+++ b/website/server/controllers/api-v3/auth.js
@@ -532,6 +532,12 @@ api.updateEmail = {
     let validationErrors = req.validationErrors();
     if (validationErrors) throw validationErrors;
 
+    let userSameEmail = await User.findOne({'auth.local.email': req.body.newEmail}).exec();
+    if (userSameEmail) {
+        console.log("email already taken by another user");
+        throw new NotAuthorized(res.t('emailTaken'));
+    }
+
     let candidatePassword = passwordUtils.encrypt(req.body.password, user.auth.local.salt);
     if (candidatePassword !== user.auth.local.hashed_password) throw new NotAuthorized(res.t('wrongPassword'));
 

--- a/website/server/controllers/api-v3/auth.js
+++ b/website/server/controllers/api-v3/auth.js
@@ -533,10 +533,7 @@ api.updateEmail = {
     if (validationErrors) throw validationErrors;
 
     let userSameEmail = await User.findOne({'auth.local.email': req.body.newEmail}).exec();
-    if (userSameEmail) {
-        console.log("email already taken by another user");
-        throw new NotAuthorized(res.t('emailTaken'));
-    }
+    if (userSameEmail) { throw new NotAuthorized(res.t('cannotFulfillReq'));}
 
     let candidatePassword = passwordUtils.encrypt(req.body.password, user.auth.local.salt);
     if (candidatePassword !== user.auth.local.hashed_password) throw new NotAuthorized(res.t('wrongPassword'));

--- a/website/server/controllers/api-v3/auth.js
+++ b/website/server/controllers/api-v3/auth.js
@@ -532,8 +532,8 @@ api.updateEmail = {
     let validationErrors = req.validationErrors();
     if (validationErrors) throw validationErrors;
 
-    let userSameEmail = await User.findOne({'auth.local.email': req.body.newEmail}).exec();
-    if (userSameEmail) throw new NotAuthorized(res.t('cannotFulfillReq'));
+    let emailAlreadyInUse = await User.findOne({'auth.local.email': req.body.newEmail}).select({_id: 1}).lean().exec();
+    if (emailAlreadyInUse) throw new NotAuthorized(res.t('cannotFulfillReq'));
 
     let candidatePassword = passwordUtils.encrypt(req.body.password, user.auth.local.salt);
     if (candidatePassword !== user.auth.local.hashed_password) throw new NotAuthorized(res.t('wrongPassword'));

--- a/website/server/controllers/api-v3/auth.js
+++ b/website/server/controllers/api-v3/auth.js
@@ -533,7 +533,7 @@ api.updateEmail = {
     if (validationErrors) throw validationErrors;
 
     let userSameEmail = await User.findOne({'auth.local.email': req.body.newEmail}).exec();
-    if (userSameEmail) { throw new NotAuthorized(res.t('cannotFulfillReq'));}
+    if (userSameEmail) throw new NotAuthorized(res.t('cannotFulfillReq'));
 
     let candidatePassword = passwordUtils.encrypt(req.body.password, user.auth.local.salt);
     if (candidatePassword !== user.auth.local.hashed_password) throw new NotAuthorized(res.t('wrongPassword'));


### PR DESCRIPTION
https://github.com/HabitRPG/habitrpg/issues/7847 Update email route should check that proposed email is not already being used 
### Changes
- throw an error when user tries to update his/her email in setting -> site to an email that is already used by another user
- can't explicitly show "email is taken" message, because this hurts users privacy (as suggested by @Alys 
- added a generic error message that goes "Your request cannot be fulfilled.  Email admin@habitica.com if this error persists.", hoping that this message can be used somewhere else.

<img width="253" alt="screen shot 2016-08-13 at 11 20 01 pm" src="https://cloud.githubusercontent.com/assets/14202218/17647632/75096336-61ad-11e6-8e21-f41df1ff1f90.png">

Note: the updated message has a period at the end.  This is a slightly outdated screenshot.

---

UUID: 62d73118-8bef-4085-b2ff-81f522b4a3e2
