### PR TITLE
Added party sync and request sync events

### DIFF
--- a/website/client-old/js/controllers/notificationCtrl.js
+++ b/website/client-old/js/controllers/notificationCtrl.js
@@ -14,6 +14,7 @@ habitrpg.controller('NotificationCtrl',
       if (after == before) return;
       if (User.user.stats.lvl == 0) return;
       Notification.hp(after - before, 'hp');
+      $rootScope.$broadcast('syncPartyRequest'); // Sync party to update members
       if (after < 0) $rootScope.playSound('Minus_Habit');
     });
 

--- a/website/client-old/js/controllers/notificationCtrl.js
+++ b/website/client-old/js/controllers/notificationCtrl.js
@@ -14,7 +14,10 @@ habitrpg.controller('NotificationCtrl',
       if (after == before) return;
       if (User.user.stats.lvl == 0) return;
       Notification.hp(after - before, 'hp');
-      $rootScope.$broadcast('syncPartyRequest'); // Sync party to update members
+      $rootScope.$broadcast('syncPartyRequest', {
+        type: 'user_update',
+        user: User.user,
+      }); // Sync party to update members
       if (after < 0) $rootScope.playSound('Minus_Habit');
     });
 

--- a/website/client-old/js/controllers/partyCtrl.js
+++ b/website/client-old/js/controllers/partyCtrl.js
@@ -18,6 +18,11 @@ habitrpg.controller("PartyCtrl", ['$rootScope','$scope','Groups','Chat','User','
       var partyMessageNumber = Math.floor(Math.random() * PARTY_LOADING_MESSAGES) + 1;
       $scope.partyLoadingMessage = window.env.t('partyLoading' + partyMessageNumber);
 
+      $rootScope.$on('partySynced', function (group) {
+        _.assign($rootScope.party, group);
+        $scope.group = $rootScope.party;
+      });
+
       function handlePartyResponse (group) {
         // Assign and not replace so that all the references get the modifications
         _.assign($rootScope.party, group);

--- a/website/client-old/js/controllers/partyCtrl.js
+++ b/website/client-old/js/controllers/partyCtrl.js
@@ -18,11 +18,6 @@ habitrpg.controller("PartyCtrl", ['$rootScope','$scope','Groups','Chat','User','
       var partyMessageNumber = Math.floor(Math.random() * PARTY_LOADING_MESSAGES) + 1;
       $scope.partyLoadingMessage = window.env.t('partyLoading' + partyMessageNumber);
 
-      $rootScope.$on('partySynced', function (group) {
-        _.assign($rootScope.party, group);
-        $scope.group = $rootScope.party;
-      });
-
       function handlePartyResponse (group) {
         // Assign and not replace so that all the references get the modifications
         _.assign($rootScope.party, group);

--- a/website/client-old/js/services/groupServices.js
+++ b/website/client-old/js/services/groupServices.js
@@ -107,8 +107,12 @@ angular.module('habitrpg')
       });
     };
 
-    $rootScope.$on('syncPartyRequest', function () {
-      party(true);
+    $rootScope.$on('syncPartyRequest', function (event, options) {
+      if (options.type === 'user_update') {
+        var index = _.findIndex(data.party.members, function(user) { return user._id === options.user._id; });
+        var memberToUpdate = data.party.members[index];
+        _.assign(memberToUpdate, User.user);
+      }
     });
 
     //On page load, multiple controller request the party.

--- a/website/client-old/js/services/groupServices.js
+++ b/website/client-old/js/services/groupServices.js
@@ -143,7 +143,6 @@ angular.module('habitrpg')
               })
               .then(function (response) {
                 data.party.challenges = response.data.data;
-                $rootScope.$broadcast('partySynced', data.party);
                 _cachedPartyPromise.resolve(data.party);
               });
           }, function (response) {

--- a/website/client-old/js/services/groupServices.js
+++ b/website/client-old/js/services/groupServices.js
@@ -107,6 +107,10 @@ angular.module('habitrpg')
       });
     };
 
+    $rootScope.$on('syncPartyRequest', function () {
+      party(true);
+    });
+
     //On page load, multiple controller request the party.
     //So, we cache the promise until the first result is returned
     var _cachedPartyPromise;
@@ -135,6 +139,7 @@ angular.module('habitrpg')
               })
               .then(function (response) {
                 data.party.challenges = response.data.data;
+                $rootScope.$broadcast('partySynced', data.party);
                 _cachedPartyPromise.resolve(data.party);
               });
           }, function (response) {

--- a/website/client-old/js/services/groupServices.js
+++ b/website/client-old/js/services/groupServices.js
@@ -111,7 +111,7 @@ angular.module('habitrpg')
       if (options.type === 'user_update') {
         var index = _.findIndex(data.party.members, function(user) { return user._id === options.user._id; });
         var memberToUpdate = data.party.members[index];
-        _.assign(memberToUpdate, User.user);
+        _.assign(memberToUpdate, _.pick(User.user, _.keys(memberToUpdate)));
       }
     });
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #8046

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

There are two ways to fix issue 8046 (and other sync issues). One, is to request a sync every time a page is loaded or removed the cache - but this is inefficient. The second, is to request a sync when necessary.

This provides an example of how to solve sync problems. It starts with solving 8046 by requesting a sync when the user's hp has changed because we know that the members in the party will need to be updated as well. This sort of request can be optimized further, but this is a good start. 


[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: 

