### PR TITLE
chore: Correct use of NotAuthorized Errors to Forbidden

### DIFF
--- a/test/api/v3/integration/challenges/DELETE-challenges_challengeId.test.js
+++ b/test/api/v3/integration/challenges/DELETE-challenges_challengeId.test.js
@@ -53,8 +53,8 @@ describe('DELETE /challenges/:challengeId', () => {
       let user = await generateUser();
 
       await expect(user.del(`/challenges/${challenge._id}`)).to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('onlyLeaderDeleteChal'),
       });
     });

--- a/test/api/v3/integration/challenges/POST-challenges.test.js
+++ b/test/api/v3/integration/challenges/POST-challenges.test.js
@@ -35,8 +35,8 @@ describe('POST /challenges', () => {
       group: 'habitrpg',
       prize: 0,
     })).to.eventually.be.rejected.and.eql({
-      code: 401,
-      error: 'NotAuthorized',
+      code: 403,
+      error: 'Forbidden',
       message: t('tavChalsMinPrize'),
     });
   });
@@ -54,8 +54,8 @@ describe('POST /challenges', () => {
       group: group._id,
       prize: 4,
     })).to.eventually.be.rejected.and.eql({
-      code: 401,
-      error: 'NotAuthorized',
+      code: 403,
+      error: 'Forbidden',
       message: t('mustBeGroupMember'),
     });
   });
@@ -88,8 +88,8 @@ describe('POST /challenges', () => {
       await expect(groupMember.post('/challenges', {
         group: group._id,
       })).to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('onlyGroupLeaderChal'),
       });
     });
@@ -98,8 +98,8 @@ describe('POST /challenges', () => {
       await expect(groupMember.post('/challenges', {
         group: group._id,
       })).to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('onlyGroupLeaderChal'),
       });
     });
@@ -146,8 +146,8 @@ describe('POST /challenges', () => {
         shortName: 'TC Label',
         prize: 20,
       })).to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('cantAfford'),
       });
     });

--- a/test/api/v3/integration/challenges/POST-challenges_challengeId_join.test.js
+++ b/test/api/v3/integration/challenges/POST-challenges_challengeId_join.test.js
@@ -84,8 +84,8 @@ describe('POST /challenges/:challengeId/join', () => {
       await authorizedUser.post(`/challenges/${challenge._id}/join`);
 
       await expect(authorizedUser.post(`/challenges/${challenge._id}/join`)).to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('userAlreadyInChallenge'),
       });
     });

--- a/test/api/v3/integration/challenges/POST-challenges_challengeId_leave.test.js
+++ b/test/api/v3/integration/challenges/POST-challenges_challengeId_leave.test.js
@@ -70,8 +70,8 @@ describe('POST /challenges/:challengeId/leave', () => {
 
     it('returns an error when user isn\'t a member of the challenge', async () => {
       await expect(notInChallengeUser.post(`/challenges/${challenge._id}/leave`)).to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('challengeMemberNotFound'),
       });
     });

--- a/test/api/v3/integration/challenges/POST-challenges_challengeId_winner_winnerId.test.js
+++ b/test/api/v3/integration/challenges/POST-challenges_challengeId_winner_winnerId.test.js
@@ -70,8 +70,8 @@ describe('POST /challenges/:challengeId/winner/:winnerId', () => {
 
     it('returns an error when user doesn\'t have permissions to select winner', async () => {
       await expect(winningUser.post(`/challenges/${challenge._id}/selectWinner/${winningUser._id}`)).to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('onlyLeaderDeleteChal'),
       });
     });

--- a/test/api/v3/integration/challenges/PUT-challenges_challengeId.test.js
+++ b/test/api/v3/integration/challenges/PUT-challenges_challengeId.test.js
@@ -40,8 +40,8 @@ describe('PUT /challenges/:challengeId', () => {
   it('should only allow the leader or an admin to update the challenge', async () => {
     await expect(member.put(`/challenges/${challenge._id}`))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('onlyLeaderUpdateChal'),
       });
   });

--- a/test/api/v3/integration/chat/DELETE-chat_id.test.js
+++ b/test/api/v3/integration/chat/DELETE-chat_id.test.js
@@ -36,8 +36,8 @@ describe('DELETE /groups/:groupId/chat/:chatId', () => {
 
     it('returns an error when user does not have permission to delete', async () => {
       await expect(userThatDidNotCreateChat.del(`/groups/${groupWithChat._id}/chat/${message.id}`)).to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('onlyCreatorOrAdminCanDeleteChat'),
       });
     });

--- a/test/api/v3/integration/chat/POST-groups_id_chat_id_clear_flags.test.js
+++ b/test/api/v3/integration/chat/POST-groups_id_chat_id_clear_flags.test.js
@@ -31,8 +31,8 @@ describe('POST /groups/:id/chat/:id/clearflags', () => {
     it('returns error when non-admin attempts to clear flags', async () => {
       return expect(nonAdmin.post(`/groups/${groupWithChat._id}/chat/${message.id}/clearflags`))
         .to.eventually.be.rejected.and.eql({
-          code: 401,
-          error: 'NotAuthorized',
+          code: 403,
+          error: 'Forbidden',
           message: t('messageGroupChatAdminClearFlagCount'),
         });
     });

--- a/test/api/v3/integration/coupons/GET-coupons.test.js
+++ b/test/api/v3/integration/coupons/GET-coupons.test.js
@@ -17,8 +17,8 @@ describe('GET /coupons/', () => {
   it('returns an error if user has no sudo permission', async () => {
     await user.get('/user'); // needed so the request after this will authenticate with the correct cookie session
     await expect(user.get('/coupons')).to.eventually.be.rejected.and.eql({
-      code: 401,
-      error: 'NotAuthorized',
+      code: 403,
+      error: 'Forbidden',
       message: t('noSudoAccess'),
     });
   });

--- a/test/api/v3/integration/coupons/POST-coupons_enter_code.test.js
+++ b/test/api/v3/integration/coupons/POST-coupons_enter_code.test.js
@@ -40,8 +40,8 @@ describe('POST /coupons/enter/:code', () => {
     await user.post(`/coupons/enter/${coupon._id}`); // use coupon
 
     await expect(user.post(`/coupons/enter/${coupon._id}`)).to.eventually.be.rejected.and.eql({
-      code: 401,
-      error: 'NotAuthorized',
+      code: 403,
+      error: 'Forbidden',
       message: t('couponUsed'),
     });
   });

--- a/test/api/v3/integration/coupons/POST-coupons_generate_event.test.js
+++ b/test/api/v3/integration/coupons/POST-coupons_generate_event.test.js
@@ -23,8 +23,8 @@ describe('POST /coupons/generate/:event', () => {
     });
 
     await expect(user.post('/coupons/generate/aaa')).to.eventually.be.rejected.and.eql({
-      code: 401,
-      error: 'NotAuthorized',
+      code: 403,
+      error: 'Forbidden',
       message: t('noSudoAccess'),
     });
   });

--- a/test/api/v3/integration/groups/POST-groups.test.js
+++ b/test/api/v3/integration/groups/POST-groups.test.js
@@ -56,8 +56,8 @@ describe('POST /group', () => {
           type: 'guild',
         })
       ).to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('messageInsufficientGems'),
       });
     });
@@ -207,8 +207,8 @@ describe('POST /group', () => {
       });
 
       await expect(user.post('/groups')).to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('messageGroupAlreadyInParty'),
       });
     });
@@ -219,8 +219,8 @@ describe('POST /group', () => {
         type: partyType,
         privacy: 'public',
       })).to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('partyMustbePrivate'),
       });
     });

--- a/test/api/v3/integration/groups/POST-groups_groupId_join.test.js
+++ b/test/api/v3/integration/groups/POST-groups_groupId_join.test.js
@@ -47,8 +47,8 @@ describe('POST /group/:groupId/join', () => {
     it('returns an error is user was already a member', async () => {
       await joiningUser.post(`/groups/${publicGuild._id}/join`);
       await expect(joiningUser.post(`/groups/${publicGuild._id}/join`)).to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('userAlreadyInGroup'),
       });
     });
@@ -92,8 +92,8 @@ describe('POST /group/:groupId/join', () => {
       let userWithoutInvite = await generateUser();
 
       await expect(userWithoutInvite.post(`/groups/${guild._id}/join`)).to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('messageGroupRequiresInvite'),
       });
     });
@@ -159,8 +159,8 @@ describe('POST /group/:groupId/join', () => {
       let userWithoutInvite = await generateUser();
 
       await expect(userWithoutInvite.post(`/groups/${party._id}/join`)).to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('messageGroupRequiresInvite'),
       });
     });

--- a/test/api/v3/integration/groups/POST-groups_groupId_reject.test.js
+++ b/test/api/v3/integration/groups/POST-groups_groupId_reject.test.js
@@ -26,8 +26,8 @@ describe('POST /group/:groupId/reject-invite', () => {
       let userWithoutInvite = await generateUser();
 
       await expect(userWithoutInvite.post(`/groups/${publicGuild._id}/reject-invite`)).to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('messageGroupRequiresInvite'),
       });
     });
@@ -62,8 +62,8 @@ describe('POST /group/:groupId/reject-invite', () => {
       let userWithoutInvite = await generateUser();
 
       await expect(userWithoutInvite.post(`/groups/${guild._id}/reject-invite`)).to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('messageGroupRequiresInvite'),
       });
     });
@@ -98,8 +98,8 @@ describe('POST /group/:groupId/reject-invite', () => {
       let userWithoutInvite = await generateUser();
 
       await expect(userWithoutInvite.post(`/groups/${party._id}/reject-invite`)).to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('messageGroupRequiresInvite'),
       });
     });

--- a/test/api/v3/integration/groups/POST-groups_id_removeMember.test.js
+++ b/test/api/v3/integration/groups/POST-groups_id_removeMember.test.js
@@ -35,8 +35,8 @@ describe('POST /groups/:groupId/removeMember/:memberId', () => {
 
       expect(nonMember.post(`/groups/${guild._id}/removeMember/${member._id}`))
         .to.eventually.be.rejected.and.eql({
-          code: 401,
-          type: 'NotAuthorized',
+          code: 403,
+          type: 'Forbidden',
           message: t('onlyLeaderCanRemoveMember'),
         });
     });
@@ -44,8 +44,8 @@ describe('POST /groups/:groupId/removeMember/:memberId', () => {
     it('returns an error when user is a non-leader member of a group', async () => {
       expect(member2.post(`/groups/${guild._id}/removeMember/${member._id}`))
         .to.eventually.be.rejected.and.eql({
-          code: 401,
-          type: 'NotAuthorized',
+          code: 403,
+          type: 'Forbidden',
           message: t('onlyLeaderCanRemoveMember'),
         });
     });

--- a/test/api/v3/integration/groups/POST-groups_invite.test.js
+++ b/test/api/v3/integration/groups/POST-groups_invite.test.js
@@ -38,8 +38,8 @@ describe('Post /groups/:groupId/invite', () => {
         uuids: [inviter._id],
       }))
       .to.eventually.be.rejected.and.eql({
-        code: 400,
-        error: 'BadRequest',
+        code: 403,
+        error: 'Forbidden',
         message: t('cannotInviteSelfToGroup'),
       });
     });
@@ -278,8 +278,8 @@ describe('Post /groups/:groupId/invite', () => {
         uuids: [userToInivite._id],
       }))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('userAlreadyInvitedToGroup'),
       });
     });
@@ -295,8 +295,8 @@ describe('Post /groups/:groupId/invite', () => {
         uuids: [userToInvite._id],
       }))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('userAlreadyInGroup'),
       });
     });
@@ -322,8 +322,8 @@ describe('Post /groups/:groupId/invite', () => {
         uuids: [userToInvite._id],
       }))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('userAlreadyPendingInvitation'),
       });
     });
@@ -341,8 +341,8 @@ describe('Post /groups/:groupId/invite', () => {
         uuids: [userToInvite._id],
       }))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('userAlreadyInAParty'),
       });
     });

--- a/test/api/v3/integration/groups/PUT-groups.test.js
+++ b/test/api/v3/integration/groups/PUT-groups.test.js
@@ -28,8 +28,8 @@ describe('PUT /group', () => {
     await expect(nonLeader.put(`/groups/${groupToUpdate._id}`, {
       name: groupUpdatedName,
     })).to.eventually.be.rejected.and.eql({
-      code: 401,
-      error: 'NotAuthorized',
+      code: 403,
+      error: 'Forbidden',
       message: t('messageGroupOnlyLeaderCanUpdate'),
     });
   });

--- a/test/api/v3/integration/hall/GET-hall_heroes_heroId.test.js
+++ b/test/api/v3/integration/hall/GET-hall_heroes_heroId.test.js
@@ -17,8 +17,8 @@ describe('GET /heroes/:heroId', () => {
     let nonAdmin = await generateUser();
 
     await expect(nonAdmin.get(`/hall/heroes/${user._id}`)).to.eventually.be.rejected.and.eql({
-      code: 401,
-      error: 'NotAuthorized',
+      code: 403,
+      error: 'Forbidden',
       message: t('noAdminAccess'),
     });
   });

--- a/test/api/v3/integration/hall/PUT-hall_heores_heroId.test.js
+++ b/test/api/v3/integration/hall/PUT-hall_heores_heroId.test.js
@@ -17,8 +17,8 @@ describe('PUT /heroes/:heroId', () => {
     let nonAdmin = await generateUser();
 
     await expect(nonAdmin.put(`/hall/heroes/${user._id}`)).to.eventually.be.rejected.and.eql({
-      code: 401,
-      error: 'NotAuthorized',
+      code: 403,
+      error: 'Forbidden',
       message: t('noAdminAccess'),
     });
   });

--- a/test/api/v3/integration/members/POST-send_private_message.test.js
+++ b/test/api/v3/integration/members/POST-send_private_message.test.js
@@ -49,8 +49,8 @@ describe('POST /members/send-private-message', () => {
       message: messageToSend,
       toUserId: receiver._id,
     })).to.eventually.be.rejected.and.eql({
-      code: 401,
-      error: 'NotAuthorized',
+      code: 403,
+      error: 'Forbidden',
       message: t('notAuthorizedToSendMessageToThisUser'),
     });
   });
@@ -63,8 +63,8 @@ describe('POST /members/send-private-message', () => {
       message: messageToSend,
       toUserId: receiver._id,
     })).to.eventually.be.rejected.and.eql({
-      code: 401,
-      error: 'NotAuthorized',
+      code: 403,
+      error: 'Forbidden',
       message: t('notAuthorizedToSendMessageToThisUser'),
     });
   });
@@ -76,8 +76,8 @@ describe('POST /members/send-private-message', () => {
       message: messageToSend,
       toUserId: receiver._id,
     })).to.eventually.be.rejected.and.eql({
-      code: 401,
-      error: 'NotAuthorized',
+      code: 403,
+      error: 'Forbidden',
       message: t('notAuthorizedToSendMessageToThisUser'),
     });
   });

--- a/test/api/v3/integration/members/POST-transfer_gems.test.js
+++ b/test/api/v3/integration/members/POST-transfer_gems.test.js
@@ -53,8 +53,8 @@ describe('POST /members/transfer-gems', () => {
       gemAmount,
       toUserId: userToSendMessage._id,
     })).to.eventually.be.rejected.and.eql({
-      code: 401,
-      error: 'NotAuthorized',
+      code: 403,
+      error: 'Forbidden',
       message: t('cannotSendGemsToYourself'),
     });
   });
