### PR TITLE
A/B Testing, Round 1

### DIFF
--- a/test/api/v3/integration/user/auth/POST-register_local.test.js
+++ b/test/api/v3/integration/user/auth/POST-register_local.test.js
@@ -64,8 +64,8 @@ describe('POST /user/auth/local/register', () => {
         confirmPassword: password,
       });
 
-      expect(user.ABtest).to.exist;
-      expect(user.ABtest).to.be.a('string');
+      expect(user._ABtest).to.exist;
+      expect(user._ABtest).to.be.a('string');
     });
 
     it('requires password and confirmPassword to match', async () => {

--- a/test/api/v3/integration/user/auth/POST-register_local.test.js
+++ b/test/api/v3/integration/user/auth/POST-register_local.test.js
@@ -3,6 +3,7 @@ import {
   requester,
   translate as t,
   createAndPopulateGroup,
+  getProperty,
 } from '../../../../../helpers/api-integration/v3';
 import { v4 as generateRandomUserName } from 'uuid';
 import { each } from 'lodash';
@@ -64,8 +65,8 @@ describe('POST /user/auth/local/register', () => {
         confirmPassword: password,
       });
 
-      expect(user._ABtest).to.exist;
-      expect(user._ABtest).to.be.a('string');
+      await expect(getProperty('users', user._id, '_ABtest')).to.eventually.exist;
+      await expect(getProperty('users', user._id, '_ABtest')).to.eventually.be.a('string');
     });
 
     it('requires password and confirmPassword to match', async () => {

--- a/test/api/v3/integration/user/auth/POST-register_local.test.js
+++ b/test/api/v3/integration/user/auth/POST-register_local.test.js
@@ -52,6 +52,22 @@ describe('POST /user/auth/local/register', () => {
       expect(user.tasksOrder.habits).to.have.a.lengthOf(0);
     });
 
+    it('enrolls new users in an A/B test', async () => {
+      let username = generateRandomUserName();
+      let email = `${username}@example.com`;
+      let password = 'password';
+
+      let user = await api.post('/user/auth/local/register', {
+        username,
+        email,
+        password,
+        confirmPassword: password,
+      });
+
+      expect(user.ABtest).to.exist;
+      expect(user.ABtest).to.be.a('string');
+    });
+
     it('requires password and confirmPassword to match', async () => {
       let username = generateRandomUserName();
       let email = `${username}@example.com`;

--- a/test/helpers/api-integration/v3/index.js
+++ b/test/helpers/api-integration/v3/index.js
@@ -6,6 +6,6 @@ requester.setApiVersion('v3');
 export { requester };
 
 export { translate } from '../translate';
-export { checkExistence, resetHabiticaDB } from '../../mongo';
+export { checkExistence, getProperty, resetHabiticaDB } from '../../mongo';
 export * from  './object-generators';
 export { sleep } from '../../sleep';

--- a/test/helpers/mongo.js
+++ b/test/helpers/mongo.js
@@ -1,5 +1,6 @@
 import mongoose from 'mongoose';
 import { TAVERN_ID } from '../../website/server/models/group';
+import { get } from 'lodash';
 
 // Useful for checking things that have been deleted,
 // but you no longer have access to,
@@ -14,6 +15,20 @@ export async function checkExistence (collectionName, id) {
       let exists = docs.length > 0;
 
       resolve(exists);
+    });
+  });
+}
+
+// Obtain a property from the database. Useful if the property is private
+// and thus unavailable to the client
+export async function getProperty (collectionName, id, path) {
+  return new Promise((resolve, reject) => {
+    let collection = mongoose.connection.db.collection(collectionName);
+
+    collection.find({_id: id}, {[path]: 1}).limit(1).toArray((findError, docs) => {
+      if (findError) return reject(findError);
+
+      resolve(get(docs[0], path));
     });
   });
 }

