### PR TITLE
Random val refactor

### DIFF
--- a/test/common/fns/randomDrop.test.js
+++ b/test/common/fns/randomDrop.test.js
@@ -16,17 +16,14 @@ describe('common.fns.randomDrop', () => {
     user = generateUser();
     user._tmp = user._tmp ? user._tmp : {};
     task = generateTodo({ userId: user._id });
-    predictableRandom = () => {
-      return 0.5;
-    };
+    predictableRandom = sandbox.stub().returns(0.5);
   });
 
   it('drops an item for the user.party.quest.progress', () => {
     expect(user.party.quest.progress.collectedItems).to.eql(0);
     user.party.quest.key = 'vice2';
-    predictableRandom = () => {
-      return 0.0001;
-    };
+    predictableRandom.returns(0.0001);
+
     randomDrop(user, { task, predictableRandom });
     expect(user.party.quest.progress.collectedItems).to.eql(1);
     randomDrop(user, { task, predictableRandom });
@@ -48,9 +45,8 @@ describe('common.fns.randomDrop', () => {
     it('drops something when the task is a todo', () => {
       expect(user._tmp).to.eql({});
       user.flags.dropsEnabled = true;
-      predictableRandom = () => {
-        return 0.1;
-      };
+      predictableRandom.returns(0.1);
+
       randomDrop(user, { task, predictableRandom });
       expect(user._tmp).to.not.eql({});
     });
@@ -59,9 +55,8 @@ describe('common.fns.randomDrop', () => {
       task = generateHabit({ userId: user._id });
       expect(user._tmp).to.eql({});
       user.flags.dropsEnabled = true;
-      predictableRandom = () => {
-        return 0.1;
-      };
+      predictableRandom.returns(0.1);
+
       randomDrop(user, { task, predictableRandom });
       expect(user._tmp).to.not.eql({});
     });
@@ -70,9 +65,8 @@ describe('common.fns.randomDrop', () => {
       task = generateDaily({ userId: user._id });
       expect(user._tmp).to.eql({});
       user.flags.dropsEnabled = true;
-      predictableRandom = () => {
-        return 0.1;
-      };
+      predictableRandom.returns(0.1);
+
       randomDrop(user, { task, predictableRandom });
       expect(user._tmp).to.not.eql({});
     });
@@ -81,34 +75,30 @@ describe('common.fns.randomDrop', () => {
       task = generateReward({ userId: user._id });
       expect(user._tmp).to.eql({});
       user.flags.dropsEnabled = true;
-      predictableRandom = () => {
-        return 0.1;
-      };
+      predictableRandom.returns(0.1);
+
       randomDrop(user, { task, predictableRandom });
       expect(user._tmp).to.not.eql({});
     });
 
     it('drops food', () => {
-      predictableRandom = () => {
-        return 0.65;
-      };
+      predictableRandom.returns(0.65);
+
       randomDrop(user, { task, predictableRandom });
       expect(user._tmp.drop.type).to.eql('Food');
     });
 
     it('drops eggs', () => {
-      predictableRandom = () => {
-        return 0.35;
-      };
+      predictableRandom.returns(0.35);
+
       randomDrop(user, { task, predictableRandom });
       expect(user._tmp.drop.type).to.eql('Egg');
     });
 
     context('drops hatching potion', () => {
       it('drops a very rare potion', () => {
-        predictableRandom = () => {
-          return 0.01;
-        };
+        predictableRandom.returns(0.01);
+
         randomDrop(user, { task, predictableRandom });
         expect(user._tmp.drop.type).to.eql('HatchingPotion');
         expect(user._tmp.drop.value).to.eql(5);
@@ -116,9 +106,8 @@ describe('common.fns.randomDrop', () => {
       });
 
       it('drops a rare potion', () => {
-        predictableRandom = () => {
-          return 0.08;
-        };
+        predictableRandom.returns(0.08);
+
         randomDrop(user, { task, predictableRandom });
         expect(user._tmp.drop.type).to.eql('HatchingPotion');
         expect(user._tmp.drop.value).to.eql(4);
@@ -127,9 +116,8 @@ describe('common.fns.randomDrop', () => {
       });
 
       it('drops an uncommon potion', () => {
-        predictableRandom = () => {
-          return 0.17;
-        };
+        predictableRandom.returns(0.17);
+
         randomDrop(user, { task, predictableRandom });
         expect(user._tmp.drop.type).to.eql('HatchingPotion');
         expect(user._tmp.drop.value).to.eql(3);
@@ -138,9 +126,8 @@ describe('common.fns.randomDrop', () => {
       });
 
       it('drops a common potion', () => {
-        predictableRandom = () => {
-          return 0.20;
-        };
+        predictableRandom.returns(0.20);
+
         randomDrop(user, { task, predictableRandom });
         expect(user._tmp.drop.type).to.eql('HatchingPotion');
         expect(user._tmp.drop.value).to.eql(2);

--- a/test/common/fns/randomVal.js
+++ b/test/common/fns/randomVal.js
@@ -1,9 +1,9 @@
-import randomVal from '../../../website/common/script/fns/randomVal';
+import randomVal from '../../../website/common/script/libs/randomVal';
 import {
   generateUser,
 } from '../../helpers/common.helper';
 
-describe('shared.fns.randomVal', () => {
+describe('randomVal', () => {
   let obj;
 
   beforeEach(() => {

--- a/test/common/fns/randomVal.js
+++ b/test/common/fns/randomVal.js
@@ -4,116 +4,52 @@ import {
 } from '../../helpers/common.helper';
 
 describe('shared.fns.randomVal', () => {
-  let user;
-  let obj = {
-    a: 1,
-    b: 2,
-    c: 3,
-    d: 4,
-  };
+  let user, obj;
 
   beforeEach(() => {
     user = generateUser();
+    obj = {
+      a: 1,
+      b: 2,
+      c: 3,
+      d: 4,
+    };
   });
 
-  describe('returns a random property value from an object', () => {
-    it('returns the same value when the seed is the same', () => {
-      let val1 = randomVal(user, obj, {
-        seed: 222,
-      });
-
-      let val2 = randomVal(user, obj, {
-        seed: 222,
-      });
-
-      expect(val2).to.equal(val1);
-    });
-
-    it('returns the same value when user.stats is the same', () => {
-      user.stats.gp = 34;
-      let val1 = randomVal(user, obj);
-      let val2 = randomVal(user, obj);
-
-      expect(val2).to.equal(val1);
-    });
-
-    it('returns a different value when the seed is different', () => {
-      let val1 = randomVal(user, obj, {
-        seed: 222,
-      });
-
-      let val2 = randomVal(user, obj, {
-        seed: 333,
-      });
-
-      expect(val2).to.not.equal(val1);
-    });
-
-    it('returns a different value when user.stats is different', () => {
-      user.stats.gp = 34;
-      let val1 = randomVal(user, obj);
-      user.stats.gp = 343;
-      let val2 = randomVal(user, obj);
-
-      expect(val2).to.not.equal(val1);
-    });
+  afterEach(() => {
+    sandbox.restore();
   });
 
-  describe('returns a random key from an object', () => {
-    it('returns the same key when the seed is the same', () => {
-      let key1 = randomVal(user, obj, {
-        key: true,
-        seed: 222,
-      });
+  it('returns a random value from an object', () => {
+    let result = randomVal(user, obj);
+    expect(result).to.be.oneOf([1, 2, 3, 4]);
+  });
 
-      let key2 = randomVal(user, obj, {
-        key: true,
-        seed: 222,
-      });
+  it('uses Math.random to determine the property', () => {
+    sandbox.spy(Math, 'random');
 
-      expect(key2).to.equal(key1);
+    randomVal(user, obj);
+
+    expect(Math.random).to.be.calledOnce;
+  });
+
+  it('can pass in a custom random function that takes in the user and a seed argument', () => {
+    let randomSpy = sandbox.stub().returns(0.3);
+    sandbox.spy(Math, 'random');
+
+    let result = randomVal(user, obj, {
+      seed: 100,
+      randomFunc: randomSpy,
     });
 
-    it('returns the same key when user.stats is the same', () => {
-      user.stats.gp = 45;
-      let key1 = randomVal(user, obj, {
-        key: true,
-      });
+    expect(Math.random).to.not.be.called;
+    expect(randomSpy).to.be.calledOnce;
+    expect(randomSpy).to.be.calledWith(user, 100);
+    expect(result).to.equal(2);
+  });
 
-      let key2 = randomVal(user, obj, {
-        key: true,
-      });
-
-      expect(key2).to.equal(key1);
-    });
-
-    it('returns a different key when the seed is different', () => {
-      let key1 = randomVal(user, obj, {
-        key: true,
-        seed: 222,
-      });
-
-      let key2 = randomVal(user, obj, {
-        key: true,
-        seed: 333,
-      });
-
-      expect(key2).to.not.equal(key1);
-    });
-
-    it('returns a different key when user.stats is different', () => {
-      user.stats.gp = 45;
-      let key1 = randomVal(user, obj, {
-        key: true,
-      });
-
-      user.stats.gp = 43;
-
-      let key2 = randomVal(user, obj, {
-        key: true,
-      });
-
-      expect(key2).to.not.equal(key1);
-    });
+  it('returns a random key when the key option is passed in', () => {
+    let result = randomVal(user, obj, { key: true });
+    expect(result).to.be.oneOf(['a', 'b', 'c', 'd']);
   });
 });

--- a/test/common/fns/randomVal.js
+++ b/test/common/fns/randomVal.js
@@ -40,12 +40,11 @@ describe('shared.fns.randomVal', () => {
     let result = randomVal(obj, {
       user,
       seed: 100,
-      randomFunc: randomSpy,
+      predictableRandom: randomSpy,
     });
 
     expect(Math.random).to.not.be.called;
     expect(randomSpy).to.be.calledOnce;
-    expect(randomSpy).to.be.calledWith(user, 100);
     expect(result).to.equal(2);
   });
 

--- a/test/common/fns/randomVal.js
+++ b/test/common/fns/randomVal.js
@@ -4,10 +4,9 @@ import {
 } from '../../helpers/common.helper';
 
 describe('shared.fns.randomVal', () => {
-  let user, obj;
+  let obj;
 
   beforeEach(() => {
-    user = generateUser();
     obj = {
       a: 1,
       b: 2,
@@ -21,23 +20,25 @@ describe('shared.fns.randomVal', () => {
   });
 
   it('returns a random value from an object', () => {
-    let result = randomVal(user, obj);
+    let result = randomVal(obj);
     expect(result).to.be.oneOf([1, 2, 3, 4]);
   });
 
   it('uses Math.random to determine the property', () => {
     sandbox.spy(Math, 'random');
 
-    randomVal(user, obj);
+    randomVal(obj);
 
     expect(Math.random).to.be.calledOnce;
   });
 
   it('can pass in a custom random function that takes in the user and a seed argument', () => {
+    let user = generateUser();
     let randomSpy = sandbox.stub().returns(0.3);
     sandbox.spy(Math, 'random');
 
-    let result = randomVal(user, obj, {
+    let result = randomVal(obj, {
+      user,
       seed: 100,
       randomFunc: randomSpy,
     });
@@ -49,7 +50,7 @@ describe('shared.fns.randomVal', () => {
   });
 
   it('returns a random key when the key option is passed in', () => {
-    let result = randomVal(user, obj, { key: true });
+    let result = randomVal(obj, { key: true });
     expect(result).to.be.oneOf(['a', 'b', 'c', 'd']);
   });
 });

--- a/test/common/ops/buyArmoire.js
+++ b/test/common/ops/buyArmoire.js
@@ -1,24 +1,17 @@
 /* eslint-disable camelcase */
 
-import sinon from 'sinon'; // eslint-disable-line no-shadow
 import {
   generateUser,
 } from '../../helpers/common.helper';
 import count from '../../../website/common/script/count';
 import buyArmoire from '../../../website/common/script/ops/buyArmoire';
-import shared from '../../../website/common/script';
 import content from '../../../website/common/script/content/index';
 import {
   NotAuthorized,
 } from '../../../website/common/script/libs/errors';
 import i18n from '../../../website/common/script/i18n';
 
-describe('shared.ops.buyArmoire', () => {
-  let user;
-  let YIELD_EQUIPMENT = 0.5;
-  let YIELD_FOOD = 0.7;
-  let YIELD_EXP = 0.9;
-
+function getFullArmoire () {
   let fullArmoire = {};
 
   _(content.gearTypes).each((type) => {
@@ -29,39 +22,36 @@ describe('shared.ops.buyArmoire', () => {
     }).value();
   }).value();
 
+  return fullArmoire;
+}
+
+describe('shared.ops.buyArmoire', () => {
+  let user;
+  let YIELD_EQUIPMENT = 0.5;
+  let YIELD_FOOD = 0.7;
+  let YIELD_EXP = 0.9;
 
   beforeEach(() => {
     user = generateUser({
-      items: {
-        gear: {
-          owned: {
-            weapon_warrior_0: true,
-          },
-          equipped: {
-            weapon_warrior_0: true,
-          },
-        },
-      },
       stats: { gp: 200 },
     });
-
+    user.items.gear.owned = {
+      weapon_warrior_0: true,
+    };
     user.achievements.ultimateGearSets = { rogue: true };
     user.flags.armoireOpened = true;
     user.stats.exp = 0;
     user.items.food = {};
 
-    sinon.stub(shared.fns, 'randomVal');
-    sinon.stub(shared.fns, 'predictableRandom');
+    sandbox.stub(Math, 'random');
   });
 
   afterEach(() => {
-    shared.fns.randomVal.restore();
-    shared.fns.predictableRandom.restore();
+    Math.random.restore();
   });
 
   context('failure conditions', () => {
     it('does not open if user does not have enough gold', (done) => {
-      shared.fns.predictableRandom.returns(YIELD_EQUIPMENT);
       user.stats.gp = 50;
 
       try {
@@ -71,13 +61,6 @@ describe('shared.ops.buyArmoire', () => {
         expect(err.message).to.equal(i18n.t('messageNotEnoughGold'));
         expect(user.items.gear.owned).to.eql({
           weapon_warrior_0: true,
-          eyewear_special_blackTopFrame: true,
-          eyewear_special_blueTopFrame: true,
-          eyewear_special_greenTopFrame: true,
-          eyewear_special_pinkTopFrame: true,
-          eyewear_special_redTopFrame: true,
-          eyewear_special_whiteTopFrame: true,
-          eyewear_special_yellowTopFrame: true,
         });
         expect(user.items.food).to.be.empty;
         expect(user.stats.exp).to.eql(0);
@@ -86,7 +69,6 @@ describe('shared.ops.buyArmoire', () => {
     });
 
     it('does not open without Ultimate Gear achievement', (done) => {
-      shared.fns.predictableRandom.returns(YIELD_EQUIPMENT);
       user.achievements.ultimateGearSets = {healer: false, wizard: false, rogue: false, warrior: false};
 
       try {
@@ -96,13 +78,6 @@ describe('shared.ops.buyArmoire', () => {
         expect(err.message).to.equal(i18n.t('cannotBuyItem'));
         expect(user.items.gear.owned).to.eql({
           weapon_warrior_0: true,
-          eyewear_special_blackTopFrame: true,
-          eyewear_special_blueTopFrame: true,
-          eyewear_special_greenTopFrame: true,
-          eyewear_special_pinkTopFrame: true,
-          eyewear_special_redTopFrame: true,
-          eyewear_special_whiteTopFrame: true,
-          eyewear_special_yellowTopFrame: true,
         });
         expect(user.items.food).to.be.empty;
         expect(user.stats.exp).to.eql(0);
@@ -112,93 +87,83 @@ describe('shared.ops.buyArmoire', () => {
   });
 
   context('non-gear awards', () => {
-    // Skipped because can't stub predictableRandom correctly
-    xit('gives Experience', () => {
-      shared.fns.predictableRandom.returns(YIELD_EXP);
+    it('gives Experience', () => {
+      let previousExp = user.stats.exp;
+      Math.random.returns(YIELD_EXP);
 
       buyArmoire(user);
 
       expect(user.items.gear.owned).to.eql({weapon_warrior_0: true});
       expect(user.items.food).to.be.empty;
-      expect(user.stats.exp).to.eql(46);
-      expect(user.stats.gp).to.eql(100);
+      expect(user.stats.exp).to.be.greaterThan(previousExp);
+      expect(user.stats.gp).to.equal(100);
     });
 
-    // Skipped because can't stub predictableRandom correctly
-    xit('gives food', () => {
-      let honey = content.food.Honey;
+    it('gives food', () => {
+      let previousExp = user.stats.exp;
 
-      shared.fns.randomVal.returns(honey);
-      shared.fns.predictableRandom.returns(YIELD_FOOD);
+      Math.random.returns(YIELD_FOOD);
 
       buyArmoire(user);
 
       expect(user.items.gear.owned).to.eql({weapon_warrior_0: true});
-      expect(user.items.food).to.eql({Honey: 1});
-      expect(user.stats.exp).to.eql(0);
-      expect(user.stats.gp).to.eql(100);
+      expect(user.items.food).to.not.be.empty;
+      expect(user.stats.exp).to.equal(previousExp);
+      expect(user.stats.gp).to.equal(100);
     });
 
-    // Skipped because can't stub predictableRandom correctly
-    xit('does not give equipment if all equipment has been found', () => {
-      shared.fns.predictableRandom.returns(YIELD_EQUIPMENT);
-      user.items.gear.owned = fullArmoire;
+    it('does not give equipment if all equipment has been found', () => {
+      Math.random.returns(YIELD_EQUIPMENT);
+      user.items.gear.owned = getFullArmoire();
       user.stats.gp = 150;
 
       buyArmoire(user);
 
-      expect(user.items.gear.owned).to.eql(fullArmoire);
+      expect(user.items.gear.owned).to.eql(getFullArmoire());
       let armoireCount = count.remainingGearInSet(user.items.gear.owned, 'armoire');
 
       expect(armoireCount).to.eql(0);
 
-      expect(user.stats.exp).to.eql(30);
-      expect(user.stats.gp).to.eql(50);
+      expect(user.stats.gp).to.equal(50);
     });
   });
 
   context('gear awards', () => {
-    beforeEach(() => {
-      let shield = content.gear.tree.shield.armoire.gladiatorShield;
-
-      shared.fns.randomVal.returns(shield);
-    });
-
-    // Skipped because can't stub predictableRandom correctly
-    xit('always drops equipment the first time', () => {
+    it('always drops equipment the first time', () => {
       delete user.flags.armoireOpened;
-      shared.fns.predictableRandom.returns(YIELD_EXP);
+      Math.random.returns(YIELD_EXP);
+
+      expect(_.size(user.items.gear.owned)).to.equal(1);
 
       buyArmoire(user);
 
-      expect(user.items.gear.owned).to.eql({
-        weapon_warrior_0: true,
-        shield_armoire_gladiatorShield: true,
-      });
+      expect(_.size(user.items.gear.owned)).to.equal(2);
 
       let armoireCount = count.remainingGearInSet(user.items.gear.owned, 'armoire');
 
-      expect(armoireCount).to.eql(_.size(fullArmoire) - 1);
+      expect(armoireCount).to.eql(_.size(getFullArmoire()) - 1);
       expect(user.items.food).to.be.empty;
-      expect(user.stats.exp).to.eql(0);
-      expect(user.stats.gp).to.eql(100);
+      expect(user.stats.exp).to.equal(0);
+      expect(user.stats.gp).to.equal(100);
     });
 
-    // Skipped because can't stub predictableRandom correctly
-    xit('gives more equipment', () => {
-      shared.fns.predictableRandom.returns(YIELD_EQUIPMENT);
+    it('gives more equipment', () => {
+      Math.random.returns(YIELD_EQUIPMENT);
       user.items.gear.owned = {
         weapon_warrior_0: true,
         head_armoire_hornedIronHelm: true,
       };
       user.stats.gp = 200;
 
+      expect(_.size(user.items.gear.owned)).to.equal(2);
+
       buyArmoire(user);
 
-      expect(user.items.gear.owned).to.eql({weapon_warrior_0: true, shield_armoire_gladiatorShield: true, head_armoire_hornedIronHelm: true});
+      expect(_.size(user.items.gear.owned)).to.equal(3);
+
       let armoireCount = count.remainingGearInSet(user.items.gear.owned, 'armoire');
 
-      expect(armoireCount).to.eql(_.size(fullArmoire) - 2);
+      expect(armoireCount).to.eql(_.size(getFullArmoire()) - 2);
       expect(user.stats.gp).to.eql(100);
     });
   });

--- a/test/common/ops/buyGear.js
+++ b/test/common/ops/buyGear.js
@@ -29,12 +29,12 @@ describe('shared.ops.buyGear', () => {
       stats: { gp: 200 },
     });
 
-    sinon.stub(shared.fns, 'randomVal');
+    sinon.stub(shared, 'randomVal');
     sinon.stub(shared.fns, 'predictableRandom');
   });
 
   afterEach(() => {
-    shared.fns.randomVal.restore();
+    shared.randomVal.restore();
     shared.fns.predictableRandom.restore();
   });
 

--- a/website/common/script/fns/index.js
+++ b/website/common/script/fns/index.js
@@ -1,7 +1,6 @@
 import handleTwoHanded from './handleTwoHanded';
 import predictableRandom from './predictableRandom';
 import crit from './crit';
-import randomVal from './randomVal';
 import randomDrop from './randomDrop';
 import autoAllocate from './autoAllocate';
 import updateStats from './updateStats';
@@ -11,7 +10,6 @@ module.exports = {
   handleTwoHanded,
   predictableRandom,
   crit,
-  randomVal,
   randomDrop,
   autoAllocate,
   updateStats,

--- a/website/common/script/fns/randomDrop.js
+++ b/website/common/script/fns/randomDrop.js
@@ -5,6 +5,9 @@ import { daysSince } from '../cron';
 import { diminishingReturns } from '../statHelpers';
 import randomVal from './randomVal';
 
+// TODO This is only used on the server
+// move to user model as an instance method?
+
 // Clone a drop object maintaining its functions so that we can change it without affecting the original item
 function cloneDropItem (drop) {
   return _.cloneDeep(drop, (val) => {
@@ -12,18 +15,20 @@ function cloneDropItem (drop) {
   });
 }
 
+function trueRandom () {
+  return Math.random();
+}
+
 module.exports = function randomDrop (user, options, req = {}) {
   let acceptableDrops;
-  let chance;
   let drop;
   let dropMultiplier;
   let rarity;
-  let task;
 
-  let predictableRandom = options.predictableRandom || Math.random;
-  task = options.task;
+  let predictableRandom = options.predictableRandom || trueRandom;
+  let task = options.task;
 
-  chance = _.min([Math.abs(task.value - 21.27), 37.5]) / 150 + 0.02;
+  let chance = _.min([Math.abs(task.value - 21.27), 37.5]) / 150 + 0.02;
   chance *= task.priority *                             // Task priority: +50% for Medium, +100% for Hard
     (1 + (task.streak / 100 || 0)) *                    // Streak bonus: +1% per streak
     (1 + user._statsComputed.per / 100) *               // PERception: +1% per point
@@ -35,7 +40,7 @@ module.exports = function randomDrop (user, options, req = {}) {
     }, 0) || 0));
   chance = diminishingReturns(chance, 0.75);
 
-  if (predictableRandom(user, user.stats.gp) < chance) {
+  if (predictableRandom() < chance) {
     if (!user.party.quest.progress.collectedItems) user.party.quest.progress.collectedItems = 0;
     user.party.quest.progress.collectedItems++;
     user.markModified('party.quest.progress');
@@ -52,8 +57,8 @@ module.exports = function randomDrop (user, options, req = {}) {
     return;
   }
 
-  if (user.flags && user.flags.dropsEnabled && predictableRandom(user, user.stats.exp) < chance) {
-    rarity = predictableRandom(user, user.stats.gp);
+  if (user.flags && user.flags.dropsEnabled && predictableRandom() < chance) {
+    rarity = predictableRandom();
 
     if (rarity > 0.6) { // food 40% chance
       drop = cloneDropItem(randomVal(_.where(content.food, {

--- a/website/common/script/fns/randomDrop.js
+++ b/website/common/script/fns/randomDrop.js
@@ -3,7 +3,7 @@ import content from '../content/index';
 import i18n from '../i18n';
 import { daysSince } from '../cron';
 import { diminishingReturns } from '../statHelpers';
-import randomVal from './randomVal';
+import randomVal from '../libs/randomVal';
 
 // TODO This is only used on the server
 // move to user model as an instance method?

--- a/website/common/script/fns/randomDrop.js
+++ b/website/common/script/fns/randomDrop.js
@@ -56,7 +56,7 @@ module.exports = function randomDrop (user, options, req = {}) {
     rarity = predictableRandom(user, user.stats.gp);
 
     if (rarity > 0.6) { // food 40% chance
-      drop = cloneDropItem(randomVal(user, _.where(content.food, {
+      drop = cloneDropItem(randomVal(_.where(content.food, {
         canDrop: true,
       })));
 
@@ -71,7 +71,7 @@ module.exports = function randomDrop (user, options, req = {}) {
         dropNotes: drop.notes(req.language),
       }, req.language);
     } else if (rarity > 0.3) { // eggs 30% chance
-      drop = cloneDropItem(randomVal(user, content.dropEggs));
+      drop = cloneDropItem(randomVal(content.dropEggs));
       if (!user.items.eggs[drop.key]) {
         user.items.eggs[drop.key] = 0;
       }
@@ -91,7 +91,7 @@ module.exports = function randomDrop (user, options, req = {}) {
       } else { // common, 40% of 30%
         acceptableDrops = ['Base', 'White', 'Desert'];
       }
-      drop = cloneDropItem(randomVal(user, _.pick(content.hatchingPotions, (v, k) => {
+      drop = cloneDropItem(randomVal(_.pick(content.hatchingPotions, (v, k) => {
         return acceptableDrops.indexOf(k) >= 0;
       })));
       if (!user.items.hatchingPotions[drop.key]) {

--- a/website/common/script/fns/randomDrop.js
+++ b/website/common/script/fns/randomDrop.js
@@ -3,7 +3,6 @@ import content from '../content/index';
 import i18n from '../i18n';
 import { daysSince } from '../cron';
 import { diminishingReturns } from '../statHelpers';
-import _predictableRandom from './predictableRandom';
 import randomVal from './randomVal';
 
 // Clone a drop object maintaining its functions so that we can change it without affecting the original item
@@ -21,7 +20,7 @@ module.exports = function randomDrop (user, options, req = {}) {
   let rarity;
   let task;
 
-  let predictableRandom = options.predictableRandom || _predictableRandom;
+  let predictableRandom = options.predictableRandom || Math.random;
   task = options.task;
 
   chance = _.min([Math.abs(task.value - 21.27), 37.5]) / 150 + 0.02;

--- a/website/common/script/fns/randomVal.js
+++ b/website/common/script/fns/randomVal.js
@@ -7,9 +7,9 @@ function randomGenerator (user, seed, providedRandom) {
   return providedRandom ? providedRandom(user, seed) : Math.random();
 }
 
-module.exports = function randomVal (user, obj, options = {}) {
+module.exports = function randomVal (obj, options = {}) {
   let array = options.key ? _.keys(obj) : _.values(obj);
-  let rand = randomGenerator(user, options.seed, options.randomFunc);
+  let rand = randomGenerator(options.user, options.seed, options.randomFunc);
 
   array.sort();
 

--- a/website/common/script/fns/randomVal.js
+++ b/website/common/script/fns/randomVal.js
@@ -3,17 +3,17 @@ import _ from 'lodash';
 // Get a random property from an object
 // returns random property (the value)
 
-function randomGenerator (user, seed, providedRandom) {
-  return providedRandom ? providedRandom(user, seed) : Math.random();
+function trueRandom () {
+  return Math.random();
 }
 
 module.exports = function randomVal (obj, options = {}) {
   let array = options.key ? _.keys(obj) : _.values(obj);
-  let rand = randomGenerator(options.user, options.seed, options.randomFunc);
+  let random = (options.predictableRandom || trueRandom)();
 
   array.sort();
 
-  let randomIndex = Math.floor(rand * array.length);
+  let randomIndex = Math.floor(random * array.length);
 
   return array[randomIndex];
 };

--- a/website/common/script/fns/randomVal.js
+++ b/website/common/script/fns/randomVal.js
@@ -1,12 +1,19 @@
 import _ from 'lodash';
-import predictableRandom from './predictableRandom';
 
 // Get a random property from an object
 // returns random property (the value)
 
+function randomGenerator (user, seed, providedRandom) {
+  return providedRandom ? providedRandom(user, seed) : Math.random();
+}
+
 module.exports = function randomVal (user, obj, options = {}) {
   let array = options.key ? _.keys(obj) : _.values(obj);
-  let rand = predictableRandom(user, options.seed);
+  let rand = randomGenerator(user, options.seed, options.randomFunc);
+
   array.sort();
-  return array[Math.floor(rand * array.length)];
+
+  let randomIndex = Math.floor(rand * array.length);
+
+  return array[randomIndex];
 };

--- a/website/common/script/index.js
+++ b/website/common/script/index.js
@@ -298,7 +298,6 @@ api.wrap = function wrapUser (user, main = true) {
     handleTwoHanded: _.partial(importedFns.handleTwoHanded, user),
     predictableRandom: _.partial(importedFns.predictableRandom, user),
     crit: _.partial(importedFns.crit, user),
-    randomVal: _.partial(importedFns.randomVal, user),
     randomDrop: _.partial(importedFns.randomDrop, user),
     autoAllocate: _.partial(importedFns.autoAllocate, user),
     updateStats: _.partial(importedFns.updateStats, user),

--- a/website/common/script/index.js
+++ b/website/common/script/index.js
@@ -91,12 +91,14 @@ api.statsComputed = statsComputed;
 import shops from './libs/shops';
 api.shops = shops;
 
+import randomVal from './libs/randomVal';
+api.randomVal = randomVal;
+
 import autoAllocate from './fns/autoAllocate';
 import crit from './fns/crit';
 import handleTwoHanded from './fns/handleTwoHanded';
 import predictableRandom from './fns/predictableRandom';
 import randomDrop from './fns/randomDrop';
-import randomVal from './fns/randomVal';
 import resetGear from './fns/resetGear';
 import ultimateGear from './fns/ultimateGear';
 import updateStats from './fns/updateStats';
@@ -107,7 +109,6 @@ api.fns = {
   handleTwoHanded,
   predictableRandom,
   randomDrop,
-  randomVal,
   resetGear,
   ultimateGear,
   updateStats,

--- a/website/common/script/libs/randomVal.js
+++ b/website/common/script/libs/randomVal.js
@@ -1,12 +1,11 @@
 import _ from 'lodash';
 
-// Get a random property from an object
-// returns random property (the value)
-
 function trueRandom () {
   return Math.random();
 }
 
+// Get a random property from an object
+// returns random property (the value)
 module.exports = function randomVal (obj, options = {}) {
   let array = options.key ? _.keys(obj) : _.values(obj);
   let random = (options.predictableRandom || trueRandom)();

--- a/website/common/script/ops/buyArmoire.js
+++ b/website/common/script/ops/buyArmoire.js
@@ -6,7 +6,7 @@ import splitWhitespace from '../libs/splitWhitespace';
 import {
   NotAuthorized,
 } from '../libs/errors';
-import randomVal from '../fns/randomVal';
+import randomVal from '../libs/randomVal';
 
 // TODO this is only used on the server
 // move out of common?

--- a/website/common/script/ops/buyArmoire.js
+++ b/website/common/script/ops/buyArmoire.js
@@ -8,6 +8,9 @@ import {
 } from '../libs/errors';
 import randomVal from '../fns/randomVal';
 
+// TODO this is only used on the server
+// move out of common?
+
 const YIELD_EQUIPMENT_THRESHOLD = 0.6;
 const YIELD_FOOD_THRESHOLD = 0.8;
 
@@ -34,7 +37,7 @@ module.exports = function buyArmoire (user, req = {}, analytics) {
 
   if (armoireHasEquipment && (armoireResult < YIELD_EQUIPMENT_THRESHOLD || !user.flags.armoireOpened)) {
     eligibleEquipment.sort();
-    drop = randomVal(user, eligibleEquipment);
+    drop = randomVal(eligibleEquipment);
 
     if (user.items.gear.owned[drop.key]) {
       throw new NotAuthorized(i18n.t('equipmentAlradyOwned', req.language));
@@ -57,7 +60,7 @@ module.exports = function buyArmoire (user, req = {}, analytics) {
       dropText: drop.text(req.language),
     };
   } else if ((armoireHasEquipment && armoireResult < YIELD_FOOD_THRESHOLD) || armoireResult < 0.5) { // eslint-disable-line no-extra-parens
-    drop = randomVal(user, _.where(content.food, {
+    drop = randomVal(_.where(content.food, {
       canDrop: true,
     }));
 

--- a/website/common/script/ops/revive.js
+++ b/website/common/script/ops/revive.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import {
   NotAuthorized,
 } from '../libs/errors';
-import randomVal from '../fns/randomVal';
+import randomVal from '../libs/randomVal';
 
 // TODO this is only used on the server
 // move out of common?

--- a/website/common/script/ops/revive.js
+++ b/website/common/script/ops/revive.js
@@ -6,6 +6,9 @@ import {
 } from '../libs/errors';
 import randomVal from '../fns/randomVal';
 
+// TODO this is only used on the server
+// move out of common?
+
 module.exports = function revive (user, req = {}, analytics) {
   if (user.stats.hp > 0) {
     throw new NotAuthorized(i18n.t('cannotRevive', req.language));
@@ -21,7 +24,7 @@ module.exports = function revive (user, req = {}, analytics) {
     user.stats.lvl--;
   }
 
-  let lostStat = randomVal(user, _.reduce(['str', 'con', 'per', 'int'], function findRandomStat (m, k) {
+  let lostStat = randomVal(_.reduce(['str', 'con', 'per', 'int'], function findRandomStat (m, k) {
     if (user.stats[k]) {
       m[k] = k;
     }
@@ -68,7 +71,7 @@ module.exports = function revive (user, req = {}, analytics) {
     }
   });
 
-  let lostItem = randomVal(user, losableItems);
+  let lostItem = randomVal(losableItems);
 
   let message = '';
   let item = content.gear.flat[lostItem];

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -609,7 +609,7 @@ schema.methods._processCollectionQuest = async function processCollectionQuest (
   let itemsFound = {};
 
   _.times(progress.collectedItems, () => {
-    let item = shared.fns.randomVal(quest.collect, {key: true});
+    let item = shared.randomVal(quest.collect, {key: true});
 
     if (!itemsFound[item]) {
       itemsFound[item] = 0;

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -609,7 +609,7 @@ schema.methods._processCollectionQuest = async function processCollectionQuest (
   let itemsFound = {};
 
   _.times(progress.collectedItems, () => {
-    let item = shared.fns.randomVal(user, quest.collect, {key: true, seed: Math.random()});
+    let item = shared.fns.randomVal(quest.collect, {key: true});
 
     if (!itemsFound[item]) {
       itemsFound[item] = 0;


### PR DESCRIPTION
Piggybacking on #7994 (includes a commit from it)

Adjusts the server side only random values to use `Math.random` instead of seeded random values.

Ping @paglias @gambtho 

closes #7994
fixes #7929 
