### PR TITLE
Updating a task now sends only data that's actually needed (Fixes #7846)

### DIFF
--- a/website/client-old/js/services/taskServices.js
+++ b/website/client-old/js/services/taskServices.js
@@ -72,27 +72,16 @@ angular.module('habitrpg')
     };
 
     function updateTask (taskId, taskDetails) {
+      var taskDetailsToSend = _.omit(
+        taskDetails,
+        ['challenge', 'completed', 'createdAt', 'group', 'history', 'id',
+         'reminders', 'tags', 'type', 'updatedAt', 'userId']
+      )
+
       return $http({
         method: 'PUT',
         url: '/api/v3/tasks/' + taskId,
-        data: {
-          alias: taskDetails.alias,
-          attribute: taskDetails.attribute,
-          checklist: taskDetails.checklist,
-          collapseChecklist: taskDetails.collapseChecklist,
-          date: taskDetails.date,
-          down: taskDetails.down,
-          everyX: taskDetails.everyX,
-          frequency: taskDetails.frequency,
-          notes: taskDetails.notes,
-          priority: taskDetails.priority,
-          repeat: taskDetails.repeat,
-          startDate: taskDetails.startDate,
-          streak: taskDetails.streak,
-          text: taskDetails.text,
-          up: taskDetails.up,
-          value: taskDetails.value,
-        },
+        data: taskDetailsToSend,
       });
     };
 

--- a/website/client-old/js/services/taskServices.js
+++ b/website/client-old/js/services/taskServices.js
@@ -75,7 +75,24 @@ angular.module('habitrpg')
       return $http({
         method: 'PUT',
         url: '/api/v3/tasks/' + taskId,
-        data: taskDetails,
+        data: {
+          alias: taskDetails.alias,
+          attribute: taskDetails.attribute,
+          checklist: taskDetails.checklist,
+          collapseChecklist: taskDetails.collapseChecklist,
+          date: taskDetails.date,
+          down: taskDetails.down,
+          everyX: taskDetails.everyX,
+          frequency: taskDetails.frequency,
+          notes: taskDetails.notes,
+          priority: taskDetails.priority,
+          repeat: taskDetails.repeat,
+          startDate: taskDetails.startDate,
+          streak: taskDetails.streak,
+          text: taskDetails.text,
+          up: taskDetails.up,
+          value: taskDetails.value,
+        },
       });
     };
 


### PR DESCRIPTION
Fixes #7846
### Changes

Updating a task with a huge history lead to 'request entity too large' errors since the client attempted to send all data associated with a task, regardless of whether that data could be changed or not. With this change, the post request in updateTask is now omitting the following fields:

challenge
completed
createdAt
group
history
id
reminders
tags
type
updatedAt
userId

---

UUID: 7b45f003-63bf-4bbe-9015-88d74753595e
