### PR TITLE
Disallow interactions by blocked users; some interaction API refactoring (fixes #7971) {Continued in #8755}

### DIFF
--- a/common/locales/en/groups.json
+++ b/common/locales/en/groups.json
@@ -193,5 +193,6 @@
     "canOnlyInviteMaxInvites": "You can only invite \"<%= maxInvites %>\" at a time",
     "onlyCreatorOrAdminCanDeleteChat": "Not authorized to delete this message!",
     "onlyGroupLeaderCanEditTasks": "Not authorized to manage tasks!",
-    "onlyGroupTasksCanBeAssigned": "Only group tasks can be assigned"
+    "onlyGroupTasksCanBeAssigned": "Only group tasks can be assigned",
+    "chatPrivilegesRevoked": "Your chat privileges have been revoked."
 }

--- a/test/api/v3/integration/chat/POST-chat.test.js
+++ b/test/api/v3/integration/chat/POST-chat.test.js
@@ -44,7 +44,7 @@ describe('POST /chat', () => {
     await expect(userWithChatRevoked.post(`/groups/${groupWithChat._id}/chat`, { message: testMessage})).to.eventually.be.rejected.and.eql({
       code: 404,
       error: 'NotFound',
-      message: 'Your chat privileges have been revoked.',
+      message: t('chatPrivilegesRevoked'),
     });
   });
 

