### PR TITLE
fix: prevents blank messages from being posted to chat

### DIFF
--- a/test/api/v3/integration/chat/POST-chat.test.js
+++ b/test/api/v3/integration/chat/POST-chat.test.js
@@ -35,6 +35,15 @@ describe('POST /chat', () => {
       });
   });
 
+  it('Returns an error when an empty message is provided', async () => {
+    await expect(user.post(`/groups/${groupWithChat._id}/chat`, { message: '    '}))
+      .to.eventually.be.rejected.and.eql({
+        code: 400,
+        error: 'BadRequest',
+        message: t('invalidReqParams'),
+      });
+  });
+
   it('Returns an error when group is not found', async () => {
     await expect(user.post('/groups/invalidID/chat', { message: testMessage})).to.eventually.be.rejected.and.eql({
       code: 404,

--- a/test/api/v3/integration/chat/POST-chat.test.js
+++ b/test/api/v3/integration/chat/POST-chat.test.js
@@ -44,6 +44,15 @@ describe('POST /chat', () => {
       });
   });
 
+  it.only('Returns an error when an message containing only newlines is provided', async () => {
+    await expect(user.post(`/groups/${groupWithChat._id}/chat`, { message: '\n\n'}))
+      .to.eventually.be.rejected.and.eql({
+        code: 400,
+        error: 'BadRequest',
+        message: t('invalidReqParams'),
+      });
+  });
+
   it('Returns an error when group is not found', async () => {
     await expect(user.post('/groups/invalidID/chat', { message: testMessage})).to.eventually.be.rejected.and.eql({
       code: 404,

--- a/test/api/v3/integration/chat/POST-chat.test.js
+++ b/test/api/v3/integration/chat/POST-chat.test.js
@@ -44,7 +44,7 @@ describe('POST /chat', () => {
       });
   });
 
-  it.only('Returns an error when an message containing only newlines is provided', async () => {
+  it('Returns an error when an message containing only newlines is provided', async () => {
     await expect(user.post(`/groups/${groupWithChat._id}/chat`, { message: '\n\n'}))
       .to.eventually.be.rejected.and.eql({
         code: 400,

--- a/website/server/controllers/api-v3/chat.js
+++ b/website/server/controllers/api-v3/chat.js
@@ -93,6 +93,7 @@ api.postChat = {
     let chatUpdated;
 
     req.checkParams('groupId', res.t('groupIdRequired')).notEmpty();
+    req.sanitize('message').trim();
     req.checkBody('message', res.t('messageGroupChatBlankMessage')).notEmpty();
 
     let validationErrors = req.validationErrors();


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #8255 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
I've updated the server to reject requests to postChat when the message from the user contains only whitespace. This should prevent chat messages from being posted via the mobile or third party apps that do not have any text.