### PR TITLE
Players able to flag their own messages - Fixes #8005

### DIFF
--- a/common/locales/en/messages.json
+++ b/common/locales/en/messages.json
@@ -53,7 +53,6 @@
   "messageGroupCannotRemoveSelf": "You cannot remove yourself!",
   "messageGroupChatBlankMessage": "You cannot send a blank message",
   "messageGroupChatLikeOwnMessage": "Can't like your own message. Don't be that person.",
-  "messageGroupChatFlagOwnMessage": "Can't report your own message.",
   "messageGroupChatFlagAlreadyReported": "You have already reported this message",
   "messageGroupChatNotFound": "Message not found!",
   "messageGroupChatAdminClearFlagCount": "Only an admin can clear the flag count!",

--- a/test/api/v3/integration/chat/POST-chat.flag.test.js
+++ b/test/api/v3/integration/chat/POST-chat.flag.test.js
@@ -29,14 +29,9 @@ describe('POST /chat/:chatId/flag', () => {
       });
   });
 
-  it('Returns an error when user tries to flag their own message', async () => {
+  it('Allows players to flag their own message', async () => {
     let message = await user.post(`/groups/${group._id}/chat`, {message: TEST_MESSAGE});
-    await expect(user.post(`/groups/${group._id}/chat/${message.message.id}/flag`))
-      .to.eventually.be.rejected.and.eql({
-        code: 404,
-        error: 'NotFound',
-        message: t('messageGroupChatFlagOwnMessage'),
-      });
+    await expect(user.post(`/groups/${group._id}/chat/${message.message.id}/flag`)).to.eventually.be.ok;
   });
 
   it('Flags a chat', async () => {

--- a/website/server/controllers/api-v3/chat.js
+++ b/website/server/controllers/api-v3/chat.js
@@ -223,7 +223,7 @@ api.flagChat = {
     if (!message) throw new NotFound(res.t('messageGroupChatNotFound'));
 
     // Your own message should be flaggable
-    //if (message.uuid === user._id) throw new NotFound(res.t('messageGroupChatFlagOwnMessage'));
+    // if (message.uuid === user._id) throw new NotFound(res.t('messageGroupChatFlagOwnMessage'));
 
     let update = {$set: {}};
 

--- a/website/server/controllers/api-v3/chat.js
+++ b/website/server/controllers/api-v3/chat.js
@@ -222,7 +222,8 @@ api.flagChat = {
 
     if (!message) throw new NotFound(res.t('messageGroupChatNotFound'));
 
-    if (message.uuid === user._id) throw new NotFound(res.t('messageGroupChatFlagOwnMessage'));
+    // Your own message should be flaggable
+    //if (message.uuid === user._id) throw new NotFound(res.t('messageGroupChatFlagOwnMessage'));
 
     let update = {$set: {}};
 

--- a/website/server/controllers/api-v3/chat.js
+++ b/website/server/controllers/api-v3/chat.js
@@ -222,9 +222,6 @@ api.flagChat = {
 
     if (!message) throw new NotFound(res.t('messageGroupChatNotFound'));
 
-    // Your own message should be flaggable
-    // if (message.uuid === user._id) throw new NotFound(res.t('messageGroupChatFlagOwnMessage'));
-
     let update = {$set: {}};
 
     // Log user ids that have flagged the message

--- a/website/views/options/social/chat-message.jade
+++ b/website/views/options/social/chat-message.jade
@@ -31,7 +31,7 @@ mixin chatMessages(inbox)
         span(ng-if='#{inbox ? "true" : ":: user.contributor.admin || message.uuid == user.id"}') &nbsp; &nbsp;
           a(ng-click='#{inbox? "User.deletePM({params:{id:message.$key}})" : "deleteChatMessage(group, message)"}')
             span.glyphicon.glyphicon-trash(tooltip=env.t('delete'))
-        span(ng-if=':: user.contributor.admin || (!message.sent && user.flags.communityGuidelinesAccepted && message.uuid != user.id)') &nbsp; &nbsp;
+        span(ng-if=':: user.contributor.admin || (!message.sent && user.flags.communityGuidelinesAccepted)') &nbsp; &nbsp;
           a(ng-click="flagChatMessage(group._id, message)")
             span.glyphicon.glyphicon-flag(tooltip="{{message.flags[user._id] ? env.t('abuseAlreadyReported') : env.t('abuseFlag')}}" ng-class='message.flags[user._id] ? "text-danger" : ""')
         span &nbsp; &nbsp;


### PR DESCRIPTION
Fixes Issue #8005 - Players should be able to flag their own messages
### Changes

Players can now flag their own messages. Previously if a player sent a message in chat, they could not flag that message. Now all players can flag all messages that they personally have sent.

This is the previous front end behavior:
![old_flag](https://cloud.githubusercontent.com/assets/7362771/18476009/b842e010-7985-11e6-8bc4-94c1a006efb7.png)

This is the new front end behavior:
![flag_change](https://cloud.githubusercontent.com/assets/7362771/18476018/bb8d69ac-7985-11e6-9151-40eeb49d8036.png)

This is the front end behavior when you flag your own post:
![flag_myself](https://cloud.githubusercontent.com/assets/7362771/18476108/0a028748-7986-11e6-9c12-6660c4ac8f54.png)

---

UUID: 59197564-6563-4a98-9a35-7391033dd87a
