### PR TITLE
fix: confirm no user objects reference a group before deleting it when the member count reaches 0

### DIFF
--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -868,9 +868,9 @@ schema.methods.leave = async function leaveGroup (user, keep = 'keep-all') {
     // double check the member count is correct so we don't accidentally delete a group that still has users in it
     let members;
     if (group.type === 'guild') {
-      members = await User.find({guilds: group._id}, '_id');
+      members = await User.find({guilds: group._id}).select('_id').exec();
     } else {
-      members = await User.find({'party._id': group._id}, '_id');
+      members = await User.find({'party._id': group._id}).select('_id').exec();
     }
     _.remove(members, {_id: user._id});
     if (members.length === 0) {

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -835,9 +835,7 @@ schema.statics.tavernBoss = async function tavernBoss (user, progress) {
 
 schema.methods.leave = async function leaveGroup (user, keep = 'keep-all') {
   let group = this;
-  let update = {
-    $inc: {memberCount: -1},
-  };
+  let update = {};
 
   let challenges = await Challenge.find({
     _id: {$in: user.challenges},
@@ -867,18 +865,30 @@ schema.methods.leave = async function leaveGroup (user, keep = 'keep-all') {
 
   // If user is the last one in group and group is private, delete it
   if (group.memberCount <= 1 && group.privacy === 'private') {
-    promises.push(group.remove());
-  } else { // otherwise If the leader is leaving (or if the leader previously left, and this wasn't accounted for)
-    if (group.leader === user._id) {
-      let query = group.type === 'party' ? {'party._id': group._id} : {guilds: group._id};
-      query._id = {$ne: user._id};
-      let seniorMember = await User.findOne(query).select('_id').exec();
-
-      // could be missing in case of public guild (that can have 0 members) with 1 member who is leaving
-      if (seniorMember) update.$set = {leader: seniorMember._id};
+    // double check the member count is correct so we don't accidentally delete a group that still has users in it
+    let members;
+    if (group.type === 'guild') {
+      members = await User.find({guilds: group._id}, '_id');
+    } else {
+      members = await User.find({'party._id': group._id}, '_id');
     }
-    promises.push(group.update(update).exec());
+    _.remove(members, {_id: user._id});
+    if (members.length === 0) {
+      promises.push(group.remove());
+      return await Bluebird.all(promises);
+    }
   }
+  // otherwise If the leader is leaving (or if the leader previously left, and this wasn't accounted for)
+  update.$inc = {memberCount: -1};
+  if (group.leader === user._id) {
+    let query = group.type === 'party' ? {'party._id': group._id} : {guilds: group._id};
+    query._id = {$ne: user._id};
+    let seniorMember = await User.findOne(query).select('_id').exec();
+
+    // could be missing in case of public guild (that can have 0 members) with 1 member who is leaving
+    if (seniorMember) update.$set = {leader: seniorMember._id};
+  }
+  promises.push(group.update(update).exec());
 
   return await Bluebird.all(promises);
 };


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #7723 
### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
This code queries for any user objects that reference the group that's at risk of being deleted to confirm there are no members remaining before actually deleting the group. This helps remove the risk of accidentally deleting a group due to an inaccurate member count field. I've also added tests around this new behavior.