### PR TITLE
A/B Testing, Round 2

### DIFF
--- a/website/client-old/js/services/guideServices.js
+++ b/website/client-old/js/services/guideServices.js
@@ -52,7 +52,7 @@ function($rootScope, User, $timeout, $state, Analytics) {
         {
           state: 'tasks',
           element: "h2.task-column_title.reward-title",
-          content: window.env.t('tourRewardsBrief'),
+          content: User.user.flags.armoireEnabled ? window.env.t('tourRewardsArmoire') : window.env.t('tourRewardsBrief'),
           placement: "left",
           proceed: window.env.t('tourRewardsProceed'),
           gold: 4,

--- a/website/common/locales/en/npc.json
+++ b/website/common/locales/en/npc.json
@@ -106,6 +106,7 @@
     "tourHabitsBrief": "<strong>Good & Bad Habits</strong><ul><li>Good Habits award Gold & Experience.</li><li>Bad Habits make you lose Health.</li></ul>",
     "tourHabitsProceed": "Makes sense!",
     "tourRewardsBrief": "<strong>Reward List</strong><ul><li>Spend your hard-earned Gold here!</li><li>Purchase Equipment for your avatar, or set custom Rewards.</li></ul>",
+    "tourRewardsArmoire": "<strong>Reward List</strong><ul><li>Spend your hard-earned Gold here!</li><li>Purchase Equipment for your avatar, get a random prize from the Enchanted Armoire, or set custom Rewards.</li></ul>",
     "tourRewardsProceed": "That's all!",
 
     "welcomeToHabit": "Welcome to Habitica!",

--- a/website/server/libs/analyticsService.js
+++ b/website/server/libs/analyticsService.js
@@ -89,6 +89,10 @@ let _formatUserData = (user) => {
     properties.ABtest = user._ABtest;
   }
 
+  if (user.registeredThrough) {
+    properties.registeredPlatform = user.registeredThrough;
+  }
+
   return properties;
 };
 

--- a/website/server/models/user/hooks.js
+++ b/website/server/models/user/hooks.js
@@ -77,12 +77,12 @@ function _setUpNewUser (user) {
   let taskTypes;
   let iterableFlags = user.flags.toObject();
 
-  // A/B Test 2016-09-12: Start with Sound Enabled?
+  // A/B Test 2016-09-26: Start with Armoire Enabled?
   if (Math.random() < 0.5) {
-    user.preferences.sound = 'rosstavoTheme';
-    user._ABtest = '20160912-soundEnabled';
+    user.flags.armoireEnabled = true;
+    user._ABtest = '20160926-armoireEnabled';
   } else {
-    user._ABtest = '20160912-soundDisabled';
+    user._ABtest = '20160926-armoireDisabled';
   }
 
   if (user.registeredThrough === 'habitica-web' || user.registeredThrough === 'habitica-android') {

--- a/website/server/models/user/schema.js
+++ b/website/server/models/user/schema.js
@@ -408,7 +408,7 @@ let schema = new Schema({
     skin: {type: String, default: '915533'},
     shirt: {type: String, default: 'blue'},
     timezoneOffset: {type: Number, default: 0},
-    sound: {type: String, default: 'off', enum: ['off', 'danielTheBard', 'gokulTheme', 'luneFoxTheme', 'wattsTheme', 'rosstavoTheme', 'dewinTheme']},
+    sound: {type: String, default: 'rosstavoTheme', enum: ['off', 'danielTheBard', 'gokulTheme', 'luneFoxTheme', 'wattsTheme', 'rosstavoTheme', 'dewinTheme']},
     chair: {type: String, default: 'none'},
     timezoneOffsetAtLastCron: Number,
     language: String,


### PR DESCRIPTION
### Changes

Moves the result of the first A/B test into default site code, and begins the second test. Do users retain better if they have the Enchanted Armoire available from the beginning?

As a miscellaneous change, also adds the platform a user first registers under to their user-level analytics properties. This will allow us to look at users who started on Android vs. iOS vs. Web as distinct populations, even if over time they use the other platforms.

---

UUID: [Enchanted Wardrobe Test](https://map.what3words.com/enchanted.wardrobe.test)
