### PR TITLE
Use npm package instead of github for @slack/client.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "3.39.1",
   "main": "./website/server/index.js",
   "dependencies": {
-    "@slack/client": "slackhq/node-slack-sdk#2ee794cd31326c54f38c518eef2b9d223327d939",
+    "@slack/client": "3.6.0",
     "accepts": "^1.3.2",
     "amazon-payments": "0.0.4",
     "amplitude": "^2.0.3",


### PR DESCRIPTION
### Changes

Changed `@slack/client` dependency in `package.json` to use npm instead of github. Package is now released on npm and fixed a bug for me and possibly others not being able to download the module through github.

---

UUID: b1f8093a-76b7-4f80-95ce-5c00bec74c0a
