### PR TITLE
API Warning message

### DIFF
--- a/common/locales/en/settings.json
+++ b/common/locales/en/settings.json
@@ -68,6 +68,7 @@
     "APIv3": "API v3",
     "APIText": "Copy these for use in third party applications. However, think of your API Token like a password, and do not share it publicly. You may occasionally be asked for your User ID, but never post your API Token where others can see it, including on Github.",
     "APIToken": "API Token (this is a password - see warning above!)",
+    "APITokenWarning": "<strong>Warning!</strong> If you need a new API token, post a request on the <a href='https://habitica.com/#/options/groups/guilds/a29da26b-37de-4a71-b0c6-48e72a900dac' class='alert-link'>Report A Bug</a> guild. This may take time, and once it is reset you will need to re-authorize everything.",
     "thirdPartyApps": "Third Party Apps",
     "dataToolDesc": "A webpage that shows you certain information from your Habitica account, such as statistics about your tasks, equipment, and skills.",
     "beeminder": "Beeminder",

--- a/common/locales/en/settings.json
+++ b/common/locales/en/settings.json
@@ -68,7 +68,7 @@
     "APIv3": "API v3",
     "APIText": "Copy these for use in third party applications. However, think of your API Token like a password, and do not share it publicly. You may occasionally be asked for your User ID, but never post your API Token where others can see it, including on Github.",
     "APIToken": "API Token (this is a password - see warning above!)",
-    "APITokenWarning": "<strong>Warning!</strong> If you need a new API token, post a request on the <a href='https://habitica.com/#/options/groups/guilds/a29da26b-37de-4a71-b0c6-48e72a900dac' class='alert-link'>Report A Bug</a> guild. This may take time, and once it is reset you will need to re-authorize everything.",
+    "APITokenWarning": "If you need a new API token (e.g. if you accidentally share it), email a request to <a href='mailto:admin@habitica.com'>admin@habitica.com</a> with your API ID and current Token. Once it is reset you will need to re-authorize everything by signing out and back in on the website and/or app and providing the new token to any extensions you use.",
     "thirdPartyApps": "Third Party Apps",
     "dataToolDesc": "A webpage that shows you certain information from your Habitica account, such as statistics about your tasks, equipment, and skills.",
     "beeminder": "Beeminder",

--- a/common/locales/en/settings.json
+++ b/common/locales/en/settings.json
@@ -68,7 +68,7 @@
     "APIv3": "API v3",
     "APIText": "Copy these for use in third party applications. However, think of your API Token like a password, and do not share it publicly. You may occasionally be asked for your User ID, but never post your API Token where others can see it, including on Github.",
     "APIToken": "API Token (this is a password - see warning above!)",
-    "APITokenWarning": "If you need a new API token (e.g. if you accidentally share it), email a request to <a href='mailto:admin@habitica.com'>admin@habitica.com</a> with your API ID and current Token. Once it is reset you will need to re-authorize everything by signing out and back in on the website and/or app and providing the new token to any extensions you use.",
+    "APITokenWarning": "If you need a new API Token (e.g., if you accidentally shared it), email <a href='mailto:admin@habitica.com'>admin@habitica.com</a> with your User ID and current Token. Once it is reset you will need to re-authorize everything by logging out of the website and mobile app and by providing the new Token to any other Habitica tools that you use.",
     "thirdPartyApps": "Third Party Apps",
     "dataToolDesc": "A webpage that shows you certain information from your Habitica account, such as statistics about your tasks, equipment, and skills.",
     "beeminder": "Beeminder",

--- a/website/views/options/settings.jade
+++ b/website/views/options/settings.jade
@@ -230,7 +230,7 @@ script(type='text/ng-template', id='partials/options.settings.api.html')
         pre.prettyprint {{user.id}}
         h6=env.t('APIToken')
         pre.prettyprint {{User.settings.auth.apiToken}}
-        div.alert.alert-danger!=env.t("APITokenWarning")
+        small!=env.t("APITokenWarning")
         h6=env.t('qrCode')
         img.img-rendering-auto(src='https://chart.googleapis.com/chart?cht=qr&chs=200x200&chl=%7B%22address%22%3A%22https%3A%2F%2Fhabitrpg.com%22%2C%22user%22%3A%22{{user.id}}%22%2C%22key%22%3A%22{{User.settings.auth.apiToken}}%22%7D&choe=UTF-8&chld=L', alt='qrcode')
         br

--- a/website/views/options/settings.jade
+++ b/website/views/options/settings.jade
@@ -230,6 +230,7 @@ script(type='text/ng-template', id='partials/options.settings.api.html')
         pre.prettyprint {{user.id}}
         h6=env.t('APIToken')
         pre.prettyprint {{User.settings.auth.apiToken}}
+        div.alert.alert-danger!=env.t("APITokenWarning")
         h6=env.t('qrCode')
         img.img-rendering-auto(src='https://chart.googleapis.com/chart?cht=qr&chs=200x200&chl=%7B%22address%22%3A%22https%3A%2F%2Fhabitrpg.com%22%2C%22user%22%3A%22{{user.id}}%22%2C%22key%22%3A%22{{User.settings.auth.apiToken}}%22%7D&choe=UTF-8&chld=L', alt='qrcode')
         br


### PR DESCRIPTION
Fixes #3049 (ish)
### Changes

Adds a warning to the API screen advising users to post to the Report a Bug guild if a new token is needed, but warning them that it won't happen instantly:

![capture](https://cloud.githubusercontent.com/assets/12386291/18332536/03dcb6b6-752d-11e6-9163-c9c1ff10b1de.PNG)

---

UUID: 95f16006-1504-4a9f-95b6-0c7314dbd7ee
