### PR TITLE
Fix gift subscription termination date

### DIFF
--- a/test/api/v3/unit/libs/payments.test.js
+++ b/test/api/v3/unit/libs/payments.test.js
@@ -78,14 +78,23 @@ describe('payments/index', () => {
         expect(recipient.purchased.plan.extraMonths).to.eql(3);
       });
 
-      it('updates date terminated for an existing plan with a terminated date', async () => {
-        let dateTerminated = new Date();
+      it('adds to date terminated for an existing plan with a future terminated date', async () => {
+        let dateTerminated = moment().add(1, 'months').toDate();
         recipient.purchased.plan = plan;
         recipient.purchased.plan.dateTerminated = dateTerminated;
 
         await api.createSubscription(data);
 
         expect(recipient.purchased.plan.dateTerminated).to.eql(moment(dateTerminated).add(3, 'months').toDate());
+      });
+
+      it('replaces date terminated for an account with a past terminated date', async () => {
+        let dateTerminated = moment().subtract(1, 'months').toDate();
+        recipient.purchased.plan.dateTerminated = dateTerminated;
+
+        await api.createSubscription(data);
+
+        expect(moment(recipient.purchased.plan.dateTerminated).format('YYYY-MM-DD')).to.eql(moment().add(3, 'months').format('YYYY-MM-DD'));
       });
 
       it('sets a dateTerminated date for a user without an existing subscription', async () => {

--- a/website/server/libs/payments.js
+++ b/website/server/libs/payments.js
@@ -34,8 +34,12 @@ api.createSubscription = async function createSubscription (data) {
     if (plan.customerId && !plan.dateTerminated) { // User has active plan
       plan.extraMonths += months;
     } else {
-      plan.dateTerminated = moment(plan.dateTerminated).add({months}).toDate();
       if (!plan.dateUpdated) plan.dateUpdated = new Date();
+      if (moment(plan.dateTerminated).isAfter()) {
+        plan.dateTerminated = moment(plan.dateTerminated).add({months}).toDate();
+      } else {
+        plan.dateTerminated = moment().add({months}).toDate();
+      }
     }
 
     if (!plan.customerId) plan.customerId = 'Gift'; // don't override existing customer, but all sub need a customerId


### PR DESCRIPTION
### Changes

Previously, if a user had a past terminated date in their subscription data (i.e., they had a subscription before that ended), an incoming gift subscription would add to that termination date instead of counting forward from the current date. This often resulted in gift subscriptions terminating the cron after they began, or some other date short of what the gifting user paid for.

Now, we check to see if `dateTerminated` is in the past, and if so, we add the new subscription end date to today's date instead of that old date. We will continue to add gift subscription months on to the existing end date if that date is in the future.

---

UUID: [Gift Ending Date](https://map.what3words.com/gift.ending.date)