--- a/test/api/v3/integration/chat/POST-chat.test.js
+++ b/test/api/v3/integration/chat/POST-chat.test.js
@@ -42,8 +42,8 @@ describe('POST /chat', () => {
 
   it('Returns an error when chat privileges are revoked', async () => {
     await expect(userWithChatRevoked.post(`/groups/${groupWithChat._id}/chat`, { message: testMessage})).to.eventually.be.rejected.and.eql({
-      code: 404,
-      error: 'NotFound',
+      code: 401,
+      error: 'NotAuthorized',
       message: t('chatPrivilegesRevoked'),
     });
   });

--- a/test/api/v3/integration/members/GET-objections_to_interaction.test.js
+++ b/test/api/v3/integration/members/GET-objections_to_interaction.test.js
@@ -38,14 +38,13 @@ describe('GET /members/:toUserId/objections-to/:interaction', () => {
     await expect(
       user.get(`/members/${receiver._id}/objections-to/hug-a-whole-forest-of-trees`)
     ).to.eventually.be.rejected.and.eql({
-      code: 404,
-      error: 'NotFound',
-      message: 'Unknown kind of interaction: "hug-a-whole-forest-of-trees", expected one of send-private-message, transfer-gems',
-      // FIXME: Very fragile message, not sure what to do here
+      code: 400,
+      error: 'BadRequest',
+      message: t('invalidReqParams'),
     });
   });
 
-  it('returns nothing if there are no objections', async () => {
+  it('returns an empty array if there are no objections', async () => {
     let receiver = await generateUser();
 
     await expect(

--- a/test/api/v3/integration/members/GET-objections_to_interaction.test.js
+++ b/test/api/v3/integration/members/GET-objections_to_interaction.test.js
@@ -3,7 +3,6 @@ import {
   translate as t,
 } from '../../../../helpers/api-v3-integration.helper';
 import { v4 as generateUUID } from 'uuid';
-// import common from '../../../../../common';
 
 describe('GET /members/:toUserId/objections-to/:interaction', () => {
   let user;

--- a/test/api/v3/integration/members/GET-objections_to_interaction_if_any.test.js
+++ b/test/api/v3/integration/members/GET-objections_to_interaction_if_any.test.js
@@ -1,0 +1,56 @@
+import {
+  generateUser,
+  translate as t,
+} from '../../../../helpers/api-v3-integration.helper';
+import { v4 as generateUUID } from 'uuid';
+// import common from '../../../../../common';
+
+describe('GET /members/:toUserId/objections-to/:interaction', () => {
+  let user;
+
+  before(async () => {
+    user = await generateUser();
+  });
+
+  it('validates req.params.memberId', async () => {
+    await expect(
+      user.get('/members/invalidUUID/objections-to/send-private-message')
+    ).to.eventually.be.rejected.and.eql({
+      code: 400,
+      error: 'BadRequest',
+      message: t('invalidReqParams'),
+    });
+  });
+
+  it('handles non-existing members', async () => {
+    let dummyId = generateUUID();
+    await expect(
+      user.get(`/members/${dummyId}/objections-to/send-private-message`)
+    ).to.eventually.be.rejected.and.eql({
+      code: 404,
+      error: 'NotFound',
+      message: t('userWithIDNotFound', {userId: dummyId}),
+    });
+  });
+
+  it('handles non-existing interactions', async () => {
+    let receiver = await generateUser();
+
+    await expect(
+      user.get(`/members/${receiver._id}/objections-to/hug-a-whole-forest-of-trees`)
+    ).to.eventually.be.rejected.and.eql({
+      code: 404,
+      error: 'NotFound',
+      message: 'Unknown kind of interaction: "hug-a-whole-forest-of-trees", expected one of send-private-message, transfer-gems',
+      // FIXME: Very fragile message, not sure what to do here
+    });
+  });
+
+  it('returns nothing if there are no objections', async () => {
+    let receiver = await generateUser();
+
+    await expect(
+      user.get(`/members/${receiver._id}/objections-to/send-private-message`)
+    ).to.eventually.be.fulfilled.and.eql([]);
+  });
+});

--- a/test/api/v3/integration/members/POST-send_private_message.test.js
+++ b/test/api/v3/integration/members/POST-send_private_message.test.js
@@ -90,8 +90,8 @@ describe('POST /members/send-private-message', () => {
       message: messageToSend,
       toUserId: receiver._id,
     })).to.eventually.be.rejected.and.eql({
-      code: 404,
-      error: 'NotFound',
+      code: 401,
+      error: 'NotAuthorized',
       message: t('chatPrivilegesRevoked'),
     });
   });

--- a/test/api/v3/integration/members/POST-send_private_message.test.js
+++ b/test/api/v3/integration/members/POST-send_private_message.test.js
@@ -82,6 +82,20 @@ describe('POST /members/send-private-message', () => {
     });
   });
 
+  it('returns an error when chat privileges are revoked', async () => {
+    let userWithChatRevoked = await generateUser({'flags.chatRevoked': true});
+    let receiver = await generateUser();
+
+    await expect(userWithChatRevoked.post('/members/send-private-message', {
+      message: messageToSend,
+      toUserId: receiver._id,
+    })).to.eventually.be.rejected.and.eql({
+      code: 404,
+      error: 'NotFound',
+      message: t('chatPrivilegesRevoked'),
+    });
+  });
+
   it('sends a private message to a user', async () => {
     let receiver = await generateUser();
 

--- a/test/api/v3/integration/members/POST-transfer_gems.test.js
+++ b/test/api/v3/integration/members/POST-transfer_gems.test.js
@@ -87,21 +87,6 @@ describe('POST /members/transfer-gems', () => {
     });
   });
 
-  it('returns error when to user has opted out of messaging', async () => {
-    // FIXME: Not sure this is wanted
-    let receiverOptOut = await generateUser({'inbox.optOut': true});
-
-    await expect(userToSendMessage.post('/members/transfer-gems', {
-      message,
-      gemAmount,
-      toUserId: receiverOptOut._id,
-    })).to.eventually.be.rejected.and.eql({
-      code: 401,
-      error: 'NotAuthorized',
-      message: t('notAuthorizedToSendMessageToThisUser'),
-    });
-  });
-
   it('returns an error when chat privileges are revoked', async () => {
     let userWithChatRevoked = await generateUser({'flags.chatRevoked': true});
 

--- a/website/server/controllers/api-v3/chat.js
+++ b/website/server/controllers/api-v3/chat.js
@@ -95,7 +95,7 @@ api.postChat = {
 
     if (!group) throw new NotFound(res.t('groupNotFound'));
     if (group.type !== 'party' && user.flags.chatRevoked) {
-      throw new NotFound(res.t('chatPrivilegesRevoked'));
+      throw new NotAuthorized(res.t('chatPrivilegesRevoked'));
     }
 
     let lastClientMsg = req.query.previousMsg;

--- a/website/server/controllers/api-v3/chat.js
+++ b/website/server/controllers/api-v3/chat.js
@@ -95,7 +95,7 @@ api.postChat = {
 
     if (!group) throw new NotFound(res.t('groupNotFound'));
     if (group.type !== 'party' && user.flags.chatRevoked) {
-      throw new NotFound('Your chat privileges have been revoked.');
+      throw new NotFound(res.t('chatPrivilegesRevoked'));
     }
 
     let lastClientMsg = req.query.previousMsg;

--- a/website/server/controllers/api-v3/members.js
+++ b/website/server/controllers/api-v3/members.js
@@ -294,6 +294,8 @@ api.sendPrivateMessage = {
     let sender = res.locals.user;
     let message = req.body.message;
 
+    if (sender.flags.chatRevoked) throw new NotFound(res.t('chatPrivilegesRevoked'));
+
     let receiver = await User.findById(req.body.toUserId).exec();
     if (!receiver) throw new NotFound(res.t('userNotFound'));
 

--- a/website/server/controllers/api-v3/members.js
+++ b/website/server/controllers/api-v3/members.js
@@ -269,6 +269,22 @@ api.getChallengeMemberProgress = {
   },
 };
 
+// Throws an exception if for any reason the sender is not allowed to interact with
+// the receiver.
+function _throwUnlessInteractionAllowedBetween (sender, receiver, res) {
+  if (sender.flags.chatRevoked) {
+    throw new NotAuthorized(res.t('chatPrivilegesRevoked'));
+  }
+
+  let userBlockedSender = receiver.inbox.blocks.indexOf(sender._id) !== -1;
+  let userIsBlockBySender = sender.inbox.blocks.indexOf(receiver._id) !== -1;
+  let userOptedOutOfMessaging = receiver.inbox.optOut;
+
+  if (userBlockedSender || userIsBlockBySender || userOptedOutOfMessaging) {
+    throw new NotAuthorized(res.t('notAuthorizedToSendMessageToThisUser'));
+  }
+}
+
 /**
  * @api {posts} /api/v3/members/send-private-message Send a private message to a member
  * @apiVersion 3.0.0
@@ -293,19 +309,10 @@ api.sendPrivateMessage = {
 
     let sender = res.locals.user;
     let message = req.body.message;
-
-    if (sender.flags.chatRevoked) throw new NotFound(res.t('chatPrivilegesRevoked'));
-
     let receiver = await User.findById(req.body.toUserId).exec();
     if (!receiver) throw new NotFound(res.t('userNotFound'));
 
-    let userBlockedSender = receiver.inbox.blocks.indexOf(sender._id) !== -1;
-    let userIsBlockBySender = sender.inbox.blocks.indexOf(receiver._id) !== -1;
-    let userOptedOutOfMessaging = receiver.inbox.optOut;
-
-    if (userBlockedSender || userIsBlockBySender || userOptedOutOfMessaging) {
-      throw new NotAuthorized(res.t('notAuthorizedToSendMessageToThisUser'));
-    }
+    _throwUnlessInteractionAllowedBetween(sender, receiver, res);
 
     await sender.sendMessage(receiver, message);
 
@@ -356,13 +363,14 @@ api.transferGems = {
     if (validationErrors) throw validationErrors;
 
     let sender = res.locals.user;
-
     let receiver = await User.findById(req.body.toUserId).exec();
     if (!receiver) throw new NotFound(res.t('userNotFound'));
 
     if (receiver._id === sender._id) {
       throw new NotAuthorized(res.t('cannotSendGemsToYourself'));
     }
+
+    _throwUnlessInteractionAllowedBetween(sender, receiver, res);
 
     let gemAmount = req.body.gemAmount;
     let amount = gemAmount / 4;

--- a/website/server/controllers/api-v3/members.js
+++ b/website/server/controllers/api-v3/members.js
@@ -276,7 +276,7 @@ api.getChallengeMemberProgress = {
  * @apiGroup Member
  *
  * @apiParam {UUID} toUserId The user to interact with
- * @apiParam {String} interaction Name of the interaction to query, e.g. "send-private-message"
+ * @apiParam {String="send-private-message","transfer-gems"} interaction Name of the interaction to query
  *
  * @apiSuccess {Array} data Return an array of error messages, if the interaction would be blocked; otherwise an empty array
  */

--- a/website/server/controllers/api-v3/members.js
+++ b/website/server/controllers/api-v3/members.js
@@ -272,7 +272,7 @@ api.getChallengeMemberProgress = {
 /**
  * @api {get} /api/v3/members/:toUserId/objections-to/:interaction Get the message of any errors that would occur if the given interaction was attempted
  * @apiVersion 3.0.0
- * @apiName GetObjectionsToInteractionIfAny
+ * @apiName GetObjectionsToInteraction
  * @apiGroup Member
  *
  * @apiParam {UUID} toUserId The user to interact with
@@ -280,7 +280,7 @@ api.getChallengeMemberProgress = {
  *
  * @apiSuccess {Array} data Return an array of error messages, if the interaction would be blocked; otherwise an empty array
  */
-api.getObjectionsToInteractionIfAny = {
+api.getObjectionsToInteraction = {
   method: 'GET',
   url: '/members/:toUserId/objections-to/:interaction',
   middlewares: [authWithHeaders()],
@@ -298,8 +298,9 @@ api.getObjectionsToInteractionIfAny = {
     let response;
 
     try {
-      response = sender.getObjectionsToInteractionIfAny(req.params.interaction, receiver);
+      response = sender.getObjectionsToInteraction(req.params.interaction, receiver);
     } catch (e) {
+      // Rethrow, so that the message gets passed to the client
       throw new NotFound(e.message);
     }
 
@@ -334,7 +335,7 @@ api.sendPrivateMessage = {
     let receiver = await User.findById(req.body.toUserId).exec();
     if (!receiver) throw new NotFound(res.t('userNotFound'));
 
-    let objections = sender.getObjectionsToInteractionIfAny('send-private-message', receiver);
+    let objections = sender.getObjectionsToInteraction('send-private-message', receiver);
     if (objections.length > 0) throw new NotAuthorized(res.t(objections[0]));
 
     await sender.sendMessage(receiver, message);
@@ -389,7 +390,7 @@ api.transferGems = {
     let receiver = await User.findById(req.body.toUserId).exec();
     if (!receiver) throw new NotFound(res.t('userNotFound'));
 
-    let objections = sender.getObjectionsToInteractionIfAny('transfer-gems', receiver);
+    let objections = sender.getObjectionsToInteraction('transfer-gems', receiver);
     if (objections.length > 0) throw new NotAuthorized(res.t(objections[0]));
 
     let gemAmount = req.body.gemAmount;

--- a/website/server/models/user/methods.js
+++ b/website/server/models/user/methods.js
@@ -21,10 +21,10 @@ schema.methods.getGroups = function getUserGroups () {
 };
 
 // Get an array of error message keys that would be thrown if the given interaction was attempted
-schema.methods.getObjectionsToInteractionIfAny = function getObjectionsToInteractionIfAny (interaction, receiver) {
+schema.methods.getObjectionsToInteraction = function getObjectionsToInteraction (interaction, receiver) {
   let sender = this;
 
-  /* eslint-disable no-unused-vars */
+  /* eslint-disable no-unused-vars */ // The checks below all get access to sndr and rcvr, but not all use both
   let checks = {
     always: [
       // Revoked chat privileges block all interactions to prevent the evading of harassment protections
@@ -40,7 +40,7 @@ schema.methods.getObjectionsToInteractionIfAny = function getObjectionsToInterac
       // Private messaging has an opt-out, which does not affect other interactions
       (sndr, rcvr) => rcvr.inbox.optOut && 'notAuthorizedToSendMessageToThisUser',
 
-      // NB: We allow a player to message themselves so they can test how PMs work or send their own notes to themselves
+      // We allow a player to message themselves so they can test how PMs work or send their own notes to themselves
     ],
 
     'transfer-gems': [
@@ -50,7 +50,7 @@ schema.methods.getObjectionsToInteractionIfAny = function getObjectionsToInterac
   };
   /* eslint-enable no-unused-vars */
 
-  let knownInteractions = Object.keys(checks).filter((k) => k !== 'always');
+  let knownInteractions = Object.keys(checks).filter((key) => key !== 'always');
 
   if (!knownInteractions.includes(interaction)) {
     throw new Error(`Unknown kind of interaction: "${interaction}", expected one of ${knownInteractions.join(', ')}`);

--- a/website/server/models/user/methods.js
+++ b/website/server/models/user/methods.js
@@ -4,8 +4,7 @@ import {
   chatDefaults,
   TAVERN_ID,
 } from '../group';
-import { defaults } from 'lodash';
-
+import { defaults, map, flatten, flow, compact, unique, partialRight } from 'lodash';
 import schema from './schema';
 
 schema.methods.isSubscribed = function isSubscribed () {
@@ -20,47 +19,54 @@ schema.methods.getGroups = function getUserGroups () {
   return userGroups;
 };
 
+/* eslint-disable no-unused-vars */ // The checks below all get access to sndr and rcvr, but not all use both
+const INTERACTION_CHECKS = Object.freeze({
+  always: [
+    // Revoked chat privileges block all interactions to prevent the evading of harassment protections
+    // See issue #7971 for some discussion
+    (sndr, rcvr) => sndr.flags.chatRevoked && 'chatPrivilegesRevoked',
+
+    // Direct user blocks prevent all interactions
+    (sndr, rcvr) => rcvr.inbox.blocks.includes(sndr._id) && 'notAuthorizedToSendMessageToThisUser',
+    (sndr, rcvr) => sndr.inbox.blocks.includes(rcvr._id) && 'notAuthorizedToSendMessageToThisUser',
+  ],
+
+  'send-private-message': [
+    // Private messaging has an opt-out, which does not affect other interactions
+    (sndr, rcvr) => rcvr.inbox.optOut && 'notAuthorizedToSendMessageToThisUser',
+
+    // We allow a player to message themselves so they can test how PMs work or send their own notes to themselves
+  ],
+
+  'transfer-gems': [
+    // Unlike private messages, gems can't be sent to oneself
+    (sndr, rcvr) => rcvr._id === sndr._id && 'cannotSendGemsToYourself',
+  ],
+});
+/* eslint-enable no-unused-vars */
+
+export const KNOWN_INTERACTIONS = Object.freeze(Object.keys(INTERACTION_CHECKS).filter(key => key !== 'always'));
+
 // Get an array of error message keys that would be thrown if the given interaction was attempted
 schema.methods.getObjectionsToInteraction = function getObjectionsToInteraction (interaction, receiver) {
-  let sender = this;
-
-  /* eslint-disable no-unused-vars */ // The checks below all get access to sndr and rcvr, but not all use both
-  let checks = {
-    always: [
-      // Revoked chat privileges block all interactions to prevent the evading of harassment protections
-      // See issue #7971 for some discussion
-      (sndr, rcvr) => sndr.flags.chatRevoked && 'chatPrivilegesRevoked',
-
-      // Direct user blocks prevent all interactions
-      (sndr, rcvr) => rcvr.inbox.blocks.includes(sndr._id) && 'notAuthorizedToSendMessageToThisUser',
-      (sndr, rcvr) => sndr.inbox.blocks.includes(rcvr._id) && 'notAuthorizedToSendMessageToThisUser',
-    ],
-
-    'send-private-message': [
-      // Private messaging has an opt-out, which does not affect other interactions
-      (sndr, rcvr) => rcvr.inbox.optOut && 'notAuthorizedToSendMessageToThisUser',
-
-      // We allow a player to message themselves so they can test how PMs work or send their own notes to themselves
-    ],
-
-    'transfer-gems': [
-      // Unlike private messages, gems can't be sent to oneself
-      (sndr, rcvr) => rcvr._id === sndr._id && 'cannotSendGemsToYourself',
-    ],
-  };
-  /* eslint-enable no-unused-vars */
-
-  let knownInteractions = Object.keys(checks).filter((key) => key !== 'always');
-
-  if (!knownInteractions.includes(interaction)) {
-    throw new Error(`Unknown kind of interaction: "${interaction}", expected one of ${knownInteractions.join(', ')}`);
+  if (!KNOWN_INTERACTIONS.includes(interaction)) {
+    throw new Error(`Unknown kind of interaction: "${interaction}", expected one of ${KNOWN_INTERACTIONS.join(', ')}`);
   }
 
-  let checksToRun = checks.always.concat(checks[interaction]);
-  let results = checksToRun.map((test) => test(sender, receiver));
-  let objections = results.filter((objection) => Boolean(objection));
+  let sender = this;
+  let checks = [
+    INTERACTION_CHECKS.always,
+    INTERACTION_CHECKS[interaction],
+  ];
 
-  return objections;
+  let executeChecks = partialRight(map, (check) => check(sender, receiver));
+
+  return flow(
+    flatten,
+    executeChecks,
+    compact, // Remove passed checks (passed checks return falsy; failed checks return message keys)
+    unique
+  )(checks);
 };
 
 schema.methods.sendMessage = async function sendMessage (userToReceiveMessage, message) {


### PR DESCRIPTION
Fixes #7971

This PR changes the way objections to user-to-user interactions are handled (e.g. chat revocation or blocks). It includes some refactoring to the API to make it more flexible and allows the UI to query the estimated success of interactions. No UI changes are done at this time.

API refactoring:
- Factors out the checks in `api.sendPrivateMessage` and `api.transferGems` to see if the interaction is allowed.
- The checks are now in `User.getObjectionsToInteractionIfAny`; the method is designed to be easily extensible to new checks or new interactions.
- To allow the UI to check whether an interaction is allowed without actually preforming it, there is a new function `api.getObjectionsToInteractionIfAny`; it only applies interactions initiated by the logged in user and can not be used to query interactions by other users.
- All objections to an interaction now use NotAuthorized instead of NotFound.
- All objection strings are now translatable.

Additional checks:
- Both `api.sendPrivateMessage` and `api.transferGems` now are now blocked by `sender.flags.chatRevoked`.
- `api.transferGems` is now blocked by either user blocking the other.

Tests:
- Tests for the additional checks and the new API have been added.

---

UUID: fea892e5-ac99-4b03-83ac-d01a2154e2af
