### PR TITLE
Creating api for gifting Hall Of Heroes Item Reference

### DIFF
--- a/website/client-old/js/controllers/hallCtrl.js
+++ b/website/client-old/js/controllers/hallCtrl.js
@@ -13,7 +13,7 @@ habitrpg.controller("HallHeroesCtrl", ['$scope', '$rootScope', 'User', 'Notifica
       });
 
     function _getFormattedItemReference (pathPrefix, keys, values) {
-      let finishedString = '\n'.concat('path: ', pathPrefix, ', ', 'value: {', values, '}\n');
+      var finishedString = '\n'.concat('path: ', pathPrefix, ', ', 'value: {', values, '}\n');
 
       _.each(keys, (key) => {
         finishedString = finishedString.concat('\t', pathPrefix, '.', key, '\n');
@@ -22,17 +22,17 @@ habitrpg.controller("HallHeroesCtrl", ['$scope', '$rootScope', 'User', 'Notifica
     }
 
     function getAllItemPaths () {
-      let content = Content;
+      var content = Content;
 
-      let quests = _getFormattedItemReference('items.quests', _.keys(content.quests), 'Numeric Quantity');
-      let mounts = _getFormattedItemReference('items.mounts', _.keys(content.mountInfo), 'Boolean');
-      let food = _getFormattedItemReference('items.food', _.keys(content.food), 'Numeric Quantity');
-      let eggs = _getFormattedItemReference('items.eggs', _.keys(content.eggs), 'Numeric Quantity');
-      let hatchingPotions = _getFormattedItemReference('items.hatchingPotions', _.keys(content.hatchingPotions), 'Numeric Quantity');
-      let pets = _getFormattedItemReference('items.pets', _.keys(content.petInfo), '-1: Owns Mount, 0: Not Owned, 1-49: Progress to mount');
-      let special = _getFormattedItemReference('items.special', _.keys(content.special), 'Numeric Quantity');
+      var quests = _getFormattedItemReference('items.quests', _.keys(content.quests), 'Numeric Quantity');
+      var mounts = _getFormattedItemReference('items.mounts', _.keys(content.mountInfo), 'Boolean');
+      var food = _getFormattedItemReference('items.food', _.keys(content.food), 'Numeric Quantity');
+      var eggs = _getFormattedItemReference('items.eggs', _.keys(content.eggs), 'Numeric Quantity');
+      var hatchingPotions = _getFormattedItemReference('items.hatchingPotions', _.keys(content.hatchingPotions), 'Numeric Quantity');
+      var pets = _getFormattedItemReference('items.pets', _.keys(content.petInfo), '-1: Owns Mount, 0: Not Owned, 1-49: Progress to mount');
+      var special = _getFormattedItemReference('items.special', _.keys(content.special), 'Numeric Quantity');
 
-      let mystery = _.flatten(_.keys(content.mystery).map((mysterySetKey) => {
+      var mystery = _.flatten(_.keys(content.mystery).map((mysterySetKey) => {
         return content.mystery[mysterySetKey];
       })).map((mysteryItem) => {
         return mysteryItem.items.map((item) => {
@@ -40,13 +40,13 @@ habitrpg.controller("HallHeroesCtrl", ['$scope', '$rootScope', 'User', 'Notifica
         });
       });
 
-      let gear = _getFormattedItemReference('items.gear.owned', _.union(_.keys(content.gear.flat), _.flatten(mystery)), 'Boolean');
+      var gear = _getFormattedItemReference('items.gear.owned', _.union(_.keys(content.gear.flat), _.flatten(mystery)), 'Boolean');
 
-      let equippedGear = '\nEquipped Gear:\n\titems.gear.{equipped/costume}.{head/headAccessory/eyewear/armor/body/back/shield/weapon}.{gearKey}\n';
-      let equippedPet = '\nEquipped Pet:\n\titems.currentPet.{petKey}\n';
-      let equippedMount = '\nEquipped Mount:\n\titems.currentMount.{mountKey}\n';
+      var equippedGear = '\nEquipped Gear:\n\titems.gear.{equipped/costume}.{head/headAccessory/eyewear/armor/body/back/shield/weapon}.{gearKey}\n';
+      var equippedPet = '\nEquipped Pet:\n\titems.currentPet.{petKey}\n';
+      var equippedMount = '\nEquipped Mount:\n\titems.currentMount.{mountKey}\n';
 
-      let data = quests.concat(mounts, food, eggs, hatchingPotions, pets, special, gear, equippedGear, equippedPet, equippedMount);
+      var data = quests.concat(mounts, food, eggs, hatchingPotions, pets, special, gear, equippedGear, equippedPet, equippedMount);
 
       return data;
     }

--- a/website/client-old/js/controllers/hallCtrl.js
+++ b/website/client-old/js/controllers/hallCtrl.js
@@ -1,15 +1,55 @@
 "use strict";
 
-habitrpg.controller("HallHeroesCtrl", ['$scope', '$rootScope', 'User', 'Notification', 'ApiUrl', 'Hall',
-  function($scope, $rootScope, User, Notification, ApiUrl, Hall) {
+habitrpg.controller("HallHeroesCtrl", ['$scope', '$rootScope', 'User', 'Notification', 'ApiUrl', 'Hall', 'Content',
+  function($scope, $rootScope, User, Notification, ApiUrl, Hall, Content) {
     $scope.hero = undefined;
     $scope.currentHeroIndex = undefined;
     $scope.heroes = [];
+    $scope.allItemPaths = getAllItemPaths();
 
     Hall.getHeroes()
       .then(function (response) {
         $scope.heroes = response.data.data;
       });
+
+    function _getFormattedItemReference (pathPrefix, keys, values) {
+      let finishedString = '\n'.concat('path: ', pathPrefix, ', ', 'value: {', values, '}\n');
+
+      _.each(keys, (key) => {
+        finishedString = finishedString.concat('\t', pathPrefix, '.', key, '\n');
+      });
+      return finishedString;
+    }
+
+    function getAllItemPaths () {
+      let content = Content;
+
+      let quests = _getFormattedItemReference('items.quests', _.keys(content.quests), 'Numeric Quantity');
+      let mounts = _getFormattedItemReference('items.mounts', _.keys(content.mountInfo), 'Boolean');
+      let food = _getFormattedItemReference('items.food', _.keys(content.food), 'Numeric Quantity');
+      let eggs = _getFormattedItemReference('items.eggs', _.keys(content.eggs), 'Numeric Quantity');
+      let hatchingPotions = _getFormattedItemReference('items.hatchingPotions', _.keys(content.hatchingPotions), 'Numeric Quantity');
+      let pets = _getFormattedItemReference('items.pets', _.keys(content.petInfo), '-1: Owns Mount, 0: Not Owned, 1-49: Progress to mount');
+      let special = _getFormattedItemReference('items.special', _.keys(content.special), 'Numeric Quantity');
+
+      let mystery = _.flatten(_.keys(content.mystery).map((mysterySetKey) => {
+        return content.mystery[mysterySetKey];
+      })).map((mysteryItem) => {
+        return mysteryItem.items.map((item) => {
+          return item.key;
+        });
+      });
+
+      let gear = _getFormattedItemReference('items.gear.owned', _.union(_.keys(content.gear.flat), _.flatten(mystery)), 'Boolean');
+
+      let equippedGear = '\nEquipped Gear:\n\titems.gear.{equipped/costume}.{head/headAccessory/eyewear/armor/body/back/shield/weapon}.{gearKey}\n';
+      let equippedPet = '\nEquipped Pet:\n\titems.currentPet.{petKey}\n';
+      let equippedMount = '\nEquipped Mount:\n\titems.currentMount.{mountKey}\n';
+
+      let data = quests.concat(mounts, food, eggs, hatchingPotions, pets, special, gear, equippedGear, equippedPet, equippedMount);
+
+      return data;
+    }
 
     $scope.loadHero = function(uuid, heroIndex) {
       $scope.currentHeroIndex = heroIndex;

--- a/website/client-old/js/controllers/hallCtrl.js
+++ b/website/client-old/js/controllers/hallCtrl.js
@@ -15,32 +15,21 @@ habitrpg.controller("HallHeroesCtrl", ['$scope', '$rootScope', 'User', 'Notifica
     function _getFormattedItemReference (pathPrefix, keys, values) {
       var finishedString = '\n'.concat('path: ', pathPrefix, ', ', 'value: {', values, '}\n');
 
-      _.each(keys, (key) => {
+      _.each(keys, function (key) {
         finishedString = finishedString.concat('\t', pathPrefix, '.', key, '\n');
       });
       return finishedString;
     }
 
     function getAllItemPaths () {
-      var content = Content;
-
-      var quests = _getFormattedItemReference('items.quests', _.keys(content.quests), 'Numeric Quantity');
-      var mounts = _getFormattedItemReference('items.mounts', _.keys(content.mountInfo), 'Boolean');
-      var food = _getFormattedItemReference('items.food', _.keys(content.food), 'Numeric Quantity');
-      var eggs = _getFormattedItemReference('items.eggs', _.keys(content.eggs), 'Numeric Quantity');
-      var hatchingPotions = _getFormattedItemReference('items.hatchingPotions', _.keys(content.hatchingPotions), 'Numeric Quantity');
-      var pets = _getFormattedItemReference('items.pets', _.keys(content.petInfo), '-1: Owns Mount, 0: Not Owned, 1-49: Progress to mount');
-      var special = _getFormattedItemReference('items.special', _.keys(content.special), 'Numeric Quantity');
-
-      var mystery = _.flatten(_.keys(content.mystery).map((mysterySetKey) => {
-        return content.mystery[mysterySetKey];
-      })).map((mysteryItem) => {
-        return mysteryItem.items.map((item) => {
-          return item.key;
-        });
-      });
-
-      var gear = _getFormattedItemReference('items.gear.owned', _.union(_.keys(content.gear.flat), _.flatten(mystery)), 'Boolean');
+      var quests = _getFormattedItemReference('items.quests', _.keys(Content.quests), 'Numeric Quantity');
+      var mounts = _getFormattedItemReference('items.mounts', _.keys(Content.mountInfo), 'Boolean');
+      var food = _getFormattedItemReference('items.food', _.keys(Content.food), 'Numeric Quantity');
+      var eggs = _getFormattedItemReference('items.eggs', _.keys(Content.eggs), 'Numeric Quantity');
+      var hatchingPotions = _getFormattedItemReference('items.hatchingPotions', _.keys(Content.hatchingPotions), 'Numeric Quantity');
+      var pets = _getFormattedItemReference('items.pets', _.keys(Content.petInfo), '-1: Owns Mount, 0: Not Owned, 1-49: Progress to mount');
+      var special = _getFormattedItemReference('items.special', _.keys(Content.special), 'Numeric Quantity');
+      var gear = _getFormattedItemReference('items.gear.owned', _.keys(Content.gear.flat), 'Boolean');
 
       var equippedGear = '\nEquipped Gear:\n\titems.gear.{equipped/costume}.{head/headAccessory/eyewear/armor/body/back/shield/weapon}.{gearKey}\n';
       var equippedPet = '\nEquipped Pet:\n\titems.currentPet.{petKey}\n';

--- a/website/server/controllers/api-v3/content.js
+++ b/website/server/controllers/api-v3/content.js
@@ -23,15 +23,6 @@ function walkContent (obj, lang) {
   });
 }
 
-function _getFormattedItemReference (pathPrefix, keys, values) {
-  let finishedString = '\n'.concat('path: ', pathPrefix, ', ', 'value: {', values, '}\n');
-
-  _.each(keys, (key) => {
-    finishedString = finishedString.concat('\t', pathPrefix, '.', key, '\n');
-  });
-  return finishedString;
-}
-
 // After the getContent route is called the first time for a certain language
 // the response is saved on disk and subsequentially served directly from there to reduce computation.
 // Example: if `cachedContentResponses.en` is true it means that the response is cached
@@ -140,51 +131,6 @@ api.getContent = {
     if (cachedContentResponses[language] !== true && cacheBeingWritten[language] !== true) {
       saveContentToDisk(language, content);
     }
-  },
-};
-
-/**
- * @api {get} /api/v3/content/hallOfHeroes Get hall of heroes item path gifting reference.
- * @apiDescription Does not require authentication.
- * @apiName getAllOfHeroesItemReference
- * @apiGroup Content
- *
- * @apiSuccess {Object} Formatted hall of heroes gifting item reference
- */
-api.getHallOfHeroesItemReference = {
-  method: 'GET',
-  url: '/content/hallOfHeroes',
-  async handler (req, res) {
-    let content = _.cloneDeep(common.content);
-
-    let quests = _getFormattedItemReference('items.quests', _.keys(content.quests), 'Numeric Quantity');
-    let mounts = _getFormattedItemReference('items.mounts', _.keys(content.mountInfo), 'Boolean');
-    let food = _getFormattedItemReference('items.food', _.keys(content.food), 'Numeric Quantity');
-    let eggs = _getFormattedItemReference('items.eggs', _.keys(content.eggs), 'Numeric Quantity');
-    let hatchingPotions = _getFormattedItemReference('items.hatchingPotions', _.keys(content.hatchingPotions), 'Numeric Quantity');
-    let pets = _getFormattedItemReference('items.pets', _.keys(content.petInfo), '-1: Owns Mount, 0: Not Owned, 1-49: Progress to mount');
-    let special = _getFormattedItemReference('items.special', _.keys(content.special), 'Numeric Quantity');
-
-    let mystery = _.flatten(_.keys(content.mystery).map((mysterySetKey) => {
-      return content.mystery[mysterySetKey];
-    })).map((mysteryItem) => {
-      return mysteryItem.items.map((item) => {
-        return item.key;
-      });
-    });
-
-    let gear = _getFormattedItemReference('items.gear.owned', _.union(_.keys(content.gear.flat), _.flatten(mystery)), 'Boolean');
-
-    let equippedGear = '\nEquipped Gear:\n\titems.gear.{equipped/costume}.{head/headAccessory/eyewear/armor/body/back/shield/weapon}.{gearKey}\n';
-
-    let data = quests.concat(mounts, food, eggs, hatchingPotions, pets, special, gear, equippedGear);
-
-    res.set({
-      'Content-Type': 'application/json',
-    });
-
-    let jsonResString = `{"success": true, "data": ${data}}`;
-    res.status(200).send(jsonResString);
   },
 };
 

--- a/website/server/controllers/api-v3/content.js
+++ b/website/server/controllers/api-v3/content.js
@@ -23,6 +23,15 @@ function walkContent (obj, lang) {
   });
 }
 
+function _getFormattedItemReference (pathPrefix, keys, values) {
+  let finishedString = '\n'.concat('path: ', pathPrefix, ', ', 'value: {', values, '}\n');
+
+  _.each(keys, (key) => {
+    finishedString = finishedString.concat('\t', pathPrefix, '.', key, '\n');
+  });
+  return finishedString;
+}
+
 // After the getContent route is called the first time for a certain language
 // the response is saved on disk and subsequentially served directly from there to reduce computation.
 // Example: if `cachedContentResponses.en` is true it means that the response is cached
@@ -131,6 +140,51 @@ api.getContent = {
     if (cachedContentResponses[language] !== true && cacheBeingWritten[language] !== true) {
       saveContentToDisk(language, content);
     }
+  },
+};
+
+/**
+ * @api {get} /api/v3/content/hallOfHeroes Get hall of heroes item path gifting reference.
+ * @apiDescription Does not require authentication.
+ * @apiName getAllOfHeroesItemReference
+ * @apiGroup Content
+ *
+ * @apiSuccess {Object} Formatted hall of heroes gifting item reference
+ */
+api.getHallOfHeroesItemReference = {
+  method: 'GET',
+  url: '/content/hallOfHeroes',
+  async handler (req, res) {
+    let content = _.cloneDeep(common.content);
+
+    let quests = _getFormattedItemReference('items.quests', _.keys(content.quests), 'Numeric Quantity');
+    let mounts = _getFormattedItemReference('items.mounts', _.keys(content.mountInfo), 'Boolean');
+    let food = _getFormattedItemReference('items.food', _.keys(content.food), 'Numeric Quantity');
+    let eggs = _getFormattedItemReference('items.eggs', _.keys(content.eggs), 'Numeric Quantity');
+    let hatchingPotions = _getFormattedItemReference('items.hatchingPotions', _.keys(content.hatchingPotions), 'Numeric Quantity');
+    let pets = _getFormattedItemReference('items.pets', _.keys(content.petInfo), '-1: Owns Mount, 0: Not Owned, 1-49: Progress to mount');
+    let special = _getFormattedItemReference('items.special', _.keys(content.special), 'Numeric Quantity');
+
+    let mystery = _.flatten(_.keys(content.mystery).map((mysterySetKey) => {
+      return content.mystery[mysterySetKey];
+    })).map((mysteryItem) => {
+      return mysteryItem.items.map((item) => {
+        return item.key;
+      });
+    });
+
+    let gear = _getFormattedItemReference('items.gear.owned', _.union(_.keys(content.gear.flat), _.flatten(mystery)), 'Boolean');
+
+    let equippedGear = '\nEquipped Gear:\n\titems.gear.{equipped/costume}.{head/headAccessory/eyewear/armor/body/back/shield/weapon}.{gearKey}\n';
+
+    let data = quests.concat(mounts, food, eggs, hatchingPotions, pets, special, gear, equippedGear);
+
+    res.set({
+      'Content-Type': 'application/json',
+    });
+
+    let jsonResString = `{"success": true, "data": ${data}}`;
+    res.status(200).send(jsonResString);
   },
 };
 

--- a/website/views/options/social/hall.jade
+++ b/website/views/options/social/hall.jade
@@ -50,7 +50,7 @@ script(type='text/ng-template', id='partials/options.social.hall.heroes.html')
           h4 Update Item
           .form-group.well
             input.form-control(type='text',placeholder='Path (eg, items.pets.BearCub-Base)',ng-model='hero.itemPath')
-            small.muted Enter the <strong>item path</strong>. E.g., <code>items.pets.BearCub-Zombie</code> or <code>items.gear.owned.head_special_0</code> or <code>items.gear.equipped.head</code>. <a href='/api/v3/content' target='_blank'>See all paths here.</a> When in doubt, ask Tyler.
+            small.muted Enter the <strong>item path</strong>. E.g., <code>items.pets.BearCub-Zombie</code> or <code>items.gear.owned.head_special_0</code> or <code>items.gear.equipped.head</code>. <a href='/api/v3/content/hallOfHeroes' target='_blank'>See all paths here.</a> When in doubt, ask Tyler.
             br
             input.form-control(type='text',placeholder='Value (eg, 5)',ng-model='hero.itemVal')
             small.muted Enter the <strong>item value</strong>. E.g., <code>5</code> or <code>false</code> or <code>head_warrior_3</code> (respectively from above examples).

--- a/website/views/options/social/hall.jade
+++ b/website/views/options/social/hall.jade
@@ -50,12 +50,15 @@ script(type='text/ng-template', id='partials/options.social.hall.heroes.html')
           h4 Update Item
           .form-group.well
             input.form-control(type='text',placeholder='Path (eg, items.pets.BearCub-Base)',ng-model='hero.itemPath')
-            small.muted Enter the <strong>item path</strong>. E.g., <code>items.pets.BearCub-Zombie</code> or <code>items.gear.owned.head_special_0</code> or <code>items.gear.equipped.head</code>. <a href='/api/v3/content/hallOfHeroes' target='_blank'>See all paths here.</a>
+            small.muted Enter the <strong>item path</strong>. E.g., <code>items.pets.BearCub-Zombie</code> or <code>items.gear.owned.head_special_0</code> or <code>items.gear.equipped.head</code>. You can find all the item paths below.
             br
             input.form-control(type='text',placeholder='Value (eg, 5)',ng-model='hero.itemVal')
-            small.muted Enter the <strong>item value</strong>. E.g., <code>5</code> or <code>false</code> or <code>head_warrior_3</code> (respectively from above examples).
-          h4 Current Items
-          pre {{::toJson(hero.items,true)}}
+            small.muted Enter the <strong>item value</strong>. E.g., <code>5</code> or <code>false</code> or <code>head_warrior_3</code>. All values are listed in the All Item Paths section below.
+            accordion
+              accordion-group(heading='All Item Paths')
+                pre{{allItemPaths}}
+              accordion-group(heading='Current Items')
+                pre {{::toJson(hero.items,true)}}
         accordion-group(heading='Auth')
           h4 Auth
           pre {{::toJson(hero.auth)}}

--- a/website/views/options/social/hall.jade
+++ b/website/views/options/social/hall.jade
@@ -50,7 +50,7 @@ script(type='text/ng-template', id='partials/options.social.hall.heroes.html')
           h4 Update Item
           .form-group.well
             input.form-control(type='text',placeholder='Path (eg, items.pets.BearCub-Base)',ng-model='hero.itemPath')
-            small.muted Enter the <strong>item path</strong>. E.g., <code>items.pets.BearCub-Zombie</code> or <code>items.gear.owned.head_special_0</code> or <code>items.gear.equipped.head</code>. <a href='/api/v3/content/hallOfHeroes' target='_blank'>See all paths here.</a> When in doubt, ask Tyler.
+            small.muted Enter the <strong>item path</strong>. E.g., <code>items.pets.BearCub-Zombie</code> or <code>items.gear.owned.head_special_0</code> or <code>items.gear.equipped.head</code>. <a href='/api/v3/content/hallOfHeroes' target='_blank'>See all paths here.</a>
             br
             input.form-control(type='text',placeholder='Value (eg, 5)',ng-model='hero.itemVal')
             small.muted Enter the <strong>item value</strong>. E.g., <code>5</code> or <code>false</code> or <code>head_warrior_3</code> (respectively from above examples).

--- a/website/views/options/social/hall.jade
+++ b/website/views/options/social/hall.jade
@@ -56,7 +56,7 @@ script(type='text/ng-template', id='partials/options.social.hall.heroes.html')
             small.muted Enter the <strong>item value</strong>. E.g., <code>5</code> or <code>false</code> or <code>head_warrior_3</code>. All values are listed in the All Item Paths section below.
             accordion
               accordion-group(heading='All Item Paths')
-                pre{{allItemPaths}}
+                pre {{::allItemPaths}}
               accordion-group(heading='Current Items')
                 pre {{::toJson(hero.items,true)}}
         accordion-group(heading='Auth')


### PR DESCRIPTION
Fixes #8100 
### Changes

Screenshots of the new item reference:
This pull request creates a new api that is responsible for generating a formatted gifting reference for use when rewarding users with items through the hall of heroes.
#### Top

![screen shot 2016-10-10 at 6 32 11 pm](https://cloud.githubusercontent.com/assets/17734753/19256035/2d309f3c-8f18-11e6-8977-2898d9158ade.png)
#### Pets possible values

![screen shot 2016-10-10 at 6 32 23 pm](https://cloud.githubusercontent.com/assets/17734753/19256038/36773a2e-8f18-11e6-8419-b5033117d85f.png)
#### Equipped gear

![screen shot 2016-10-10 at 6 32 34 pm](https://cloud.githubusercontent.com/assets/17734753/19256047/409f780e-8f18-11e6-933b-cd64b8b002db.png)
