### PR TITLE
delete unread messages when a user leaves a group - fixes 7955

### DIFF
--- a/test/api/v3/integration/groups/POST-groups_groupId_leave.js
+++ b/test/api/v3/integration/groups/POST-groups_groupId_leave.js
@@ -65,6 +65,21 @@ describe('POST /groups/:groupId/leave', () => {
         expect(groupToLeave.leader).to.equal(member._id);
       });
 
+      it('removes new messages', async () => {
+        await member.post(`/groups/${groupToLeave._id}/chat`, { message: 'Some message' });
+        await member.post(`/groups/${groupToLeave._id}/leave`);
+
+        await groupToLeave.sync();
+        await member.sync();
+        await leader.sync();
+        expect(leader.newMessages[groupToLeave._id]).to.not.be.empty;
+
+        await leader.post(`/groups/${groupToLeave._id}/leave`);
+        await leader.sync();
+        await groupToLeave.sync();
+        expect(leader.newMessages[groupToLeave._id]).to.be.empty;
+      });
+
       context('With challenges', () => {
         let challenge;
 
@@ -122,6 +137,8 @@ describe('POST /groups/:groupId/leave', () => {
         privateGuild = group;
         leader = groupLeader;
         invitedUser = invitees[0];
+
+        await leader.post(`/groups/${group._id}/chat`, { message: 'Some message' });
       });
 
       it('removes a group when the last member leaves', async () => {

--- a/test/api/v3/integration/groups/POST-groups_id_removeMember.test.js
+++ b/test/api/v3/integration/groups/POST-groups_id_removeMember.test.js
@@ -87,6 +87,7 @@ describe('POST /groups/:groupId/removeMember/:memberId', () => {
     let partyLeader;
     let partyInvitedUser;
     let partyMember;
+    let removedMember;
 
     beforeEach(async () => {
       let { group, groupLeader, invitees, members } = await createAndPopulateGroup({
@@ -96,13 +97,14 @@ describe('POST /groups/:groupId/removeMember/:memberId', () => {
           privacy: 'private',
         },
         invites: 1,
-        members: 1,
+        members: 2,
       });
 
       party = group;
       partyLeader = groupLeader;
       partyInvitedUser = invitees[0];
       partyMember = members[0];
+      removedMember = members[1];
     });
 
     it('can remove other members', async () => {
@@ -127,6 +129,20 @@ describe('POST /groups/:groupId/removeMember/:memberId', () => {
       let invitedUserWithoutInvite = await partyInvitedUser.get('/user');
 
       expect(invitedUserWithoutInvite.invitations.party).to.be.empty;
+    });
+
+    it('removes new messages from a member who is removed', async () => {
+      await partyLeader.post(`/groups/${party._id}/chat`, { message: 'Some message' });
+      await partyLeader.sync();
+      await removedMember.sync();
+      await party.sync();
+      expect(removedMember.newMessages[party._id]).to.not.be.empty;
+
+      await partyLeader.post(`/groups/${party._id}/removeMember/${removedMember._id}`);
+      await party.sync();
+      await removedMember.sync();
+
+      expect(removedMember.newMessages[party._id]).to.be.empty;
     });
 
     it('removes user from quest when removing user from party after quest starts', async () => {


### PR DESCRIPTION
https://github.com/HabitRPG/habitrpg/issues/7955
### Changes

Removes unread group/party messages when a user leaves, or is removed from a group.   This includes when the final user leaves the group, preventing the issue described in 7955.   Also, added a migration script to remove any existing null messages.

---

UUID: 349ea7be-f378-4593-8702-672f75fa83f9
