### PR TITLE
Disable task buttons on challenge view/edit/create

### DIFF
--- a/website/views/shared/tasks/task_view/index.jade
+++ b/website/views/shared/tasks/task_view/index.jade
@@ -33,7 +33,7 @@
       ng-change='changeCheck(task)'
       ui-keypress='{13:"task.completed = !task.completed; changeCheck(task)"}' )
     input.visuallyhidden.focusable(id='box-{{::obj._id}}_{{::task._id}}', type='checkbox',
-      ng-if='!$state.includes("tasks")')
+      ng-if='!$state.includes("tasks")', ng-disabled='$state.includes("options.social.challenges")')
     label(for='box-{{::obj._id}}_{{::task._id}}')
 
 // main content


### PR DESCRIPTION
Fixes https://github.com/HabitRPG/habitrpg/issues/5284
### Changes

added an `ng-disabled='$state.includes("options.social.challenges")'` to disable the checkbox on challenge view/edit/create.

None of the buttons are clickable anymore, but on challenge edit/create the icon still changes when you hover the mouse on it. I wasn't able to fix that, and I was hoping someone could help me with that part.

Before
![2016-09-01](https://cloud.githubusercontent.com/assets/20071290/18168184/eda9e32a-702a-11e6-932a-5961a2c83e34.png)

After
![2016-09-01 1](https://cloud.githubusercontent.com/assets/20071290/18168191/f1be900a-702a-11e6-8214-1ff485dc248c.png)

Mouse over is still there
![2016-09-01 2](https://cloud.githubusercontent.com/assets/20071290/18168199/fb42a94a-702a-11e6-844f-044f0c4217c8.png)

---

UUID: 8389891a-ba52-4580-b08b-2cb706c7e0b4
