### PR TITLE
Allow user to save the checklist collapse and alias properties of a challenge task

### DIFF
--- a/test/api/v3/integration/tasks/PUT-tasks_id.test.js
+++ b/test/api/v3/integration/tasks/PUT-tasks_id.test.js
@@ -74,6 +74,7 @@ describe('PUT /tasks/:id', () => {
         checklist: [
           {text: 123, completed: false},
         ],
+        collapseChecklist: false,
       });
       await sleep(2);
 
@@ -111,6 +112,7 @@ describe('PUT /tasks/:id', () => {
           {text: 123, completed: false},
           {text: 456, completed: true},
         ],
+        collapseChecklist: true,
         notes: 'new notes',
         attribute: 'per',
         tags: [challengeUserTaskId],
@@ -143,6 +145,8 @@ describe('PUT /tasks/:id', () => {
       expect(savedChallengeUserTask.streak).to.equal(25);
       expect(savedChallengeUserTask.reminders.length).to.equal(2);
       expect(savedChallengeUserTask.checklist.length).to.equal(2);
+      expect(savedChallengeUserTask.alias).to.equal('a-short-task-name');
+      expect(savedChallengeUserTask.collapseChecklist).to.equal(true);
     });
   });
 

--- a/website/server/models/task.js
+++ b/website/server/models/task.js
@@ -119,7 +119,7 @@ TaskSchema.statics.findByIdOrAlias = async function findByIdOrAlias (identifier,
 TaskSchema.statics.sanitizeUserChallengeTask = function sanitizeUserChallengeTask (taskObj) {
   let initialSanitization = this.sanitize(taskObj);
 
-  return _.pick(initialSanitization, ['streak', 'checklist', 'attribute', 'reminders', 'tags', 'notes']);
+  return _.pick(initialSanitization, ['streak', 'checklist', 'attribute', 'reminders', 'tags', 'notes', 'collapseChecklist', 'alias']);
 };
 
 // Sanitize checklist objects (disallowing id)


### PR DESCRIPTION
Fixes #7875 
### Changes

This change allows the user to save an alias or the checklist collapse properties of a challenge task. Prior to this fix, if a user assigned an alias or collapsed a checklist on a challenge task, the data would be lost on a sync or refresh. After this update, a change to either (collapsing a checklist or creating an alias) will be saved to the database and preserved when the user refreshes.

I made this change for both alias and checklist collapse because the alias was listed in the existing test and just wasn't being tested for and is documented [here](http://habitica.wikia.com/wiki/Challenges#Challenge_Participant.27s_Permissions) that it should be modifiable. I've updated the test to make sure both these fields are save-able by the user.
