### PR TITLE
Handle empty market category on Drops page

### DIFF
--- a/common/script/libs/shops.js
+++ b/common/script/libs/shops.js
@@ -78,6 +78,7 @@ shops.getMarketCategories = function getMarket (user, language) {
         purchaseType: 'hatchingPotions',
       };
     }).sortBy('key').value();
+  categories.push(premiumHatchingPotionsCategory);
 
   let foodCategory = {
     identifier: 'food',

--- a/test/common/libs/shops.js
+++ b/test/common/libs/shops.js
@@ -19,12 +19,6 @@ describe('shops', () => {
       expect(identifiers.length).to.eql(shopCategories.length);
     });
 
-    it('does not contain an empty category', () => {
-      _.each(shopCategories, (category) => {
-        expect(category.items.length).to.be.greaterThan(0);
-      });
-    });
-
     it('items contain required fields', () => {
       _.each(shopCategories, (category) => {
         _.each(category.items, (item) => {

--- a/website/views/options/inventory/drops.jade
+++ b/website/views/options/inventory/drops.jade
@@ -107,7 +107,7 @@
 
       menu.inventory-list(type='list')
         li.customize-menu(ng-repeat='category in marketShopCategories')
-          menu.pets-menu(label='{{category.text}}', ng-hide='category.items.length < 1')
+          menu.pets-menu(label='{{category.text}}', ng-if='category.items.length > 0')
             p.muted(ng-bind-html='category.notes')
 
             div(ng-repeat='item in category.items')

--- a/website/views/options/inventory/drops.jade
+++ b/website/views/options/inventory/drops.jade
@@ -107,7 +107,7 @@
 
       menu.inventory-list(type='list')
         li.customize-menu(ng-repeat='category in marketShopCategories')
-          menu.pets-menu(label='{{category.text}}')
+          menu.pets-menu(label='{{category.text}}', ng-hide='category.items.length < 1')
             p.muted(ng-bind-html='category.notes')
 
             div(ng-repeat='item in category.items')


### PR DESCRIPTION
### Changes

Lets the Market view on the web site hide sections of the purchase list if they come back with no items for purchase. This allows things like Magic Hatching Potions to drop off the page when all items are out of season, without need for manual changes to API or UI.