@@ -88,8 +88,8 @@ describe('POST /members/transfer-gems', () => {
       gemAmount: -5,
       toUserId: receiver._id,
     })).to.eventually.be.rejected.and.eql({
-      code: 401,
-      error: 'NotAuthorized',
+      code: 403,
+      error: 'Forbidden',
       message: t('badAmountOfGemsToSend'),
     });
   });
@@ -100,8 +100,8 @@ describe('POST /members/transfer-gems', () => {
       gemAmount: gemAmount + 4,
       toUserId: receiver._id,
     })).to.eventually.be.rejected.and.eql({
-      code: 401,
-      error: 'NotAuthorized',
+      code: 403,
+      error: 'Forbidden',
       message: t('badAmountOfGemsToSend'),
     });
   });

--- a/test/api/v3/integration/payments/GET-payments_amazon_subscribe_cancel.test.js
+++ b/test/api/v3/integration/payments/GET-payments_amazon_subscribe_cancel.test.js
@@ -13,8 +13,8 @@ describe('payments : amazon #subscribeCancel', () => {
 
   it('verifies subscription', async () => {
     await expect(user.get(endpoint)).to.eventually.be.rejected.and.eql({
-      code: 401,
-      error: 'NotAuthorized',
+      code: 403,
+      error: 'Forbidden',
       message: t('missingSubscription'),
     });
   });

--- a/test/api/v3/integration/payments/GET-payments_paypal_checkout.test.js
+++ b/test/api/v3/integration/payments/GET-payments_paypal_checkout.test.js
@@ -13,8 +13,8 @@ xdescribe('payments : paypal #checkout', () => {
 
   it('verifies subscription', async () => {
     await expect(user.get(endpoint)).to.eventually.be.rejected.and.eql({
-      code: 401,
-      error: 'NotAuthorized',
+      code: 403,
+      error: 'Forbidden',
       message: t('missingSubscription'),
     });
   });

--- a/test/api/v3/integration/payments/GET-payments_paypal_checkout_success.test.js
+++ b/test/api/v3/integration/payments/GET-payments_paypal_checkout_success.test.js
@@ -13,8 +13,8 @@ xdescribe('payments : paypal #checkoutSuccess', () => {
 
   it('verifies subscription', async () => {
     await expect(user.get(endpoint)).to.eventually.be.rejected.and.eql({
-      code: 401,
-      error: 'NotAuthorized',
+      code: 403,
+      error: 'Forbidden',
       message: t('missingSubscription'),
     });
   });

--- a/test/api/v3/integration/payments/GET-payments_paypal_subscribe.test.js
+++ b/test/api/v3/integration/payments/GET-payments_paypal_subscribe.test.js
@@ -13,8 +13,8 @@ xdescribe('payments : paypal #subscribe', () => {
 
   it('verifies credentials', async () => {
     await expect(user.get(endpoint)).to.eventually.be.rejected.and.eql({
-      code: 401,
-      error: 'NotAuthorized',
+      code: 403,
+      error: 'Forbidden',
       message: t('missingSubscription'),
     });
   });

--- a/test/api/v3/integration/payments/GET-payments_paypal_subscribe_cancel.test.js
+++ b/test/api/v3/integration/payments/GET-payments_paypal_subscribe_cancel.test.js
@@ -13,8 +13,8 @@ describe('payments : paypal #subscribeCancel', () => {
 
   it('verifies credentials', async () => {
     await expect(user.get(endpoint)).to.eventually.be.rejected.and.eql({
-      code: 401,
-      error: 'NotAuthorized',
+      code: 403,
+      error: 'Forbidden',
       message: t('missingSubscription'),
     });
   });

--- a/test/api/v3/integration/payments/GET-payments_paypal_subscribe_success.test.js
+++ b/test/api/v3/integration/payments/GET-payments_paypal_subscribe_success.test.js
@@ -13,8 +13,8 @@ xdescribe('payments : paypal #subscribeSuccess', () => {
 
   it('verifies credentials', async () => {
     await expect(user.get(endpoint)).to.eventually.be.rejected.and.eql({
-      code: 401,
-      error: 'NotAuthorized',
+      code: 403,
+      error: 'Forbidden',
       message: t('missingSubscription'),
     });
   });

--- a/test/api/v3/integration/payments/GET-payments_stripe_subscribe_cancel.test.js
+++ b/test/api/v3/integration/payments/GET-payments_stripe_subscribe_cancel.test.js
@@ -13,8 +13,8 @@ describe('payments - stripe - #subscribeCancel', () => {
 
   it('verifies credentials', async () => {
     await expect(user.get(endpoint)).to.eventually.be.rejected.and.eql({
-      code: 401,
-      error: 'NotAuthorized',
+      code: 403,
+      error: 'Forbidden',
       message: t('missingSubscription'),
     });
   });

--- a/test/api/v3/integration/payments/POST-payments_stripe_subscribe_edit.test.js
+++ b/test/api/v3/integration/payments/POST-payments_stripe_subscribe_edit.test.js
@@ -13,8 +13,8 @@ describe('payments - stripe - #subscribeEdit', () => {
 
   it('verifies credentials', async () => {
     await expect(user.post(endpoint)).to.eventually.be.rejected.and.eql({
-      code: 401,
-      error: 'NotAuthorized',
+      code: 403,
+      error: 'Forbidden',
       message: t('missingSubscription'),
     });
   });

--- a/test/api/v3/integration/quests/POST-groups_groupId_quests_accept.test.js
+++ b/test/api/v3/integration/quests/POST-groups_groupId_quests_accept.test.js
@@ -56,8 +56,8 @@ describe('POST /groups/:groupId/quests/accept', () => {
 
       await expect(guildLeader.post(`/groups/${guild._id}/quests/accept`))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('guildQuestsNotSupported'),
       });
     });
@@ -97,8 +97,8 @@ describe('POST /groups/:groupId/quests/accept', () => {
 
       await expect(partyMembers[0].post(`/groups/${questingGroup._id}/quests/accept`))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('questAlreadyUnderway'),
       });
     });

--- a/test/api/v3/integration/quests/POST-groups_groupId_quests_force-start.test.js
+++ b/test/api/v3/integration/quests/POST-groups_groupId_quests_force-start.test.js
@@ -46,8 +46,8 @@ describe('POST /groups/:groupId/quests/force-start', () => {
 
       await expect(guildLeader.post(`/groups/${guild._id}/quests/force-start`))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('guildQuestsNotSupported'),
       });
     });
@@ -70,8 +70,8 @@ describe('POST /groups/:groupId/quests/force-start', () => {
 
       await expect(leader.post(`/groups/${questingGroup._id}/quests/force-start`))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('questAlreadyUnderway'),
       });
     });
@@ -81,8 +81,8 @@ describe('POST /groups/:groupId/quests/force-start', () => {
 
       await expect(partyMembers[0].post(`/groups/${questingGroup._id}/quests/force-start`))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('questOrGroupLeaderOnlyStartQuest'),
       });
     });

--- a/test/api/v3/integration/quests/POST-groups_groupId_quests_invite.test.js
+++ b/test/api/v3/integration/quests/POST-groups_groupId_quests_invite.test.js
@@ -56,8 +56,8 @@ describe('POST /groups/:groupId/quests/invite/:questKey', () => {
       let alternateGroup = group;
 
       await expect(leader.post(`/groups/${alternateGroup._id}/quests/invite/${PET_QUEST}`)).to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('guildQuestsNotSupported'),
       });
     });
@@ -74,8 +74,8 @@ describe('POST /groups/:groupId/quests/invite/:questKey', () => {
 
     it('does not issue invites for a quest the user does not own', async () => {
       await expect(leader.post(`/groups/${questingGroup._id}/quests/invite/${PET_QUEST}`)).to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('questNotOwned'),
       });
     });
@@ -90,8 +90,8 @@ describe('POST /groups/:groupId/quests/invite/:questKey', () => {
       await leader.update(leaderUpdate);
 
       await expect(leader.post(`/groups/${questingGroup._id}/quests/invite/${LEVELED_QUEST}`)).to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('questLevelTooHigh', {level: LEVELED_QUEST_REQ}),
       });
     });
@@ -105,8 +105,8 @@ describe('POST /groups/:groupId/quests/invite/:questKey', () => {
       await questingGroup.update({ 'quest.key': QUEST_IN_PROGRESS });
 
       await expect(leader.post(`/groups/${questingGroup._id}/quests/invite/${PET_QUEST}`)).to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('questAlreadyUnderway'),
       });
     });

--- a/test/api/v3/integration/quests/POST-groups_groupid_quests_abort.test.js
+++ b/test/api/v3/integration/quests/POST-groups_groupid_quests_abort.test.js
@@ -55,8 +55,8 @@ describe('POST /groups/:groupId/quests/abort', () => {
 
       await expect(guildLeader.post(`/groups/${guild._id}/quests/abort`))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('guildQuestsNotSupported'),
       });
     });
@@ -77,8 +77,8 @@ describe('POST /groups/:groupId/quests/abort', () => {
 
       await expect(partyMembers[0].post(`/groups/${questingGroup._id}/quests/abort`))
         .to.eventually.be.rejected.and.eql({
-          code: 401,
-          error: 'NotAuthorized',
+          code: 403,
+          error: 'Forbidden',
           message: t('onlyLeaderAbortQuest'),
         });
     });

--- a/test/api/v3/integration/quests/POST-groups_groupid_quests_cancel.test.js
+++ b/test/api/v3/integration/quests/POST-groups_groupid_quests_cancel.test.js
@@ -55,8 +55,8 @@ describe('POST /groups/:groupId/quests/cancel', () => {
 
       await expect(guildLeader.post(`/groups/${guild._id}/quests/cancel`))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('guildQuestsNotSupported'),
       });
     });
@@ -75,8 +75,8 @@ describe('POST /groups/:groupId/quests/cancel', () => {
 
       await expect(partyMembers[0].post(`/groups/${questingGroup._id}/quests/cancel`))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('onlyLeaderCancelQuest'),
       });
     });
@@ -89,8 +89,8 @@ describe('POST /groups/:groupId/quests/cancel', () => {
 
       await expect(leader.post(`/groups/${questingGroup._id}/quests/cancel`))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('cantCancelActiveQuest'),
       });
     });

--- a/test/api/v3/integration/quests/POST-groups_groupid_quests_leave.test.js
+++ b/test/api/v3/integration/quests/POST-groups_groupid_quests_leave.test.js
@@ -55,8 +55,8 @@ describe('POST /groups/:groupId/quests/leave', () => {
 
       await expect(guildLeader.post(`/groups/${guild._id}/quests/leave`))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('guildQuestsNotSupported'),
       });
     });
@@ -77,8 +77,8 @@ describe('POST /groups/:groupId/quests/leave', () => {
 
       await expect(leader.post(`/groups/${questingGroup._id}/quests/leave`))
         .to.eventually.be.rejected.and.eql({
-          code: 401,
-          error: 'NotAuthorized',
+          code: 403,
+          error: 'Forbidden',
           message: t('questLeaderCannotLeaveQuest'),
         });
     });
@@ -90,8 +90,8 @@ describe('POST /groups/:groupId/quests/leave', () => {
 
       await expect(partyMembers[1].post(`/groups/${questingGroup._id}/quests/leave`))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('notPartOfQuest'),
       });
     });

--- a/test/api/v3/integration/quests/POST-groups_groupid_quests_reject.test.js
+++ b/test/api/v3/integration/quests/POST-groups_groupid_quests_reject.test.js
@@ -56,8 +56,8 @@ describe('POST /groups/:groupId/quests/reject', () => {
 
       await expect(guildLeader.post(`/groups/${guild._id}/quests/reject`))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('guildQuestsNotSupported'),
       });
     });
@@ -118,8 +118,8 @@ describe('POST /groups/:groupId/quests/reject', () => {
 
       await expect(partyMembers[0].post(`/groups/${questingGroup._id}/quests/reject`))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('questAlreadyUnderway'),
       });
     });

--- a/test/api/v3/integration/tasks/challenges/DELETE-tasks_challenge_challengeId_checklist_itemId.test.js
+++ b/test/api/v3/integration/tasks/challenges/DELETE-tasks_challenge_challengeId_checklist_itemId.test.js
@@ -53,8 +53,8 @@ describe('DELETE /tasks/:taskId/checklist/:itemId', () => {
 
     await expect(anotherUser.del(`/tasks/${task._id}/checklist/${savedTask.checklist[0].id}`))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('onlyChalLeaderEditTasks'),
       });
   });

--- a/test/api/v3/integration/tasks/challenges/DELETE-tasks_id_challenge_challengeId.test.js
+++ b/test/api/v3/integration/tasks/challenges/DELETE-tasks_id_challenge_challengeId.test.js
@@ -38,8 +38,8 @@ describe('DELETE /tasks/:id', () => {
     let anotherUser = await generateUser();
 
     await expect(anotherUser.del(`/tasks/${task._id}`)).to.eventually.be.rejected.and.eql({
-      code: 401,
-      error: 'NotAuthorized',
+      code: 403,
+      error: 'Forbidden',
       message: t('onlyChalLeaderEditTasks'),
     });
   });
@@ -77,8 +77,8 @@ describe('DELETE /tasks/:id', () => {
     it('returns error when user attempts to delete an active challenge task', async () => {
       await expect(anotherUser.del(`/tasks/${anotherUsersNewChallengeTaskID}`))
         .to.eventually.be.rejected.and.eql({
-          code: 401,
-          error: 'NotAuthorized',
+          code: 403,
+          error: 'Forbidden',
           message: t('cantDeleteChallengeTasks'),
         });
     });

--- a/test/api/v3/integration/tasks/challenges/POST-tasks_challenge_challengeId_taskId_checklist.test.js
+++ b/test/api/v3/integration/tasks/challenges/POST-tasks_challenge_challengeId_taskId_checklist.test.js
@@ -41,8 +41,8 @@ describe('POST /tasks/:taskId/checklist/', () => {
       _id: 123,
     }))
     .to.eventually.be.rejected.and.eql({
-      code: 401,
-      error: 'NotAuthorized',
+      code: 403,
+      error: 'Forbidden',
       message: t('onlyChalLeaderEditTasks'),
     });
   });

--- a/test/api/v3/integration/tasks/challenges/POST-tasks_challenge_id.test.js
+++ b/test/api/v3/integration/tasks/challenges/POST-tasks_challenge_id.test.js
@@ -72,8 +72,8 @@ describe('POST /tasks/challenge/:challengeId', () => {
       down: true,
       notes: 1976,
     })).to.eventually.be.rejected.and.eql({
-      code: 401,
-      error: 'NotAuthorized',
+      code: 403,
+      error: 'Forbidden',
       message: t('onlyChalLeaderEditTasks'),
     });
   });

--- a/test/api/v3/integration/tasks/challenges/PUT-tasks_challenge_challengeId.test.js
+++ b/test/api/v3/integration/tasks/challenges/PUT-tasks_challenge_challengeId.test.js
@@ -49,8 +49,8 @@ describe('PUT /tasks/:id', () => {
         down: false,
         notes: 'some new notes',
       })).to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('onlyChalLeaderEditTasks'),
       });
     });

