### PR TITLE
added message for challenges that could not be found - fixes #5538

### DIFF
--- a/website/client-old/js/controllers/challengesCtrl.js
+++ b/website/client-old/js/controllers/challengesCtrl.js
@@ -493,7 +493,7 @@ habitrpg.controller("ChallengesCtrl", ['$rootScope','$scope', 'Shared', 'User', 
           .then(function (response) {
             var challenge = response.data.data;
             $scope.challenges = [challenge];
-          });
+          }).catch(function() { $scope.challengeNotFound = true; });
       } else {
         Challenges.getUserChallenges()
           .then(function(response){

--- a/website/views/options/social/challenges.jade
+++ b/website/views/options/social/challenges.jade
@@ -210,3 +210,6 @@ script(type='text/ng-template', id='partials/options.social.challenges.html')
             .panel-body(ng-class='{collapse: !$stateParams.cid == challenge._id}')
               .accordion-inner(ng-if='$stateParams.cid == challenge._id')
                 div(ui-view)
+
+  .container-fluid
+    .alert.alert-danger(ng-if='challengeNotFound')=env.t('challengeNotFound')


### PR DESCRIPTION
Fixes https://github.com/HabitRPG/habitica/issues/5538
### Changes

If a user tries to access a challenge that no longer exists, a message will be displayed.

![screenshot from 2016-10-29 23-08-14](https://cloud.githubusercontent.com/assets/14113727/19833068/c266bde4-9e35-11e6-8f32-eb8d5942a2e9.png)

---

UUID:  712c8649-991b-479a-aed2-ff09f803e592
