### PR TITLE
GP will not be deducted if health is max

### DIFF
--- a/common/locales/en/messages.json
+++ b/common/locales/en/messages.json
@@ -30,6 +30,7 @@
 
   "messageAlreadyPurchasedGear": "You purchased this gear in the past, but do not currently own it. You can buy it again in the rewards column on the tasks page.",
   "messageAlreadyOwnGear": "You already own this item. Equip it by going to the equipment page.",
+  "messageHealthAlreadyMax": "You already have maximum health.",
 
   "armoireEquipment": "<%= image %> You found a piece of rare Equipment in the Armoire: <%= dropText %>! Awesome!",
   "armoireFood": "<%= image %> You rummage in the Armoire and find <%= dropArticle %><%= dropText %>. What's that doing in here?",

--- a/common/script/ops/buyHealthPotion.js
+++ b/common/script/ops/buyHealthPotion.js
@@ -15,6 +15,10 @@ module.exports = function buyHealthPotion (user, req = {}, analytics) {
     throw new NotAuthorized(i18n.t('cannotBuyItem', req.language));
   }
 
+  if (user.stats.hp >= 50) {
+    throw new NotAuthorized(i18n.t('messageHealthAlreadyMax', req.language));
+  }
+
   user.stats.hp += 15;
   if (user.stats.hp > 50) {
     user.stats.hp = 50;

--- a/test/api/v3/integration/user/POST-user_buy.test.js
+++ b/test/api/v3/integration/user/POST-user_buy.test.js
@@ -31,6 +31,7 @@ describe('POST /user/buy/:key', () => {
   it('buys a potion', async () => {
     await user.update({
       'stats.gp': 400,
+      'stats.hp': 40,
     });
 
     let potion = content.potion;
@@ -42,6 +43,19 @@ describe('POST /user/buy/:key', () => {
     expect(res.message).to.equal(t('messageBought', {itemText: potion.text()}));
   });
 
+  it('returns an error if user tries to buy a potion with full health', async () => {
+    await user.update({
+      'stats.gp': 40,
+      'stats.hp': 50,
+    });
+
+    await expect(user.post('/user/buy/potion'))
+      .to.eventually.be.rejected.and.eql({
+        code: 401,
+        error: 'NotAuthorized',
+        message: t('messageHealthAlreadyMax'),
+      });
+  });
   it('buys a piece of gear', async () => {
     let key = 'armor_warrior_1';
 

--- a/test/common/ops/buyHealthPotion.js
+++ b/test/common/ops/buyHealthPotion.js
@@ -61,5 +61,20 @@ describe('shared.ops.buyHealthPotion', () => {
         done();
       }
     });
+
+    it('does not purchase if hp is full', (done) => {
+      user.stats.hp = 50;
+      user.stats.gp = 40;
+      try {
+        buyHealthPotion(user);
+      } catch (err) {
+        expect(err).to.be.an.instanceof(NotAuthorized);
+        expect(err.message).to.equal(i18n.t('messageHealthAlreadyMax'));
+        expect(user.stats.hp).to.eql(50);
+        expect(user.stats.gp).to.eql(40);
+
+        done();
+      }
+    });
   });
 });


### PR DESCRIPTION
https://github.com/HabitRPG/habitrpg/issues/6384
### Changes

Now if the user tries to buy potion if he/she has max health, it will not deduct any GP

Note: Need to update message.json for all languages. 

---

UUID: 
2d7c17ad-3f7e-4783-b697-b77820fff31d
