### PR TITLE
Fix a bug where 1005-768 the avatars and health bar get covered up.

### DIFF
--- a/website/client-old/css/header.styl
+++ b/website/client-old/css/header.styl
@@ -91,6 +91,10 @@
   height: 10.5em
   width: 100%
 
+  // Covers avatars, health bar at 1005-768. Fix:
+  @media  (max-width: 1005px) and (min-width: 768px)
+    margin-top: 2.8em;
+
 // this is a wrapper for avatars in the header
 // inside this is the actual `herobox` module
 // that can be used anywhere on the site


### PR DESCRIPTION
Fixes https://github.com/HabitRPG/habitica/issues/8089

### Changes
Fixes an annoyance where wrapping the stats bar at the top 1005-768 would cover the avatars and health bar. Original bug topped out at 979 but other changes to the stat bar shifted the max to 1005.

In screenshot, top is Before, bottom is After.

![ss](https://cloud.githubusercontent.com/assets/862954/20970631/7c3a9512-bc5c-11e6-8c2c-ea8feafbf3bf.png)


----
UUID: 3453f276-65dd-4736-ace5-28d5ab484957

