### PR TITLE
Handle social auth in A/B testing

### DIFF
--- a/test/api/v3/integration/user/auth/POST-user_auth_social.test.js
+++ b/test/api/v3/integration/user/auth/POST-user_auth_social.test.js
@@ -2,6 +2,7 @@ import {
   generateUser,
   requester,
   translate as t,
+  getProperty,
 } from '../../../../../helpers/api-integration/v3';
 import passport from 'passport';
 
@@ -42,6 +43,15 @@ describe('POST /user/auth/social', () => {
     expect(response.apiToken).to.exist;
     expect(response.id).to.exist;
     expect(response.newUser).to.be.true;
+  });
+
+  it('enrolls a new user in an A/B test', async () => {
+    await api.post(endpoint, {
+      authResponse: {access_token: randomAccessToken}, // eslint-disable-line camelcase
+      network,
+    });
+
+    await expect(getProperty('users', user._id, '_ABtest')).to.eventually.be.a('string');
   });
 
   it('logs an existing user in', async () => {

--- a/website/server/controllers/api-v3/auth.js
+++ b/website/server/controllers/api-v3/auth.js
@@ -50,17 +50,6 @@ async function _handleGroupInvitation (user, invite) {
   }
 }
 
-function _assignABtest (user) {
-  // A/B Test 2016-09-12: Start with Sound Enabled?
-  if (Math.random() < 0.5) {
-    user.preferences.sound = 'rosstavoTheme';
-    user._ABtest = '20160912-soundEnabled';
-  } else {
-    user._ABtest = '20160912-soundDisabled';
-  }
-  return user;
-}
-
 /**
  * @api {post} /api/v3/user/auth/local/register Register
  * @apiDescription Register a new user with email, username and password or attach local auth to a social user
@@ -138,7 +127,6 @@ api.registerLocal = {
       newUser = fbUser;
     } else {
       newUser = new User(newUser);
-      newUser = _assignABtest(newUser);
       newUser.registeredThrough = req.headers['x-client']; // Not saved, used to create the correct tasks based on the device used
     }
 
@@ -279,7 +267,6 @@ api.loginSocial = {
           language: req.language,
         },
       });
-      user = _assignABtest(user);
       user.registeredThrough = req.headers['x-client'];
 
       let savedUser = await user.save();

--- a/website/server/controllers/api-v3/auth.js
+++ b/website/server/controllers/api-v3/auth.js
@@ -50,6 +50,17 @@ async function _handleGroupInvitation (user, invite) {
   }
 }
 
+function _assignABtest (user) {
+  // A/B Test 2016-09-12: Start with Sound Enabled?
+  if (Math.random() < 0.5) {
+    user.preferences.sound = 'rosstavoTheme';
+    user._ABtest = '20160912-soundEnabled';
+  } else {
+    user._ABtest = '20160912-soundDisabled';
+  }
+  return user;
+}
+
 /**
  * @api {post} /api/v3/user/auth/local/register Register
  * @apiDescription Register a new user with email, username and password or attach local auth to a social user
@@ -127,15 +138,8 @@ api.registerLocal = {
       newUser = fbUser;
     } else {
       newUser = new User(newUser);
+      newUser = _assignABtest(newUser);
       newUser.registeredThrough = req.headers['x-client']; // Not saved, used to create the correct tasks based on the device used
-    }
-
-    // A/B Test 2016-09-12: Start with Sound Enabled?
-    if (Math.random() < 0.5) {
-      newUser.preferences.sound = 'rosstavoTheme';
-      newUser._ABtest = '20160912-soundEnabled';
-    } else {
-      newUser._ABtest = '20160912-soundDisabled';
     }
 
     // we check for partyInvite for backward compatibility
@@ -275,6 +279,7 @@ api.loginSocial = {
           language: req.language,
         },
       });
+      user = _assignABtest(user);
       user.registeredThrough = req.headers['x-client'];
 
       let savedUser = await user.save();

--- a/website/server/models/user/hooks.js
+++ b/website/server/models/user/hooks.js
@@ -73,9 +73,17 @@ function _populateDefaultTasks (user, taskTypes) {
     });
 }
 
-function _populateDefaultsForNewUser (user) {
+function _setUpNewUser (user) {
   let taskTypes;
   let iterableFlags = user.flags.toObject();
+
+  // A/B Test 2016-09-12: Start with Sound Enabled?
+  if (Math.random() < 0.5) {
+    user.preferences.sound = 'rosstavoTheme';
+    user._ABtest = '20160912-soundEnabled';
+  } else {
+    user._ABtest = '20160912-soundDisabled';
+  }
 
   if (user.registeredThrough === 'habitica-web' || user.registeredThrough === 'habitica-android') {
     taskTypes = ['habit', 'daily', 'todo', 'reward', 'tag'];
@@ -158,7 +166,7 @@ schema.pre('save', true, function preSaveUser (next, done) {
 
   // Populate new users with default content
   if (this.isNew) {
-    _populateDefaultsForNewUser(this)
+    _setUpNewUser(this)
       .then(() => done())
       .catch(done);
   } else {


### PR DESCRIPTION
### Changes

Previously,
1. It was possible for a user who registered prior to the implementation of A/B tests to get assigned to an A/B test, which could in turn modify their preferences undesirably. This happened if they signed up using a Facebook account, then later added an email/username based sign-in method.
2. Users registering via Facebook authentication were not being added to A/B tests.

This PR corrects both of the above, hopefully in a futureproof fashion--as we move from one A/B test to the next, all we need to do is tweak the block in the pre save hook to make the needed user updates.

---

UUID: [Authentic Test Correction](https://map.what3words.com/authentic.test.correction)
