### PR TITLE
Clear up login button text

### DIFF
--- a/common/locales/en/front.json
+++ b/common/locales/en/front.json
@@ -130,7 +130,7 @@
     "passMan": "In case you are using a password manager (like 1Password) and have problems logging in, try typing your username and password manually.",
     "password": "Password",
     "playButton": "Play",
-    "playButtonFull": "Play Habitica",
+    "playButtonFull": "Enter Habitica",
     "presskit": "Press Kit",
     "presskitDownload": "Download all images:",
     "presskitText": "Thanks for your interest in Habitica! The following images can be used for articles or videos about Habitica. For more information, please contact the staff at admin@habitica.com.",


### PR DESCRIPTION
Fixes https://github.com/HabitRPG/habitrpg/issues/7634
### Changes

Changes "Play Habitica" to "Enter Habitica" to make it more obvious that it is a Login button

---

UUID: [Login Play Enter](https://map.what3words.com/login.play.enter) 95f16006-1504-4a9f-95b6-0c7314dbd7ee
