### PR TITLE
Fixes character appears too high in avatar on profile when no pet/mount is equipped

### DIFF
--- a/website/client-old/css/avatar.styl
+++ b/website/client-old/css/avatar.styl
@@ -80,7 +80,7 @@ future re: pets and whatnot, this is just temporary.
   &.hasPet
     padding-top: 1.75em
   &.hasMount
-    padding-top:0em
+    padding-top: 0em !important
 
   // Backgrounds – Set a background color when no background image is set
   &.noBackgroundImage

--- a/website/client-old/css/index.styl
+++ b/website/client-old/css/index.styl
@@ -130,6 +130,7 @@ html, body
     &.herobox
       padding-right: 0px
       padding-left: 0px
+      padding-top: 2em
 
 .death-modal // a .modal-body
   margin: 10px
@@ -217,8 +218,7 @@ div[window-class="vertically-centered-modals"]:before
   vertical-align: middle
   margin-right: -4px // Adjusts for spacing
 
-div[window-class="vertically-centered-modals"] .modal-dialog 
+div[window-class="vertically-centered-modals"] .modal-dialog
   display: inline-block
   text-align: left
   vertical-align: middle
-


### PR DESCRIPTION
Fixes  #7916

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
The glitch happens because ".modal-body figure" class is overriding ".herobox" class' padding.
So I explicitly define top padding for herobox child class of modal-body class.

![screen shot 2559-12-28 at 9 04 51 pm](https://cloud.githubusercontent.com/assets/1594393/21523547/d34ec3b4-cd41-11e6-9352-0e815393ced8.png)

[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: 889bd197-3c24-47f4-a758-cd1da949213b