--- a/website/server/controllers/api-v3/auth.js
+++ b/website/server/controllers/api-v3/auth.js
@@ -133,9 +133,9 @@ api.registerLocal = {
     // A/B Test 2016-09-12: Start with Sound Enabled?
     if (Math.random() < 0.5) {
       newUser.preferences.sound = 'rosstavoTheme';
-      newUser.ABtest = '20160912-soundEnabled';
+      newUser._ABtest = '20160912-soundEnabled';
     } else {
-      newUser.ABtest = '20160912-soundDisabled';
+      newUser._ABtest = '20160912-soundDisabled';
     }
 
     // we check for partyInvite for backward compatibility

--- a/website/server/controllers/api-v3/auth.js
+++ b/website/server/controllers/api-v3/auth.js
@@ -130,6 +130,14 @@ api.registerLocal = {
       newUser.registeredThrough = req.headers['x-client']; // Not saved, used to create the correct tasks based on the device used
     }
 
+    // A/B Test 2016-09-12: Start with Sound Enabled?
+    if (Math.random() < 0.5) {
+      newUser.preferences.sound = 'rosstavoTheme';
+      newUser.ABtest = '20160912-soundEnabled';
+    } else {
+      newUser.ABtest = '20160912-soundDisabled';
+    }
+
     // we check for partyInvite for backward compatibility
     if (req.query.groupInvite || req.query.partyInvite) {
       await _handleGroupInvitation(newUser, req.query.groupInvite || req.query.partyInvite);

--- a/website/server/libs/analyticsService.js
+++ b/website/server/libs/analyticsService.js
@@ -85,8 +85,8 @@ let _formatUserData = (user) => {
     properties.subscription = user.purchased.plan.planId;
   }
 
-  if (user.ABtest) {
-    properties.ABtest = user.ABtest;
+  if (user._ABtest) {
+    properties.ABtest = user._ABtest;
   }
 
   return properties;

--- a/website/server/libs/analyticsService.js
+++ b/website/server/libs/analyticsService.js
@@ -85,6 +85,10 @@ let _formatUserData = (user) => {
     properties.subscription = user.purchased.plan.planId;
   }
 
+  if (user.ABtest) {
+    properties.ABtest = user.ABtest;
+  }
+
   return properties;
 };
 

--- a/website/server/models/user/hooks.js
+++ b/website/server/models/user/hooks.js
@@ -10,7 +10,7 @@ import schema from './schema';
 schema.plugin(baseModel, {
   // noSet is not used as updating uses a whitelist and creating only accepts specific params (password, email, username, ...)
   noSet: [],
-  private: ['auth.local.hashed_password', 'auth.local.salt', '_cronSignature', 'ABtest'],
+  private: ['auth.local.hashed_password', 'auth.local.salt', '_cronSignature'],
   toJSONTransform: function userToJSON (plainObj, originalDoc) {
     plainObj._tmp = originalDoc._tmp; // be sure to send down drop notifs
     delete plainObj.filters;

--- a/website/server/models/user/hooks.js
+++ b/website/server/models/user/hooks.js
@@ -10,7 +10,7 @@ import schema from './schema';
 schema.plugin(baseModel, {
   // noSet is not used as updating uses a whitelist and creating only accepts specific params (password, email, username, ...)
   noSet: [],
-  private: ['auth.local.hashed_password', 'auth.local.salt', '_cronSignature'],
+  private: ['auth.local.hashed_password', 'auth.local.salt', '_cronSignature', 'ABtest'],
   toJSONTransform: function userToJSON (plainObj, originalDoc) {
     plainObj._tmp = originalDoc._tmp; // be sure to send down drop notifs
     delete plainObj.filters;

--- a/website/server/models/user/hooks.js
+++ b/website/server/models/user/hooks.js
@@ -10,7 +10,7 @@ import schema from './schema';
 schema.plugin(baseModel, {
   // noSet is not used as updating uses a whitelist and creating only accepts specific params (password, email, username, ...)
   noSet: [],
-  private: ['auth.local.hashed_password', 'auth.local.salt', '_cronSignature'],
+  private: ['auth.local.hashed_password', 'auth.local.salt', '_cronSignature', '_ABtest'],
   toJSONTransform: function userToJSON (plainObj, originalDoc) {
     plainObj._tmp = originalDoc._tmp; // be sure to send down drop notifs
     delete plainObj.filters;

--- a/website/server/models/user/schema.js
+++ b/website/server/models/user/schema.js
@@ -521,7 +521,7 @@ let schema = new Schema({
     return {};
   }},
   pushDevices: [PushDeviceSchema],
-  ABtest: {type: String},
+  _ABtest: {type: String},
 }, {
   strict: true,
   minimize: false, // So empty objects are returned

--- a/website/server/models/user/schema.js
+++ b/website/server/models/user/schema.js
@@ -521,6 +521,7 @@ let schema = new Schema({
     return {};
   }},
   pushDevices: [PushDeviceSchema],
+  ABtest: {type: String},
 }, {
   strict: true,
   minimize: false, // So empty objects are returned


### PR DESCRIPTION
### Changes

Implements a user property `ABtest` that is then sent as part of user-level properties for analytics calls. This will be used to sort new users into cohorts to test different setups for improving retention.

The first of these tests is included as part of this PR: do users retain better if the site uses sound effects from the beginning? ~50% of new users during the test will have the "Rosstavo Theme" enabled by default, while the rest continue with the current setup of no starting sounds.

---

UUID: [Sound Test Retention](https://map.what3words.com/sound.test.retention)
