### PR TITLE
Prevent submission of blank invitation, fixes #7807

### DIFF
--- a/test/api/v3/integration/groups/POST-groups_invite.test.js
+++ b/test/api/v3/integration/groups/POST-groups_invite.test.js
@@ -57,11 +57,28 @@ describe('Post /groups/:groupId/invite', () => {
       });
     });
 
-    it('returns empty when uuids is empty', async () => {
+    it('returns an error when uuids and emails are empty', async () => {
       await expect(inviter.post(`/groups/${group._id}/invite`, {
+        emails: [],
         uuids: [],
       }))
-      .to.eventually.be.empty;
+      .to.eventually.be.rejected.and.eql({
+        code: 400,
+        error: 'BadRequest',
+        message: t('inviteMustNotBeEmpty'),
+      });
+    });
+
+    it('returns an error when uuids is empty and emails is undefined', async () => {
+      await expect(inviter.post(`/groups/${group._id}/invite`, {
+        emails: undefined,
+        uuids: [],
+      }))
+      .to.eventually.be.rejected.and.eql({
+        code: 400,
+        error: 'BadRequest',
+        message: t('inviteMissingUuid'),
+      });
     });
 
     it('returns an error when there are more than INVITES_LIMIT uuids', async () => {
@@ -159,11 +176,16 @@ describe('Post /groups/:groupId/invite', () => {
       });
     });
 
-    it('returns empty when emails is an empty array', async () => {
+    it('returns an error when emails is empty and uuids is undefined', async () => {
       await expect(inviter.post(`/groups/${group._id}/invite`, {
         emails: [],
+        uuids: undefined,
       }))
-      .to.eventually.be.empty;
+      .to.eventually.be.rejected.and.eql({
+        code: 400,
+        error: 'BadRequest',
+        message: t('inviteMissingEmail'),
+      });
     });
 
     it('returns an error when there are more than INVITES_LIMIT emails', async () => {

--- a/website/common/locales/en/groups.json
+++ b/website/common/locales/en/groups.json
@@ -186,6 +186,8 @@
     "keepOrRemove": "req.query.keep must be either \"keep\" or \"remove\"",
     "canOnlyInviteEmailUuid": "Can only invite using uuids or emails.",
     "inviteMissingEmail": "Missing email address in invite.",
+    "inviteMissingUuid": "Missing user id in invite",
+    "inviteMustNotBeEmpty": "Invite must not be empty.",
     "partyMustbePrivate": "Parties must be private",
     "userAlreadyInGroup": "User already in that group.",
     "cannotInviteSelfToGroup": "You cannot invite yourself to a group.",

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -675,28 +675,33 @@ api.inviteToGroup = {
 
     let uuidsIsArray = Array.isArray(uuids);
     let emailsIsArray = Array.isArray(emails);
+    let emptyEmails = emailsIsArray && emails.length < 1;
+    let emptyUuids = uuidsIsArray && uuids.length < 1;
+
 
     if (!uuids && !emails) {
       throw new BadRequest(res.t('canOnlyInviteEmailUuid'));
+    } else if (uuids && !uuidsIsArray) {
+      throw new BadRequest(res.t('uuidsMustBeAnArray'));
+    } else if (emails && !emailsIsArray) {
+      throw new BadRequest(res.t('emailsMustBeAnArray'));
+    } else if (!emails && emptyUuids) {
+      throw new BadRequest(res.t('inviteMissingUuid'));
+    } else if (!uuids && emptyEmails) {
+      throw new BadRequest(res.t('inviteMissingEmail'));
+    } else if (emptyEmails && emptyUuids) {
+      throw new BadRequest(res.t('inviteMustNotBeEmpty'));
     }
 
     let results = [];
     let totalInvites = 0;
 
     if (uuids) {
-      if (!uuidsIsArray) {
-        throw new BadRequest(res.t('uuidsMustBeAnArray'));
-      } else {
-        totalInvites += uuids.length;
-      }
+      totalInvites += uuids.length;
     }
 
     if (emails) {
-      if (!emailsIsArray) {
-        throw new BadRequest(res.t('emailsMustBeAnArray'));
-      } else {
-        totalInvites += emails.length;
-      }
+      totalInvites += emails.length;
     }
 
     if (totalInvites > INVITES_LIMIT) {


### PR DESCRIPTION
Fixes https://github.com/HabitRPG/habitrpg/issues/7807
### Changes

Previous Behavior: Submitting an invite with no email or UUID displayed message 'Invite Sent', and then redirected to Guild or Party page, as with successful submission.

![screen shot 2016-09-25 at 6 35 24 pm](https://cloud.githubusercontent.com/assets/7951702/18937651/31d92ce0-85c0-11e6-8610-295f9b4aed47.png)

Current Behavior:

Email invitations with an empty array of emails triggers a BadRequest error, with message 'Missing Email in Invite.'

UUID invitations with an empty array of UUIDs triggers a BadRequest error, with message 'Missing User ID in Invite.'

Modal window stays open instead of closing and redirecting.

![screen shot 2016-09-28 at 9 07 50 pm](https://cloud.githubusercontent.com/assets/7951702/18937605/c06a34c8-85bf-11e6-8571-e597907f6aff.png)

![screen shot 2016-09-28 at 9 07 38 pm](https://cloud.githubusercontent.com/assets/7951702/18937608/c92830d8-85bf-11e6-98d2-9492c4fcd4b0.png)

---

UUID: 1bf2957d-600e-4952-9e7b-d796cf99763d
