### PR TITLE
Subscriptions Fixes

### DIFF
--- a/test/api/v3/unit/libs/cron.test.js
+++ b/test/api/v3/unit/libs/cron.test.js
@@ -72,9 +72,9 @@ describe('cron', () => {
     });
 
     it('resets plan.dateUpdated on a new month', () => {
-      let currentMonth = moment().format('YYYY-MM');
+      let currentMonth = moment().startOf('month');
       cron({user, tasksByType, daysMissed, analytics});
-      expect(moment(user.purchased.plan.dateUpdated).format('YYYY-MM')).to.equal(currentMonth);
+      expect(moment(user.purchased.plan.dateUpdated).startOf('month').isSame(currentMonth)).to.eql(true);
     });
 
     it('increments plan.consecutive.count', () => {

--- a/test/api/v3/unit/libs/cron.test.js
+++ b/test/api/v3/unit/libs/cron.test.js
@@ -62,7 +62,7 @@ describe('cron', () => {
   describe('end of the month perks', () => {
     beforeEach(() => {
       user.purchased.plan.customerId = 'subscribedId';
-      user.purchased.plan.dateUpdated = moment('012013', 'MMYYYY');
+      user.purchased.plan.dateUpdated = moment().subtract(1, 'months').format('YYYY-MM');
     });
 
     it('resets plan.gemsBought on a new month', () => {
@@ -72,9 +72,9 @@ describe('cron', () => {
     });
 
     it('resets plan.dateUpdated on a new month', () => {
-      let currentMonth = moment().format('MMYYYY');
+      let currentMonth = moment().format('YYYY-MM');
       cron({user, tasksByType, daysMissed, analytics});
-      expect(moment(user.purchased.plan.dateUpdated).format('MMYYYY')).to.equal(currentMonth);
+      expect(moment(user.purchased.plan.dateUpdated).format('YYYY-MM')).to.equal(currentMonth);
     });
 
     it('increments plan.consecutive.count', () => {

--- a/test/api/v3/unit/libs/payments.test.js
+++ b/test/api/v3/unit/libs/payments.test.js
@@ -80,6 +80,24 @@ describe('payments/index', () => {
         expect(recipient.purchased.plan.extraMonths).to.eql(3);
       });
 
+      it('does not set negative extraMonths if plan has past dateTerminated date', async () => {
+        let dateTerminated = moment().subtract(2, 'months').toDate();
+        recipient.purchased.plan.dateTerminated = dateTerminated;
+
+        await api.createSubscription(data);
+
+        expect(recipient.purchased.plan.extraMonths).to.eql(0);
+      });
+
+      it('does not reset Gold-to-Gems cap on an existing subscription', async () => {
+        recipient.purchased.plan = plan;
+        recipient.purchased.plan.gemsBought = 12;
+
+        await api.createSubscription(data);
+
+        expect(recipient.purchased.plan.gemsBought).to.eql(12);
+      });
+
       it('adds to date terminated for an existing plan with a future terminated date', async () => {
         let dateTerminated = moment().add(1, 'months').toDate();
         recipient.purchased.plan = plan;
@@ -210,6 +228,25 @@ describe('payments/index', () => {
         expect(user.purchased.plan.extraMonths).to.within(1.9, 2);
       });
 
+      it('does not set negative extraMonths if plan has past dateTerminated date', async () => {
+        user.purchased.plan = plan;
+        user.purchased.plan.dateTerminated = moment(new Date()).subtract(2, 'months');
+        expect(user.purchased.plan.extraMonths).to.eql(0);
+
+        await api.createSubscription(data);
+
+        expect(user.purchased.plan.extraMonths).to.eql(0);
+      });
+
+      it('does not reset Gold-to-Gems cap on additional subscription', async () => {
+        user.purchased.plan = plan;
+        user.purchased.plan.gemsBought = 10;
+
+        await api.createSubscription(data);
+
+        expect(user.purchased.plan.gemsBought).to.eql(10);
+      });
+
       it('sets lastBillingDate if payment method is "Amazon Payments"', async () => {
         data.paymentMethod = 'Amazon Payments';
 
@@ -218,7 +255,7 @@ describe('payments/index', () => {
         expect(user.purchased.plan.lastBillingDate).to.exist;
       });
 
-      it('increases the user\'s transcation count', async () => {
+      it('increases the user\'s transaction count', async () => {
         expect(user.purchased.txnCount).to.eql(0);
 
         await api.createSubscription(data);

--- a/website/server/libs/cron.js
+++ b/website/server/libs/cron.js
@@ -8,7 +8,6 @@ import nconf from 'nconf';
 
 const CRON_SAFE_MODE = nconf.get('CRON_SAFE_MODE') === 'true';
 const CRON_SEMI_SAFE_MODE = nconf.get('CRON_SEMI_SAFE_MODE') === 'true';
-const YEAR_MONTH_FORMAT = 'YYYY-MM';
 const shouldDo = common.shouldDo;
 const scoreTask = common.ops.scoreTask;
 // const maxPMs = 200;
@@ -47,8 +46,8 @@ let CLEAR_BUFFS = {
 
 function grantEndOfTheMonthPerks (user, now) {
   let plan = user.purchased.plan;
-  let subscriptionEndDate = moment(plan.dateTerminated).isBefore() ? moment(plan.dateTerminated).format(YEAR_MONTH_FORMAT) : moment(now).format(YEAR_MONTH_FORMAT);
-  let dateUpdatedMoment = moment(plan.dateUpdated).format(YEAR_MONTH_FORMAT);
+  let subscriptionEndDate = moment(plan.dateTerminated).isBefore() ? moment(plan.dateTerminated).startOf('month') : moment(now).startOf('month');
+  let dateUpdatedMoment = moment(plan.dateUpdated).startOf('month');
   let elapsedMonths = moment(subscriptionEndDate).diff(dateUpdatedMoment, 'months');
 
   if (elapsedMonths > 0) {
@@ -126,7 +125,7 @@ export function cron (options = {}) {
   let perfect = true;
 
   // Reset Gold-to-Gems cap if it's the start of the month
-  if (user.purchased && user.purchased.plan && moment(user.purchased.plan.dateUpdated).format(YEAR_MONTH_FORMAT) !== moment().format(YEAR_MONTH_FORMAT)) {
+  if (user.purchased && user.purchased.plan && moment(user.purchased.plan.dateUpdated).startOf('month') !== moment().startOf('month')) {
     user.purchased.plan.gemsBought = 0;
   }
   if (user.isSubscribed()) {

--- a/website/server/libs/cron.js
+++ b/website/server/libs/cron.js
@@ -48,7 +48,6 @@ function grantEndOfTheMonthPerks (user, now) {
   let plan = user.purchased.plan;
 
   if (moment(plan.dateUpdated).format('MMYYYY') !== moment().format('MMYYYY')) {
-    plan.gemsBought = 0; // reset gem-cap
     plan.dateUpdated = now;
     // For every month, inc their "consecutive months" counter. Give perks based on consecutive blocks
     // If they already got perks for those blocks (eg, 6mo subscription, subscription gifts, etc) - then dec the offset until it hits 0
@@ -121,6 +120,10 @@ export function cron (options = {}) {
   // "Perfect Day" achievement for perfect days
   let perfect = true;
 
+  // Reset Gold-to-Gems cap if it's the start of the month
+  if (user.purchased && user.purchased.plan && moment(user.purchased.plan.dateUpdated).format('MMYYYY') !== moment().format('MMYYYY')) {
+    user.purchased.plan.gemsBought = 0;
+  }
   if (user.isSubscribed()) {
     grantEndOfTheMonthPerks(user, now);
     if (!CRON_SAFE_MODE) removeTerminatedSubscription(user);

--- a/website/server/libs/cron.js
+++ b/website/server/libs/cron.js
@@ -8,6 +8,7 @@ import nconf from 'nconf';
 
 const CRON_SAFE_MODE = nconf.get('CRON_SAFE_MODE') === 'true';
 const CRON_SEMI_SAFE_MODE = nconf.get('CRON_SEMI_SAFE_MODE') === 'true';
+const YEAR_MONTH_FORMAT = 'YYYY-MM';
 const shouldDo = common.shouldDo;
 const scoreTask = common.ops.scoreTask;
 // const maxPMs = 200;
@@ -46,8 +47,8 @@ let CLEAR_BUFFS = {
 
 function grantEndOfTheMonthPerks (user, now) {
   let plan = user.purchased.plan;
-  let subscriptionEndDate = moment(plan.dateTerminated).isBefore() ? moment(plan.dateTerminated).format('YYYY-MM') : moment(now).format('YYYY-MM');
-  let dateUpdatedMoment = moment(plan.dateUpdated).format('YYYY-MM');
+  let subscriptionEndDate = moment(plan.dateTerminated).isBefore() ? moment(plan.dateTerminated).format(YEAR_MONTH_FORMAT) : moment(now).format(YEAR_MONTH_FORMAT);
+  let dateUpdatedMoment = moment(plan.dateUpdated).format(YEAR_MONTH_FORMAT);
   let elapsedMonths = moment(subscriptionEndDate).diff(dateUpdatedMoment, 'months');
 
   if (elapsedMonths > 0) {
@@ -125,7 +126,7 @@ export function cron (options = {}) {
   let perfect = true;
 
   // Reset Gold-to-Gems cap if it's the start of the month
-  if (user.purchased && user.purchased.plan && moment(user.purchased.plan.dateUpdated).format('MMYYYY') !== moment().format('MMYYYY')) {
+  if (user.purchased && user.purchased.plan && moment(user.purchased.plan.dateUpdated).format(YEAR_MONTH_FORMAT) !== moment().format(YEAR_MONTH_FORMAT)) {
     user.purchased.plan.gemsBought = 0;
   }
   if (user.isSubscribed()) {

--- a/website/server/libs/cron.js
+++ b/website/server/libs/cron.js
@@ -46,23 +46,27 @@ let CLEAR_BUFFS = {
 
 function grantEndOfTheMonthPerks (user, now) {
   let plan = user.purchased.plan;
+  let subscriptionEndDate = moment(plan.dateTerminated).isBefore() ? moment(plan.dateTerminated).format('YYYY-MM') : moment(now).format('YYYY-MM');
+  let dateUpdatedMoment = moment(plan.dateUpdated).format('YYYY-MM');
+  let elapsedMonths = moment(subscriptionEndDate).diff(dateUpdatedMoment, 'months');
 
-  if (moment(plan.dateUpdated).format('MMYYYY') !== moment().format('MMYYYY')) {
+  if (elapsedMonths > 0) {
     plan.dateUpdated = now;
     // For every month, inc their "consecutive months" counter. Give perks based on consecutive blocks
     // If they already got perks for those blocks (eg, 6mo subscription, subscription gifts, etc) - then dec the offset until it hits 0
-    // TODO use month diff instead of ++ / --? see https://github.com/HabitRPG/habitrpg/issues/4317
     _.defaults(plan.consecutive, {count: 0, offset: 0, trinkets: 0, gemCapExtra: 0});
 
-    plan.consecutive.count++;
+    for (let i = 0; i < elapsedMonths; i++) {
+      plan.consecutive.count++;
 
-    if (plan.consecutive.offset > 1) {
-      plan.consecutive.offset--;
-    } else if (plan.consecutive.count % 3 === 0) { // every 3 months
-      if (plan.consecutive.offset === 1) plan.consecutive.offset--;
-      plan.consecutive.trinkets++;
-      plan.consecutive.gemCapExtra += 5;
-      if (plan.consecutive.gemCapExtra > 25) plan.consecutive.gemCapExtra = 25; // cap it at 50 (hard 25 limit + extra 25)
+      if (plan.consecutive.offset > 1) {
+        plan.consecutive.offset--;
+      } else if (plan.consecutive.count % 3 === 0) { // every 3 months
+        if (plan.consecutive.offset === 1) plan.consecutive.offset--;
+        plan.consecutive.trinkets++;
+        plan.consecutive.gemCapExtra += 5;
+        if (plan.consecutive.gemCapExtra > 25) plan.consecutive.gemCapExtra = 25; // cap it at 50 (hard 25 limit + extra 25)
+      }
     }
   }
 }

--- a/website/server/libs/payments.js
+++ b/website/server/libs/payments.js
@@ -24,11 +24,8 @@ function revealMysteryItems (user) {
   });
 }
 
-function _roundDateDiff (earlyDate, lateDate) {
+function _dateDiff (earlyDate, lateDate) {
   if (!earlyDate || !lateDate || moment(lateDate).isBefore(earlyDate)) return 0;
-
-  earlyDate = moment(earlyDate).format('YYYYMMDD');
-  lateDate = moment(lateDate).format('YYYYMMDD');
 
   return moment(lateDate).diff(earlyDate, 'months', true);
 }
@@ -61,7 +58,7 @@ api.createSubscription = async function createSubscription (data) {
       customerId: data.customerId,
       dateUpdated: today,
       paymentMethod: data.paymentMethod,
-      extraMonths: Number(plan.extraMonths) + _roundDateDiff(today, plan.dateTerminated),
+      extraMonths: Number(plan.extraMonths) + _dateDiff(today, plan.dateTerminated),
       dateTerminated: null,
       // Specify a lastBillingDate just for Amazon Payments
       // Resetted every time the subscription restarts

--- a/website/server/libs/payments.js
+++ b/website/server/libs/payments.js
@@ -129,7 +129,7 @@ api.cancelSubscription = async function cancelSubscription (data) {
   let plan = data.user.purchased.plan;
   let now = moment();
   let remaining = data.nextBill ? moment(data.nextBill).diff(new Date(), 'days') : 30;
-  let extraDays = Math.ceil(30 * plan.extraMonths);
+  let extraDays = Math.ceil(30.5 * plan.extraMonths);
   let nowStr = `${now.format('MM')}/${moment(plan.dateUpdated).format('DD')}/${now.format('YYYY')}`;
   let nowStrFormat = 'MM/DD/YYYY';
 

--- a/website/server/libs/payments.js
+++ b/website/server/libs/payments.js
@@ -38,12 +38,13 @@ api.createSubscription = async function createSubscription (data) {
   let plan = recipient.purchased.plan;
   let block = shared.content.subscriptionBlocks[data.gift ? data.gift.subscription.key : data.sub.key];
   let months = Number(block.months);
+  let today = new Date();
 
   if (data.gift) {
     if (plan.customerId && !plan.dateTerminated) { // User has active plan
       plan.extraMonths += months;
     } else {
-      if (!plan.dateUpdated) plan.dateUpdated = new Date();
+      if (!plan.dateUpdated) plan.dateUpdated = today;
       if (moment(plan.dateTerminated).isAfter()) {
         plan.dateTerminated = moment(plan.dateTerminated).add({months}).toDate();
       } else {
@@ -53,21 +54,21 @@ api.createSubscription = async function createSubscription (data) {
 
     if (!plan.customerId) plan.customerId = 'Gift'; // don't override existing customer, but all sub need a customerId
   } else {
-    if (!plan.dateTerminated) plan.dateTerminated = new Date();
+    if (!plan.dateTerminated) plan.dateTerminated = today;
 
     _(plan).merge({ // override with these values
       planId: block.key,
       customerId: data.customerId,
-      dateUpdated: new Date(),
-      gemsBought: 0,
+      dateUpdated: today,
       paymentMethod: data.paymentMethod,
-      extraMonths: Number(plan.extraMonths) + _roundDateDiff(new Date(), plan.dateTerminated),
+      extraMonths: Number(plan.extraMonths) + _roundDateDiff(today, plan.dateTerminated),
       dateTerminated: null,
       // Specify a lastBillingDate just for Amazon Payments
       // Resetted every time the subscription restarts
-      lastBillingDate: data.paymentMethod === 'Amazon Payments' ? new Date() : undefined,
+      lastBillingDate: data.paymentMethod === 'Amazon Payments' ? today : undefined,
     }).defaults({ // allow non-override if a plan was previously used
-      dateCreated: new Date(),
+      gemsBought: 0,
+      dateCreated: today,
       mysteryItems: [],
     }).value();
   }


### PR DESCRIPTION
Fixes https://github.com/HabitRPG/habitica/issues/4846
### Changes
- Subscription credits can no longer go negative when resubscribing after a lapse.
- Gem cap no longer resets when a user purchases or is gifted an additional month of subscription during an ongoing subscription.
- When converting month credits to subscription duration, use a factor of 30.5 days/month instead of 30 to avoid shorting the user a day for each 31-day month.
- A user with continuous subscription who logs in after more than a month's absence correctly receives consecutive subscription benefits for the paid-for but unused month or months.
- Some code refactored to normalize `moment`s to days without sub-day data, and store repeated uses of `new Date()` in variables, to eliminate possible race scenarios.

I need to add/update some tests to cover the fixed scenarios, and more fixes are forthcoming, but the code thus far can be reviewed in the meantime.
