### PR TITLE
Hitting enter no longer sends a chat message, instead inserts a new line

### DIFF
--- a/website/common/locales/en/groups.json
+++ b/website/common/locales/en/groups.json
@@ -46,6 +46,7 @@
     "chat": "Chat",
     "sendChat": "Send Chat",
     "toolTipMsg": "Fetch Recent Messages",
+    "sendChatToolTip": "You can send a chat from the keyboard by tabbing to the 'Send Chat' button and pressing Enter or by pressing Control (Command on a Mac) + Enter.",
     "syncPartyAndChat": "Sync Party and Chat",
     "guildBankPop1": "Guild Bank",
     "guildBankPop2": "Gems which your guild leader can use for challenge prizes.",

--- a/website/views/options/social/chat-box.jade
+++ b/website/views/options/social/chat-box.jade
@@ -15,7 +15,7 @@ form.chat-form(ng-if='user.flags.communityGuidelinesAccepted' ng-submit='postCha
           span.username.label.label-default(ng-class=':: userLevelStyle(msg)') {{::msg.user}}
   .chat-controls.clearfix
     .chat-buttons
-      input.btn(type='submit', value=env.t('sendChat'), ng-disabled='_sending')
+      input.btn(type='submit', value=env.t('sendChat'), ng-disabled='_sending', tooltip=env.t('sendChatToolTip'))
       button.btn(type="button", ng-click='sync(group)', ng-disabled='_sending') {{group.type === 'party' ? env.t('syncPartyAndChat') : env.t('toolTipMsg')}}
     include ../../shared/formatting-help
   .chat-controls.clearfix

--- a/website/views/options/social/chat-box.jade
+++ b/website/views/options/social/chat-box.jade
@@ -8,7 +8,7 @@ div.chat-form.guidelines-not-accepted(ng-if='!user.flags.communityGuidelinesAcce
 
 form.chat-form(ng-if='user.flags.communityGuidelinesAccepted' ng-submit='postChat(group,message.content)')
   div(ng-controller='AutocompleteCtrl')
-    textarea.form-control(rows=4, ui-keydown='{"meta-enter":"postChat(group,message.content)"}', ui-keypress='{13:"postChat(group,message.content)"}', ng-model='message.content', updateinterval='250', flag='@', at-user, auto-complete placeholder="{{group._id == TAVERN_ID ? env.t('tavernCommunityGuidelinesPlaceholder') : ''}}", ng-disabled='_sending == true')
+    textarea.form-control(rows=4, ui-keydown='{"meta-enter":"postChat(group,message.content)"}', ng-model='message.content', updateinterval='250', flag='@', at-user, auto-complete placeholder="{{group._id == TAVERN_ID ? env.t('tavernCommunityGuidelinesPlaceholder') : ''}}", ng-disabled='_sending == true')
     span.user-list
       ul.list-at-user(ng-show="query")
         li(ng-repeat='msg in response | filter:filterUser | limitTo: 5', ng-click='performCompletion(msg)')


### PR DESCRIPTION
Fixes #8066 
### Changes

changing behavior so hitting enter in a chat box only now inserts a newline instead of submitting the form.

The user can now tab to send chat and click enter or use Control(command) + enter to submit thanks to Blade's feature here: https://github.com/HabitRPG/habitica/issues/4460
