### PR TITLE
Avatar's eyes can be set to open or closed in modals while in the Inn fixes #6282

### DIFF
--- a/website/views/shared/avatar/generated_avatar.jade
+++ b/website/views/shared/avatar/generated_avatar.jade
@@ -10,6 +10,8 @@ mixin generatedAvatar(options)
   +costumeSetting('back')
   if options.sleep
     span(ng-class="'skin_' + profile.preferences.skin + '_sleep'")
+  else if options.sleep == false
+    span(ng-class="'skin_' + profile.preferences.skin")
   else
     span(ng-class="profile.preferences.sleep ? 'skin_' + profile.preferences.skin + '_sleep' : 'skin_' + profile.preferences.skin")
   span(class='{{profile.preferences.size}}_shirt_{{profile.preferences.shirt}}')

--- a/website/views/shared/avatar/generated_avatar.jade
+++ b/website/views/shared/avatar/generated_avatar.jade
@@ -8,9 +8,9 @@ mixin generatedAvatar(options)
   - options = options || {}
   span(class='chair_{{profile.preferences.chair}}')
   +costumeSetting('back')
-  if options.sleep
+  if options.sleep === true
     span(ng-class="'skin_' + profile.preferences.skin + '_sleep'")
-  else if options.sleep == false
+  else if options.sleep === false
     span(ng-class="'skin_' + profile.preferences.skin")
   else
     span(ng-class="profile.preferences.sleep ? 'skin_' + profile.preferences.skin + '_sleep' : 'skin_' + profile.preferences.skin")


### PR DESCRIPTION
Fixes 6282
### Changes

Avatar's eyes can be specified to show as open, closed, or to match their current Inn status by setting the `sleep` variable in `generatedAvatar` to false, true, or null (respectively). Now the avatar can be specified to be displayed with open eyes even if the user is in the Inn (e.g. when levelling up).

I did not change any calling functions to display the modal with eyes open in this commit, only local modifications to generate the images below. But I can also make those changes if desired.

Old Functionality: User in the Inn
![old11](https://cloud.githubusercontent.com/assets/2165770/18402646/7ae4c17c-76ae-11e6-9259-edf5e7e5f65a.png)

Old Functionality: User not in the Inn
![old00](https://cloud.githubusercontent.com/assets/2165770/18402659/86a52d44-76ae-11e6-975f-1fb6ff994b26.png)

New Functionality: User in the Inn, `sleep=true` and `sleep=null`
![new1n](https://cloud.githubusercontent.com/assets/2165770/18402699/a3194212-76ae-11e6-9c8c-7f32b8317a0b.png)

New Functionality: User in the Inn, `sleep=false`
![new10](https://cloud.githubusercontent.com/assets/2165770/18402711/b0b3ecba-76ae-11e6-93c6-511388fa5a49.png)

New Functionality: User not in the Inn, `sleep=true`
![new01](https://cloud.githubusercontent.com/assets/2165770/18402736/dee5f272-76ae-11e6-900e-8c5033bb3d50.png)

New Functionality: User not in the Inn, `sleep=false`  and `sleep=null`
## ![new0n](https://cloud.githubusercontent.com/assets/2165770/18402740/ea485632-76ae-11e6-910f-bb6efdda89cd.png)

UUID: f5a68145-b375-4b99-8fb4-f9ff7a2c52b5
