### PR TITLE
Only unequip Gen 1 pets/mounts when releasing pets/mounts, fixes #5366

### DIFF
--- a/test/common/ops/releaseBoth.js
+++ b/test/common/ops/releaseBoth.js
@@ -1,4 +1,5 @@
 import releaseBoth from '../../../website/common/script/ops/releaseBoth';
+import content from '../../../website/common/script/content/index';
 import i18n from '../../../website/common/script/i18n';
 import {
   generateUser,
@@ -65,35 +66,39 @@ describe('shared.ops.releaseBoth', () => {
     expect(user.items.mounts[animal]).to.equal(null);
   });
 
-  it('removes currentPet', () => {
+  it('removes drop currentPet', () => {
+    let petInfo = content.petInfo[user.items.currentPet];
+    expect(petInfo.type).to.equal('drop');
     releaseBoth(user);
 
     expect(user.items.currentMount).to.be.empty;
     expect(user.items.currentPet).to.be.empty;
   });
 
-  it('removes currentMount', () => {
+  it('removes drop currentMount', () => {
+    let mountInfo = content.mountInfo[user.items.currentMount];
+    expect(mountInfo.type).to.equal('drop');
     releaseBoth(user);
 
     expect(user.items.currentMount).to.be.empty;
   });
 
-  it('leaves quest pets and mounts equipped', () => {
+  it('leaves non-drop pets and mounts equipped', () => {
     let questAnimal = 'Gryphon-Base';
     user.items.currentMount = questAnimal;
     user.items.currentPet = questAnimal;
     user.items.pets[questAnimal] = 5;
     user.items.mounts[questAnimal] = true;
+
+    let petInfo = content.petInfo[user.items.currentPet];
+    expect(petInfo.type).to.not.equal('drop');
+    let mountInfo = content.mountInfo[user.items.currentMount];
+    expect(mountInfo.type).to.not.equal('drop');
+
     releaseBoth(user);
 
     expect(user.items.currentMount).to.equal(questAnimal);
     expect(user.items.currentPet).to.equal(questAnimal);
-  });
-
-  it('removes currentMount', () => {
-    releaseBoth(user);
-
-    expect(user.items.currentMount).to.be.empty;
   });
 
   it('decreases user\'s balance', () => {

--- a/test/common/ops/releaseBoth.js
+++ b/test/common/ops/releaseBoth.js
@@ -78,6 +78,24 @@ describe('shared.ops.releaseBoth', () => {
     expect(user.items.currentMount).to.be.empty;
   });
 
+  it('leaves quest pets and mounts equipped', () => {
+    let questAnimal = 'Gryphon-Base';
+    user.items.currentMount = questAnimal;
+    user.items.currentPet = questAnimal;
+    user.items.pets[questAnimal] = 5;
+    user.items.mounts[questAnimal] = true;
+    releaseBoth(user);
+
+    expect(user.items.currentMount).to.equal(questAnimal);
+    expect(user.items.currentPet).to.equal(questAnimal);
+  });
+
+  it('removes currentMount', () => {
+    releaseBoth(user);
+
+    expect(user.items.currentMount).to.be.empty;
+  });
+
   it('decreases user\'s balance', () => {
     releaseBoth(user);
 

--- a/test/common/ops/releaseMounts.js
+++ b/test/common/ops/releaseMounts.js
@@ -43,6 +43,15 @@ describe('shared.ops.releaseMounts', () => {
     expect(user.items.currentMount).to.be.empty;
   });
 
+  it('leaves quest mounts equipped', () => {
+    let questAnimal = 'Gryphon-Base';
+    user.items.currentMount = questAnimal;
+    user.items.mounts[questAnimal] = true;
+    releaseMounts(user);
+
+    expect(user.items.currentMount).to.equal(questAnimal);
+  });
+
   it('increases mountMasterCount achievement', () => {
     releaseMounts(user);
 

--- a/test/common/ops/releaseMounts.js
+++ b/test/common/ops/releaseMounts.js
@@ -1,4 +1,5 @@
 import releaseMounts from '../../../website/common/script/ops/releaseMounts';
+import content from '../../../website/common/script/content/index';
 import i18n from '../../../website/common/script/i18n';
 import {
   generateUser,
@@ -37,16 +38,21 @@ describe('shared.ops.releaseMounts', () => {
     expect(user.items.mounts[animal]).to.equal(null);
   });
 
-  it('removes currentMount', () => {
+  it('removes drop currentMount', () => {
+    let mountInfo = content.mountInfo[user.items.currentMount];
+    expect(mountInfo.type).to.equal('drop');
     releaseMounts(user);
 
     expect(user.items.currentMount).to.be.empty;
   });
 
-  it('leaves quest mounts equipped', () => {
+  it('leaves non-drop mount equipped', () => {
     let questAnimal = 'Gryphon-Base';
     user.items.currentMount = questAnimal;
     user.items.mounts[questAnimal] = true;
+
+    let mountInfo = content.mountInfo[user.items.currentMount];
+    expect(mountInfo.type).to.not.equal('drop');
     releaseMounts(user);
 
     expect(user.items.currentMount).to.equal(questAnimal);

--- a/test/common/ops/releasePets.js
+++ b/test/common/ops/releasePets.js
@@ -43,6 +43,15 @@ describe('shared.ops.releasePets', () => {
     expect(user.items.currentPet).to.be.empty;
   });
 
+  it('leaves quest pets equipped', () => {
+    let questAnimal = 'Gryphon-Base';
+    user.items.currentPet = questAnimal;
+    user.items.pets[questAnimal] = 5;
+    releasePets(user);
+
+    expect(user.items.currentPet).to.equal(questAnimal);
+  });
+
   it('decreases user\'s balance', () => {
     releasePets(user);
 

--- a/test/common/ops/releasePets.js
+++ b/test/common/ops/releasePets.js
@@ -1,4 +1,5 @@
 import releasePets from '../../../website/common/script/ops/releasePets';
+import content from '../../../website/common/script/content/index';
 import i18n from '../../../website/common/script/i18n';
 import {
   generateUser,
@@ -37,16 +38,21 @@ describe('shared.ops.releasePets', () => {
     expect(user.items.pets[animal]).to.equal(0);
   });
 
-  it('removes currentPet', () => {
+  it('removes drop currentPet', () => {
+    let petInfo = content.petInfo[user.items.currentPet];
+    expect(petInfo.type).to.equal('drop');
     releasePets(user);
 
     expect(user.items.currentPet).to.be.empty;
   });
 
-  it('leaves quest pets equipped', () => {
+  it('leaves non-drop pets equipped', () => {
     let questAnimal = 'Gryphon-Base';
     user.items.currentPet = questAnimal;
     user.items.pets[questAnimal] = 5;
+
+    let petInfo = content.petInfo[user.items.currentPet];
+    expect(petInfo.type).to.not.equal('drop');
     releasePets(user);
 
     expect(user.items.currentPet).to.equal(questAnimal);

--- a/website/common/script/ops/releaseBoth.js
+++ b/website/common/script/ops/releaseBoth.js
@@ -29,12 +29,16 @@ module.exports = function releaseBoth (user, req = {}, analytics) {
     user.balance -= 1.5;
   }
 
-  // Only remove current mount if it is Gen 1
-  if (Object.keys(content.pets).indexOf(user.items.currentMount) > -1) {
+  // Only remove current mount if it is Gen 1 (dropped)
+  let mount = content.mountInfo[user.items.currentMount];
+
+  if (mount && mount.type === 'drop') {
     user.items.currentMount = '';
   }
-  // Only remove current pet if it is Gen 1
-  if (Object.keys(content.pets).indexOf(user.items.currentPet) > -1) {
+  // Only remove current pet if it is Gen 1 (dropped)
+  let pet = content.petInfo[user.items.currentPet];
+
+  if (pet && pet.type === 'drop') {
     user.items.currentPet = '';
   }
 

--- a/website/common/script/ops/releaseBoth.js
+++ b/website/common/script/ops/releaseBoth.js
@@ -29,13 +29,12 @@ module.exports = function releaseBoth (user, req = {}, analytics) {
     user.balance -= 1.5;
   }
 
-  // Only remove current mount if it is Gen 1 (dropped)
   let mountInfo = content.mountInfo[user.items.currentMount];
 
   if (mountInfo && mountInfo.type === 'drop') {
     user.items.currentMount = '';
   }
-  // Only remove current pet if it is Gen 1 (dropped)
+
   let petInfo = content.petInfo[user.items.currentPet];
 
   if (petInfo && petInfo.type === 'drop') {

--- a/website/common/script/ops/releaseBoth.js
+++ b/website/common/script/ops/releaseBoth.js
@@ -30,15 +30,15 @@ module.exports = function releaseBoth (user, req = {}, analytics) {
   }
 
   // Only remove current mount if it is Gen 1 (dropped)
-  let mount = content.mountInfo[user.items.currentMount];
+  let mountInfo = content.mountInfo[user.items.currentMount];
 
-  if (mount && mount.type === 'drop') {
+  if (mountInfo && mountInfo.type === 'drop') {
     user.items.currentMount = '';
   }
   // Only remove current pet if it is Gen 1 (dropped)
-  let pet = content.petInfo[user.items.currentPet];
+  let petInfo = content.petInfo[user.items.currentPet];
 
-  if (pet && pet.type === 'drop') {
+  if (petInfo && petInfo.type === 'drop') {
     user.items.currentPet = '';
   }
 

--- a/website/common/script/ops/releaseBoth.js
+++ b/website/common/script/ops/releaseBoth.js
@@ -29,8 +29,14 @@ module.exports = function releaseBoth (user, req = {}, analytics) {
     user.balance -= 1.5;
   }
 
-  user.items.currentMount = '';
-  user.items.currentPet = '';
+  // Only remove current mount if it is Gen 1
+  if (Object.keys(content.pets).indexOf(user.items.currentMount) > -1) {
+    user.items.currentMount = '';
+  }
+  // Only remove current pet if it is Gen 1
+  if (Object.keys(content.pets).indexOf(user.items.currentPet) > -1) {
+    user.items.currentPet = '';
+  }
 
   for (animal in content.pets) {
     if (user.items.pets[animal] === -1) {

--- a/website/common/script/ops/releaseMounts.js
+++ b/website/common/script/ops/releaseMounts.js
@@ -11,8 +11,10 @@ module.exports = function releaseMounts (user, req = {}, analytics) {
 
   user.balance -= 1;
 
-  // Only remove current mount if it is Gen 1
-  if (Object.keys(content.pets).indexOf(user.items.currentMount) > -1) {
+  // Only remove current mount if it is Gen 1 (dropped)
+  let mountInfo = content.mountInfo[user.items.currentMount];
+
+  if (mountInfo && mountInfo.type === 'drop') {
     user.items.currentMount = '';
   }
 

--- a/website/common/script/ops/releaseMounts.js
+++ b/website/common/script/ops/releaseMounts.js
@@ -5,8 +5,6 @@ import {
 } from '../libs/errors';
 
 module.exports = function releaseMounts (user, req = {}, analytics) {
-  let mount;
-
   if (user.balance < 1) {
     throw new NotAuthorized(i18n.t('notEnoughGems', req.language));
   }
@@ -18,7 +16,7 @@ module.exports = function releaseMounts (user, req = {}, analytics) {
     user.items.currentMount = '';
   }
 
-  for (mount in content.pets) {
+  for (let mount in content.pets) {
     user.items.mounts[mount] = null;
   }
 

--- a/website/common/script/ops/releaseMounts.js
+++ b/website/common/script/ops/releaseMounts.js
@@ -11,7 +11,6 @@ module.exports = function releaseMounts (user, req = {}, analytics) {
 
   user.balance -= 1;
 
-  // Only remove current mount if it is Gen 1 (dropped)
   let mountInfo = content.mountInfo[user.items.currentMount];
 
   if (mountInfo && mountInfo.type === 'drop') {

--- a/website/common/script/ops/releaseMounts.js
+++ b/website/common/script/ops/releaseMounts.js
@@ -12,7 +12,11 @@ module.exports = function releaseMounts (user, req = {}, analytics) {
   }
 
   user.balance -= 1;
-  user.items.currentMount = '';
+
+  // Only remove current mount if it is Gen 1
+  if (Object.keys(content.pets).indexOf(user.items.currentMount) > -1) {
+    user.items.currentMount = '';
+  }
 
   for (mount in content.pets) {
     user.items.mounts[mount] = null;

--- a/website/common/script/ops/releasePets.js
+++ b/website/common/script/ops/releasePets.js
@@ -11,7 +11,6 @@ module.exports = function releasePets (user, req = {}, analytics) {
 
   user.balance -= 1;
 
-  // Only remove current pet if it is Gen 1 (dropped)
   let petInfo = content.petInfo[user.items.currentPet];
 
   if (petInfo && petInfo.type === 'drop') {

--- a/website/common/script/ops/releasePets.js
+++ b/website/common/script/ops/releasePets.js
@@ -11,8 +11,10 @@ module.exports = function releasePets (user, req = {}, analytics) {
 
   user.balance -= 1;
 
-  // Only remove current pet if it is Gen 1
-  if (Object.keys(content.pets).indexOf(user.items.currentPet) > -1) {
+  // Only remove current pet if it is Gen 1 (dropped)
+  let petInfo = content.petInfo[user.items.currentPet];
+
+  if (petInfo && petInfo.type === 'drop') {
     user.items.currentPet = '';
   }
 

--- a/website/common/script/ops/releasePets.js
+++ b/website/common/script/ops/releasePets.js
@@ -10,7 +10,11 @@ module.exports = function releasePets (user, req = {}, analytics) {
   }
 
   user.balance -= 1;
-  user.items.currentPet = '';
+
+  // Only remove current pet if it is Gen 1
+  if (Object.keys(content.pets).indexOf(user.items.currentPet) > -1) {
+    user.items.currentPet = '';
+  }
 
   for (let pet in content.pets) {
     user.items.pets[pet] = 0;


### PR DESCRIPTION
Fixes #5366
### Changes

When releasing pets, mounts, or both, it will no longer unequip your pet or mount if it is a quest or special pet/mount.

Tests in  `releasePets`, `releaseMounts`, and `releaseBoth` check that quest pets/mounts (i.e. Gryphon-Base) is not unequipped.

---

UUID: f5a68145-b375-4b99-8fb4-f9ff7a2c52b5
