### PR TITLE
Group plan subscription

### DIFF
--- a/scripts/paypalBillingSetup.js
+++ b/scripts/paypalBillingSetup.js
@@ -7,8 +7,7 @@ var path = require('path');
 var nconf = require('nconf');
 var _ = require('lodash');
 var paypal = require('paypal-rest-sdk');
-var common = require('../website/common');
-// var blocks = require('../website/common').content.subscriptionBlocks;
+var blocks = require('../../../../common').content.subscriptionBlocks;
 var live = nconf.get('PAYPAL:mode')=='live';
 
 nconf.argv().env().file('user', path.join(path.resolve(__dirname, '../../../config.json')));

--- a/scripts/paypalBillingSetup.js
+++ b/scripts/paypalBillingSetup.js
@@ -7,7 +7,8 @@ var path = require('path');
 var nconf = require('nconf');
 var _ = require('lodash');
 var paypal = require('paypal-rest-sdk');
-var blocks = require('../../../../common').content.subscriptionBlocks;
+var common = require('../website/common');
+// var blocks = require('../website/common').content.subscriptionBlocks;
 var live = nconf.get('PAYPAL:mode')=='live';
 
 nconf.argv().env().file('user', path.join(path.resolve(__dirname, '../../../config.json')));

--- a/test/api/v3/unit/libs/payments.test.js
+++ b/test/api/v3/unit/libs/payments.test.js
@@ -562,5 +562,23 @@ describe('payments/index', () => {
         expect(notifications.sendNotification).to.be.calledOnce;
       });
     });
+
+    context('Purchasing a subscription for self', () => {
+      it.only('creates a subscription', async () => {
+        // expect(user.purchased.plan.planId).to.not.exist;
+        //
+        // await api.createSubscription(data);
+        //
+        // expect(user.purchased.plan.planId).to.eql('basic_3mo');
+        // expect(user.purchased.plan.customerId).to.eql('customer-id');
+        // expect(user.purchased.plan.dateUpdated).to.exist;
+        // expect(user.purchased.plan.gemsBought).to.eql(0);
+        // expect(user.purchased.plan.paymentMethod).to.eql('Payment Method');
+        // expect(user.purchased.plan.extraMonths).to.eql(0);
+        // expect(user.purchased.plan.dateTerminated).to.eql(null);
+        // expect(user.purchased.plan.lastBillingDate).to.not.exist;
+        // expect(user.purchased.plan.dateCreated).to.exist;
+      });
+    });
   });
 });

