### PR TITLE
fix(api): Allow x-client to be set in cors middleware

### DIFF
--- a/test/api/v3/unit/middlewares/cors.test.js
+++ b/test/api/v3/unit/middlewares/cors.test.js
@@ -20,7 +20,7 @@ describe('cors middleware', () => {
     expect(res.set).to.have.been.calledWith({
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Methods': 'OPTIONS,GET,POST,PUT,HEAD,DELETE',
-      'Access-Control-Allow-Headers': 'Content-Type,Accept,Content-Encoding,X-Requested-With,x-api-user,x-api-key',
+      'Access-Control-Allow-Headers': 'Content-Type,Accept,Content-Encoding,X-Requested-With,x-api-user,x-api-key,x-client',
     });
     expect(res.sendStatus).to.not.have.been.called;
     expect(next).to.have.been.called.once;
@@ -32,7 +32,7 @@ describe('cors middleware', () => {
     expect(res.set).to.have.been.calledWith({
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Methods': 'OPTIONS,GET,POST,PUT,HEAD,DELETE',
-      'Access-Control-Allow-Headers': 'Content-Type,Accept,Content-Encoding,X-Requested-With,x-api-user,x-api-key',
+      'Access-Control-Allow-Headers': 'Content-Type,Accept,Content-Encoding,X-Requested-With,x-api-user,x-api-key,x-client',
     });
     expect(res.sendStatus).to.have.been.calledWith(200);
     expect(next).to.not.have.been.called;

--- a/website/server/middlewares/cors.js
+++ b/website/server/middlewares/cors.js
@@ -2,7 +2,7 @@ module.exports = function corsMiddleware (req, res, next) {
   res.set({
     'Access-Control-Allow-Origin': req.header('origin') || '*',
     'Access-Control-Allow-Methods': 'OPTIONS,GET,POST,PUT,HEAD,DELETE',
-    'Access-Control-Allow-Headers': 'Content-Type,Accept,Content-Encoding,X-Requested-With,x-api-user,x-api-key',
+    'Access-Control-Allow-Headers': 'Content-Type,Accept,Content-Encoding,X-Requested-With,x-api-user,x-api-key,x-client',
   });
   if (req.method === 'OPTIONS') return res.sendStatus(200);
   return next();


### PR DESCRIPTION
Allow 3rd party extensions in browsers to set `x-client` header.

Currently it seems like protocols that don't use CORS (such as the mobile apps) can set the `x-client` header, but browser based extensions cannot.

@paglias Is there a reason not to do this?
