### PR TITLE
Removing links to outdated tutorials

### DIFF
--- a/website/views/options/social/tavern.jade
+++ b/website/views/options/social/tavern.jade
@@ -36,9 +36,6 @@
                 a(href='https://habitica.com/#/options/groups/guilds/f2db2a7f-13c5-454d-b3ee-ea1f5089e601')=env.t('lfgPosts')
             tr
               td
-                a(target='_blank', href='https://vimeo.com/57654086')=env.t('tutorial')
-            tr
-              td
                 a(target='_blank', href='https://habitica.com/static/FAQ')=env.t('FAQ')
             tr
               td

--- a/website/views/shared/header/menu.jade
+++ b/website/views/shared/header/menu.jade
@@ -265,8 +265,6 @@ nav.toolbar(ng-controller='MenuCtrl')
             ul.toolbar-submenu
               li
                 a(href='https://habitica.com/static/faq', target='_blank')=env.t('FAQ')
-              li
-                a(href='https://vimeo.com/57654086', target='_blank')=env.t('tutorials')
           ul.toolbar-controls
             li.toolbar-controls-button
               a(data-close-menu)=env.t('close')


### PR DESCRIPTION
Fixes #7814 
### Changes

This change removes the links to old vimeo video tutorials from the tavern and the drop down settings menu as requested.

chore(cleanup): removing links to outdated tutorials
closes #7814
