### PR TITLE
Convert test UUID to string to avoid test warning

### DIFF
--- a/test/common/ops/blockUser.test.js
+++ b/test/common/ops/blockUser.test.js
@@ -18,7 +18,7 @@ describe('shared.ops.blockUser', () => {
 
   it('validates uuid', (done) => {
     try {
-      blockUser(user, { params: { uuid: 1 } });
+      blockUser(user, { params: { uuid: '1' } });
     } catch (error) {
       expect(error.message).to.eql(i18n.t('invalidUUID'));
       done();


### PR DESCRIPTION
When running unit tests for blockUser, the following warning would be posted in the test logs:

```
validator deprecated you tried to validate a number but this library (validator.js) validates strings only. Please update your code as this will be an error soon. website/common/script/ops/blockUser.js:18:28
```

### Changes

Converts the test fake user id to a string to avoid the error.

May be advisable to change the code in `blockUser` to ignore non-string input, but it seems like an edge case.

----
UUID: 4f82317e-6f0c-4855-9512-3b9b8ca0017d

