### PR TITLE
Send user to analytics on register

### DIFF
--- a/website/server/controllers/api-v3/auth.js
+++ b/website/server/controllers/api-v3/auth.js
@@ -155,6 +155,7 @@ api.registerLocal = {
         gaLabel: 'local',
         uuid: savedUser._id,
         headers: req.headers,
+        user: savedUser,
       });
     }
 

--- a/website/server/libs/analyticsService.js
+++ b/website/server/libs/analyticsService.js
@@ -144,7 +144,7 @@ let _formatDataForAmplitude = (data) => {
   let itemName = _lookUpItemName(data.itemKey);
 
   if (itemName) {
-    event_properties.itemName = itemName;
+    ampData.event_properties.itemName = itemName;
   }
   return ampData;
 };


### PR DESCRIPTION
### Changes

Previously, we only sent the full user object to the analytics service when tracking the `cron` event. While that makes sense from an efficiency perspective (we don't want to ship the whole user object around more often than necessary), it meant that we didn't capture some important user data until their second day of activity. Now, we send user data to Analytics when the user completes registration, which allows us to collect e.g. A/B test assignment information that was often missing before.

Also fixes an issue that could prevent item name data from being correctly sent to Amplitude when tracking drops and similar acquisitions.