--- a/test/api/v3/integration/tasks/challenges/PUT-tasks_challenge_challengeId_tasksId_checklist_itemId.test.js
+++ b/test/api/v3/integration/tasks/challenges/PUT-tasks_challenge_challengeId_tasksId_checklist_itemId.test.js
@@ -54,8 +54,8 @@ describe('PUT /tasks/:taskId/checklist/:itemId', () => {
       _id: 123, // ignored
     }))
     .to.eventually.be.rejected.and.eql({
-      code: 401,
-      error: 'NotAuthorized',
+      code: 403,
+      error: 'Forbidden',
       message: t('onlyChalLeaderEditTasks'),
     });
   });

--- a/test/api/v3/integration/tasks/groups/POST-tasks_group_id.test.js
+++ b/test/api/v3/integration/tasks/groups/POST-tasks_group_id.test.js
@@ -55,8 +55,8 @@ describe('POST /tasks/group/:groupid', () => {
       down: true,
       notes: 1976,
     })).to.eventually.be.rejected.and.eql({
-      code: 401,
-      error: 'NotAuthorized',
+      code: 403,
+      error: 'Forbidden',
       message: t('onlyGroupLeaderCanEditTasks'),
     });
   });

--- a/test/api/v3/integration/tasks/groups/POST-tasks_group_id_assign_user_id.test.js
+++ b/test/api/v3/integration/tasks/groups/POST-tasks_group_id_assign_user_id.test.js
@@ -56,8 +56,8 @@ describe('POST /tasks/:taskId', () => {
 
     await expect(user.post(`/tasks/${nonGroupTask._id}/assign/${member._id}`))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('onlyGroupTasksCanBeAssigned'),
       });
   });
@@ -76,8 +76,8 @@ describe('POST /tasks/:taskId', () => {
   it('returns error when non leader tries to create a task', async () => {
     await expect(member.post(`/tasks/${task._id}/assign/${member._id}`))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('onlyGroupLeaderCanEditTasks'),
       });
   });

--- a/test/api/v3/integration/tasks/groups/POST-tasks_task_id_unassign.test.js
+++ b/test/api/v3/integration/tasks/groups/POST-tasks_task_id_unassign.test.js
@@ -58,8 +58,8 @@ describe('POST /tasks/:taskId/unassign/:memberId', () => {
 
     await expect(user.post(`/tasks/${nonGroupTask._id}/unassign/${member._id}`))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('onlyGroupTasksCanBeAssigned'),
       });
   });
@@ -78,8 +78,8 @@ describe('POST /tasks/:taskId/unassign/:memberId', () => {
   it('returns error when non leader tries to create a task', async () => {
     await expect(member.post(`/tasks/${task._id}/unassign/${member._id}`))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('onlyGroupLeaderCanEditTasks'),
       });
   });

--- a/test/api/v3/integration/user/POST-user_allocate.test.js
+++ b/test/api/v3/integration/user/POST-user_allocate.test.js
@@ -24,8 +24,8 @@ describe('POST /user/allocate', () => {
   it('returns an error if the user doesn\'t have attribute points', async () => {
     await expect(user.post('/user/allocate'))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('notEnoughAttrPoints'),
       });
   });

--- a/test/api/v3/integration/user/POST-user_buy.test.js
+++ b/test/api/v3/integration/user/POST-user_buy.test.js
@@ -51,8 +51,8 @@ describe('POST /user/buy/:key', () => {
 
     await expect(user.post('/user/buy/potion'))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('messageHealthAlreadyMax'),
       });
   });

--- a/test/api/v3/integration/user/POST-user_buy_armoire.test.js
+++ b/test/api/v3/integration/user/POST-user_buy_armoire.test.js
@@ -21,8 +21,8 @@ describe('POST /user/buy-armoire', () => {
 
     await expect(user.post('/user/buy-armoire'))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('messageNotEnoughGold'),
       });
   });

--- a/test/api/v3/integration/user/POST-user_buy_health_potion.test.js
+++ b/test/api/v3/integration/user/POST-user_buy_health_potion.test.js
@@ -20,8 +20,8 @@ describe('POST /user/buy-health-potion', () => {
   it('returns an error if user does not have enough gold', async () => {
     await expect(user.post('/user/buy-health-potion'))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('messageNotEnoughGold'),
       });
   });

--- a/test/api/v3/integration/user/POST-user_class_cast_spellId.test.js
+++ b/test/api/v3/integration/user/POST-user_class_cast_spellId.test.js
@@ -40,8 +40,8 @@ describe('POST /user/class/cast/:spellId', () => {
     await user.update({'stats.class': 'rogue'});
     await expect(user.post('/user/class/cast/backStab'))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('notEnoughMana'),
       });
   });
@@ -49,8 +49,8 @@ describe('POST /user/class/cast/:spellId', () => {
   it('returns an error if spell.value > user.gold', async () => {
     await expect(user.post('/user/class/cast/birthday'))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('messageNotEnoughGold'),
       });
   });
@@ -59,8 +59,8 @@ describe('POST /user/class/cast/:spellId', () => {
     await user.update({'stats.mp': 200, 'stats.class': 'wizard'});
     await expect(user.post('/user/class/cast/earth'))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('spellLevelTooHigh', {level: 13}),
       });
   });
@@ -68,8 +68,8 @@ describe('POST /user/class/cast/:spellId', () => {
   it('returns an error if user doesn\'t own the spell', async () => {
     await expect(user.post('/user/class/cast/snowball'))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('spellNotOwned'),
       });
   });

--- a/test/api/v3/integration/user/POST-user_purchase.test.js
+++ b/test/api/v3/integration/user/POST-user_purchase.test.js
@@ -19,8 +19,8 @@ describe('POST /user/purchase/:type/:key', () => {
   it('returns an error when key is not provided', async () => {
     await expect(user.post('/user/purchase/gems/gem'))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('mustSubscribeToPurchaseGems'),
       });
   });

--- a/test/api/v3/integration/user/POST-user_push_device.test.js
+++ b/test/api/v3/integration/user/POST-user_push_device.test.js
@@ -43,8 +43,8 @@ describe('POST /user/push-devices', () => {
     await user.post('/user/push-devices', {type, regId});
     await expect(user.post('/user/push-devices', {type, regId}))
       .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('pushDeviceAlreadyAdded'),
       });
   });

--- a/test/api/v3/integration/user/POST-user_read_card.test.js
+++ b/test/api/v3/integration/user/POST-user_read_card.test.js
@@ -14,8 +14,8 @@ describe('POST /user/read-card/:cardType', () => {
   it('returns an error when unknown cardType is provded', async () => {
     await expect(user.post('/user/read-card/randomCardType'))
       .to.eventually.be.rejected.and.to.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('cardTypeNotAllowed'),
       });
   });

--- a/test/api/v3/integration/user/POST-user_rebirth.test.js
+++ b/test/api/v3/integration/user/POST-user_rebirth.test.js
@@ -15,8 +15,8 @@ describe('POST /user/rebirth', () => {
   it('returns an error when user balance is too low', async () => {
     await expect(user.post('/user/rebirth'))
       .to.eventually.be.rejected.and.to.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('notEnoughGems'),
       });
   });

--- a/test/api/v3/integration/user/POST-user_release_both.test.js
+++ b/test/api/v3/integration/user/POST-user_release_both.test.js
@@ -19,8 +19,8 @@ describe('POST /user/release-both', () => {
   it('returns an error when user balance is too low and user does not have triadBingo', async () => {
     await expect(user.post('/user/release-both'))
       .to.eventually.be.rejected.and.to.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('notEnoughGems'),
       });
   });

--- a/test/api/v3/integration/user/POST-user_release_mounts.test.js
+++ b/test/api/v3/integration/user/POST-user_release_mounts.test.js
@@ -17,8 +17,8 @@ describe('POST /user/release-mounts', () => {
   it('returns an error when user balance is too low', async () => {
     await expect(user.post('/user/release-mounts'))
       .to.eventually.be.rejected.and.to.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('notEnoughGems'),
       });
   });

--- a/test/api/v3/integration/user/POST-user_release_pets.test.js
+++ b/test/api/v3/integration/user/POST-user_release_pets.test.js
@@ -17,8 +17,8 @@ describe('POST /user/release-pets', () => {
   it('returns an error when user balance is too low', async () => {
     await expect(user.post('/user/release-pets'))
       .to.eventually.be.rejected.and.to.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('notEnoughGems'),
       });
   });

--- a/test/api/v3/integration/user/POST-user_reroll.test.js
+++ b/test/api/v3/integration/user/POST-user_reroll.test.js
@@ -15,8 +15,8 @@ describe('POST /user/reroll', () => {
   it('returns an error when user balance is too low', async () => {
     await expect(user.post('/user/reroll'))
       .to.eventually.be.rejected.and.to.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('notEnoughGems'),
       });
   });

--- a/test/api/v3/integration/user/POST-user_revive.test.js
+++ b/test/api/v3/integration/user/POST-user_revive.test.js
@@ -15,8 +15,8 @@ describe('POST /user/revive', () => {
   it('returns an error when user is not dead', async () => {
     await expect(user.post('/user/revive'))
       .to.eventually.be.rejected.and.to.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('cannotRevive'),
       });
   });

--- a/test/api/v3/integration/user/POST-user_unlock.js
+++ b/test/api/v3/integration/user/POST-user_unlock.js
@@ -16,8 +16,8 @@ describe('POST /user/unlock', () => {
   it('returns an error when user balance is too low', async () => {
     await expect(user.post(`/user/unlock?path=${unlockPath}`))
       .to.eventually.be.rejected.and.to.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('notEnoughGems'),
       });
   });

--- a/test/api/v3/integration/user/PUT-user.test.js
+++ b/test/api/v3/integration/user/PUT-user.test.js
@@ -45,8 +45,8 @@ describe('PUT /user', () => {
         let errorText = t('messageUserOperationProtected', { operation: Object.keys(data)[0] });
 
         await expect(user.put('/user', data)).to.eventually.be.rejected.and.eql({
-          code: 401,
-          error: 'NotAuthorized',
+          code: 403,
+          error: 'Forbidden',
           message: errorText,
         });
       });
@@ -67,8 +67,8 @@ describe('PUT /user', () => {
         let errorText = t('messageUserOperationProtected', { operation: Object.keys(data)[0] });
 
         await expect(user.put('/user', data)).to.eventually.be.rejected.and.eql({
-          code: 401,
-          error: 'NotAuthorized',
+          code: 403,
+          error: 'Forbidden',
           message: errorText,
         });
       });
@@ -108,8 +108,8 @@ describe('PUT /user', () => {
       await expect(user.put('/user', {
         'preferences.size': 'round',
       })).to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('mustPurchaseToSet', { val: 'round', key: 'preferences.size' }),
       });
     });
@@ -158,8 +158,8 @@ describe('PUT /user', () => {
 
       it(`returns an error if user tries to update ${type} with ${type} the user does not own`, async () => {
         await expect(user.put('/user', update)).to.eventually.be.rejected.and.eql({
-          code: 401,
-          error: 'NotAuthorized',
+          code: 403,
+          error: 'Forbidden',
           message: t('mustPurchaseToSet', {val: item, key: `preferences.${type}`}),
         });
       });

--- a/test/api/v3/integration/user/auth/DELETE-user_auth_social_network.test.js
+++ b/test/api/v3/integration/user/auth/DELETE-user_auth_social_network.test.js
@@ -27,8 +27,8 @@ describe('DELETE social registration', () => {
         'auth.local': { ok: true },
       });
       await expect(user.del('/user/auth/social/facebook')).to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('cantDetachSocial'),
       });
     });
@@ -65,8 +65,8 @@ describe('DELETE social registration', () => {
         'auth.local': { ok: true },
       });
       await expect(user.del('/user/auth/social/google')).to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('cantDetachSocial'),
       });
     });

--- a/test/api/v3/integration/user/auth/POST-login-local.test.js
+++ b/test/api/v3/integration/user/auth/POST-login-local.test.js
@@ -36,8 +36,8 @@ describe('POST /user/auth/local/login', () => {
       username: user.auth.local.username,
       password,
     })).to.eventually.be.rejected.and.eql({
-      code: 401,
-      error: 'NotAuthorized',
+      code: 403,
+      error: 'Forbidden',
       message: t('accountSuspended', { userId: user._id }),
     });
   });

--- a/test/api/v3/integration/user/auth/POST-register_local.test.js
+++ b/test/api/v3/integration/user/auth/POST-register_local.test.js
@@ -200,8 +200,8 @@ describe('POST /user/auth/local/register', () => {
         password,
         confirmPassword: password,
       })).to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('onlySocialAttachLocal'),
       });
     });
@@ -244,8 +244,8 @@ describe('POST /user/auth/local/register', () => {
         password,
         confirmPassword: password,
       })).to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('usernameTaken'),
       });
     });
@@ -260,8 +260,8 @@ describe('POST /user/auth/local/register', () => {
         password,
         confirmPassword: password,
       })).to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
+        code: 403,
+        error: 'Forbidden',
         message: t('emailTaken'),
       });
     });

--- a/test/api/v3/integration/user/auth/PUT-user_update_username.test.js
+++ b/test/api/v3/integration/user/auth/PUT-user_update_username.test.js
@@ -33,8 +33,8 @@ describe('PUT /user/auth/update-username', async () => {
         username: existingUsername,
         password,
       })).to.eventually.be.rejected.and.eql({
-        code: 400,
-        error: 'BadRequest',
+        code: 403,
+        error: 'Forbidden',
         message: t('usernameTaken'),
       });
     });

--- a/test/api/v3/unit/libs/errors.test.js
+++ b/test/api/v3/unit/libs/errors.test.js
@@ -2,6 +2,8 @@
 import {
   CustomError,
   NotAuthorized,
+  Forbidden,
+  UnprocessableEntity,
   BadRequest,
   InternalServerError,
   NotFound,
@@ -39,6 +41,32 @@ describe('Custom Errors', () => {
       let notAuthorizedError = new NotAuthorized('Custom Error Message');
 
       expect(notAuthorizedError.message).to.eql('Custom Error Message');
+    });
+  });
+
+  describe('Forbidden', () => {
+    it('is an instance of CustomError', () => {
+      let forbiddenError = new Forbidden();
+
+      expect(forbiddenError).to.be.an.instanceOf(CustomError);
+    });
+
+    it('it returns an http code of 403', () => {
+      let forbiddenError = new Forbidden();
+
+      expect(forbiddenError.httpCode).to.eql(403);
+    });
+
+    it('returns a default message', () => {
+      let forbiddenError = new Forbidden();
+
+      expect(forbiddenError.message).to.eql('Forbidden.');
+    });
+
+    it('allows a custom message', () => {
+      let forbiddenError = new Forbidden('Custom Error Message');
+
+      expect(forbiddenError.message).to.eql('Custom Error Message');
     });
   });
 
@@ -91,6 +119,32 @@ describe('Custom Errors', () => {
       let badRequestError = new BadRequest('Custom Error Message');
 
       expect(badRequestError.message).to.eql('Custom Error Message');
+    });
+  });
+
+  describe('UnprocessableEntity', () => {
+    it('is an instance of CustomError', () => {
+      let unprocessibleEntityError = new UnprocessableEntity();
+
+      expect(unprocessibleEntityError).to.be.an.instanceOf(CustomError);
+    });
+
+    it('it returns an http code of 422', () => {
+      let unprocessibleEntityError = new UnprocessableEntity();
+
+      expect(unprocessibleEntityError.httpCode).to.eql(422);
+    });
+
+    it('returns a default message', () => {
+      let unprocessibleEntityError = new UnprocessableEntity();
+
+      expect(unprocessibleEntityError.message).to.eql('Unprocessable Entity.');
+    });
+
+    it('allows a custom message', () => {
+      let unprocessibleEntityError = new UnprocessableEntity('Custom Error Message');
+
+      expect(unprocessibleEntityError.message).to.eql('Custom Error Message');
     });
   });
 

