### PR TITLE
Add flagger language to flag message sent to slack, fixes #8140

### DIFF
--- a/test/api/v3/unit/libs/slack.js
+++ b/test/api/v3/unit/libs/slack.js
@@ -19,6 +19,9 @@ describe('slack', () => {
           profile: {
             name: 'flagger',
           },
+          preferences: {
+            language: 'flagger-lang',
+          },
         },
         group: {
           id: 'group-id',
@@ -44,7 +47,7 @@ describe('slack', () => {
 
       expect(IncomingWebhook.prototype.send).to.be.calledOnce;
       expect(IncomingWebhook.prototype.send).to.be.calledWith({
-        text: 'flagger (flagger-id) flagged a message',
+        text: 'flagger (flagger-id) flagged a message (language set to flagger-lang)',
         attachments: [{
           fallback: 'Flag Message',
           color: 'danger',

--- a/website/server/libs/slack.js
+++ b/website/server/libs/slack.js
@@ -28,7 +28,7 @@ function sendFlagNotification ({
   let titleLink;
   let authorName;
   let title = `Flag in ${group.name}`;
-  let text = `${flagger.profile.name} (${flagger.id}) flagged a message`;
+  let text = `${flagger.profile.name} (${flagger.id}) flagged a message (language set to ${flagger.preferences.language})`;
 
   if (group.id === TAVERN_ID) {
     titleLink = `${BASE_URL}/#/options/groups/tavern`;


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes https://github.com/HabitRPG/habitica/issues/8140

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

The language of the person flagging a message is included in the notification to the slack channel when a message is flagged.  Tests updated to expect this.

[//]: # (Put User ID in here - found in Settings -> API)
----
UUID: dc41166c-af92-4d82-a02b-51512e26254b

