### PR TITLE
Implementing retries on failed user updates when finishing a quest

### DIFF
--- a/test/api/v3/unit/models/group.test.js
+++ b/test/api/v3/unit/models/group.test.js
@@ -1173,11 +1173,12 @@ describe('Group Model', () => {
         it('updates participating members with rewards', async () => {
           await party.finishQuest(quest);
 
-          expect(User.update).to.be.calledOnce;
+          expect(User.update).to.be.calledTwice;
           expect(User.update).to.be.calledWithMatch({
-            _id: {
-              $in: [questLeader._id, participatingMember._id],
-            },
+            _id: questLeader._id,
+          });
+          expect(User.update).to.be.calledWithMatch({
+            _id: participatingMember._id,
           });
         });
 

--- a/test/api/v3/unit/models/group.test.js
+++ b/test/api/v3/unit/models/group.test.js
@@ -1071,7 +1071,7 @@ describe('Group Model', () => {
         };
         let failedMock = {
           exec: () => {
-            return Promise.reject('err');
+            return Promise.reject(new Error('error'));
           },
         };
 
@@ -1096,7 +1096,7 @@ describe('Group Model', () => {
         it('retries failed updates at most five times per user', async () => {
           sandbox.stub(User, 'update').returns(failedMock);
 
-          await party.finishQuest(quest);
+          await expect(party.finishQuest(quest)).to.eventually.be.rejected;
 
           expect(User.update.callCount).to.eql(10);
         });

--- a/test/api/v3/unit/models/group.test.js
+++ b/test/api/v3/unit/models/group.test.js
@@ -1065,13 +1065,13 @@ describe('Group Model', () => {
 
       describe('user update retry failures', () => {
         let successfulMock = {
-          exec: (callback) => {
-            callback(null, 'sucess');
+          exec: () => {
+            return Promise.resolve({raw: 'sucess'});
           },
         };
         let failedMock = {
-          exec: (callback) => {
-            callback('error', null);
+          exec: () => {
+            return Promise.reject('err');
           },
         };
 

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -586,7 +586,7 @@ async function _updateUserWithRetries (userId, updates, numTry = 1) {
       if (numTry < MAX_UPDATE_RETRIES) {
         return _updateUserWithRetries(userId, updates, ++numTry);
       } else {
-        return err;
+        throw err;
       }
     });
 }

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -582,7 +582,7 @@ async function _updateUserWithRetries (userId, updates, numTry = 1) {
   return await User.update({_id: userId}, updates).exec()
     .then((raw) => {
       return raw;
-    }, (err) => {
+    }).catch((err) => {
       if (numTry < MAX_UPDATE_RETRIES) {
         return _updateUserWithRetries(userId, updates, ++numTry);
       } else {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #8035 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Added a finite retry system for individual user updates when finishing a quest. This should help prevent users not getting the quest rewards when their party finishes a quest. The retry system currently allows up to 30 seconds of retries but this can be adjusted as needed depending on the load and timeouts seen by mongo.

Let me know if you have any comments!