### PR TITLE
allows leader of challenge to create new challenge tasks even when not a participant

### DIFF
--- a/test/api/v3/integration/tasks/challenges/POST-tasks_challenge_id.test.js
+++ b/test/api/v3/integration/tasks/challenges/POST-tasks_challenge_id.test.js
@@ -33,19 +33,14 @@ describe('POST /tasks/challenge/:challengeId', () => {
     });
   });
 
-  it('returns error when user does not have the challenge', async () => {
-    let userWithoutChallenge = await generateUser();
-
-    await expect(userWithoutChallenge.post(`/tasks/challenge/${challenge._id}`, {
+  it('allows leader to modify challenge when not a member', async () => {
+    await user.post(`/challenges/${challenge._id}/leave`);
+    await user.post(`/tasks/challenge/${challenge._id}`, {
       text: 'test habit',
       type: 'habit',
       up: false,
       down: true,
       notes: 1976,
-    })).to.eventually.be.rejected.and.eql({
-      code: 404,
-      error: 'NotFound',
-      message: t('challengeNotFound'),
     });
   });
 

--- a/website/server/controllers/api-v3/tasks.js
+++ b/website/server/controllers/api-v3/tasks.js
@@ -120,7 +120,7 @@ api.createChallengeTasks = {
     let challenge = await Challenge.findOne({_id: challengeId}).exec();
 
     // If the challenge does not exist, or if it exists but user is not the leader -> throw error
-    if (!challenge || user.challenges.indexOf(challengeId) === -1) throw new NotFound(res.t('challengeNotFound'));
+    if (!challenge) throw new NotFound(res.t('challengeNotFound'));
     if (challenge.leader !== user._id) throw new NotAuthorized(res.t('onlyChalLeaderEditTasks'));
 
     let tasks = await _createTasks(req, res, user, challenge);


### PR DESCRIPTION
Fixes #7918 
### Changes

Allows the leader of a challenge to add new tasks to the challenge even if they are not participating in the challenge.

---

UUID: 
