### PR TITLE
Fix "All" button to select all guilds in the filter list

### DIFF
--- a/test/client-old/spec/controllers/challengesCtrlSpec.js
+++ b/test/client-old/spec/controllers/challengesCtrlSpec.js
@@ -160,7 +160,7 @@ describe('Challenges Controller', function() {
 
       it('filters challenges to a single group when group id filter is set', inject(function($controller) {
         scope.search = { };
-        scope.groups = {
+        scope.groupsFilter = {
           0: specHelper.newGroup({_id: 'group-one'}),
           1: specHelper.newGroup({_id: 'group-two'}),
           2: specHelper.newGroup({_id: 'group-three'})
@@ -175,7 +175,7 @@ describe('Challenges Controller', function() {
     describe('selectAll', function() {
       it('sets all groups in seach.group to true', function() {
         scope.search = { };
-        scope.groups = {
+        scope.groupsFilter = {
           0: specHelper.newGroup({_id: 'group-one'}),
           1: specHelper.newGroup({_id: 'group-two'}),
           2: specHelper.newGroup({_id: 'group-three'})
@@ -193,7 +193,7 @@ describe('Challenges Controller', function() {
     describe('selectNone', function() {
       it('sets all groups in seach.group to false', function() {
         scope.search = { };
-        scope.groups = {
+        scope.groupsFilter = {
           0: specHelper.newGroup({_id: 'group-one'}),
           1: specHelper.newGroup({_id: 'group-two'}),
           2: specHelper.newGroup({_id: 'group-three'})

--- a/website/client-old/js/controllers/challengesCtrl.js
+++ b/website/client-old/js/controllers/challengesCtrl.js
@@ -391,13 +391,13 @@ habitrpg.controller("ChallengesCtrl", ['$rootScope','$scope', 'Shared', 'User', 
     })
 
     $scope.selectAll = function(){
-      $scope.search.group = _.transform($scope.groups, function(searchPool, group){
+      $scope.search.group = _.transform($scope.groupsFilter, function(searchPool, group){
         searchPool[group._id] = true;
       });
     }
 
     $scope.selectNone = function(){
-      $scope.search.group = _.transform($scope.groups, function(searchPool, group){
+      $scope.search.group = _.transform($scope.groupsFilter, function(searchPool, group){
         searchPool[group._id] = false;
       });
     }
@@ -435,7 +435,7 @@ habitrpg.controller("ChallengesCtrl", ['$rootScope','$scope', 'Shared', 'User', 
       $scope.groupsFilter = _.uniq(_.compact(_.pluck($scope.challenges, 'group')), function(g) {return g._id});
 
       $scope.search = {
-        group: _.transform($scope.groups, function(m,g) { m[g._id] = true;}),
+        group: _.transform($scope.groupsFilter, function(m,g) { m[g._id] = true;}),
         _isMember: "either",
         _isOwner: "either"
       };


### PR DESCRIPTION
Fixes https://github.com/HabitRPG/habitrpg/issues/7763
### Changes

Changed the `selectAll` and `selectNone` functions to use the `groupsFilter` array, which is the same used to fill the list of guilds to filter. Also for `filterInitialChallenges` function so the same thing happens by default when you open the challenges page.

Let me know if I got the tests right.

Before / After
![2016-09-17 2](https://cloud.githubusercontent.com/assets/20071290/18605529/78e2d73a-7c6a-11e6-90e6-b941f3113b38.png)

---

UUID: 8389891a-ba52-4580-b08b-2cb706c7e0b4