--- a/test/api/v3/unit/middlewares/ensureAccessRight.test.js
+++ b/test/api/v3/unit/middlewares/ensureAccessRight.test.js
@@ -6,7 +6,7 @@ import {
 } from '../../../../helpers/api-unit.helper';
 import i18n from '../../../../../website/common/script/i18n';
 import { ensureAdmin, ensureSudo } from '../../../../../website/server/middlewares/ensureAccessRight';
-import { NotAuthorized } from '../../../../../website/server/libs/errors';
+import { Forbidden } from '../../../../../website/server/libs/errors';
 
 describe('ensure access middlewares', () => {
   let res, req, next;
@@ -18,12 +18,12 @@ describe('ensure access middlewares', () => {
   });
 
   context('ensure admin', () => {
-    it('returns not authorized when user is not an admin', () => {
+    it('returns forbidden when user is not an admin', () => {
       res.locals = {user: {contributor: {admin: false}}};
 
       ensureAdmin(req, res, next);
 
-      expect(next).to.be.calledWith(new NotAuthorized(i18n.t('noAdminAccess')));
+      expect(next).to.be.calledWith(new Forbidden(i18n.t('noAdminAccess')));
     });
 
     it('passes when user is an admin', () => {
@@ -37,12 +37,12 @@ describe('ensure access middlewares', () => {
   });
 
   context('ensure sudo', () => {
-    it('returns not authorized when user is not a sudo user', () => {
+    it('returns forbidden when user is not a sudo user', () => {
       res.locals = {user: {contributor: {sudo: false}}};
 
       ensureSudo(req, res, next);
 
-      expect(next).to.be.calledWith(new NotAuthorized(i18n.t('noSudoAccess')));
+      expect(next).to.be.calledWith(new Forbidden(i18n.t('noSudoAccess')));
     });
 
     it('passes when user is a sudo user', () => {

--- a/test/common/ops/allocate.js
+++ b/test/common/ops/allocate.js
@@ -1,7 +1,7 @@
 import allocate from '../../../website/common/script/ops/allocate';
 import {
   BadRequest,
-  NotAuthorized,
+  Forbidden,
 } from '../../../website/common/script/libs/errors';
 import i18n from '../../../website/common/script/i18n';
 import {
@@ -31,7 +31,7 @@ describe('shared.ops.allocate', () => {
     try {
       allocate(user);
     } catch (err) {
-      expect(err).to.be.an.instanceof(NotAuthorized);
+      expect(err).to.be.an.instanceof(Forbidden);
       expect(err.message).to.equal(i18n.t('notEnoughAttrPoints'));
       done();
     }

--- a/test/common/ops/buyArmoire.js
+++ b/test/common/ops/buyArmoire.js
@@ -7,7 +7,7 @@ import count from '../../../website/common/script/count';
 import buyArmoire from '../../../website/common/script/ops/buyArmoire';
 import content from '../../../website/common/script/content/index';
 import {
-  NotAuthorized,
+  Forbidden,
 } from '../../../website/common/script/libs/errors';
 import i18n from '../../../website/common/script/i18n';
 
@@ -57,7 +57,7 @@ describe('shared.ops.buyArmoire', () => {
       try {
         buyArmoire(user);
       } catch (err) {
-        expect(err).to.be.an.instanceof(NotAuthorized);
+        expect(err).to.be.an.instanceof(Forbidden);
         expect(err.message).to.equal(i18n.t('messageNotEnoughGold'));
         expect(user.items.gear.owned).to.eql({
           weapon_warrior_0: true,
@@ -74,7 +74,7 @@ describe('shared.ops.buyArmoire', () => {
       try {
         buyArmoire(user);
       } catch (err) {
-        expect(err).to.be.an.instanceof(NotAuthorized);
+        expect(err).to.be.an.instanceof(Forbidden);
         expect(err.message).to.equal(i18n.t('cannotBuyItem'));
         expect(user.items.gear.owned).to.eql({
           weapon_warrior_0: true,

--- a/test/common/ops/buyGear.js
+++ b/test/common/ops/buyGear.js
@@ -7,7 +7,7 @@ import {
 import buyGear from '../../../website/common/script/ops/buyGear';
 import shared from '../../../website/common/script';
 import {
-  NotAuthorized,
+  Forbidden,
 } from '../../../website/common/script/libs/errors';
 import i18n from '../../../website/common/script/i18n';
 
@@ -90,7 +90,7 @@ describe('shared.ops.buyGear', () => {
       try {
         buyGear(user, {params: {key: 'armor_warrior_1'}});
       } catch (err) {
-        expect(err).to.be.an.instanceof(NotAuthorized);
+        expect(err).to.be.an.instanceof(Forbidden);
         expect(err.message).to.equal(i18n.t('equipmentAlreadyOwned'));
         done();
       }
@@ -132,7 +132,7 @@ describe('shared.ops.buyGear', () => {
       try {
         buyGear(user, {params: {key: 'armor_warrior_1'}});
       } catch (err) {
-        expect(err).to.be.an.instanceof(NotAuthorized);
+        expect(err).to.be.an.instanceof(Forbidden);
         expect(err.message).to.equal(i18n.t('messageNotEnoughGold'));
         expect(user.items.gear.owned).to.not.have.property('armor_warrior_1');
         done();

--- a/test/common/ops/buyHealthPotion.js
+++ b/test/common/ops/buyHealthPotion.js
@@ -4,7 +4,7 @@ import {
 } from '../../helpers/common.helper';
 import buyHealthPotion from '../../../website/common/script/ops/buyHealthPotion';
 import {
-  NotAuthorized,
+  Forbidden,
 } from '../../../website/common/script/libs/errors';
 import i18n from '../../../website/common/script/i18n';
 
@@ -53,7 +53,7 @@ describe('shared.ops.buyHealthPotion', () => {
       try {
         buyHealthPotion(user);
       } catch (err) {
-        expect(err).to.be.an.instanceof(NotAuthorized);
+        expect(err).to.be.an.instanceof(Forbidden);
         expect(err.message).to.equal(i18n.t('messageNotEnoughGold'));
         expect(user.stats.hp).to.eql(45);
         expect(user.stats.gp).to.eql(5);
@@ -68,7 +68,7 @@ describe('shared.ops.buyHealthPotion', () => {
       try {
         buyHealthPotion(user);
       } catch (err) {
-        expect(err).to.be.an.instanceof(NotAuthorized);
+        expect(err).to.be.an.instanceof(Forbidden);
         expect(err.message).to.equal(i18n.t('messageHealthAlreadyMax'));
         expect(user.stats.hp).to.eql(50);
         expect(user.stats.gp).to.eql(40);

--- a/test/common/ops/buyMysterySet.js
+++ b/test/common/ops/buyMysterySet.js
@@ -5,7 +5,7 @@ import {
 } from '../../helpers/common.helper';
 import buyMysterySet from '../../../website/common/script/ops/buyMysterySet';
 import {
-  NotAuthorized,
+  Forbidden,
   NotFound,
 } from '../../../website/common/script/libs/errors';
 import i18n from '../../../website/common/script/i18n';
@@ -31,7 +31,7 @@ describe('shared.ops.buyMysterySet', () => {
         try {
           buyMysterySet(user, {params: {key: '201501'}});
         } catch (err) {
-          expect(err).to.be.an.instanceof(NotAuthorized);
+          expect(err).to.be.an.instanceof(Forbidden);
           expect(err.message).to.eql(i18n.t('notEnoughHourglasses'));
           expect(user.items.gear.owned).to.have.property('weapon_warrior_0', true);
           done();

--- a/test/common/ops/buyQuest.js
+++ b/test/common/ops/buyQuest.js
@@ -3,7 +3,7 @@ import {
 } from '../../helpers/common.helper';
 import buyQuest from '../../../website/common/script/ops/buyQuest';
 import {
-  NotAuthorized,
+  Forbidden,
   NotFound,
 } from '../../../website/common/script/libs/errors';
 import i18n from '../../../website/common/script/i18n';
@@ -37,7 +37,7 @@ describe('shared.ops.buyQuest', () => {
         },
       });
     } catch (err) {
-      expect(err).to.be.an.instanceof(NotAuthorized);
+      expect(err).to.be.an.instanceof(Forbidden);
       expect(err.message).to.equal(i18n.t('messageNotEnoughGold'));
       expect(user.items.quests).to.eql({});
       expect(user.stats.gp).to.equal(1);
@@ -71,7 +71,7 @@ describe('shared.ops.buyQuest', () => {
         },
       });
     } catch (err) {
-      expect(err).to.be.an.instanceof(NotAuthorized);
+      expect(err).to.be.an.instanceof(Forbidden);
       expect(err.message).to.equal(i18n.t('questNotGoldPurchasable', {key: 'kraken'}));
       expect(user.items.quests).to.eql({});
       expect(user.stats.gp).to.equal(9999);

--- a/test/common/ops/buySpecialSpell.js
+++ b/test/common/ops/buySpecialSpell.js
@@ -2,7 +2,7 @@ import buySpecialSpell from '../../../website/common/script/ops/buySpecialSpell'
 import {
   BadRequest,
   NotFound,
-  NotAuthorized,
+  Forbidden,
 } from '../../../website/common/script/libs/errors';
 import i18n from '../../../website/common/script/i18n';
 import {
@@ -50,7 +50,7 @@ describe('shared.ops.buySpecialSpell', () => {
         },
       });
     } catch (err) {
-      expect(err).to.be.an.instanceof(NotAuthorized);
+      expect(err).to.be.an.instanceof(Forbidden);
       expect(err.message).to.equal(i18n.t('messageNotEnoughGold'));
       done();
     }

--- a/test/common/ops/changeClass.js
+++ b/test/common/ops/changeClass.js
@@ -1,6 +1,6 @@
 import changeClass from '../../../website/common/script/ops/changeClass';
 import {
-  NotAuthorized,
+  Forbidden,
 } from '../../../website/common/script/libs/errors';
 import i18n from '../../../website/common/script/i18n';
 import {
@@ -21,7 +21,7 @@ describe('shared.ops.changeClass', () => {
     try {
       changeClass(user, {query: {class: 'rogue'}});
     } catch (err) {
-      expect(err).to.be.an.instanceof(NotAuthorized);
+      expect(err).to.be.an.instanceof(Forbidden);
       expect(err.message).to.equal(i18n.t('lvl10ChangeClass'));
       done();
     }
@@ -36,7 +36,7 @@ describe('shared.ops.changeClass', () => {
       try {
         changeClass(user, {query: {class: 'rogue'}});
       } catch (err) {
-        expect(err).to.be.an.instanceof(NotAuthorized);
+        expect(err).to.be.an.instanceof(Forbidden);
         expect(err.message).to.equal(i18n.t('notEnoughGems'));
         done();
       }
@@ -103,7 +103,7 @@ describe('shared.ops.changeClass', () => {
         try {
           changeClass(user);
         } catch (err) {
-          expect(err).to.be.an.instanceof(NotAuthorized);
+          expect(err).to.be.an.instanceof(Forbidden);
           expect(err.message).to.equal(i18n.t('notEnoughGems'));
           done();
         }

--- a/test/common/ops/feed.js
+++ b/test/common/ops/feed.js
@@ -2,7 +2,7 @@ import feed from '../../../website/common/script/ops/feed';
 import content from '../../../website/common/script/content';
 import {
   BadRequest,
-  NotAuthorized,
+  Forbidden,
   NotFound,
 } from '../../../website/common/script/libs/errors';
 import i18n from '../../../website/common/script/i18n';
@@ -75,7 +75,7 @@ describe('shared.ops.feed', () => {
       try {
         feed(user, {params: {pet: 'Wolf-Veteran', food: 'Meat'}});
       } catch (err) {
-        expect(err).to.be.an.instanceof(NotAuthorized);
+        expect(err).to.be.an.instanceof(Forbidden);
         expect(err.message).to.equal(i18n.t('messageCannotFeedPet'));
         done();
       }
@@ -88,7 +88,7 @@ describe('shared.ops.feed', () => {
       try {
         feed(user, {params: {pet: 'Wolf-Base', food: 'Meat'}});
       } catch (err) {
-        expect(err).to.be.an.instanceof(NotAuthorized);
+        expect(err).to.be.an.instanceof(Forbidden);
         expect(err.message).to.equal(i18n.t('messageAlreadyMount'));
         done();
       }

--- a/test/common/ops/hatch.js
+++ b/test/common/ops/hatch.js
@@ -1,7 +1,7 @@
 import hatch from '../../../website/common/script/ops/hatch';
 import {
   BadRequest,
-  NotAuthorized,
+  Forbidden,
   NotFound,
 } from '../../../website/common/script/libs/errors';
 import i18n from '../../../website/common/script/i18n';
@@ -68,7 +68,7 @@ describe('shared.ops.hatch', () => {
         try {
           hatch(user, {params: {egg: 'Wolf', hatchingPotion: 'Base'}});
         } catch (err) {
-          expect(err).to.be.an.instanceof(NotAuthorized);
+          expect(err).to.be.an.instanceof(Forbidden);
           expect(err.message).to.equal(i18n.t('messageAlreadyPet'));
           expect(user.items.pets).to.eql({'Wolf-Base': 10});
           expect(user.items.eggs).to.eql({Wolf: 1});

--- a/test/common/ops/hourglassPurchase.js
+++ b/test/common/ops/hourglassPurchase.js
@@ -1,7 +1,7 @@
 import hourglassPurchase from '../../../website/common/script/ops/hourglassPurchase';
 import {
   BadRequest,
-  NotAuthorized,
+  Forbidden,
 } from '../../../website/common/script/libs/errors';
 import i18n from '../../../website/common/script/i18n';
 import content from '../../../website/common/script/content/index';
@@ -41,7 +41,7 @@ describe('user.ops.hourglassPurchase', () => {
       try {
         hourglassPurchase(user, {params: {type: 'notAType', key: 'MantisShrimp-Base'}});
       } catch (err) {
-        expect(err).to.be.an.instanceof(NotAuthorized);
+        expect(err).to.be.an.instanceof(Forbidden);
         expect(err.message).to.eql(i18n.t('typeNotAllowedHourglass', {allowedTypes: _.keys(content.timeTravelStable).toString()}));
         done();
       }
@@ -51,7 +51,7 @@ describe('user.ops.hourglassPurchase', () => {
       try {
         hourglassPurchase(user, {params: {type: 'pets', key: 'MantisShrimp-Base'}});
       } catch (err) {
-        expect(err).to.be.an.instanceof(NotAuthorized);
+        expect(err).to.be.an.instanceof(Forbidden);
         expect(err.message).to.eql(i18n.t('notEnoughHourglasses'));
         done();
       }
@@ -61,7 +61,7 @@ describe('user.ops.hourglassPurchase', () => {
       try {
         hourglassPurchase(user, {params: {type: 'mounts', key: 'MantisShrimp-Base'}});
       } catch (err) {
-        expect(err).to.be.an.instanceof(NotAuthorized);
+        expect(err).to.be.an.instanceof(Forbidden);
         expect(err.message).to.eql(i18n.t('notEnoughHourglasses'));
         done();
       }
@@ -73,7 +73,7 @@ describe('user.ops.hourglassPurchase', () => {
       try {
         hourglassPurchase(user, {params: {type: 'pets', key: 'Wolf-Veteran'}});
       } catch (err) {
-        expect(err).to.be.an.instanceof(NotAuthorized);
+        expect(err).to.be.an.instanceof(Forbidden);
         expect(err.message).to.eql(i18n.t('notAllowedHourglass'));
         done();
       }
@@ -85,7 +85,7 @@ describe('user.ops.hourglassPurchase', () => {
       try {
         hourglassPurchase(user, {params: {type: 'mounts', key: 'Orca-Base'}});
       } catch (err) {
-        expect(err).to.be.an.instanceof(NotAuthorized);
+        expect(err).to.be.an.instanceof(Forbidden);
         expect(err.message).to.eql(i18n.t('notAllowedHourglass'));
         done();
       }
@@ -100,7 +100,7 @@ describe('user.ops.hourglassPurchase', () => {
       try {
         hourglassPurchase(user, {params: {type: 'pets', key: 'MantisShrimp-Base'}});
       } catch (err) {
-        expect(err).to.be.an.instanceof(NotAuthorized);
+        expect(err).to.be.an.instanceof(Forbidden);
         expect(err.message).to.eql(i18n.t('petsAlreadyOwned'));
         done();
       }
@@ -115,7 +115,7 @@ describe('user.ops.hourglassPurchase', () => {
       try {
         hourglassPurchase(user, {params: {type: 'mounts', key: 'MantisShrimp-Base'}});
       } catch (err) {
-        expect(err).to.be.an.instanceof(NotAuthorized);
+        expect(err).to.be.an.instanceof(Forbidden);
         expect(err.message).to.eql(i18n.t('mountsAlreadyOwned'));
         done();
       }

--- a/test/common/ops/purchase.js
+++ b/test/common/ops/purchase.js
@@ -2,7 +2,7 @@ import purchase from '../../../website/common/script/ops/purchase';
 import planGemLimits from '../../../website/common/script/libs/planGemLimits';
 import {
   BadRequest,
-  NotAuthorized,
+  Forbidden,
   NotFound,
 } from '../../../website/common/script/libs/errors';
 import i18n from '../../../website/common/script/i18n';
@@ -45,7 +45,7 @@ describe('shared.ops.purchase', () => {
       try {
         purchase(user, {params: {type: 'gems', key: 'gem'}});
       } catch (err) {
-        expect(err).to.be.an.instanceof(NotAuthorized);
+        expect(err).to.be.an.instanceof(Forbidden);
         expect(err.message).to.equal(i18n.t('mustSubscribeToPurchaseGems'));
         done();
       }
@@ -57,7 +57,7 @@ describe('shared.ops.purchase', () => {
       try {
         purchase(user, {params: {type: 'gems', key: 'gem'}});
       } catch (err) {
-        expect(err).to.be.an.instanceof(NotAuthorized);
+        expect(err).to.be.an.instanceof(Forbidden);
         expect(err.message).to.equal(i18n.t('messageNotEnoughGold'));
         done();
       }
@@ -70,7 +70,7 @@ describe('shared.ops.purchase', () => {
       try {
         purchase(user, {params: {type: 'gems', key: 'gem'}});
       } catch (err) {
-        expect(err).to.be.an.instanceof(NotAuthorized);
+        expect(err).to.be.an.instanceof(Forbidden);
         expect(err.message).to.equal(i18n.t('reachedGoldToGemCap', {convCap: planGemLimits.convCap}));
         done();
       }
@@ -92,7 +92,7 @@ describe('shared.ops.purchase', () => {
       try {
         purchase(user, {params: {type: 'gear', key: 'shield_rogue_1'}});
       } catch (err) {
-        expect(err).to.be.an.instanceof(NotAuthorized);
+        expect(err).to.be.an.instanceof(Forbidden);
         expect(err.message).to.equal(i18n.t('alreadyHave'));
         done();
       }
@@ -112,7 +112,7 @@ describe('shared.ops.purchase', () => {
       try {
         purchase(user, {params: {type: 'gear', key: 'eyewear_mystery_301405'}});
       } catch (err) {
-        expect(err).to.be.an.instanceof(NotAuthorized);
+        expect(err).to.be.an.instanceof(Forbidden);
         expect(err.message).to.equal(i18n.t('messageNotAvailable'));
         done();
       }
@@ -122,7 +122,7 @@ describe('shared.ops.purchase', () => {
       try {
         purchase(user, {params: {type: 'gear', key: 'headAccessory_special_wolfEars'}});
       } catch (err) {
-        expect(err).to.be.an.instanceof(NotAuthorized);
+        expect(err).to.be.an.instanceof(Forbidden);
         expect(err.message).to.equal(i18n.t('notEnoughGems'));
         done();
       }

--- a/test/common/ops/readCard.js
+++ b/test/common/ops/readCard.js
@@ -5,7 +5,7 @@ import {
 } from '../../helpers/common.helper';
 import {
   BadRequest,
-  NotAuthorized,
+  Forbidden,
 } from '../../../website/common/script/libs/errors';
 
 describe('shared.ops.readCard', () => {
@@ -32,7 +32,7 @@ describe('shared.ops.readCard', () => {
     try {
       readCard(user, {params: {cardType: 'randomCardType'}});
     } catch (err) {
-      expect(err).to.be.an.instanceof(NotAuthorized);
+      expect(err).to.be.an.instanceof(Forbidden);
       expect(err.message).to.equal(i18n.t('cardTypeNotAllowed'));
       done();
     }

--- a/test/common/ops/rebirth.js
+++ b/test/common/ops/rebirth.js
@@ -9,7 +9,7 @@ import {
   generateReward,
 } from '../../helpers/common.helper';
 import {
-  NotAuthorized,
+  Forbidden,
 } from '../../../website/common/script/libs/errors';
 
 describe('shared.ops.rebirth', () => {
@@ -30,7 +30,7 @@ describe('shared.ops.rebirth', () => {
     try {
       rebirth(user);
     } catch (err) {
-      expect(err).to.be.an.instanceof(NotAuthorized);
+      expect(err).to.be.an.instanceof(Forbidden);
       expect(err.message).to.equal(i18n.t('notEnoughGems'));
       done();
     }

--- a/test/common/ops/releaseBoth.js
+++ b/test/common/ops/releaseBoth.js
@@ -4,7 +4,7 @@ import {
   generateUser,
 } from '../../helpers/common.helper';
 import {
-  NotAuthorized,
+  Forbidden,
 } from '../../../website/common/script/libs/errors';
 
 describe('shared.ops.releaseBoth', () => {
@@ -26,7 +26,7 @@ describe('shared.ops.releaseBoth', () => {
     try {
       releaseBoth(user);
     } catch (err) {
-      expect(err).to.be.an.instanceof(NotAuthorized);
+      expect(err).to.be.an.instanceof(Forbidden);
       expect(err.message).to.equal(i18n.t('notEnoughGems'));
       done();
     }

--- a/test/common/ops/releaseMounts.js
+++ b/test/common/ops/releaseMounts.js
@@ -4,7 +4,7 @@ import {
   generateUser,
 } from '../../helpers/common.helper';
 import {
-  NotAuthorized,
+  Forbidden,
 } from '../../../website/common/script/libs/errors';
 
 describe('shared.ops.releaseMounts', () => {
@@ -24,7 +24,7 @@ describe('shared.ops.releaseMounts', () => {
     try {
       releaseMounts(user);
     } catch (err) {
-      expect(err).to.be.an.instanceof(NotAuthorized);
+      expect(err).to.be.an.instanceof(Forbidden);
       expect(err.message).to.equal(i18n.t('notEnoughGems'));
       done();
     }

--- a/test/common/ops/releasePets.js
+++ b/test/common/ops/releasePets.js
@@ -4,7 +4,7 @@ import {
   generateUser,
 } from '../../helpers/common.helper';
 import {
-  NotAuthorized,
+  Forbidden,
 } from '../../../website/common/script/libs/errors';
 
 describe('shared.ops.releasePets', () => {
@@ -24,7 +24,7 @@ describe('shared.ops.releasePets', () => {
     try {
       releasePets(user);
     } catch (err) {
-      expect(err).to.be.an.instanceof(NotAuthorized);
+      expect(err).to.be.an.instanceof(Forbidden);
       expect(err.message).to.equal(i18n.t('notEnoughGems'));
       done();
     }

--- a/test/common/ops/reroll.js
+++ b/test/common/ops/reroll.js
@@ -6,7 +6,7 @@ import {
   generateReward,
 } from '../../helpers/common.helper';
 import {
-  NotAuthorized,
+  Forbidden,
 } from '../../../website/common/script/libs/errors';
 
 describe('shared.ops.reroll', () => {
@@ -25,7 +25,7 @@ describe('shared.ops.reroll', () => {
     try {
       reroll(user);
     } catch (err) {
-      expect(err).to.be.an.instanceof(NotAuthorized);
+      expect(err).to.be.an.instanceof(Forbidden);
       expect(err.message).to.equal(i18n.t('notEnoughGems'));
       done();
     }

--- a/test/common/ops/revive.js
+++ b/test/common/ops/revive.js
@@ -4,7 +4,7 @@ import {
   generateUser,
 } from '../../helpers/common.helper';
 import {
-  NotAuthorized,
+  Forbidden,
 } from '../../../website/common/script/libs/errors';
 import content from '../../../website/common/script/content/index';
 
@@ -22,7 +22,7 @@ describe('shared.ops.revive', () => {
     try {
       revive(user);
     } catch (err) {
-      expect(err).to.be.an.instanceof(NotAuthorized);
+      expect(err).to.be.an.instanceof(Forbidden);
       expect(err.message).to.equal(i18n.t('cannotRevive'));
       done();
     }

--- a/test/common/ops/scoreTask.test.js
+++ b/test/common/ops/scoreTask.test.js
@@ -9,7 +9,7 @@ import {
 import common from '../../../website/common';
 import i18n from '../../../website/common/script/i18n';
 import {
-  NotAuthorized,
+  Forbidden,
 } from '../../../website/common/script/libs/errors';
 
 let EPSILON = 0.0001; // negligible distance between datapoints
@@ -66,7 +66,7 @@ describe('shared.ops.scoreTask', () => {
     try {
       scoreTask({ user: ref.afterUser, task: reward });
     } catch (err) {
-      expect(err).to.be.an.instanceof(NotAuthorized);
+      expect(err).to.be.an.instanceof(Forbidden);
       expect(err.message).to.eql(i18n.t('messageNotEnoughGold'));
       done();
     }

--- a/test/common/ops/sell.js
+++ b/test/common/ops/sell.js
@@ -4,7 +4,7 @@ import {
   generateUser,
 } from '../../helpers/common.helper';
 import {
-  NotAuthorized,
+  Forbidden,
   BadRequest,
   NotFound,
 } from '../../../website/common/script/libs/errors';
@@ -47,7 +47,7 @@ describe('shared.ops.sell', () => {
     try {
       sell(user, {params: { type: nonSellableType, key } });
     } catch (err) {
-      expect(err).to.be.an.instanceof(NotAuthorized);
+      expect(err).to.be.an.instanceof(Forbidden);
       expect(err.message).to.equal(i18n.t('typeNotSellable', {acceptedTypes: acceptedTypes.join(', ')}));
       done();
     }

--- a/test/common/ops/unlock.js
+++ b/test/common/ops/unlock.js
@@ -4,7 +4,7 @@ import {
   generateUser,
 } from '../../helpers/common.helper';
 import {
-  NotAuthorized,
+  Forbidden,
   BadRequest,
 } from '../../../website/common/script/libs/errors';
 
@@ -37,7 +37,7 @@ describe('shared.ops.unlock', () => {
     try {
       unlock(user, {query: {path: unlockPath}});
     } catch (err) {
-      expect(err).to.be.an.instanceof(NotAuthorized);
+      expect(err).to.be.an.instanceof(Forbidden);
       expect(err.message).to.equal(i18n.t('notEnoughGems'));
       done();
     }
@@ -48,7 +48,7 @@ describe('shared.ops.unlock', () => {
       unlock(user, {query: {path: unlockPath}});
       unlock(user, {query: {path: unlockPath}});
     } catch (err) {
-      expect(err).to.be.an.instanceof(NotAuthorized);
+      expect(err).to.be.an.instanceof(Forbidden);
       expect(err.message).to.equal(i18n.t('alreadyUnlocked'));
       done();
     }
@@ -60,7 +60,7 @@ describe('shared.ops.unlock', () => {
       unlock(user, {query: {path: unlockPath}});
       unlock(user, {query: {path: unlockPath}});
     } catch (err) {
-      expect(err).to.be.an.instanceof(NotAuthorized);
+      expect(err).to.be.an.instanceof(Forbidden);
       expect(err.message).to.equal(i18n.t('alreadyUnlocked'));
       done();
     }

--- a/website/common/script/content/spells.js
+++ b/website/common/script/content/spells.js
@@ -1,6 +1,6 @@
 import t from './translation';
 import _ from 'lodash';
-import { NotAuthorized } from '../libs/errors';
+import { Forbidden } from '../libs/errors';
 /*
   ---------------------------------------------------------------
   Spells
@@ -263,7 +263,7 @@ spells.special = {
     target: 'user',
     notes: t('spellSpecialSnowballAuraNotes'),
     cast (user, target, req) {
-      if (!user.items.special.snowball) throw new NotAuthorized(t('spellNotOwned')(req.language));
+      if (!user.items.special.snowball) throw new Forbidden(t('spellNotOwned')(req.language));
       target.stats.buffs.snowball = true;
       target.stats.buffs.spookySparkles = false;
       target.stats.buffs.shinySeed = false;
@@ -293,7 +293,7 @@ spells.special = {
     target: 'user',
     notes: t('spellSpecialSpookySparklesNotes'),
     cast (user, target, req) {
-      if (!user.items.special.spookySparkles) throw new NotAuthorized(t('spellNotOwned')(req.language));
+      if (!user.items.special.spookySparkles) throw new Forbidden(t('spellNotOwned')(req.language));
       target.stats.buffs.snowball = false;
       target.stats.buffs.spookySparkles = true;
       target.stats.buffs.shinySeed = false;
@@ -323,7 +323,7 @@ spells.special = {
     target: 'user',
     notes: t('spellSpecialShinySeedNotes'),
     cast (user, target, req) {
-      if (!user.items.special.shinySeed) throw new NotAuthorized(t('spellNotOwned')(req.language));
+      if (!user.items.special.shinySeed) throw new Forbidden(t('spellNotOwned')(req.language));
       target.stats.buffs.snowball = false;
       target.stats.buffs.spookySparkles = false;
       target.stats.buffs.shinySeed = true;
@@ -353,7 +353,7 @@ spells.special = {
     target: 'user',
     notes: t('spellSpecialSeafoamNotes'),
     cast (user, target, req) {
-      if (!user.items.special.seafoam) throw new NotAuthorized(t('spellNotOwned')(req.language));
+      if (!user.items.special.seafoam) throw new Forbidden(t('spellNotOwned')(req.language));
       target.stats.buffs.snowball = false;
       target.stats.buffs.spookySparkles = false;
       target.stats.buffs.shinySeed = false;

--- a/website/common/script/libs/errors.js
+++ b/website/common/script/libs/errors.js
@@ -32,11 +32,29 @@ export class BadRequest extends CustomError {
   }
 }
 
+export class Forbidden extends CustomError {
+  constructor (customMessage) {
+    super();
+    this.name = this.constructor.name;
+    this.httpCode = 403;
+    this.message = customMessage || 'Forbidden.';
+  }
+}
+
 export class NotFound extends CustomError {
   constructor (customMessage) {
     super();
     this.name = this.constructor.name;
     this.httpCode = 404;
     this.message = customMessage || 'Not found.';
+  }
+}
+
+export class UnprocessableEntity extends CustomError {
+  constructor (customMessage) {
+    super();
+    this.name = this.constructor.name;
+    this.httpCode = 422;
+    this.message = customMessage || 'Unprocessable Entity.';
   }
 }

--- a/website/common/script/ops/allocate.js
+++ b/website/common/script/ops/allocate.js
@@ -4,7 +4,7 @@ import {
 } from '../constants';
 import {
   BadRequest,
-  NotAuthorized,
+  Forbidden,
 } from '../libs/errors';
 import i18n from '../i18n';
 
@@ -22,7 +22,7 @@ module.exports = function allocate (user, req = {}) {
       user.stats.mp++;
     }
   } else {
-    throw new NotAuthorized(i18n.t('notEnoughAttrPoints', req.language));
+    throw new Forbidden(i18n.t('notEnoughAttrPoints', req.language));
   }
 
   return [

--- a/website/common/script/ops/buyArmoire.js
+++ b/website/common/script/ops/buyArmoire.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import count from '../count';
 import splitWhitespace from '../libs/splitWhitespace';
 import {
-  NotAuthorized,
+  Forbidden,
 } from '../libs/errors';
 import randomVal from '../libs/randomVal';
 
@@ -18,11 +18,11 @@ module.exports = function buyArmoire (user, req = {}, analytics) {
   let item = content.armoire;
 
   if (user.stats.gp < item.value) {
-    throw new NotAuthorized(i18n.t('messageNotEnoughGold', req.language));
+    throw new Forbidden(i18n.t('messageNotEnoughGold', req.language));
   }
 
   if (item.canOwn && !item.canOwn(user)) {
-    throw new NotAuthorized(i18n.t('cannotBuyItem', req.language));
+    throw new Forbidden(i18n.t('cannotBuyItem', req.language));
   }
 
   let armoireResp;
@@ -40,7 +40,7 @@ module.exports = function buyArmoire (user, req = {}, analytics) {
     drop = randomVal(eligibleEquipment);
 
     if (user.items.gear.owned[drop.key]) {
-      throw new NotAuthorized(i18n.t('equipmentAlradyOwned', req.language));
+      throw new Forbidden(i18n.t('equipmentAlreadyOwned', req.language));
     }
 
     user.items.gear.owned[drop.key] = true;

--- a/website/common/script/ops/buyGear.js
+++ b/website/common/script/ops/buyGear.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import splitWhitespace from '../libs/splitWhitespace';
 import {
   BadRequest,
-  NotAuthorized,
+  Forbidden,
   NotFound,
 } from '../libs/errors';
 import handleTwoHanded from '../fns/handleTwoHanded';
@@ -19,17 +19,17 @@ module.exports = function buyGear (user, req = {}, analytics) {
   if (!item) throw new NotFound(i18n.t('itemNotFound', {key}, req.language));
 
   if (user.stats.gp < item.value) {
-    throw new NotAuthorized(i18n.t('messageNotEnoughGold', req.language));
+    throw new Forbidden(i18n.t('messageNotEnoughGold', req.language));
   }
 
   if (item.canOwn && !item.canOwn(user)) {
-    throw new NotAuthorized(i18n.t('cannotBuyItem', req.language));
+    throw new Forbidden(i18n.t('cannotBuyItem', req.language));
   }
 
   let message;
 
   if (user.items.gear.owned[item.key]) {
-    throw new NotAuthorized(i18n.t('equipmentAlreadyOwned', req.language));
+    throw new Forbidden(i18n.t('equipmentAlreadyOwned', req.language));
   }
 
   if (user.preferences.autoEquip) {

--- a/website/common/script/ops/buyHealthPotion.js
+++ b/website/common/script/ops/buyHealthPotion.js
@@ -1,22 +1,22 @@
 import content from '../content/index';
 import i18n from '../i18n';
 import {
-  NotAuthorized,
+  Forbidden,
 } from '../libs/errors';
 
 module.exports = function buyHealthPotion (user, req = {}, analytics) {
   let item = content.potion;
 
   if (user.stats.gp < item.value) {
-    throw new NotAuthorized(i18n.t('messageNotEnoughGold', req.language));
+    throw new Forbidden(i18n.t('messageNotEnoughGold', req.language));
   }
 
   if (item.canOwn && !item.canOwn(user)) {
-    throw new NotAuthorized(i18n.t('cannotBuyItem', req.language));
+    throw new Forbidden(i18n.t('cannotBuyItem', req.language));
   }
 
   if (user.stats.hp >= 50) {
-    throw new NotAuthorized(i18n.t('messageHealthAlreadyMax', req.language));
+    throw new Forbidden(i18n.t('messageHealthAlreadyMax', req.language));
   }
 
   user.stats.hp += 15;

--- a/website/common/script/ops/buyMysterySet.js
+++ b/website/common/script/ops/buyMysterySet.js
@@ -3,7 +3,7 @@ import content from '../content/index';
 import _ from 'lodash';
 import {
   BadRequest,
-  NotAuthorized,
+  Forbidden,
   NotFound,
 } from '../libs/errors';
 
@@ -12,7 +12,7 @@ module.exports = function buyMysterySet (user, req = {}, analytics) {
   if (!key) throw new BadRequest(i18n.t('missingKeyParam', req.language));
 
   if (!(user.purchased.plan.consecutive.trinkets > 0)) {
-    throw new NotAuthorized(i18n.t('notEnoughHourglasses', req.language));
+    throw new Forbidden(i18n.t('notEnoughHourglasses', req.language));
   }
 
   let ref = content.timeTravelerStore(user.items.gear.owned);

--- a/website/common/script/ops/buyQuest.js
+++ b/website/common/script/ops/buyQuest.js
@@ -2,7 +2,7 @@ import i18n from '../i18n';
 import content from '../content/index';
 import {
   BadRequest,
-  NotAuthorized,
+  Forbidden,
   NotFound,
 } from '../libs/errors';
 import _ from 'lodash';
@@ -16,10 +16,10 @@ module.exports = function buyQuest (user, req = {}, analytics) {
   if (!item) throw new NotFound(i18n.t('questNotFound', {key}, req.language));
 
   if (!(item.category === 'gold' && item.goldValue)) {
-    throw new NotAuthorized(i18n.t('questNotGoldPurchasable', {key}, req.language));
+    throw new Forbidden(i18n.t('questNotGoldPurchasable', {key}, req.language));
   }
   if (user.stats.gp < item.goldValue) {
-    throw new NotAuthorized(i18n.t('messageNotEnoughGold', req.language));
+    throw new Forbidden(i18n.t('messageNotEnoughGold', req.language));
   }
 
   user.items.quests[item.key] = user.items.quests[item.key] || 0;

--- a/website/common/script/ops/buySpecialSpell.js
+++ b/website/common/script/ops/buySpecialSpell.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import splitWhitespace from '../libs/splitWhitespace';
 import {
   BadRequest,
-  NotAuthorized,
+  Forbidden,
   NotFound,
 } from '../libs/errors';
 
@@ -16,7 +16,7 @@ module.exports = function buySpecialSpell (user, req = {}) {
   if (!item) throw new NotFound(i18n.t('spellNotFound', {spellId: key}, req.language));
 
   if (user.stats.gp < item.value) {
-    throw new NotAuthorized(i18n.t('messageNotEnoughGold', req.language));
+    throw new Forbidden(i18n.t('messageNotEnoughGold', req.language));
   }
   user.stats.gp -= item.value;
 

--- a/website/common/script/ops/changeClass.js
+++ b/website/common/script/ops/changeClass.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import splitWhitespace from '../libs/splitWhitespace';
 import { capByLevel } from '../statHelpers';
 import {
-  NotAuthorized,
+  Forbidden,
 } from '../libs/errors';
 
 module.exports = function changeClass (user, req = {}, analytics) {
@@ -11,7 +11,7 @@ module.exports = function changeClass (user, req = {}, analytics) {
 
   // user.flags.classSelected is set to false after the user paid the 3 gems
   if (user.stats.lvl < 10) {
-    throw new NotAuthorized(i18n.t('lvl10ChangeClass', req.language));
+    throw new Forbidden(i18n.t('lvl10ChangeClass', req.language));
   } else if (!user.flags.classSelected && (klass === 'warrior' || klass === 'rogue' || klass === 'wizard' || klass === 'healer')) {
     user.stats.class = klass;
     user.flags.classSelected = true;
@@ -57,7 +57,7 @@ module.exports = function changeClass (user, req = {}, analytics) {
       user.preferences.disableClasses = false;
       user.preferences.autoAllocate = false;
     } else {
-      if (user.balance < 0.75) throw new NotAuthorized(i18n.t('notEnoughGems', req.language));
+      if (user.balance < 0.75) throw new Forbidden(i18n.t('notEnoughGems', req.language));
       user.balance -= 0.75;
     }
 

--- a/website/common/script/ops/feed.js
+++ b/website/common/script/ops/feed.js
@@ -3,7 +3,7 @@ import i18n from '../i18n';
 import _ from 'lodash';
 import {
   BadRequest,
-  NotAuthorized,
+  Forbidden,
   NotFound,
 } from '../libs/errors';
 
@@ -48,11 +48,11 @@ module.exports = function feed (user, req = {}) {
   }
 
   if (pet.type === 'special') {
-    throw new NotAuthorized(i18n.t('messageCannotFeedPet', req.language));
+    throw new Forbidden(i18n.t('messageCannotFeedPet', req.language));
   }
 
   if (user.items.mounts[pet.key]) {
-    throw new NotAuthorized(i18n.t('messageAlreadyMount', req.language));
+    throw new Forbidden(i18n.t('messageAlreadyMount', req.language));
   }
 
   let message;

--- a/website/common/script/ops/hatch.js
+++ b/website/common/script/ops/hatch.js
@@ -3,7 +3,7 @@ import i18n from '../i18n';
 import _ from 'lodash';
 import {
   BadRequest,
-  NotAuthorized,
+  Forbidden,
   NotFound,
 } from '../libs/errors';
 
@@ -26,7 +26,7 @@ module.exports = function hatch (user, req = {}) {
   let pet = `${egg}-${hatchingPotion}`;
 
   if (user.items.pets[pet] && user.items.pets[pet] > 0) {
-    throw new NotAuthorized(i18n.t('messageAlreadyPet', req.language));
+    throw new Forbidden(i18n.t('messageAlreadyPet', req.language));
   }
 
   user.items.pets[pet] = 5;

--- a/website/common/script/ops/hourglassPurchase.js
+++ b/website/common/script/ops/hourglassPurchase.js
@@ -3,7 +3,7 @@ import i18n from '../i18n';
 import _ from 'lodash';
 import {
   BadRequest,
-  NotAuthorized,
+  Forbidden,
 } from '../libs/errors';
 
 module.exports = function purchaseHourglass (user, req = {}, analytics) {
@@ -14,19 +14,19 @@ module.exports = function purchaseHourglass (user, req = {}, analytics) {
   if (!type) throw new BadRequest(i18n.t('missingTypeParam', req.language));
 
   if (!content.timeTravelStable[type]) {
-    throw new NotAuthorized(i18n.t('typeNotAllowedHourglass', {allowedTypes: _.keys(content.timeTravelStable).toString()}, req.language));
+    throw new Forbidden(i18n.t('typeNotAllowedHourglass', {allowedTypes: _.keys(content.timeTravelStable).toString()}, req.language));
   }
 
   if (!_.contains(_.keys(content.timeTravelStable[type]), key)) {
-    throw new NotAuthorized(i18n.t('notAllowedHourglass', req.language));
+    throw new Forbidden(i18n.t('notAllowedHourglass', req.language));
   }
 
   if (user.items[type][key]) {
-    throw new NotAuthorized(i18n.t(`${type}AlreadyOwned`, req.language));
+    throw new Forbidden(i18n.t(`${type}AlreadyOwned`, req.language));
   }
 
   if (user.purchased.plan.consecutive.trinkets <= 0) {
-    throw new NotAuthorized(i18n.t('notEnoughHourglasses', req.language));
+    throw new Forbidden(i18n.t('notEnoughHourglasses', req.language));
   }
 
   user.purchased.plan.consecutive.trinkets--;

--- a/website/common/script/ops/purchase.js
+++ b/website/common/script/ops/purchase.js
@@ -5,7 +5,7 @@ import splitWhitespace from '../libs/splitWhitespace';
 import planGemLimits from '../libs/planGemLimits';
 import {
   NotFound,
-  NotAuthorized,
+  Forbidden,
   BadRequest,
 } from '../libs/errors';
 
@@ -29,15 +29,15 @@ module.exports = function purchase (user, req = {}, analytics) {
     convCap += user.purchased.plan.consecutive.gemCapExtra;
 
     if (!user.purchased || !user.purchased.plan || !user.purchased.plan.customerId) {
-      throw new NotAuthorized(i18n.t('mustSubscribeToPurchaseGems', req.language));
+      throw new Forbidden(i18n.t('mustSubscribeToPurchaseGems', req.language));
     }
 
     if (user.stats.gp < convRate) {
-      throw new NotAuthorized(i18n.t('messageNotEnoughGold', req.language));
+      throw new Forbidden(i18n.t('messageNotEnoughGold', req.language));
     }
 
     if (user.purchased.plan.gemsBought >= convCap) {
-      throw new NotAuthorized(i18n.t('reachedGoldToGemCap', {convCap}, req.language));
+      throw new Forbidden(i18n.t('reachedGoldToGemCap', {convCap}, req.language));
     }
 
     user.balance += 0.25;
@@ -74,7 +74,7 @@ module.exports = function purchase (user, req = {}, analytics) {
     }
 
     if (user.items.gear.owned[key]) {
-      throw new NotAuthorized(i18n.t('alreadyHave', req.language));
+      throw new Forbidden(i18n.t('alreadyHave', req.language));
     }
 
     price = (item.twoHanded || item.gearSet === 'animal' ? 2 : 1) / 4;
@@ -89,11 +89,11 @@ module.exports = function purchase (user, req = {}, analytics) {
   }
 
   if (!item.canBuy(user)) {
-    throw new NotAuthorized(i18n.t('messageNotAvailable', req.language));
+    throw new Forbidden(i18n.t('messageNotAvailable', req.language));
   }
 
   if (!user.balance || user.balance < price) {
-    throw new NotAuthorized(i18n.t('notEnoughGems', req.language));
+    throw new Forbidden(i18n.t('notEnoughGems', req.language));
   }
 
   user.balance -= price;

--- a/website/common/script/ops/readCard.js
+++ b/website/common/script/ops/readCard.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import i18n from '../i18n';
 import {
   BadRequest,
-  NotAuthorized,
+  Forbidden,
 } from '../libs/errors';
 import content from '../content/index';
 
@@ -14,7 +14,7 @@ module.exports = function readCard (user, req = {}) {
   }
 
   if (_.keys(content.cardTypes).indexOf(cardType) === -1) {
-    throw new NotAuthorized(i18n.t('cardTypeNotAllowed', req.language));
+    throw new Forbidden(i18n.t('cardTypeNotAllowed', req.language));
   }
 
   user.items.special[`${cardType}Received`].shift();

--- a/website/common/script/ops/rebirth.js
+++ b/website/common/script/ops/rebirth.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import { capByLevel } from '../statHelpers';
 import { MAX_LEVEL } from '../constants';
 import {
-  NotAuthorized,
+  Forbidden,
 } from '../libs/errors';
 import equip from './equip';
 
@@ -11,7 +11,7 @@ const USERSTATSLIST = ['per', 'int', 'con', 'str', 'points', 'gp', 'exp', 'mp'];
 
 module.exports = function rebirth (user, tasks = [], req = {}, analytics) {
   if (user.balance < 1.5 && user.stats.lvl < MAX_LEVEL) {
-    throw new NotAuthorized(i18n.t('notEnoughGems', req.language));
+    throw new Forbidden(i18n.t('notEnoughGems', req.language));
   }
 
   let analyticsData = {

--- a/website/common/script/ops/releaseBoth.js
+++ b/website/common/script/ops/releaseBoth.js
@@ -1,7 +1,7 @@
 import content from '../content/index';
 import i18n from '../i18n';
 import {
-  NotAuthorized,
+  Forbidden,
 } from '../libs/errors';
 import splitWhitespace from '../libs/splitWhitespace';
 import _ from 'lodash';
@@ -10,7 +10,7 @@ module.exports = function releaseBoth (user, req = {}, analytics) {
   let animal;
 
   if (user.balance < 1.5 && !user.achievements.triadBingo) {
-    throw new NotAuthorized(i18n.t('notEnoughGems', req.language));
+    throw new Forbidden(i18n.t('notEnoughGems', req.language));
   }
 
   let giveTriadBingo = true;

--- a/website/common/script/ops/releaseMounts.js
+++ b/website/common/script/ops/releaseMounts.js
@@ -1,14 +1,14 @@
 import content from '../content/index';
 import i18n from '../i18n';
 import {
-  NotAuthorized,
+  Forbidden,
 } from '../libs/errors';
 
 module.exports = function releaseMounts (user, req = {}, analytics) {
   let mount;
 
   if (user.balance < 1) {
-    throw new NotAuthorized(i18n.t('notEnoughGems', req.language));
+    throw new Forbidden(i18n.t('notEnoughGems', req.language));
   }
 
   user.balance -= 1;

--- a/website/common/script/ops/releasePets.js
+++ b/website/common/script/ops/releasePets.js
@@ -1,12 +1,12 @@
 import content from '../content/index';
 import i18n from '../i18n';
 import {
-  NotAuthorized,
+  Forbidden,
 } from '../libs/errors';
 
 module.exports = function releasePets (user, req = {}, analytics) {
   if (user.balance < 1) {
-    throw new NotAuthorized(i18n.t('notEnoughGems', req.language));
+    throw new Forbidden(i18n.t('notEnoughGems', req.language));
   }
 
   user.balance -= 1;

--- a/website/common/script/ops/reroll.js
+++ b/website/common/script/ops/reroll.js
@@ -1,12 +1,12 @@
 import i18n from '../i18n';
 import _ from 'lodash';
 import {
-  NotAuthorized,
+  Forbidden,
 } from '../libs/errors';
 
 module.exports = function reroll (user, tasks = [], req = {}, analytics) {
   if (user.balance < 1) {
-    throw new NotAuthorized(i18n.t('notEnoughGems', req.language));
+    throw new Forbidden(i18n.t('notEnoughGems', req.language));
   }
 
   user.balance--;

--- a/website/common/script/ops/revive.js
+++ b/website/common/script/ops/revive.js
@@ -2,14 +2,14 @@ import content from '../content/index';
 import i18n from '../i18n';
 import _ from 'lodash';
 import {
-  NotAuthorized,
+  Forbidden,
 } from '../libs/errors';
 import randomVal from '../libs/randomVal';
 import predictableRandom from '../fns/predictableRandom';
 
 module.exports = function revive (user, req = {}, analytics) {
   if (user.stats.hp > 0) {
-    throw new NotAuthorized(i18n.t('cannotRevive', req.language));
+    throw new Forbidden(i18n.t('cannotRevive', req.language));
   }
 
   _.merge(user.stats, {

--- a/website/common/script/ops/scoreTask.js
+++ b/website/common/script/ops/scoreTask.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import {
-  NotAuthorized,
+  Forbidden,
 } from '../libs/errors';
 import i18n from '../i18n';
 import updateStats from '../fns/updateStats';
@@ -184,7 +184,7 @@ module.exports = function scoreTask (options = {}, req = {}) {
   user._tmp = {};
 
   // If they're trying to purchase a too-expensive reward, don't allow them to do that.
-  if (task.value > user.stats.gp && task.type === 'reward') throw new NotAuthorized(i18n.t('messageNotEnoughGold', req.language));
+  if (task.value > user.stats.gp && task.type === 'reward') throw new Forbidden(i18n.t('messageNotEnoughGold', req.language));
 
   if (task.type === 'habit') {
     delta += _changeTaskValue(user, task, direction, times, cron);

--- a/website/common/script/ops/sell.js
+++ b/website/common/script/ops/sell.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import splitWhitespace from '../libs/splitWhitespace';
 import {
   NotFound,
-  NotAuthorized,
+  Forbidden,
   BadRequest,
 } from '../libs/errors';
 
@@ -23,7 +23,7 @@ module.exports = function sell (user, req = {}) {
   }
 
   if (ACCEPTEDTYPES.indexOf(type) === -1) {
-    throw new NotAuthorized(i18n.t('typeNotSellable', {acceptedTypes: ACCEPTEDTYPES.join(', ')}, req.language));
+    throw new Forbidden(i18n.t('typeNotSellable', {acceptedTypes: ACCEPTEDTYPES.join(', ')}, req.language));
   }
 
   if (!user.items[type][key]) {

--- a/website/common/script/ops/unlock.js
+++ b/website/common/script/ops/unlock.js
@@ -2,7 +2,7 @@ import i18n from '../i18n';
 import _ from 'lodash';
 import splitWhitespace from '../libs/splitWhitespace';
 import {
-  NotAuthorized,
+  Forbidden,
   BadRequest,
 } from '../libs/errors';
 import setWith from 'lodash.setwith'; // Not available in lodash 3
@@ -44,18 +44,18 @@ module.exports = function unlock (user, req = {}, analytics) {
     });
 
     if (alreadyOwnedItems === setPaths.length) {
-      throw new NotAuthorized(i18n.t('alreadyUnlocked', req.language));
+      throw new Forbidden(i18n.t('alreadyUnlocked', req.language));
     // TODO write math formula to check if buying the full set is cheaper than the items individually
     // (item cost * number of remaining items) < setCost`
     } /* else if (alreadyOwnedItems > 0) {
-      throw new NotAuthorized(i18n.t('alreadyUnlockedPart', req.language));
+      throw new Forbidden(i18n.t('alreadyUnlockedPart', req.language));
     } */
   } else {
     alreadyOwns = _.get(user, `purchased.${path}`) === true;
   }
 
   if ((!user.balance || user.balance < cost) && !alreadyOwns) {
-    throw new NotAuthorized(i18n.t('notEnoughGems', req.language));
+    throw new Forbidden(i18n.t('notEnoughGems', req.language));
   }
 
   if (isFullSet) {

--- a/website/server/controllers/api-v3/chat.js
+++ b/website/server/controllers/api-v3/chat.js
@@ -3,7 +3,7 @@ import { model as Group } from '../../models/group';
 import { model as User } from '../../models/user';
 import {
   NotFound,
-  NotAuthorized,
+  Forbidden,
 } from '../../libs/errors';
 import _ from 'lodash';
 import { removeFromArray } from '../../libs/collectionManipulators';
@@ -325,7 +325,7 @@ api.clearChatFlags = {
     if (validationErrors) throw validationErrors;
 
     if (!user.contributor.admin) {
-      throw new NotAuthorized(res.t('messageGroupChatAdminClearFlagCount'));
+      throw new Forbidden(res.t('messageGroupChatAdminClearFlagCount'));
     }
 
     let group = await Group.getGroup({
@@ -444,7 +444,7 @@ api.deleteChat = {
     if (!message) throw new NotFound(res.t('messageGroupChatNotFound'));
 
     if (user._id !== message.uuid && !user.contributor.admin) {
-      throw new NotAuthorized(res.t('onlyCreatorOrAdminCanDeleteChat'));
+      throw new Forbidden(res.t('onlyCreatorOrAdminCanDeleteChat'));
     }
 
     let lastClientMsg = req.query.previousMsg;

--- a/website/server/controllers/api-v3/members.js
+++ b/website/server/controllers/api-v3/members.js
@@ -8,7 +8,7 @@ import { model as Group } from '../../models/group';
 import { model as Challenge } from '../../models/challenge';
 import {
   NotFound,
-  NotAuthorized,
+  Forbidden,
 } from '../../libs/errors';
 import * as Tasks from '../../models/task';
 import {
@@ -311,7 +311,7 @@ api.sendPrivateMessage = {
     let userOptedOutOfMessaging = receiver.inbox.optOut;
 
     if (userBlockedSender || userIsBlockBySender || userOptedOutOfMessaging) {
-      throw new NotAuthorized(res.t('notAuthorizedToSendMessageToThisUser'));
+      throw new Forbidden(res.t('notAuthorizedToSendMessageToThisUser'));
     }
 
     await sender.sendMessage(receiver, message);
@@ -369,14 +369,14 @@ api.transferGems = {
     if (!receiver) throw new NotFound(res.t('userNotFound'));
 
     if (receiver._id === sender._id) {
-      throw new NotAuthorized(res.t('cannotSendGemsToYourself'));
+      throw new Forbidden(res.t('cannotSendGemsToYourself'));
     }
 
     let gemAmount = req.body.gemAmount;
     let amount = gemAmount / 4;
 
     if (amount <= 0 || sender.balance < amount) {
-      throw new NotAuthorized(res.t('badAmountOfGemsToSend'));
+      throw new Forbidden(res.t('badAmountOfGemsToSend'));
     }
 
     receiver.balance += amount;

--- a/website/server/controllers/api-v3/pushNotifications.js
+++ b/website/server/controllers/api-v3/pushNotifications.js
@@ -1,6 +1,6 @@
 import { authWithHeaders } from '../../middlewares/auth';
 import {
-  NotAuthorized,
+  Forbidden,
   NotFound,
 } from '../../libs/errors';
 
@@ -39,7 +39,7 @@ api.addPushDevice = {
     };
 
     if (pushDevices.find(device => device.regId === item.regId)) {
-      throw new NotAuthorized(res.t('pushDeviceAlreadyAdded'));
+      throw new Forbidden(res.t('pushDeviceAlreadyAdded'));
     }
 
     pushDevices.push(item);

--- a/website/server/controllers/api-v3/tasks.js
+++ b/website/server/controllers/api-v3/tasks.js
@@ -9,7 +9,7 @@ import { model as Challenge } from '../../models/challenge';
 import { model as Group } from '../../models/group';
 import {
   NotFound,
-  NotAuthorized,
+  Forbidden,
   BadRequest,
 } from '../../libs/errors';
 import {
@@ -90,7 +90,7 @@ api.createChallengeTasks = {
 
     // If the challenge does not exist, or if it exists but user is not the leader -> throw error
     if (!challenge) throw new NotFound(res.t('challengeNotFound'));
-    if (challenge.leader !== user._id) throw new NotAuthorized(res.t('onlyChalLeaderEditTasks'));
+    if (challenge.leader !== user._id) throw new Forbidden(res.t('onlyChalLeaderEditTasks'));
 
     let tasks = await createTasks(req, res, {user, challenge});
 
@@ -236,11 +236,11 @@ api.updateTask = {
       //  @TODO: Abstract this access snippet
       group = await Group.getGroup({user, groupId: task.group.id, fields: requiredGroupFields});
       if (!group) throw new NotFound(res.t('groupNotFound'));
-      if (group.leader !== user._id) throw new NotAuthorized(res.t('onlyGroupLeaderCanEditTasks'));
+      if (group.leader !== user._id) throw new Forbidden(res.t('onlyGroupLeaderCanEditTasks'));
     } else if (task.challenge.id && !task.userId) { // If the task belongs to a challenge make sure the user has rights
       challenge = await Challenge.findOne({_id: task.challenge.id}).exec();
       if (!challenge) throw new NotFound(res.t('challengeNotFound'));
-      if (challenge.leader !== user._id) throw new NotAuthorized(res.t('onlyChalLeaderEditTasks'));
+      if (challenge.leader !== user._id) throw new Forbidden(res.t('onlyChalLeaderEditTasks'));
     } else if (task.userId !== user._id) { // If the task is owned by a user make it's the current one
       throw new NotFound(res.t('taskNotFound'));
     }
@@ -469,11 +469,11 @@ api.addChecklistItem = {
     } else if (task.group.id && !task.userId) {
       group = await Group.getGroup({user, groupId: task.group.id, fields: requiredGroupFields});
       if (!group) throw new NotFound(res.t('groupNotFound'));
-      if (group.leader !== user._id) throw new NotAuthorized(res.t('onlyGroupLeaderCanEditTasks'));
+      if (group.leader !== user._id) throw new Forbidden(res.t('onlyGroupLeaderCanEditTasks'));
     } else if (task.challenge.id && !task.userId) { // If the task belongs to a challenge make sure the user has rights
       challenge = await Challenge.findOne({_id: task.challenge.id}).exec();
       if (!challenge) throw new NotFound(res.t('challengeNotFound'));
-      if (challenge.leader !== user._id) throw new NotAuthorized(res.t('onlyChalLeaderEditTasks'));
+      if (challenge.leader !== user._id) throw new Forbidden(res.t('onlyChalLeaderEditTasks'));
     } else if (task.userId !== user._id) { // If the task is owned by a user make it's the current one
       throw new NotFound(res.t('taskNotFound'));
     }
@@ -570,11 +570,11 @@ api.updateChecklistItem = {
     } else if (task.group.id && !task.userId) {
       group = await Group.getGroup({user, groupId: task.group.id, fields: requiredGroupFields});
       if (!group) throw new NotFound(res.t('groupNotFound'));
-      if (group.leader !== user._id) throw new NotAuthorized(res.t('onlyGroupLeaderCanEditTasks'));
+      if (group.leader !== user._id) throw new Forbidden(res.t('onlyGroupLeaderCanEditTasks'));
     } else if (task.challenge.id && !task.userId) { // If the task belongs to a challenge make sure the user has rights
       challenge = await Challenge.findOne({_id: task.challenge.id}).exec();
       if (!challenge) throw new NotFound(res.t('challengeNotFound'));
-      if (challenge.leader !== user._id) throw new NotAuthorized(res.t('onlyChalLeaderEditTasks'));
+      if (challenge.leader !== user._id) throw new Forbidden(res.t('onlyChalLeaderEditTasks'));
     } else if (task.userId !== user._id) { // If the task is owned by a user make it's the current one
       throw new NotFound(res.t('taskNotFound'));
     }
@@ -631,11 +631,11 @@ api.removeChecklistItem = {
     } else if (task.group.id && !task.userId) {
       group = await Group.getGroup({user, groupId: task.group.id, fields: requiredGroupFields});
       if (!group) throw new NotFound(res.t('groupNotFound'));
-      if (group.leader !== user._id) throw new NotAuthorized(res.t('onlyGroupLeaderCanEditTasks'));
+      if (group.leader !== user._id) throw new Forbidden(res.t('onlyGroupLeaderCanEditTasks'));
     } else if (task.challenge.id && !task.userId) { // If the task belongs to a challenge make sure the user has rights
       challenge = await Challenge.findOne({_id: task.challenge.id}).exec();
       if (!challenge) throw new NotFound(res.t('challengeNotFound'));
-      if (challenge.leader !== user._id) throw new NotAuthorized(res.t('onlyChalLeaderEditTasks'));
+      if (challenge.leader !== user._id) throw new Forbidden(res.t('onlyChalLeaderEditTasks'));
     } else if (task.userId !== user._id) { // If the task is owned by a user make it's the current one
       throw new NotFound(res.t('taskNotFound'));
     }
@@ -903,16 +903,16 @@ api.deleteTask = {
       //  @TODO: Abstract this access snippet
       let group = await Group.getGroup({user, groupId: task.group.id, fields: requiredGroupFields});
       if (!group) throw new NotFound(res.t('groupNotFound'));
-      if (group.leader !== user._id) throw new NotAuthorized(res.t('onlyGroupLeaderCanEditTasks'));
+      if (group.leader !== user._id) throw new Forbidden(res.t('onlyGroupLeaderCanEditTasks'));
       await group.removeTask(task);
     } else if (task.challenge.id && !task.userId) { // If the task belongs to a challenge make sure the user has rights
       challenge = await Challenge.findOne({_id: task.challenge.id}).exec();
       if (!challenge) throw new NotFound(res.t('challengeNotFound'));
-      if (challenge.leader !== user._id) throw new NotAuthorized(res.t('onlyChalLeaderEditTasks'));
+      if (challenge.leader !== user._id) throw new Forbidden(res.t('onlyChalLeaderEditTasks'));
     } else if (task.userId !== user._id) { // If the task is owned by a user make it's the current one
       throw new NotFound(res.t('taskNotFound'));
     } else if (task.userId && task.challenge.id && !task.challenge.broken) {
-      throw new NotAuthorized(res.t('cantDeleteChallengeTasks'));
+      throw new Forbidden(res.t('cantDeleteChallengeTasks'));
     }
 
     if (task.type !== 'todo' || !task.completed) {

--- a/website/server/controllers/api-v3/tasks/groups.js
+++ b/website/server/controllers/api-v3/tasks/groups.js
@@ -5,7 +5,7 @@ import { model as Group } from '../../../models/group';
 import { model as User } from '../../../models/user';
 import {
   NotFound,
-  NotAuthorized,
+  Forbidden,
 } from '../../../libs/errors';
 import {
   createTasks,
@@ -42,7 +42,7 @@ api.createGroupTasks = {
     let group = await Group.getGroup({user, groupId: req.params.groupId, fields: requiredGroupFields});
     if (!group) throw new NotFound(res.t('groupNotFound'));
 
-    if (group.leader !== user._id) throw new NotAuthorized(res.t('onlyGroupLeaderCanEditTasks'));
+    if (group.leader !== user._id) throw new Forbidden(res.t('onlyGroupLeaderCanEditTasks'));
 
     let tasks = await createTasks(req, res, {user, group});
 
@@ -116,13 +116,13 @@ api.assignTask = {
     }
 
     if (!task.group.id) {
-      throw new NotAuthorized(res.t('onlyGroupTasksCanBeAssigned'));
+      throw new Forbidden(res.t('onlyGroupTasksCanBeAssigned'));
     }
 
     let group = await Group.getGroup({user, groupId: task.group.id, fields: requiredGroupFields});
     if (!group) throw new NotFound(res.t('groupNotFound'));
 
-    if (group.leader !== user._id) throw new NotAuthorized(res.t('onlyGroupLeaderCanEditTasks'));
+    if (group.leader !== user._id) throw new Forbidden(res.t('onlyGroupLeaderCanEditTasks'));
 
     await group.syncTask(task, assignedUser);
 
@@ -164,13 +164,13 @@ api.unassignTask = {
     }
 
     if (!task.group.id) {
-      throw new NotAuthorized(res.t('onlyGroupTasksCanBeAssigned'));
+      throw new Forbidden(res.t('onlyGroupTasksCanBeAssigned'));
     }
 
     let group = await Group.getGroup({user, groupId: task.group.id, fields: requiredGroupFields});
     if (!group) throw new NotFound(res.t('groupNotFound'));
 
-    if (group.leader !== user._id) throw new NotAuthorized(res.t('onlyGroupLeaderCanEditTasks'));
+    if (group.leader !== user._id) throw new Forbidden(res.t('onlyGroupLeaderCanEditTasks'));
 
     await group.unlinkTask(task, assignedUser);
 

--- a/website/server/controllers/api-v3/user.js
+++ b/website/server/controllers/api-v3/user.js
@@ -2,8 +2,9 @@ import { authWithHeaders } from '../../middlewares/auth';
 import common from '../../../common';
 import {
   NotFound,
-  BadRequest,
   NotAuthorized,
+  BadRequest,
+  Forbidden,
 } from '../../libs/errors';
 import * as Tasks from '../../models/task';
 import {
@@ -159,13 +160,13 @@ api.updateUser = {
       let purchasable = requiresPurchase[key];
 
       if (purchasable && !checkPreferencePurchase(user, purchasable, val)) {
-        throw new NotAuthorized(res.t('mustPurchaseToSet', { val, key }));
+        throw new Forbidden(res.t('mustPurchaseToSet', { val, key }));
       }
 
       if (acceptablePUTPaths[key]) {
         _.set(user, key, val);
       } else {
-        throw new NotAuthorized(res.t('messageUserOperationProtected', { operation: key }));
+        throw new Forbidden(res.t('messageUserOperationProtected', { operation: key }));
       }
     });
 
@@ -357,9 +358,9 @@ api.castSpell = {
     let spell = common.content.spells[klass][spellId];
 
     if (!spell) throw new NotFound(res.t('spellNotFound', {spellId}));
-    if (spell.mana > user.stats.mp) throw new NotAuthorized(res.t('notEnoughMana'));
-    if (spell.value > user.stats.gp && !spell.previousPurchase) throw new NotAuthorized(res.t('messageNotEnoughGold'));
-    if (spell.lvl > user.stats.lvl) throw new NotAuthorized(res.t('spellLevelTooHigh', {level: spell.lvl}));
+    if (spell.mana > user.stats.mp) throw new Forbidden(res.t('notEnoughMana'));
+    if (spell.value > user.stats.gp && !spell.previousPurchase) throw new Forbidden(res.t('messageNotEnoughGold'));
+    if (spell.lvl > user.stats.lvl) throw new Forbidden(res.t('spellLevelTooHigh', {level: spell.lvl}));
 
     let targetType = spell.target;
 

--- a/website/server/controllers/top-level/payments/amazon.js
+++ b/website/server/controllers/top-level/payments/amazon.js
@@ -1,6 +1,6 @@
 import {
   BadRequest,
-  NotAuthorized,
+  Forbidden,
 } from '../../../libs/errors';
 import amzLib from '../../../libs/amazonPayments';
 import {
@@ -171,7 +171,7 @@ api.subscribe = {
     if (sub.discount) { // apply discount
       if (!coupon) throw new BadRequest(res.t('couponCodeRequired'));
       let result = await Coupon.findOne({_id: cc.validate(coupon), event: sub.key});
-      if (!result) throw new NotAuthorized(res.t('invalidCoupon'));
+      if (!result) throw new Forbidden(res.t('invalidCoupon'));
     }
 
     await amzLib.setBillingAgreementDetails({
@@ -233,7 +233,7 @@ api.subscribeCancel = {
     let user = res.locals.user;
     let billingAgreementId = user.purchased.plan.customerId;
 
-    if (!billingAgreementId) throw new NotAuthorized(res.t('missingSubscription'));
+    if (!billingAgreementId) throw new Forbidden(res.t('missingSubscription'));
 
     await amzLib.closeBillingAgreement({
       AmazonBillingAgreementId: billingAgreementId,

--- a/website/server/controllers/top-level/payments/iap.js
+++ b/website/server/controllers/top-level/payments/iap.js
@@ -5,7 +5,7 @@ import {
 import iap from '../../../libs/inAppPurchases';
 import payments from '../../../libs/payments';
 import {
-  NotAuthorized,
+  Forbidden,
 } from '../../../libs/errors';
 import { model as IapPurchaseReceipt } from '../../../models/iapPurchaseReceipt';
 import logger from '../../../libs/logger';
@@ -38,7 +38,7 @@ api.iapAndroidVerify = {
     let googleRes = await iap.validate(iap.GOOGLE, testObj);
 
     let isValidated = iap.isValidated(googleRes);
-    if (!isValidated) throw new NotAuthorized('INVALID_RECEIPT');
+    if (!isValidated) throw new Forbidden('INVALID_RECEIPT');
 
     let receiptObj = JSON.parse(testObj.data); // passed as a string
     let token = receiptObj.token || receiptObj.purchaseToken;
@@ -46,7 +46,7 @@ api.iapAndroidVerify = {
     let existingReceipt = await IapPurchaseReceipt.findOne({
       _id: token,
     }).exec();
-    if (existingReceipt) throw new NotAuthorized('RECEIPT_ALREADY_USED');
+    if (existingReceipt) throw new Forbidden('RECEIPT_ALREADY_USED');
 
     await IapPurchaseReceipt.create({
       _id: token,

--- a/website/server/controllers/top-level/payments/paypal.js
+++ b/website/server/controllers/top-level/payments/paypal.js
@@ -17,7 +17,7 @@ import {
 } from '../../../middlewares/auth';
 import {
   BadRequest,
-  NotAuthorized,
+  Forbidden,
 } from '../../../libs/errors';
 
 const BASE_URL = nconf.get('BASE_URL');
@@ -160,7 +160,7 @@ api.subscribe = {
     if (sub.discount) {
       if (!req.query.coupon) throw new BadRequest(res.t('couponCodeRequired'));
       let coupon = await Coupon.findOne({_id: cc.validate(req.query.coupon), event: sub.key});
-      if (!coupon) throw new NotAuthorized(res.t('invalidCoupon'));
+      if (!coupon) throw new Forbidden(res.t('invalidCoupon'));
     }
 
     let billingPlanTitle = `Habitica Subscription ($${sub.price} every ${sub.months} months, recurring)`;
@@ -224,7 +224,7 @@ api.subscribeCancel = {
   async handler (req, res) {
     let user = res.locals.user;
     let customerId = user.purchased.plan.customerId;
-    if (!user.purchased.plan.customerId) throw new NotAuthorized(res.t('missingSubscription'));
+    if (!user.purchased.plan.customerId) throw new Forbidden(res.t('missingSubscription'));
 
     let customer = await paypalBillingAgreementGet(customerId);
 

--- a/website/server/controllers/top-level/payments/stripe.js
+++ b/website/server/controllers/top-level/payments/stripe.js
@@ -2,7 +2,7 @@ import stripeModule from 'stripe';
 import shared from '../../../../common';
 import {
   BadRequest,
-  NotAuthorized,
+  Forbidden,
 } from '../../../libs/errors';
 import { model as Coupon } from '../../../models/coupon';
 import payments from '../../../libs/payments';
@@ -127,7 +127,7 @@ api.subscribeEdit = {
     let user = res.locals.user;
     let customerId = user.purchased.plan.customerId;
 
-    if (!customerId) throw new NotAuthorized(res.t('missingSubscription'));
+    if (!customerId) throw new Forbidden(res.t('missingSubscription'));
     if (!token) throw new BadRequest('Missing req.body.id');
 
     let subscriptions = await stripe.customers.listSubscriptions(customerId);
@@ -150,7 +150,7 @@ api.subscribeCancel = {
   middlewares: [authWithUrl],
   async handler (req, res) {
     let user = res.locals.user;
-    if (!user.purchased.plan.customerId) throw new NotAuthorized(res.t('missingSubscription'));
+    if (!user.purchased.plan.customerId) throw new Forbidden(res.t('missingSubscription'));
 
     let customer = await stripe.customers.retrieve(user.purchased.plan.customerId);
     await stripe.customers.del(user.purchased.plan.customerId);

--- a/website/server/libs/errors.js
+++ b/website/server/libs/errors.js
@@ -29,6 +29,19 @@ export const NotAuthorized = common.errors.NotAuthorized;
 export const BadRequest = common.errors.BadRequest;
 
 /**
+ * @apiDefine Forbidden
+ * @apiError Forbidden The user did not have access to the requested resource.
+ *
+ * @apiErrorExample Error-Response:
+ *     HTTP/1.1 403 Not Found
+ *     {
+ *       "error": "Forbidden",
+ *       "message": "Forbidden."
+ *     }
+ */
+export const Forbidden = common.errors.Forbidden;
+
+/**
  * @apiDefine NotFound
  * @apiError NotFound The requested resource was not found.
  *
@@ -40,6 +53,19 @@ export const BadRequest = common.errors.BadRequest;
  *     }
  */
 export const NotFound = common.errors.NotFound;
+
+/**
+ * @apiDefine UnprocessableEntity
+ * @apiError UnprocessableEntity The syntax of the request was correct, but it could not be processed.
+ *
+ * @apiErrorExample Error-Response:
+ *     HTTP/1.1 422 Not Found
+ *     {
+ *       "error": "UnprocessableEntity",
+ *       "message": "Unprocessable Entity."
+ *     }
+ */
+export const UnprocessableEntity = common.errors.UnprocessableEntity;
 
 /**
  * @apiDefine InternalServerError

--- a/website/server/middlewares/ensureAccessRight.js
+++ b/website/server/middlewares/ensureAccessRight.js
@@ -1,12 +1,12 @@
 import {
-  NotAuthorized,
+  Forbidden,
 } from '../libs/errors';
 
 export function ensureAdmin (req, res, next) {
   let user = res.locals.user;
 
   if (!user.contributor.admin) {
-    return next(new NotAuthorized(res.t('noAdminAccess')));
+    return next(new Forbidden(res.t('noAdminAccess')));
   }
 
   next();
@@ -16,7 +16,7 @@ export function ensureSudo (req, res, next) {
   let user = res.locals.user;
 
   if (!user.contributor.sudo) {
-    return next(new NotAuthorized(res.t('noSudoAccess')));
+    return next(new Forbidden(res.t('noSudoAccess')));
   }
 
   next();

--- a/website/server/models/coupon.js
+++ b/website/server/models/coupon.js
@@ -7,7 +7,7 @@ import couponCode from 'coupon-code';
 import baseModel from '../libs/baseModel';
 import {
   BadRequest,
-  NotAuthorized,
+  Forbidden,
 } from '../libs/errors';
 
 export let schema = new mongoose.Schema({
@@ -35,7 +35,7 @@ schema.statics.generate = async function generateCoupons (event, count = 1) {
 schema.statics.apply = async function applyCoupon (user, req, code) {
   let coupon = await this.findById(couponCode.validate(code)).exec();
   if (!coupon) throw new BadRequest(shared.i18n.t('invalidCoupon', req.language));
-  if (coupon.user) throw new NotAuthorized(shared.i18n.t('couponUsed', req.language));
+  if (coupon.user) throw new Forbidden(shared.i18n.t('couponUsed', req.language));
 
   if (coupon.event === 'wondercon') {
     user.items.gear.owned.eyewear_special_wondercon_red = true;


### PR DESCRIPTION
@paglias you were right that a 401 NotAuthorized error should only be used in the case that a user needs to authenticate. I've switched all of the NotAuthorized errors to 403 Forbidden errors (except for the auth ones)

I caught some some BadRequest errors that should actually be 403 Forbidden, and I'm sure there are more, but we can do those later. 