--- a/test/api/v3/unit/libs/payments.test.js
+++ b/test/api/v3/unit/libs/payments.test.js
@@ -564,7 +564,7 @@ describe('payments/index', () => {
     });
 
     context('Purchasing a subscription for self', () => {
-      it.only('creates a subscription', async () => {
+      it('creates a subscription', async () => {
         // expect(user.purchased.plan.planId).to.not.exist;
         //
         // await api.createSubscription(data);

--- a/test/api/v3/unit/libs/payments.test.js
+++ b/test/api/v3/unit/libs/payments.test.js
@@ -3,14 +3,26 @@ import * as api from '../../../../../website/server/libs/payments';
 import analytics from '../../../../../website/server/libs/analyticsService';
 import notifications from '../../../../../website/server/libs/pushNotifications';
 import { model as User } from '../../../../../website/server/models/user';
+import { model as Group } from '../../../../../website/server/models/group';
 import moment from 'moment';
+import {
+  generateGroup,
+} from '../../../../helpers/api-unit.helper.js';
 
 describe('payments/index', () => {
-  let user, data, plan;
+  let user, group, data, plan;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     user = new User();
     user.profile.name = 'sender';
+
+    group = generateGroup({
+      name: 'test group',
+      type: 'guild',
+      privacy: 'public',
+      leader: user._id,
+    });
+    await group.save();
 
     sandbox.stub(sender, 'sendTxn');
     sandbox.stub(user, 'sendMessage');
@@ -291,6 +303,53 @@ describe('payments/index', () => {
       });
     });
 
+    context('Purchasing a subscription for group', () => {
+      it('creates a subscription', async () => {
+        expect(group.purchased.plan.planId).to.not.exist;
+        data.groupId = group._id;
+
+        await api.createSubscription(data);
+
+        let updatedGroup = await Group.findById(group._id).exec();
+
+        expect(updatedGroup.purchased.plan.planId).to.eql('basic_3mo');
+        expect(updatedGroup.purchased.plan.customerId).to.eql('customer-id');
+        expect(updatedGroup.purchased.plan.dateUpdated).to.exist;
+        expect(updatedGroup.purchased.plan.gemsBought).to.eql(0);
+        expect(updatedGroup.purchased.plan.paymentMethod).to.eql('Payment Method');
+        expect(updatedGroup.purchased.plan.extraMonths).to.eql(0);
+        expect(updatedGroup.purchased.plan.dateTerminated).to.eql(null);
+        expect(updatedGroup.purchased.plan.lastBillingDate).to.not.exist;
+        expect(updatedGroup.purchased.plan.dateCreated).to.exist;
+      });
+
+      it('sets extraMonths if plan has dateTerminated date', async () => {
+        group.purchased.plan = plan;
+        group.purchased.plan.dateTerminated = moment(new Date()).add(2, 'months');
+        await group.save();
+        expect(group.purchased.plan.extraMonths).to.eql(0);
+        data.groupId = group._id;
+
+        await api.createSubscription(data);
+
+        let updatedGroup = await Group.findById(group._id).exec();
+        expect(updatedGroup.purchased.plan.extraMonths).to.within(1.9, 2);
+      });
+
+      it('does not set negative extraMonths if plan has past dateTerminated date', async () => {
+        group.purchased.plan = plan;
+        group.purchased.plan.dateTerminated = moment(new Date()).subtract(2, 'months');
+        await group.save();
+        expect(group.purchased.plan.extraMonths).to.eql(0);
+        data.groupId = group._id;
+
+        await api.createSubscription(data);
+
+        let updatedGroup = await Group.findById(group._id).exec();
+        expect(updatedGroup.purchased.plan.extraMonths).to.eql(0);
+      });
+    });
+
     context('Block subscription perks', () => {
       it('adds block months to plan.consecutive.offset', async () => {
         await api.createSubscription(data);
@@ -426,61 +485,136 @@ describe('payments/index', () => {
       data = { user };
     });
 
-    it('adds a month termination date by default', async () => {
-      await api.cancelSubscription(data);
+    context('Canceling a subscription for self', () => {
+      it('adds a month termination date by default', async () => {
+        await api.cancelSubscription(data);
 
-      let now = new Date();
-      let daysTillTermination = moment(user.purchased.plan.dateTerminated).diff(now, 'days');
+        let now = new Date();
+        let daysTillTermination = moment(user.purchased.plan.dateTerminated).diff(now, 'days');
 
-      expect(daysTillTermination).to.be.within(29, 30); // 1 month +/- 1 days
+        expect(daysTillTermination).to.be.within(29, 30); // 1 month +/- 1 days
+      });
+
+      it('adds extraMonths to dateTerminated value', async () => {
+        user.purchased.plan.extraMonths = 2;
+
+        await api.cancelSubscription(data);
+
+        let now = new Date();
+        let daysTillTermination = moment(user.purchased.plan.dateTerminated).diff(now, 'days');
+
+        expect(daysTillTermination).to.be.within(89, 90); // 3 months +/- 1 days
+      });
+
+      it('handles extra month fractions', async () => {
+        user.purchased.plan.extraMonths = 0.3;
+
+        await api.cancelSubscription(data);
+
+        let now = new Date();
+        let daysTillTermination = moment(user.purchased.plan.dateTerminated).diff(now, 'days');
+
+        expect(daysTillTermination).to.be.within(38, 39); // should be about 1 month + 1/3 month
+      });
+
+      it('terminates at next billing date if it exists', async () => {
+        data.nextBill = moment().add({ days: 15 });
+
+        await api.cancelSubscription(data);
+
+        let now = new Date();
+        let daysTillTermination = moment(user.purchased.plan.dateTerminated).diff(now, 'days');
+
+        expect(daysTillTermination).to.be.within(13, 15);
+      });
+
+      it('resets plan.extraMonths', async () => {
+        user.purchased.plan.extraMonths = 5;
+
+        await api.cancelSubscription(data);
+
+        expect(user.purchased.plan.extraMonths).to.eql(0);
+      });
+
+      it('sends an email', async () => {
+        await api.cancelSubscription(data);
+
+        expect(sender.sendTxn).to.be.calledOnce;
+        expect(sender.sendTxn).to.be.calledWith(user, 'cancel-subscription');
+      });
     });
 
-    it('adds extraMonths to dateTerminated value', async () => {
-      user.purchased.plan.extraMonths = 2;
+    context('Canceling a subscription for group', () => {
+      it('adds a month termination date by default', async () => {
+        data.groupId = group._id;
+        await api.cancelSubscription(data);
 
-      await api.cancelSubscription(data);
+        let now = new Date();
+        let updatedGroup = await Group.findById(group._id).exec();
+        let daysTillTermination = moment(updatedGroup.purchased.plan.dateTerminated).diff(now, 'days');
 
-      let now = new Date();
-      let daysTillTermination = moment(user.purchased.plan.dateTerminated).diff(now, 'days');
+        expect(daysTillTermination).to.be.within(29, 30); // 1 month +/- 1 days
+      });
 
-      expect(daysTillTermination).to.be.within(89, 90); // 3 months +/- 1 days
-    });
+      it('adds extraMonths to dateTerminated value', async () => {
+        group.purchased.plan.extraMonths = 2;
+        await group.save();
+        data.groupId = group._id;
 
-    it('handles extra month fractions', async () => {
-      user.purchased.plan.extraMonths = 0.3;
+        await api.cancelSubscription(data);
 
-      await api.cancelSubscription(data);
+        let now = new Date();
+        let updatedGroup = await Group.findById(group._id).exec();
+        let daysTillTermination = moment(updatedGroup.purchased.plan.dateTerminated).diff(now, 'days');
 
-      let now = new Date();
-      let daysTillTermination = moment(user.purchased.plan.dateTerminated).diff(now, 'days');
+        expect(daysTillTermination).to.be.within(89, 90); // 3 months +/- 1 days
+      });
 
-      expect(daysTillTermination).to.be.within(38, 39); // should be about 1 month + 1/3 month
-    });
+      it('handles extra month fractions', async () => {
+        group.purchased.plan.extraMonths = 0.3;
+        await group.save();
+        data.groupId = group._id;
 
-    it('terminates at next billing date if it exists', async () => {
-      data.nextBill = moment().add({ days: 15 });
+        await api.cancelSubscription(data);
 
-      await api.cancelSubscription(data);
+        let now = new Date();
+        let updatedGroup = await Group.findById(group._id).exec();
+        let daysTillTermination = moment(updatedGroup.purchased.plan.dateTerminated).diff(now, 'days');
 
-      let now = new Date();
-      let daysTillTermination = moment(user.purchased.plan.dateTerminated).diff(now, 'days');
+        expect(daysTillTermination).to.be.within(38, 39); // should be about 1 month + 1/3 month
+      });
 
-      expect(daysTillTermination).to.be.within(13, 15);
-    });
+      it('terminates at next billing date if it exists', async () => {
+        data.nextBill = moment().add({ days: 15 });
+        data.groupId = group._id;
 
-    it('resets plan.extraMonths', async () => {
-      user.purchased.plan.extraMonths = 5;
+        await api.cancelSubscription(data);
 
-      await api.cancelSubscription(data);
+        let now = new Date();
+        let updatedGroup = await Group.findById(group._id).exec();
+        let daysTillTermination = moment(updatedGroup.purchased.plan.dateTerminated).diff(now, 'days');
 
-      expect(user.purchased.plan.extraMonths).to.eql(0);
-    });
+        expect(daysTillTermination).to.be.within(13, 15);
+      });
 
-    it('sends an email', async () => {
-      await api.cancelSubscription(data);
+      it('resets plan.extraMonths', async () => {
+        group.purchased.plan.extraMonths = 5;
+        await group.save();
+        data.groupId = group._id;
 
-      expect(sender.sendTxn).to.be.calledOnce;
-      expect(sender.sendTxn).to.be.calledWith(user, 'cancel-subscription');
+        await api.cancelSubscription(data);
+
+        let updatedGroup = await Group.findById(group._id).exec();
+        expect(updatedGroup.purchased.plan.extraMonths).to.eql(0);
+      });
+
+      it('sends an email', async () => {
+        data.groupId = group._id;
+        await api.cancelSubscription(data);
+
+        expect(sender.sendTxn).to.be.calledOnce;
+        expect(sender.sendTxn).to.be.calledWith(user, 'cancel-subscription');
+      });
     });
   });
 
@@ -560,24 +694,6 @@ describe('payments/index', () => {
       it('sends a push notification if user did not gift to self', async () => {
         await api.buyGems(data);
         expect(notifications.sendNotification).to.be.calledOnce;
-      });
-    });
-
-    context('Purchasing a subscription for self', () => {
-      it('creates a subscription', async () => {
-        // expect(user.purchased.plan.planId).to.not.exist;
-        //
-        // await api.createSubscription(data);
-        //
-        // expect(user.purchased.plan.planId).to.eql('basic_3mo');
-        // expect(user.purchased.plan.customerId).to.eql('customer-id');
-        // expect(user.purchased.plan.dateUpdated).to.exist;
-        // expect(user.purchased.plan.gemsBought).to.eql(0);
-        // expect(user.purchased.plan.paymentMethod).to.eql('Payment Method');
-        // expect(user.purchased.plan.extraMonths).to.eql(0);
-        // expect(user.purchased.plan.dateTerminated).to.eql(null);
-        // expect(user.purchased.plan.lastBillingDate).to.not.exist;
-        // expect(user.purchased.plan.dateCreated).to.exist;
       });
     });
   });

--- a/test/api/v3/unit/libs/payments.test.js
+++ b/test/api/v3/unit/libs/payments.test.js
@@ -198,6 +198,7 @@ describe('payments/index', () => {
         expect(analytics.trackPurchase).to.be.calledOnce;
         expect(analytics.trackPurchase).to.be.calledWith({
           uuid: user._id,
+          groupId: undefined,
           itemPurchased: 'Subscription',
           sku: 'payment method-subscription',
           purchaseType: 'subscribe',
@@ -288,6 +289,7 @@ describe('payments/index', () => {
         expect(analytics.trackPurchase).to.be.calledOnce;
         expect(analytics.trackPurchase).to.be.calledWith({
           uuid: user._id,
+          groupId: undefined,
           itemPurchased: 'Subscription',
           sku: 'payment method-subscription',
           purchaseType: 'subscribe',

--- a/website/client-old/js/services/paymentServices.js
+++ b/website/client-old/js/services/paymentServices.js
@@ -12,15 +12,21 @@ function($rootScope, User, $http, Content) {
   };
 
   Payments.showStripe = function(data) {
-    var sub =
-      data.subscription ? data.subscription
-        : data.gift && data.gift.type=='subscription' ? data.gift.subscription.key
-        : false;
+    var sub = false;
+
+    if (data.subscription) {
+      sub = data.subscription;
+    } else if (data.gift && data.gift.type=='subscription') {
+      sub = data.gift.subscription.key;
+    }
+
     sub = sub && Content.subscriptionBlocks[sub];
+
     var amount = // 500 = $5
       sub ? sub.price*100
         : data.gift && data.gift.type=='gems' ? data.gift.gems.amount/4*100
         : 500;
+
     StripeCheckout.open({
       key: window.env.STRIPE_PUB_KEY,
       address: false,
@@ -34,8 +40,9 @@ function($rootScope, User, $http, Content) {
         if (data.gift) url += '&gift=' + Payments.encodeGift(data.uuid, data.gift);
         if (data.subscription) url += '&sub='+sub.key;
         if (data.coupon) url += '&coupon='+data.coupon;
+        if (data.groupId) url += '&groupId=' + data.groupId;
         $http.post(url, res).success(function() {
-          window.location.reload(true);
+          // window.location.reload(true);
         }).error(function(res) {
           alert(res.message);
         });

--- a/website/client-old/js/services/paymentServices.js
+++ b/website/client-old/js/services/paymentServices.js
@@ -265,20 +265,33 @@ function($rootScope, User, $http, Content) {
     }
   }
 
-  Payments.cancelSubscription = function(){
+  Payments.cancelSubscription = function(config) {
     if (!confirm(window.env.t('sureCancelSub'))) return;
-    var paymentMethod = User.user.purchased.plan.paymentMethod;
 
-    if(paymentMethod === 'Amazon Payments'){
+    var group;
+    if (config.group) {
+      group = config.group;
+    }
+
+    var paymentMethod = User.user.purchased.plan.paymentMethod;
+    if (group) {
+      var paymentMethod = group.purchased.plan.paymentMethod;
+    }
+
+    if (paymentMethod === 'Amazon Payments') {
       paymentMethod = 'amazon';
-    }else{
+    } else {
       paymentMethod = paymentMethod.toLowerCase();
     }
 
-    window.location.href = '/' + paymentMethod + '/subscribe/cancel?_id=' + User.user._id + '&apiToken=' + User.settings.auth.apiToken;
+    var cancelUrl = '/' + paymentMethod + '/subscribe/cancel?_id=' + User.user._id + '&apiToken=' + User.settings.auth.apiToken;
+    if (group) {
+      cancelUrl += '&groupId=' + group._id;
+    }
+    window.location.href = cancelUrl;
   }
 
-  Payments.encodeGift = function(uuid, gift){
+  Payments.encodeGift = function(uuid, gift) {
     gift.uuid = uuid;
     var encodedString = JSON.stringify(gift);
     return encodeURIComponent(encodedString);

--- a/website/client-old/js/services/paymentServices.js
+++ b/website/client-old/js/services/paymentServices.js
@@ -42,7 +42,7 @@ function($rootScope, User, $http, Content) {
         if (data.coupon) url += '&coupon='+data.coupon;
         if (data.groupId) url += '&groupId=' + data.groupId;
         $http.post(url, res).success(function() {
-          // window.location.reload(true);
+          window.location.reload(true);
         }).error(function(res) {
           alert(res.message);
         });

--- a/website/client-old/js/services/paymentServices.js
+++ b/website/client-old/js/services/paymentServices.js
@@ -50,7 +50,12 @@ function($rootScope, User, $http, Content) {
     });
   }
 
-  Payments.showStripeEdit = function(){
+  Payments.showStripeEdit = function(config) {
+    var groupId;
+    if (config.groupId) {
+      groupId = config.groupId;
+    }
+
     StripeCheckout.open({
       key: window.env.STRIPE_PUB_KEY,
       address: false,
@@ -58,6 +63,7 @@ function($rootScope, User, $http, Content) {
       description: window.env.t('subUpdateDescription'),
       panelLabel: window.env.t('subUpdateCard'),
       token: function(data) {
+        data.groupId = groupId;
         var url = '/stripe/subscribe/edit';
         $http.post(url, data).success(function() {
           window.location.reload(true);

--- a/website/client-old/js/services/paymentServices.js
+++ b/website/client-old/js/services/paymentServices.js
@@ -280,7 +280,7 @@ function($rootScope, User, $http, Content) {
 
     var paymentMethod = User.user.purchased.plan.paymentMethod;
     if (group) {
-      var paymentMethod = group.purchased.plan.paymentMethod;
+      paymentMethod = group.purchased.plan.paymentMethod;
     }
 
     if (paymentMethod === 'Amazon Payments') {

--- a/website/common/locales/en/groups.json
+++ b/website/common/locales/en/groups.json
@@ -215,5 +215,6 @@
     "confirmRemoveTag": "Do you really want to remove \"<%= tag %>\"?",
     "assignTask": "Assign Task",
     "desktopNotificationsText": "We need your permission to enable desktop notifications for new messages in party chat! Follow your browser's instructions to turn them on.<br><br>You'll receive these notifications only while you have Habitica open. If you decide you don't like them, they can be disabled in your browser's settings.<br><br>This box will close automatically when a decision is made.",
-    "claim": "Claim"
+    "claim": "Claim",
+    "onlyGroupLeaderCanManageSubscription": "Only the group leader can manage the group's subscription"
 }

--- a/website/common/script/content/index.js
+++ b/website/common/script/content/index.js
@@ -2628,7 +2628,11 @@ api.subscriptionBlocks = {
   basic_12mo: {
     months: 12,
     price: 48
-  }
+  },
+  group_monthly: {
+    months: 1,
+    price: 5
+  },
 };
 
 _.each(api.subscriptionBlocks, function(b, k) {

--- a/website/common/script/content/index.js
+++ b/website/common/script/content/index.js
@@ -2633,6 +2633,10 @@ api.subscriptionBlocks = {
     months: 1,
     price: 5
   },
+  group_yearly: {
+    months: 1,
+    price: 48,
+  },
 };
 
 _.each(api.subscriptionBlocks, function(b, k) {

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -127,7 +127,7 @@ api.getGroups = {
     if (validationErrors) throw validationErrors;
 
     let types = req.query.type.split(',');
-    let groupFields = basicGroupFields.concat(' description memberCount balance');
+    let groupFields = basicGroupFields.concat(' description memberCount balance purchased');
     let sort = '-memberCount';
 
     let results = await Group.getGroups({user, types, groupFields, sort});

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -168,7 +168,7 @@ api.getGroup = {
     let groupJson = Group.toJSONCleanChat(group, user);
 
     if (groupJson.leader === user._id) {
-      groupJson.purchased.plan = group.purchased.plan.toObject()
+      groupJson.purchased.plan = group.purchased.plan.toObject();
     }
 
     // Instead of populate we make a find call manually because of https://github.com/Automattic/mongoose/issues/3833

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -165,17 +165,17 @@ api.getGroup = {
       throw new NotFound(res.t('groupNotFound'));
     }
 
-    group = Group.toJSONCleanChat(group, user);
+    let groupJson = Group.toJSONCleanChat(group, user);
 
-    if (group.leader !== user._id) {
-      delete group.purchased.plan;
+    if (groupJson.leader === user._id) {
+      groupJson.purchased.plan = group.purchased.plan.toObject()
     }
 
     // Instead of populate we make a find call manually because of https://github.com/Automattic/mongoose/issues/3833
-    let leader = await User.findById(group.leader).select(nameFields).exec();
-    if (leader) group.leader = leader.toJSON({minimize: true});
+    let leader = await User.findById(groupJson.leader).select(nameFields).exec();
+    if (leader) groupJson.leader = leader.toJSON({minimize: true});
 
-    res.respond(200, group);
+    res.respond(200, groupJson);
   },
 };
 

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -167,7 +167,6 @@ api.getGroup = {
 
     group = Group.toJSONCleanChat(group, user);
 
-    if (group.purchased.plan.customerId) group.purchased.active = true;
     if (group.leader !== user._id) {
       delete group.purchased.plan;
     }

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -127,7 +127,7 @@ api.getGroups = {
     if (validationErrors) throw validationErrors;
 
     let types = req.query.type.split(',');
-    let groupFields = basicGroupFields.concat(' description memberCount balance purchased');
+    let groupFields = basicGroupFields.concat(' description memberCount balance');
     let sort = '-memberCount';
 
     let results = await Group.getGroups({user, types, groupFields, sort});
@@ -166,6 +166,12 @@ api.getGroup = {
     }
 
     group = Group.toJSONCleanChat(group, user);
+
+    if (group.purchased.plan.customerId) group.purchased.active = true;
+    if (group.leader !== user._id) {
+      delete group.purchased.plan;
+    }
+
     // Instead of populate we make a find call manually because of https://github.com/Automattic/mongoose/issues/3833
     let leader = await User.findById(group.leader).select(nameFields).exec();
     if (leader) group.leader = leader.toJSON({minimize: true});

--- a/website/server/controllers/top-level/payments/amazon.js
+++ b/website/server/controllers/top-level/payments/amazon.js
@@ -33,7 +33,11 @@ api.verifyAccessToken = {
 
     if (!accessToken) throw new BadRequest('Missing req.body.access_token');
 
-    await amzLib.getTokenInfo(accessToken);
+    // try {
+      await amzLib.getTokenInfo(accessToken)
+    // } catch(err) {
+    //   console.log(err);
+    // };
     res.respond(200, {});
   },
 };
@@ -164,6 +168,7 @@ api.subscribe = {
     let sub = req.body.subscription ? shared.content.subscriptionBlocks[req.body.subscription] : false;
     let coupon = req.body.coupon;
     let user = res.locals.user;
+    let groupId = req.body.groupId;
 
     if (!sub) throw new BadRequest(res.t('missingSubscriptionCode'));
     if (!billingAgreementId) throw new BadRequest('Missing req.body.billingAgreementId');
@@ -213,6 +218,7 @@ api.subscribe = {
       paymentMethod: 'Amazon Payments',
       sub,
       headers: req.headers,
+      groupId,
     });
 
     res.respond(200);

--- a/website/server/controllers/top-level/payments/amazon.js
+++ b/website/server/controllers/top-level/payments/amazon.js
@@ -240,6 +240,7 @@ api.subscribeCancel = {
     let billingAgreementId = user.purchased.plan.customerId;
     let planId = user.purchased.plan.planId;
     let lastBillingDate = user.purchased.plan.lastBillingDate;
+
     if (groupId) {
       let group = await Group.findById(groupId).exec();
       billingAgreementId = group.purchased.plan.customerId;

--- a/website/server/controllers/top-level/payments/amazon.js
+++ b/website/server/controllers/top-level/payments/amazon.js
@@ -34,11 +34,8 @@ api.verifyAccessToken = {
 
     if (!accessToken) throw new BadRequest('Missing req.body.access_token');
 
-    // try {
-      await amzLib.getTokenInfo(accessToken)
-    // } catch(err) {
-    //   console.log(err);
-    // };
+    await amzLib.getTokenInfo(accessToken);
+
     res.respond(200, {});
   },
 };

--- a/website/server/controllers/top-level/payments/amazon.js
+++ b/website/server/controllers/top-level/payments/amazon.js
@@ -241,9 +241,9 @@ api.subscribeCancel = {
     let user = res.locals.user;
     let groupId = req.query.groupId;
 
-    let billingAgreementId = user.purchased.plan.customerId;
-    let planId = user.purchased.plan.planId;
-    let lastBillingDate = user.purchased.plan.lastBillingDate;
+    let billingAgreementId;
+    let planId;
+    let lastBillingDate;
 
     if (groupId) {
       let groupFields = basicGroupFields.concat(' purchased');
@@ -260,8 +260,11 @@ api.subscribeCancel = {
       billingAgreementId = group.purchased.plan.customerId;
       planId = group.purchased.plan.planId;
       lastBillingDate = group.purchased.plan.lastBillingDate;
+    } else {
+      billingAgreementId = user.purchased.plan.customerId;
+      planId = user.purchased.plan.planId;
+      lastBillingDate = user.purchased.plan.lastBillingDate;
     }
-
 
     if (!billingAgreementId) throw new NotAuthorized(res.t('missingSubscription'));
 

--- a/website/server/controllers/top-level/payments/paypal.js
+++ b/website/server/controllers/top-level/payments/paypal.js
@@ -235,7 +235,7 @@ api.subscribeCancel = {
     let user = res.locals.user;
     let groupId = req.query.groupId;
 
-    let customerId = user.purchased.plan.customerId;
+    let customerId;
     if (groupId) {
       let groupFields = basicGroupFields.concat(' purchased');
       let group = await Group.getGroup({user, groupId, populateLeader: false, groupFields});
@@ -248,9 +248,11 @@ api.subscribeCancel = {
         throw new NotAuthorized(res.t('onlyGroupLeaderCanManageSubscription'));
       }
       customerId = group.purchased.plan.customerId;
+    } else {
+      customerId = user.purchased.plan.customerId;
     }
 
-    if (!user.purchased.plan.customerId) throw new NotAuthorized(res.t('missingSubscription'));
+    if (!customerId) throw new NotAuthorized(res.t('missingSubscription'));
 
     let customer = await paypalBillingAgreementGet(customerId);
 

--- a/website/server/controllers/top-level/payments/paypal.js
+++ b/website/server/controllers/top-level/payments/paypal.js
@@ -178,6 +178,7 @@ api.subscribe = {
     let billingAgreement = await paypalBillingAgreementCreate(billingAgreementAttributes);
 
     req.session.paypalBlock = req.query.sub;
+    req.session.groupId = req.query.groupId;
     let link = _.find(billingAgreement.links, { rel: 'approval_url' }).href;
     res.redirect(link);
   },
@@ -196,11 +197,15 @@ api.subscribeSuccess = {
   async handler (req, res) {
     let user = res.locals.user;
     let block = shared.content.subscriptionBlocks[req.session.paypalBlock];
+    let groupId = req.session.groupId;
+
     delete req.session.paypalBlock;
+    delete req.session.groupId;
 
     let result = await paypalBillingAgreementExecute(req.query.token, {});
     await payments.createSubscription({
       user,
+      groupId,
       customerId: result.id,
       paymentMethod: 'Paypal',
       sub: block,

--- a/website/server/controllers/top-level/payments/paypal.js
+++ b/website/server/controllers/top-level/payments/paypal.js
@@ -279,6 +279,12 @@ api.ipn = {
       let user = await User.findOne({ 'purchased.plan.customerId': req.body.recurring_payment_id });
       if (user) {
         await payments.cancelSubscription({ user, paymentMethod: 'Paypal' });
+        return;
+      }
+
+      let group = await Group.findOne({ 'purchased.plan.customerId': req.body.recurring_payment_id });
+      if (group) {
+        await payments.cancelSubscription({ group, paymentMethod: 'Paypal' });
       }
     }
   },

--- a/website/server/controllers/top-level/payments/stripe.js
+++ b/website/server/controllers/top-level/payments/stripe.js
@@ -41,6 +41,7 @@ api.checkout = {
     let user = res.locals.user;
     let gift = req.query.gift ? JSON.parse(req.query.gift) : undefined;
     let sub = req.query.sub ? shared.content.subscriptionBlocks[req.query.sub] : false;
+    let groupId = req.query.groupId;
     let coupon;
     let response;
 
@@ -84,6 +85,7 @@ api.checkout = {
         paymentMethod: 'Stripe',
         sub,
         headers: req.headers,
+        groupId,
       });
     } else {
       let method = 'buyGems';

--- a/website/server/controllers/top-level/payments/stripe.js
+++ b/website/server/controllers/top-level/payments/stripe.js
@@ -133,7 +133,7 @@ api.subscribeEdit = {
     let token = req.body.id;
     let groupId = req.body.groupId;
     let user = res.locals.user;
-    let customerId = user.purchased.plan.customerId;
+    let customerId;
 
     //  If we are buying a group subscription
     if (groupId) {
@@ -148,6 +148,8 @@ api.subscribeEdit = {
         throw new NotAuthorized(res.t('onlyGroupLeaderCanManageSubscription'));
       }
       customerId = group.purchased.plan.customerId;
+    } else {
+      customerId = user.purchased.plan.customerId;
     }
 
     if (!customerId) throw new NotAuthorized(res.t('missingSubscription'));
@@ -174,7 +176,7 @@ api.subscribeCancel = {
   async handler (req, res) {
     let user = res.locals.user;
     let groupId = req.query.groupId;
-    let customerId = user.purchased.plan.customerId;
+    let customerId;
 
     if (groupId) {
       let groupFields = basicGroupFields.concat(' purchased');
@@ -188,6 +190,8 @@ api.subscribeCancel = {
         throw new NotAuthorized(res.t('onlyGroupLeaderCanManageSubscription'));
       }
       customerId = group.purchased.plan.customerId;
+    } else {
+      customerId = user.purchased.plan.customerId;
     }
 
     if (!customerId) throw new NotAuthorized(res.t('missingSubscription'));

--- a/website/server/controllers/top-level/payments/stripe.js
+++ b/website/server/controllers/top-level/payments/stripe.js
@@ -131,7 +131,7 @@ api.subscribeEdit = {
     let user = res.locals.user;
     let customerId = user.purchased.plan.customerId;
 
-    //If we are buying a group subscription
+    //  If we are buying a group subscription
     if (groupId) {
       let group = await Group.findById(groupId).exec();
       customerId = group.purchased.plan.customerId;

--- a/website/server/controllers/top-level/payments/stripe.js
+++ b/website/server/controllers/top-level/payments/stripe.js
@@ -8,6 +8,7 @@ import { model as Coupon } from '../../../models/coupon';
 import payments from '../../../libs/payments';
 import nconf from 'nconf';
 import { model as User } from '../../../models/user';
+import { model as Group } from '../../../models/group';
 import cc from 'coupon-code';
 import {
   authWithHeaders,
@@ -126,8 +127,15 @@ api.subscribeEdit = {
   middlewares: [authWithHeaders()],
   async handler (req, res) {
     let token = req.body.id;
+    let groupId = req.body.groupId;
     let user = res.locals.user;
     let customerId = user.purchased.plan.customerId;
+
+    //If we are buying a group subscription
+    if (groupId) {
+      let group = await Group.findById(groupId).exec();
+      customerId = group.purchased.plan.customerId;
+    }
 
     if (!customerId) throw new NotAuthorized(res.t('missingSubscription'));
     if (!token) throw new BadRequest('Missing req.body.id');

--- a/website/server/libs/amazonPayments.js
+++ b/website/server/libs/amazonPayments.js
@@ -25,7 +25,6 @@ let setOrderReferenceDetails = Bluebird.promisify(amzPayment.offAmazonPayments.s
 let confirmOrderReference = Bluebird.promisify(amzPayment.offAmazonPayments.confirmOrderReference, {context: amzPayment.offAmazonPayments});
 let closeOrderReference = Bluebird.promisify(amzPayment.offAmazonPayments.closeOrderReference, {context: amzPayment.offAmazonPayments});
 let setBillingAgreementDetails = Bluebird.promisify(amzPayment.offAmazonPayments.setBillingAgreementDetails, {context: amzPayment.offAmazonPayments});
-let getBillingAgreementDetails = Bluebird.promisify(amzPayment.offAmazonPayments.getBillingAgreementDetails, {context: amzPayment.offAmazonPayments});
 let confirmBillingAgreement = Bluebird.promisify(amzPayment.offAmazonPayments.confirmBillingAgreement, {context: amzPayment.offAmazonPayments});
 let closeBillingAgreement = Bluebird.promisify(amzPayment.offAmazonPayments.closeBillingAgreement, {context: amzPayment.offAmazonPayments});
 
@@ -57,7 +56,6 @@ module.exports = {
   closeOrderReference,
   confirmBillingAgreement,
   setBillingAgreementDetails,
-  getBillingAgreementDetails,
   closeBillingAgreement,
   authorizeOnBillingAgreement,
   authorize,

--- a/website/server/libs/amazonPayments.js
+++ b/website/server/libs/amazonPayments.js
@@ -25,6 +25,7 @@ let setOrderReferenceDetails = Bluebird.promisify(amzPayment.offAmazonPayments.s
 let confirmOrderReference = Bluebird.promisify(amzPayment.offAmazonPayments.confirmOrderReference, {context: amzPayment.offAmazonPayments});
 let closeOrderReference = Bluebird.promisify(amzPayment.offAmazonPayments.closeOrderReference, {context: amzPayment.offAmazonPayments});
 let setBillingAgreementDetails = Bluebird.promisify(amzPayment.offAmazonPayments.setBillingAgreementDetails, {context: amzPayment.offAmazonPayments});
+let getBillingAgreementDetails = Bluebird.promisify(amzPayment.offAmazonPayments.getBillingAgreementDetails, {context: amzPayment.offAmazonPayments});
 let confirmBillingAgreement = Bluebird.promisify(amzPayment.offAmazonPayments.confirmBillingAgreement, {context: amzPayment.offAmazonPayments});
 let closeBillingAgreement = Bluebird.promisify(amzPayment.offAmazonPayments.closeBillingAgreement, {context: amzPayment.offAmazonPayments});
 
@@ -55,6 +56,7 @@ module.exports = {
   confirmOrderReference,
   closeOrderReference,
   confirmBillingAgreement,
+  getBillingAgreementDetails,
   setBillingAgreementDetails,
   closeBillingAgreement,
   authorizeOnBillingAgreement,

--- a/website/server/libs/payments.js
+++ b/website/server/libs/payments.js
@@ -94,17 +94,17 @@ api.createSubscription = async function createSubscription (data) {
     txnEmail(data.user, 'subscription-begins');
   }
 
-  // analytics.trackPurchase({
-  //   uuid: data.user._id,
-  //   itemPurchased: 'Subscription',
-  //   sku: `${data.paymentMethod.toLowerCase()}-subscription`,
-  //   purchaseType: 'subscribe',
-  //   paymentMethod: data.paymentMethod,
-  //   quantity: 1,
-  //   gift: Boolean(data.gift),
-  //   purchaseValue: block.price,
-  //   headers: data.headers,
-  // });
+  analytics.trackPurchase({
+    uuid: data.user._id,
+    itemPurchased: 'Subscription',
+    sku: `${data.paymentMethod.toLowerCase()}-subscription`,
+    purchaseType: 'subscribe',
+    paymentMethod: data.paymentMethod,
+    quantity: 1,
+    gift: Boolean(data.gift),
+    purchaseValue: block.price,
+    headers: data.headers,
+  });
 
   data.user.purchased.txnCount++;
 
@@ -142,7 +142,7 @@ api.createSubscription = async function createSubscription (data) {
   } else {
     await data.user.save();
   }
-  console.log(group);
+
   if (data.gift) await data.gift.member.save();
 };
 

--- a/website/server/libs/payments.js
+++ b/website/server/libs/payments.js
@@ -39,7 +39,7 @@ api.createSubscription = async function createSubscription (data) {
   let today = new Date();
   let group;
 
-  //If we are buying a group subscription
+  //  If we are buying a group subscription
   if (data.groupId) {
     group = await Group.findById(data.groupId).exec();
     recipient = group;
@@ -151,7 +151,7 @@ api.cancelSubscription = async function cancelSubscription (data) {
   let plan = data.user.purchased.plan;
   let group;
 
-  //If we are buying a group subscription
+  //  If we are buying a group subscription
   if (data.groupId) {
     group = await Group.findById(data.groupId).exec();
     plan = group.purchased.plan;

--- a/website/server/libs/payments.js
+++ b/website/server/libs/payments.js
@@ -14,7 +14,7 @@ import {
 import {
   NotAuthorized,
   NotFound,
-} from './libs/errors';
+} from './errors';
 
 let api = {};
 

--- a/website/server/libs/payments.js
+++ b/website/server/libs/payments.js
@@ -169,7 +169,16 @@ api.cancelSubscription = async function cancelSubscription (data) {
 
   //  If we are buying a group subscription
   if (data.groupId) {
-    group = await Group.findById(data.groupId).exec();
+    let groupFields = basicGroupFields.concat(' purchased');
+    group = await Group.getGroup({user: data.user, groupId: data.groupId, populateLeader: false, groupFields});
+
+    if (!group) {
+      throw new NotFound(shared.i18n.t('groupNotFound'));
+    }
+
+    if (!group.leader === data.user._id) {
+      throw new NotAuthorized(shared.i18n.t('onlyGroupLeaderCanManageSubscription'));
+    }
     plan = group.purchased.plan;
   }
 

--- a/website/server/libs/payments.js
+++ b/website/server/libs/payments.js
@@ -40,10 +40,10 @@ function _dateDiff (earlyDate, lateDate) {
 
 api.createSubscription = async function createSubscription (data) {
   let recipient = data.gift ? data.gift.member : data.user;
-  let plan = recipient.purchased.plan;
   let block = shared.content.subscriptionBlocks[data.gift ? data.gift.subscription.key : data.sub.key];
   let months = Number(block.months);
   let today = new Date();
+  let plan;
   let group;
 
   //  If we are buying a group subscription
@@ -59,8 +59,9 @@ api.createSubscription = async function createSubscription (data) {
       throw new NotAuthorized(shared.i18n.t('onlyGroupLeaderCanManageSubscription'));
     }
     recipient = group;
-    plan = recipient.purchased.plan;
   }
+
+  plan = recipient.purchased.plan;
 
   if (data.gift) {
     if (plan.customerId && !plan.dateTerminated) { // User has active plan
@@ -164,7 +165,7 @@ api.createSubscription = async function createSubscription (data) {
 
 // Sets their subscription to be cancelled later
 api.cancelSubscription = async function cancelSubscription (data) {
-  let plan = data.user.purchased.plan;
+  let plan;
   let group;
 
   //  If we are buying a group subscription
@@ -180,6 +181,8 @@ api.cancelSubscription = async function cancelSubscription (data) {
       throw new NotAuthorized(shared.i18n.t('onlyGroupLeaderCanManageSubscription'));
     }
     plan = group.purchased.plan;
+  } else {
+    plan = data.user.purchased.plan;
   }
 
   let now = moment();

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -23,6 +23,9 @@ import pusher from '../libs/pusher';
 import {
   syncableAttrs,
 } from '../libs/taskManager';
+import {
+  schema as SubscriptionPlanSchema,
+} from './subscriptionPlan';
 
 const questScrolls = shared.content.quests;
 const Schema = mongoose.Schema;
@@ -92,24 +95,9 @@ export let schema = new Schema({
   },
   purchased: {
     active: {type: Boolean, default: false},
-    plan: {
-      planId: String,
-      paymentMethod: String, // enum: ['Paypal','Stripe', 'Gift', 'Amazon Payments', '']}
-      customerId: String, // Billing Agreement Id in case of Amazon Payments
-      dateCreated: Date,
-      dateTerminated: Date,
-      dateUpdated: Date,
-      extraMonths: {type: Number, default: 0},
-      gemsBought: {type: Number, default: 0},
-      mysteryItems: {type: Array, default: () => []},
-      lastBillingDate: Date, // Used only for Amazon Payments to keep track of billing date
-      consecutive: {
-        count: {type: Number, default: 0},
-        offset: {type: Number, default: 0}, // when gifted subs, offset++ for each month. offset-- each new-month (cron). count doesn't ++ until offset==0
-        gemCapExtra: {type: Number, default: 0},
-        trinkets: {type: Number, default: 0},
-      },
-    },
+    plan: {type: SubscriptionPlanSchema, default: () => {
+      return {};
+    }},
   },
 }, {
   strict: true,

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -105,6 +105,10 @@ export let schema = new Schema({
 
 schema.plugin(baseModel, {
   noSet: ['_id', 'balance', 'quest', 'memberCount', 'chat', 'challengeCount', 'tasksOrder', 'purchased'],
+  toJSONTransform: function userToJSON (plainObj, originalDoc) {
+    plainObj._tmp = originalDoc._tmp; // be sure to send down drop notifs
+    return plainObj;
+  },
 });
 
 // A list of additional fields that cannot be updated (but can be set on creation)

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -94,7 +94,6 @@ export let schema = new Schema({
     rewards: [{type: String, ref: 'Task'}],
   },
   purchased: {
-    active: {type: Boolean, default: false},
     plan: {type: SubscriptionPlanSchema, default: () => {
       return {};
     }},

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -105,10 +105,6 @@ export let schema = new Schema({
 
 schema.plugin(baseModel, {
   noSet: ['_id', 'balance', 'quest', 'memberCount', 'chat', 'challengeCount', 'tasksOrder', 'purchased'],
-  toJSONTransform: function userToJSON (plainObj, originalDoc) {
-    plainObj._tmp = originalDoc._tmp; // be sure to send down drop notifs
-    return plainObj;
-  },
 });
 
 // A list of additional fields that cannot be updated (but can be set on creation)
@@ -274,6 +270,9 @@ schema.statics.toJSONCleanChat = function groupToJSONCleanChat (group, user) {
       return chatMsg.flagCount >= 2;
     });
   }
+
+  toJSON.purchased.active = false;
+  if (group.purchased.plan.customerId) toJSON.purchased.active = true;
 
   return toJSON;
 };

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -272,7 +272,7 @@ schema.statics.toJSONCleanChat = function groupToJSONCleanChat (group, user) {
   }
 
   toJSON.purchased.active = false;
-  if (group.purchased.plan.customerId) toJSON.purchased.active = true;
+  if (group.purchased.plan && group.purchased.plan.customerId) toJSON.purchased.active = true;
 
   return toJSON;
 };

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -105,6 +105,10 @@ export let schema = new Schema({
 
 schema.plugin(baseModel, {
   noSet: ['_id', 'balance', 'quest', 'memberCount', 'chat', 'challengeCount', 'tasksOrder', 'purchased'],
+  private: ['purchased.plan'],
+  toJSONTransform (plainObj, originalDoc) {
+    if (plainObj.purchased) plainObj.purchased.active = originalDoc.purchased.plan && originalDoc.purchased.plan.customerId;
+  },
 });
 
 // A list of additional fields that cannot be updated (but can be set on creation)
@@ -270,9 +274,6 @@ schema.statics.toJSONCleanChat = function groupToJSONCleanChat (group, user) {
       return chatMsg.flagCount >= 2;
     });
   }
-
-  toJSON.purchased.active = false;
-  if (group.purchased.plan && group.purchased.plan.customerId) toJSON.purchased.active = true;
 
   return toJSON;
 };

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -127,7 +127,7 @@ schema.statics.sanitizeUpdate = function sanitizeUpdate (updateObj) {
 };
 
 // Basic fields to fetch for populating a group info
-export let basicFields = 'name type privacy leader purchased';
+export let basicFields = 'name type privacy leader';
 
 schema.pre('remove', true, async function preRemoveGroup (next, done) {
   next();

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -92,6 +92,24 @@ export let schema = new Schema({
   },
   purchased: {
     active: {type: Boolean, default: false},
+    plan: {
+      planId: String,
+      paymentMethod: String, // enum: ['Paypal','Stripe', 'Gift', 'Amazon Payments', '']}
+      customerId: String, // Billing Agreement Id in case of Amazon Payments
+      dateCreated: Date,
+      dateTerminated: Date,
+      dateUpdated: Date,
+      extraMonths: {type: Number, default: 0},
+      gemsBought: {type: Number, default: 0},
+      mysteryItems: {type: Array, default: () => []},
+      lastBillingDate: Date, // Used only for Amazon Payments to keep track of billing date
+      consecutive: {
+        count: {type: Number, default: 0},
+        offset: {type: Number, default: 0}, // when gifted subs, offset++ for each month. offset-- each new-month (cron). count doesn't ++ until offset==0
+        gemCapExtra: {type: Number, default: 0},
+        trinkets: {type: Number, default: 0},
+      },
+    },
   },
 }, {
   strict: true,
@@ -109,7 +127,7 @@ schema.statics.sanitizeUpdate = function sanitizeUpdate (updateObj) {
 };
 
 // Basic fields to fetch for populating a group info
-export let basicFields = 'name type privacy leader';
+export let basicFields = 'name type privacy leader purchased';
 
 schema.pre('remove', true, async function preRemoveGroup (next, done) {
   next();

--- a/website/server/models/subscriptionPlan.js
+++ b/website/server/models/subscriptionPlan.js
@@ -21,11 +21,12 @@ export let schema = new mongoose.Schema({
 }, {
   strict: true,
   minimize: false, // So empty objects are returned
+  _id: false,
 });
 
 schema.plugin(baseModel, {
   noSet: ['_id'],
-  timestamps: true,
+  timestamps: false,
 });
 
 export let model = mongoose.model('SubscriptionPlan', schema);

--- a/website/server/models/subscriptionPlan.js
+++ b/website/server/models/subscriptionPlan.js
@@ -1,0 +1,31 @@
+import mongoose from 'mongoose';
+import baseModel from '../libs/baseModel';
+
+export let schema = new mongoose.Schema({
+  planId: String,
+  paymentMethod: String, // enum: ['Paypal','Stripe', 'Gift', 'Amazon Payments', '']}
+  customerId: String, // Billing Agreement Id in case of Amazon Payments
+  dateCreated: Date,
+  dateTerminated: Date,
+  dateUpdated: Date,
+  extraMonths: {type: Number, default: 0},
+  gemsBought: {type: Number, default: 0},
+  mysteryItems: {type: Array, default: () => []},
+  lastBillingDate: Date, // Used only for Amazon Payments to keep track of billing date
+  consecutive: {
+    count: {type: Number, default: 0},
+    offset: {type: Number, default: 0}, // when gifted subs, offset++ for each month. offset-- each new-month (cron). count doesn't ++ until offset==0
+    gemCapExtra: {type: Number, default: 0},
+    trinkets: {type: Number, default: 0},
+  },
+}, {
+  strict: true,
+  minimize: false, // So empty objects are returned
+});
+
+schema.plugin(baseModel, {
+  noSet: ['_id'],
+  timestamps: true,
+});
+
+export let model = mongoose.model('SubscriptionPlan', schema);

--- a/website/server/models/user/schema.js
+++ b/website/server/models/user/schema.js
@@ -8,6 +8,9 @@ import { schema as WebhookSchema } from '../webhook';
 import {
   schema as UserNotificationSchema,
 } from '../userNotification';
+import {
+  schema as SubscriptionPlanSchema,
+} from '../subscriptionPlan';
 
 const Schema = mongoose.Schema;
 
@@ -144,24 +147,9 @@ let schema = new Schema({
     }},
     txnCount: {type: Number, default: 0},
     mobileChat: Boolean,
-    plan: {
-      planId: String,
-      paymentMethod: String, // enum: ['Paypal','Stripe', 'Gift', 'Amazon Payments', '']}
-      customerId: String, // Billing Agreement Id in case of Amazon Payments
-      dateCreated: Date,
-      dateTerminated: Date,
-      dateUpdated: Date,
-      extraMonths: {type: Number, default: 0},
-      gemsBought: {type: Number, default: 0},
-      mysteryItems: {type: Array, default: () => []},
-      lastBillingDate: Date, // Used only for Amazon Payments to keep track of billing date
-      consecutive: {
-        count: {type: Number, default: 0},
-        offset: {type: Number, default: 0}, // when gifted subs, offset++ for each month. offset-- each new-month (cron). count doesn't ++ until offset==0
-        gemCapExtra: {type: Number, default: 0},
-        trinkets: {type: Number, default: 0},
-      },
-    },
+    plan: {type: SubscriptionPlanSchema, default: () => {
+      return {};
+    }},
   },
 
   flags: {

--- a/website/views/options/social/group.jade
+++ b/website/views/options/social/group.jade
@@ -147,17 +147,14 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
                 h3.popover-title {{group.leader.profile.name}}
                 .popover-content
                   markdown(text='group._editing ? groupCopy.leaderMessage : group.leaderMessage')
-
+                  
       ul.options-menu(ng-init="groupPane = 'chat'")
         li
-          a(ng-click="groupPane = 'chat'")
-            | Chat
+          a(ng-click="groupPane = 'chat'")=env.t('chat')
         li
-          a(ng-click="groupPane = 'tasks'", ng-if='group.purchased.plan.customerId')
-            | Tasks
+          a(ng-click="groupPane = 'tasks'", ng-if='group.purchased.active')=env.t('tasks')
         li
-          a(ng-click="groupPane = 'subscription'")
-            | Subscription
+          a(ng-click="groupPane = 'subscription'", ng-show='group.leader._id === user._id')=env.t('subscription')
     
       .tab-content
         .tab-pane.active

--- a/website/views/options/social/group.jade
+++ b/website/views/options/social/group.jade
@@ -148,49 +148,16 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
                 .popover-content
                   markdown(text='group._editing ? groupCopy.leaderMessage : group.leaderMessage')
 
-      ul.options-menu(ng-init="groupPane = 'chat'", ng-show="group.purchased.active")
+      ul.options-menu(ng-init="groupPane = 'chat'")
         li
           a(ng-click="groupPane = 'chat'")
             | Chat
         li
-          a(ng-click="groupPane = 'tasks'")
+          a(ng-click="groupPane = 'tasks'", ng-if='group.purchased.plan.customerId')
             | Tasks
-      
-      .col-md-12
-        table.table.alert.alert-info(ng-if='group.purchased.plan.customerId')
-          tr(ng-if='group.purchased.plan.dateTerminated'): td.alert.alert-warning
-            span.noninteractive-button.btn-danger=env.t('canceledSubscription')
-            i.glyphicon.glyphicon-time
-            |  #{env.t('subCanceled')} <strong>{{moment(group.purchased.plan.dateTerminated).format('MM/DD/YYYY')}}</strong>
-          tr(ng-if='!group.purchased.plan.dateTerminated'): td
-            h4=env.t('subscribed')
-            p(ng-if='group.purchased.plan.planId')=env.t('purchasedPlanId', {price: '{{Content.subscriptionBlocks[group.purchased.plan.planId].price}}', months: '{{Content.subscriptionBlocks[group.purchased.plan.planId].months}}', plan: '{{group.purchased.plan.paymentMethod}}'})
-          tr(ng-if='group.purchased.plan.extraMonths'): td
-            span.glyphicon.glyphicon-credit-card
-            | &nbsp;#{env.t('purchasedPlanExtraMonths', {months: '{{group.purchased.plan.extraMonths | number:2}}'})}
-          tr(ng-if='group.purchased.plan.consecutive.count || group.purchased.plan.consecutive.offset'): td
-            span.glyphicon.glyphicon-forward
-            | &nbsp;#{env.t('consecutiveSubscription')}
-            ul.list-unstyled
-              li #{env.t('consecutiveMonths')} {{group.purchased.plan.consecutive.count + group.purchased.plan.consecutive.offset}}
-              li #{env.t('gemCapExtra')} {{group.purchased.plan.consecutive.gemCapExtra}}
-              li #{env.t('mysticHourglasses')} {{group.purchased.plan.consecutive.trinkets}}
-
-        div(ng-if='group.purchased.plan.customerId')
-          .btn.btn-primary(ng-if='!group.purchased.plan.dateTerminated && group.purchased.plan.paymentMethod=="Stripe"', ng-click='Payments.showStripeEdit({groupId: group.id})')=env.t('subUpdateCard')
-          .btn.btn-sm.btn-danger(ng-if='!group.purchased.plan.dateTerminated', ng-click='Payments.cancelSubscription({group: group})')=env.t('cancelSub')
-
-      .container-fluid.slight-vertical-padding(ng-if='!group.purchased.plan.customerId || (group.purchased.plan.customerId && group.purchased.plan.dateTerminated)', ng-init="_subscription.key='group_monthly'")
-        small.muted=env.t('subscribeUsing')
-        .row.text-center
-          .col-xs-4
-            a.purchase.btn.btn-primary(ng-click='Payments.showStripe({subscription:_subscription.key, coupon:_subscription.coupon, groupId: group.id})', ng-disabled='!_subscription.key')= env.t('card')
-          .col-xs-4
-            a.purchase(href='/paypal/subscribe?_id={{user._id}}&apiToken={{User.settings.auth.apiToken}}&sub={{_subscription.key}}{{_subscription.coupon ? "&coupon="+_subscription.coupon : ""}}&groupId={{group.id}}', ng-disabled='!_subscription.key')
-              img(src='https://www.paypalobjects.com/webstatic/en_US/i/buttons/pp-acceptance-small.png',alt=env.t('paypal'))
-          .col-xs-4
-            a.purchase(ng-click="Payments.amazonPayments.init({type: 'subscription', subscription:_subscription.key, coupon:_subscription.coupon, groupId: group.id})")
-              img(src='https://payments.amazon.com/gp/cba/button',alt=env.t('amazonPayments'))
+        li
+          a(ng-click="groupPane = 'subscription'")
+            | Subscription
     
       .tab-content
         .tab-pane.active
@@ -203,5 +170,43 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
         +chatMessages()
         h4(ng-if='group.chat.length < 1 && group.type === "party"')=env.t('partyChatEmpty')
         h4(ng-if='group.chat.length < 1 && group.type === "guild"')=env.t('guildChatEmpty')
+  
+      group-tasks(ng-show="groupPane == 'tasks'")
+      
+      //TODO: This can be a directive and the group/user can be an object passed via attribute
+      div(ng-show="groupPane == 'subscription'")
+       .col-md-12
+         table.table.alert.alert-info(ng-if='group.purchased.plan.customerId')
+           tr(ng-if='group.purchased.plan.dateTerminated'): td.alert.alert-warning
+             span.noninteractive-button.btn-danger=env.t('canceledSubscription')
+             i.glyphicon.glyphicon-time
+             |  #{env.t('subCanceled')} <strong>{{moment(group.purchased.plan.dateTerminated).format('MM/DD/YYYY')}}</strong>
+           tr(ng-if='!group.purchased.plan.dateTerminated'): td
+             h4=env.t('subscribed')
+             p(ng-if='group.purchased.plan.planId')=env.t('purchasedPlanId', {price: '{{Content.subscriptionBlocks[group.purchased.plan.planId].price}}', months: '{{Content.subscriptionBlocks[group.purchased.plan.planId].months}}', plan: '{{group.purchased.plan.paymentMethod}}'})
+           tr(ng-if='group.purchased.plan.extraMonths'): td
+             span.glyphicon.glyphicon-credit-card
+             | &nbsp;#{env.t('purchasedPlanExtraMonths', {months: '{{group.purchased.plan.extraMonths | number:2}}'})}
+           tr(ng-if='group.purchased.plan.consecutive.count || group.purchased.plan.consecutive.offset'): td
+             span.glyphicon.glyphicon-forward
+             | &nbsp;#{env.t('consecutiveSubscription')}
+             ul.list-unstyled
+               li #{env.t('consecutiveMonths')} {{group.purchased.plan.consecutive.count + group.purchased.plan.consecutive.offset}}
+               li #{env.t('gemCapExtra')} {{group.purchased.plan.consecutive.gemCapExtra}}
+               li #{env.t('mysticHourglasses')} {{group.purchased.plan.consecutive.trinkets}}
 
-     group-tasks(ng-show="groupPane == 'tasks'")
+         div(ng-if='group.purchased.plan.customerId')
+           .btn.btn-primary(ng-if='!group.purchased.plan.dateTerminated && group.purchased.plan.paymentMethod=="Stripe"', ng-click='Payments.showStripeEdit({groupId: group.id})')=env.t('subUpdateCard')
+           .btn.btn-sm.btn-danger(ng-if='!group.purchased.plan.dateTerminated', ng-click='Payments.cancelSubscription({group: group})')=env.t('cancelSub')
+
+       .container-fluid.slight-vertical-padding(ng-if='!group.purchased.plan.customerId || (group.purchased.plan.customerId && group.purchased.plan.dateTerminated)', ng-init="_subscription.key='group_monthly'")
+         small.muted=env.t('subscribeUsing')
+         .row.text-center
+           .col-xs-4
+             a.purchase.btn.btn-primary(ng-click='Payments.showStripe({subscription:_subscription.key, coupon:_subscription.coupon, groupId: group.id})', ng-disabled='!_subscription.key')= env.t('card')
+           .col-xs-4
+             a.purchase(href='/paypal/subscribe?_id={{user._id}}&apiToken={{User.settings.auth.apiToken}}&sub={{_subscription.key}}{{_subscription.coupon ? "&coupon="+_subscription.coupon : ""}}&groupId={{group.id}}', ng-disabled='!_subscription.key')
+               img(src='https://www.paypalobjects.com/webstatic/en_US/i/buttons/pp-acceptance-small.png',alt=env.t('paypal'))
+           .col-xs-4
+             a.purchase(ng-click="Payments.amazonPayments.init({type: 'subscription', subscription:_subscription.key, coupon:_subscription.coupon, groupId: group.id})")
+               img(src='https://payments.amazon.com/gp/cba/button',alt=env.t('amazonPayments'))

--- a/website/views/options/social/group.jade
+++ b/website/views/options/social/group.jade
@@ -157,26 +157,26 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
             | Tasks
       
       .col-md-12
-        table.table.alert.alert-info(ng-if='user.purchased.plan.customerId')
-          tr(ng-if='user.purchased.plan.dateTerminated'): td.alert.alert-warning
+        table.table.alert.alert-info(ng-if='group.purchased.plan.customerId')
+          tr(ng-if='group.purchased.plan.dateTerminated'): td.alert.alert-warning
             span.noninteractive-button.btn-danger=env.t('canceledSubscription')
             i.glyphicon.glyphicon-time
-            |  #{env.t('subCanceled')} <strong>{{moment(user.purchased.plan.dateTerminated).format('MM/DD/YYYY')}}</strong>
-          tr(ng-if='!user.purchased.plan.dateTerminated'): td
+            |  #{env.t('subCanceled')} <strong>{{moment(group.purchased.plan.dateTerminated).format('MM/DD/YYYY')}}</strong>
+          tr(ng-if='!group.purchased.plan.dateTerminated'): td
             h4=env.t('subscribed')
-            p(ng-if='user.purchased.plan.planId')=env.t('purchasedPlanId', {price: '{{Content.subscriptionBlocks[user.purchased.plan.planId].price}}', months: '{{Content.subscriptionBlocks[user.purchased.plan.planId].months}}', plan: '{{user.purchased.plan.paymentMethod}}'})
-          tr(ng-if='user.purchased.plan.extraMonths'): td
+            p(ng-if='group.purchased.plan.planId')=env.t('purchasedPlanId', {price: '{{Content.subscriptionBlocks[group.purchased.plan.planId].price}}', months: '{{Content.subscriptionBlocks[group.purchased.plan.planId].months}}', plan: '{{group.purchased.plan.paymentMethod}}'})
+          tr(ng-if='group.purchased.plan.extraMonths'): td
             span.glyphicon.glyphicon-credit-card
-            | &nbsp;#{env.t('purchasedPlanExtraMonths', {months: '{{user.purchased.plan.extraMonths | number:2}}'})}
-          tr(ng-if='user.purchased.plan.consecutive.count || user.purchased.plan.consecutive.offset'): td
+            | &nbsp;#{env.t('purchasedPlanExtraMonths', {months: '{{group.purchased.plan.extraMonths | number:2}}'})}
+          tr(ng-if='group.purchased.plan.consecutive.count || group.purchased.plan.consecutive.offset'): td
             span.glyphicon.glyphicon-forward
             | &nbsp;#{env.t('consecutiveSubscription')}
             ul.list-unstyled
-              li #{env.t('consecutiveMonths')} {{user.purchased.plan.consecutive.count + user.purchased.plan.consecutive.offset}}
-              li #{env.t('gemCapExtra')} {{user.purchased.plan.consecutive.gemCapExtra}}
-              li #{env.t('mysticHourglasses')} {{user.purchased.plan.consecutive.trinkets}}
-        div(ng-if='!user.purchased.plan.customerId || (user.purchased.plan.customerId && user.purchased.plan.dateTerminated)')
-          h4(ng-if='(user.purchased.plan.customerId && user.purchased.plan.dateTerminated)')= env.t("resubscribe")
+              li #{env.t('consecutiveMonths')} {{group.purchased.plan.consecutive.count + group.purchased.plan.consecutive.offset}}
+              li #{env.t('gemCapExtra')} {{group.purchased.plan.consecutive.gemCapExtra}}
+              li #{env.t('mysticHourglasses')} {{group.purchased.plan.consecutive.trinkets}}
+        div(ng-if='!group.purchased.plan.customerId || (group.purchased.plan.customerId && group.purchased.plan.dateTerminated)')
+          h4(ng-if='(group.purchased.plan.customerId && group.purchased.plan.dateTerminated)')= env.t("resubscribe")
           .form-group.reduce-top-margin
             .radio(ng-repeat='block in Content.subscriptionBlocks | toArray | omit: "discount==true" | orderBy:"months"')
               label
@@ -196,7 +196,7 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
 
         div(ng-if='group.purchased.plan.customerId')
           .btn.btn-primary(ng-if='!group.purchased.plan.dateTerminated && group.purchased.plan.paymentMethod=="Stripe"', ng-click='Payments.showStripeEdit({groupId: group.id})')=env.t('subUpdateCard')
-          .btn.btn-sm.btn-danger(ng-if='!user.purchased.plan.dateTerminated', ng-click='Payments.cancelSubscription()')=env.t('cancelSub')
+          .btn.btn-sm.btn-danger(ng-if='!group.purchased.plan.dateTerminated', ng-click='Payments.cancelSubscription({group: group})')=env.t('cancelSub')
 
       .container-fluid.slight-vertical-padding(ng-if='!group.purchased.plan.customerId || (group.purchased.plan.customerId && group.purchased.plan.dateTerminated)')
         small.muted=env.t('subscribeUsing')

--- a/website/views/options/social/group.jade
+++ b/website/views/options/social/group.jade
@@ -195,10 +195,10 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
               button.pull-right.btn.btn-small(type='button',ng-click='applyCoupon(_subscription.coupon)')= env.t("apply")
 
         div(ng-if='group.purchased.plan.customerId')
-          .btn.btn-primary(ng-if='!group.purchased.plan.dateTerminated && group.purchased.plan.paymentMethod=="Stripe"', ng-click='Payments.showStripeEdit()')=env.t('subUpdateCard')
+          .btn.btn-primary(ng-if='!group.purchased.plan.dateTerminated && group.purchased.plan.paymentMethod=="Stripe"', ng-click='Payments.showStripeEdit({groupId: group.id})')=env.t('subUpdateCard')
           .btn.btn-sm.btn-danger(ng-if='!user.purchased.plan.dateTerminated', ng-click='Payments.cancelSubscription()')=env.t('cancelSub')
 
-      .container-fluid.slight-vertical-padding(ng-if='!user.purchased.plan.customerId || (user.purchased.plan.customerId && user.purchased.plan.dateTerminated)')
+      .container-fluid.slight-vertical-padding(ng-if='!group.purchased.plan.customerId || (group.purchased.plan.customerId && group.purchased.plan.dateTerminated)')
         small.muted=env.t('subscribeUsing')
         .row.text-center
           .col-xs-4

--- a/website/views/options/social/group.jade
+++ b/website/views/options/social/group.jade
@@ -184,9 +184,9 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
         small.muted=env.t('subscribeUsing')
         .row.text-center
           .col-xs-4
-            a.purchase.btn.btn-primary(ng-click='Payments.showStripe({subscription:"group_monthly", coupon:_subscription.coupon, groupId: group.id})', ng-disabled='!_subscription.key')= env.t('card')
+            a.purchase.btn.btn-primary(ng-click='Payments.showStripe({subscription:_subscription.key, coupon:_subscription.coupon, groupId: group.id})', ng-disabled='!_subscription.key')= env.t('card')
           .col-xs-4
-            a.purchase(href='/paypal/subscribe?_id={{user._id}}&apiToken={{User.settings.auth.apiToken}}&sub=group_monthly{{_subscription.coupon ? "&coupon="+_subscription.coupon : ""}}', ng-disabled='!_subscription.key')
+            a.purchase(href='/paypal/subscribe?_id={{user._id}}&apiToken={{User.settings.auth.apiToken}}&sub={{_subscription.key}}{{_subscription.coupon ? "&coupon="+_subscription.coupon : ""}}&groupId={{group.id}}', ng-disabled='!_subscription.key')
               img(src='https://www.paypalobjects.com/webstatic/en_US/i/buttons/pp-acceptance-small.png',alt=env.t('paypal'))
           .col-xs-4
             a.purchase(ng-click="Payments.amazonPayments.init({type: 'subscription', subscription:_subscription.key, coupon:_subscription.coupon, groupId: group.id})")

--- a/website/views/options/social/group.jade
+++ b/website/views/options/social/group.jade
@@ -155,8 +155,61 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
         li
           a(ng-click="groupPane = 'tasks'")
             | Tasks
+      
+      .col-md-12
+        table.table.alert.alert-info(ng-if='user.purchased.plan.customerId')
+          tr(ng-if='user.purchased.plan.dateTerminated'): td.alert.alert-warning
+            span.noninteractive-button.btn-danger=env.t('canceledSubscription')
+            i.glyphicon.glyphicon-time
+            |  #{env.t('subCanceled')} <strong>{{moment(user.purchased.plan.dateTerminated).format('MM/DD/YYYY')}}</strong>
+          tr(ng-if='!user.purchased.plan.dateTerminated'): td
+            h4=env.t('subscribed')
+            p(ng-if='user.purchased.plan.planId')=env.t('purchasedPlanId', {price: '{{Content.subscriptionBlocks[user.purchased.plan.planId].price}}', months: '{{Content.subscriptionBlocks[user.purchased.plan.planId].months}}', plan: '{{user.purchased.plan.paymentMethod}}'})
+          tr(ng-if='user.purchased.plan.extraMonths'): td
+            span.glyphicon.glyphicon-credit-card
+            | &nbsp;#{env.t('purchasedPlanExtraMonths', {months: '{{user.purchased.plan.extraMonths | number:2}}'})}
+          tr(ng-if='user.purchased.plan.consecutive.count || user.purchased.plan.consecutive.offset'): td
+            span.glyphicon.glyphicon-forward
+            | &nbsp;#{env.t('consecutiveSubscription')}
+            ul.list-unstyled
+              li #{env.t('consecutiveMonths')} {{user.purchased.plan.consecutive.count + user.purchased.plan.consecutive.offset}}
+              li #{env.t('gemCapExtra')} {{user.purchased.plan.consecutive.gemCapExtra}}
+              li #{env.t('mysticHourglasses')} {{user.purchased.plan.consecutive.trinkets}}
+        div(ng-if='!user.purchased.plan.customerId || (user.purchased.plan.customerId && user.purchased.plan.dateTerminated)')
+          h4(ng-if='(user.purchased.plan.customerId && user.purchased.plan.dateTerminated)')= env.t("resubscribe")
+          .form-group.reduce-top-margin
+            .radio(ng-repeat='block in Content.subscriptionBlocks | toArray | omit: "discount==true" | orderBy:"months"')
+              label
+                input(type="radio", name="subRadio", ng-value="block.key", ng-model='_subscription.key')
+                span(ng-show='block.original')
+                  span.label.label-success.line-through
+                    | ${{:: block.original }}
+                  =env.t('subscriptionRateText', {price:'{{::block.price}}', months: '{{::block.months}}'})
+                span(ng-hide='block.original')
+                  =env.t('subscriptionRateText', {price: '{{::block.price}}', months: '{{block.months}}'})
 
+          .form-inline
+            .form-group
+              input.form-control(type='text', ng-model='_subscription.coupon', placeholder= env.t('couponPlaceholder'))
+            .form-group
+              button.pull-right.btn.btn-small(type='button',ng-click='applyCoupon(_subscription.coupon)')= env.t("apply")
 
+        div(ng-if='group.purchased.plan.customerId')
+          .btn.btn-primary(ng-if='!group.purchased.plan.dateTerminated && group.purchased.plan.paymentMethod=="Stripe"', ng-click='Payments.showStripeEdit()')=env.t('subUpdateCard')
+          .btn.btn-sm.btn-danger(ng-if='!user.purchased.plan.dateTerminated', ng-click='Payments.cancelSubscription()')=env.t('cancelSub')
+
+      .container-fluid.slight-vertical-padding(ng-if='!user.purchased.plan.customerId || (user.purchased.plan.customerId && user.purchased.plan.dateTerminated)')
+        small.muted=env.t('subscribeUsing')
+        .row.text-center
+          .col-xs-4
+            a.purchase.btn.btn-primary(ng-click='Payments.showStripe({subscription:"group_monthly", coupon:_subscription.coupon, groupId: group.id})', ng-disabled='!_subscription.key')= env.t('card')
+          .col-xs-4
+            a.purchase(href='/paypal/subscribe?_id={{user._id}}&apiToken={{User.settings.auth.apiToken}}&sub={{_subscription.key}}{{_subscription.coupon ? "&coupon="+_subscription.coupon : ""}}', ng-disabled='!_subscription.key')
+              img(src='https://www.paypalobjects.com/webstatic/en_US/i/buttons/pp-acceptance-small.png',alt=env.t('paypal'))
+          .col-xs-4
+            a.purchase(ng-click="Payments.amazonPayments.init({type: 'subscription', subscription:_subscription.key, coupon:_subscription.coupon})")
+              img(src='https://payments.amazon.com/gp/cba/button',alt=env.t('amazonPayments'))
+    
       .tab-content
         .tab-pane.active
 

--- a/website/views/options/social/group.jade
+++ b/website/views/options/social/group.jade
@@ -175,39 +175,21 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
               li #{env.t('consecutiveMonths')} {{group.purchased.plan.consecutive.count + group.purchased.plan.consecutive.offset}}
               li #{env.t('gemCapExtra')} {{group.purchased.plan.consecutive.gemCapExtra}}
               li #{env.t('mysticHourglasses')} {{group.purchased.plan.consecutive.trinkets}}
-        div(ng-if='!group.purchased.plan.customerId || (group.purchased.plan.customerId && group.purchased.plan.dateTerminated)')
-          h4(ng-if='(group.purchased.plan.customerId && group.purchased.plan.dateTerminated)')= env.t("resubscribe")
-          .form-group.reduce-top-margin
-            .radio(ng-repeat='block in Content.subscriptionBlocks | toArray | omit: "discount==true" | orderBy:"months"')
-              label
-                input(type="radio", name="subRadio", ng-value="block.key", ng-model='_subscription.key')
-                span(ng-show='block.original')
-                  span.label.label-success.line-through
-                    | ${{:: block.original }}
-                  =env.t('subscriptionRateText', {price:'{{::block.price}}', months: '{{::block.months}}'})
-                span(ng-hide='block.original')
-                  =env.t('subscriptionRateText', {price: '{{::block.price}}', months: '{{block.months}}'})
-
-          .form-inline
-            .form-group
-              input.form-control(type='text', ng-model='_subscription.coupon', placeholder= env.t('couponPlaceholder'))
-            .form-group
-              button.pull-right.btn.btn-small(type='button',ng-click='applyCoupon(_subscription.coupon)')= env.t("apply")
 
         div(ng-if='group.purchased.plan.customerId')
           .btn.btn-primary(ng-if='!group.purchased.plan.dateTerminated && group.purchased.plan.paymentMethod=="Stripe"', ng-click='Payments.showStripeEdit({groupId: group.id})')=env.t('subUpdateCard')
           .btn.btn-sm.btn-danger(ng-if='!group.purchased.plan.dateTerminated', ng-click='Payments.cancelSubscription({group: group})')=env.t('cancelSub')
 
-      .container-fluid.slight-vertical-padding(ng-if='!group.purchased.plan.customerId || (group.purchased.plan.customerId && group.purchased.plan.dateTerminated)')
+      .container-fluid.slight-vertical-padding(ng-if='!group.purchased.plan.customerId || (group.purchased.plan.customerId && group.purchased.plan.dateTerminated)', ng-init="_subscription.key='group_monthly'")
         small.muted=env.t('subscribeUsing')
         .row.text-center
           .col-xs-4
             a.purchase.btn.btn-primary(ng-click='Payments.showStripe({subscription:"group_monthly", coupon:_subscription.coupon, groupId: group.id})', ng-disabled='!_subscription.key')= env.t('card')
           .col-xs-4
-            a.purchase(href='/paypal/subscribe?_id={{user._id}}&apiToken={{User.settings.auth.apiToken}}&sub={{_subscription.key}}{{_subscription.coupon ? "&coupon="+_subscription.coupon : ""}}', ng-disabled='!_subscription.key')
+            a.purchase(href='/paypal/subscribe?_id={{user._id}}&apiToken={{User.settings.auth.apiToken}}&sub=group_monthly{{_subscription.coupon ? "&coupon="+_subscription.coupon : ""}}', ng-disabled='!_subscription.key')
               img(src='https://www.paypalobjects.com/webstatic/en_US/i/buttons/pp-acceptance-small.png',alt=env.t('paypal'))
           .col-xs-4
-            a.purchase(ng-click="Payments.amazonPayments.init({type: 'subscription', subscription:_subscription.key, coupon:_subscription.coupon})")
+            a.purchase(ng-click="Payments.amazonPayments.init({type: 'subscription', subscription:_subscription.key, coupon:_subscription.coupon, groupId: group.id})")
               img(src='https://payments.amazon.com/gp/cba/button',alt=env.t('amazonPayments'))
     
       .tab-content


### PR DESCRIPTION
Fixes put_issue_url_here
### Changes
- [x] I will be abstracting the subscription details from Group and User before this is merged. I forgot to before the PR

This adds Group Subscriptions. More specifically:
1. There is now a subscription tab on the group page
2. Users can create a group sub with Stripe, Update their card, and Cancel
3. Users can create a group sub with Paypal and cancel
4. Users can create a group sub with Amazon and cancel

A few things will need to be set up for this to work:
1. Stripe needs a group_monthly plan added via the console
2. Paypal needs a group monthly plan added via the rest API and the P-[id] will need to be added to the config.json
3. I believe amazon should work by itself

---

UUID: 
