### PR TITLE
Updating group.removeMember api to send an email for rescinded party invite

### DIFF
--- a/test/api/v3/integration/groups/POST-groups_id_removeMember.test.js
+++ b/test/api/v3/integration/groups/POST-groups_id_removeMember.test.js
@@ -4,6 +4,9 @@ import {
   translate as t,
 } from '../../../../helpers/api-v3-integration.helper';
 import * as email from '../../../../../website/server/libs/email';
+import { model as User } from '../../../../../website/server/models/user';
+
+
 
 describe('POST /groups/:groupId/removeMember/:memberId', () => {
   let leader;
@@ -94,6 +97,7 @@ describe('POST /groups/:groupId/removeMember/:memberId', () => {
       await leader.post(`/groups/${guild._id}/removeMember/${invitedUser._id}`);
 
       expect(email.sendTxn).to.be.calledOnce;
+      expect(email.sendTxn.args[0][0]._id).to.be.eql(invitedUser._id);
       expect(email.sendTxn.args[0][1]).to.be.eql('guild-invite-rescinded');
     });
 
@@ -101,6 +105,7 @@ describe('POST /groups/:groupId/removeMember/:memberId', () => {
       await leader.post(`/groups/${guild._id}/removeMember/${member._id}`);
 
       expect(email.sendTxn).to.be.calledOnce;
+      expect(email.sendTxn.args[0][0]._id).to.be.eql(member._id);
       expect(email.sendTxn.args[0][1]).to.be.eql('kicked-from-guild');
     });
   });
@@ -220,6 +225,7 @@ describe('POST /groups/:groupId/removeMember/:memberId', () => {
       await partyLeader.post(`/groups/${party._id}/removeMember/${partyInvitedUser._id}`);
 
       expect(email.sendTxn).to.be.calledOnce;
+      expect(email.sendTxn.args[0][0]._id).to.be.eql(partyInvitedUser._id);
       expect(email.sendTxn.args[0][1]).to.be.eql('party-invite-rescinded');
     });
 
@@ -227,6 +233,7 @@ describe('POST /groups/:groupId/removeMember/:memberId', () => {
       await partyLeader.post(`/groups/${party._id}/removeMember/${partyMember._id}`);
 
       expect(email.sendTxn).to.be.calledOnce;
+      expect(email.sendTxn.args[0][0]._id).to.be.eql(partyMember._id);
       expect(email.sendTxn.args[0][1]).to.be.eql('kicked-from-party');
     });
   });

--- a/test/api/v3/integration/groups/POST-groups_id_removeMember.test.js
+++ b/test/api/v3/integration/groups/POST-groups_id_removeMember.test.js
@@ -4,9 +4,6 @@ import {
   translate as t,
 } from '../../../../helpers/api-v3-integration.helper';
 import * as email from '../../../../../website/server/libs/email';
-import { model as User } from '../../../../../website/server/models/user';
-
-
 
 describe('POST /groups/:groupId/removeMember/:memberId', () => {
   let leader;

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -468,9 +468,10 @@ api.leaveGroup = {
 };
 
 // Send an email to the removed user with an optional message from the leader
-function _sendMessageToRemoved (group, removedUser, message) {
+function _sendMessageToRemoved (group, removedUser, message, isInGroup) {
   if (removedUser.preferences.emailNotifications.kickedGroup !== false) {
-    sendTxnEmail(removedUser, `kicked-from-${group.type}`, [
+    let subject = isInGroup ? `kicked-from-${group.type}` : `${group.type}-invite-rescinded`;
+    sendTxnEmail(removedUser, subject, [
       {name: 'GROUP_NAME', content: group.name},
       {name: 'MESSAGE', content: message},
       {name: 'GUILDS_LINK', content: '/#/options/groups/guilds/public'},
@@ -575,7 +576,7 @@ api.removeGroupMember = {
     }
 
     let message = req.query.message;
-    if (message) _sendMessageToRemoved(group, member, message);
+    _sendMessageToRemoved(group, member, message, isInGroup);
 
     await Bluebird.all([
       member.save(),


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #7618 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
This change makes it so a user is sent an email notification when they have an invite rescinded for a group or when they are removed from the group even when the user doesn't send a message. This still requires text to be added to the email server by an admin.

Let me know any feedback you have!