### PR TITLE
Use correct URL in CSS

### DIFF
--- a/website/assets/sprites/css/css.template.handlebars
+++ b/website/assets/sprites/css/css.template.handlebars
@@ -1,13 +1,13 @@
 {{#sprites}}
 .{{name}} {
-  background-image: url({{{escaped_image}}});
+  background-image: url(/assets/sprites/{{{escaped_image}}});
   background-position: {{px.offset_x}} {{px.offset_y}};
   width: {{px.width}};
   height: {{px.height}};
 }
 {{#if custom}}
 .customize-option.{{name}} {
-  background-image: url({{{escaped_image}}});
+  background-image: url(/assets/sprites/{{{escaped_image}}});
   background-position: {{custom.px.offset_x}} {{custom.px.offset_y}};
   width: {{custom.px.width}};
   height: {{custom.px.height}};


### PR DESCRIPTION
### Changes

Previously, the full URL/path for spritesheet assets was not included in the handlebars template for spritesmith. Due to the recent reorganization of common and dist files, this led to 404 errors when attempting to load spritesheet assets. Now, the correct URL as defined in our Express routing for sprite assets is included, so the CSS has it built in after running spritesmith.

---

UUID: [Sprite Path Correction](https://map.what3words.com/sprite.path.correction)
