### PR TITLE
fix(client): Correct logic to show premium pets (hide pawprints for unobtainable magic hatching potion pets)

### DIFF
--- a/website/client/js/controllers/inventoryCtrl.js
+++ b/website/client/js/controllers/inventoryCtrl.js
@@ -357,6 +357,34 @@ habitrpg.controller("InventoryCtrl",
     $scope.timeTravelersCategories = Shared.shops.getTimeTravelersCategories(user);
     $scope.seasonalShopCategories = Shared.shops.getSeasonalShopCategories(user);
 
+    $scope.shouldShowPremiumPetRow = function (potion) {
+      potion = Content.premiumHatchingPotions[potion];
+
+      if (!potion) {
+        return false;
+      }
+      if (user.items.hatchingPotions[potion.key] > 0) {
+        return true;
+      }
+      if (potion.canBuy()) {
+        return true;
+      }
+
+      var pets = Object.keys(user.items.pets);
+      var hasAPetOfPotion = pets.find(function (pet) {
+        return pet.indexOf(potion.key) !== -1;
+      });
+
+      return hasAPetOfPotion;
+    };
+
+    $scope.shouldShowPremiumPetSection = function () {
+      var potions = Content.premiumHatchingPotions;
+      return Object.keys(potions).find(function (potion) {
+        return $scope.shouldShowPremiumPetRow(potions[potion].key);
+      });
+    };
+
     function _updateDropAnimalCount(items) {
       $scope.petCount = Shared.count.beastMasterProgress(items.pets);
       $scope.mountCount = Shared.count.mountMasterProgress(items.mounts);

--- a/website/views/options/inventory/pets.jade
+++ b/website/views/options/inventory/pets.jade
@@ -25,11 +25,11 @@ mixin petList(eggSource, potionSource)
         h4 {{:: env.t('stableBeastMasterProgress', { number: beastMasterProgress }) }}
   .row: .col-md-12
     +petList(env.Content.dropEggs,env.Content.dropHatchingPotions)
-  .row: .col-md-12
+  .row(ng-if="::shouldShowPremiumPetSection()"): .col-md-12
     h4=env.t('magicPets')
     menu.pets(type='list')
       each potion in env.Content.premiumHatchingPotions
-        li.customize-menu
+        li.customize-menu(ng-if="::shouldShowPremiumPetRow('#{potion.key}')")
           menu
             each egg in env.Content.dropEggs
               - pet = egg.key+"-"+potion.key


### PR DESCRIPTION
Fixes #7888 
### Changes
- Shows premium pet row if user has any potions of that type
- Shows premium pet row if potions of that type can be purchased
- Shows premium pet row if user has a pet of that type already
### Note:

The logic is written such that if a user has no potions of the row's type, and cannot purchase a potion, but does have a pet of that type, the pet will show up but the paw prints do not. This makes sense because it will be impossible for the user to hatch those pets at this time. However, it might be confusing as it will look different than the other sections.

![pets](https://cloud.githubusercontent.com/assets/2916945/17810290/3eca43ee-65ea-11e6-98c5-d322e54e3895.png)
