### PR TITLE
reduce number of required items for collection quests (fixes #5842) {continued in #8754}

### DIFF
--- a/common/script/content/index.js
+++ b/common/script/content/index.js
@@ -1283,7 +1283,7 @@ api.quests = {
     collect: {
       lightCrystal: {
         text: t('questVice2CollectLightCrystal'),
-        count: 45
+        count: 30
       }
     },
     drop: {
@@ -1351,7 +1351,7 @@ api.quests = {
     collect: {
       plainEgg: {
         text: t('questEggHuntCollectPlainEgg'),
-        count: 100
+        count: 40
       }
     },
     drop: {
@@ -1684,7 +1684,7 @@ api.quests = {
     collect: {
       moonstone: {
         text: t('questMoonstone1CollectMoonstone'),
-        count: 500
+        count: 100
       }
     },
     drop: {
@@ -1789,7 +1789,7 @@ api.quests = {
     collect: {
       testimony: {
         text: t('questGoldenknight1CollectTestimony'),
-        count: 300
+        count: 60
       }
     },
     drop: {
@@ -2230,11 +2230,11 @@ api.quests = {
     collect: {
       fireCoral: {
         text: t('questDilatoryDistress1CollectFireCoral'),
-        count: 25
+        count: 20
       },
       blueFins: {
         text: t('questDilatoryDistress1CollectBlueFins'),
-        count: 25
+        count: 20
       }
     },
     drop: {


### PR DESCRIPTION
Fixes https://github.com/HabitRPG/habitrpg/issues/5618
### Changes

Reduce the number of required items for collection quests, with values proposed by [lemoness](https://github.com/HabitRPG/habitrpg/issues/5618#issuecomment-157479872):

| Quest Name | Quest Object Name | Old value(s) | new value(s) |
| :-- | :-- | :-- | :-- |
| Dish Disaster | atom1 | 20 | no change |
| Find the Cub | evilsanta2 | 30 (10 branches + 20 tracks) | no change |
| Find the Lair of the Wyrm | vice2 | 45 | 30 |
| Egg Hunt | egg | 100 | 40 |
| Message in a Bottle | dilatoryDistress1 | 50 (25 fireCoral + 25 blueFins) | 40 (20 fireCoral + 20 blueFins) |
| A Stern Talking-To | goldenknight1 | 300 | 60 |
| The Moonstone Chain | moonstone1 | 500 | 100 |

---

UUID: b6d7a7ca-98e1-4f11-b895-47c2b3667b9d
