### PR TITLE
Add 'Save & Close' and 'Cancel' buttons to top of task edit modal

### DIFF
--- a/website/client-old/css/tasks.styl
+++ b/website/client-old/css/tasks.styl
@@ -556,7 +556,11 @@ form
         min-width: 2.5em
   .save-close
     text-align: center
+    display: inline
+    padding: 0 0.5em
     @extend $hrpg-button
+  h2#task-edit-title
+    margin-top: 1em
 
 // Dailies
 .dailies

--- a/website/views/shared/tasks/edit/index.jade
+++ b/website/views/shared/tasks/edit/index.jade
@@ -1,7 +1,14 @@
 div(ng-if='task._editing')
   .task-options
-    h2 {{task._edit.text}}
-  
+    .save-close
+      button(type='submit', ng-click='saveTask(task,false,true); $close()')=env.t('saveAndClose')
+    .save-close
+      button(ng-click='cancelTaskEdit(task); $close()')=env.t('cancel')
+
+    br
+
+    h2#task-edit-title {{task._edit.text}}
+
     // Broken Challenge
     .well(ng-if='task.challenge.broken')
       div(ng-if='task.challenge.broken=="TASK_DELETED" || task.challenge.broken=="CHALLENGE_TASK_NOT_FOUND"')
@@ -51,10 +58,5 @@ div(ng-if='task._editing')
 
       .save-close
         button(type='submit', ng-click='saveTask(task,false,true); $close()')=env.t('saveAndClose')
-      
-      br
-      br
-      
       .save-close
         button(ng-click='cancelTaskEdit(task); $close()')=env.t('cancel')
-        


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #8316 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Implements 'Save & Close' and 'Cancel' buttons at the top of the edit task modal to prevent users from having to scroll all the way to the bottom of the modal to use these buttons. I found that having the two buttons centered inline looked best, but feedback is welcome.

![top](https://cloud.githubusercontent.com/assets/12753198/21505931/fa1fd220-cc39-11e6-9f95-db8053c3afc4.png)

I've also adjusted the styles of the buttons at the bottom of the modal to be consistent with the top buttons.

![bottom](https://cloud.githubusercontent.com/assets/12753198/21505935/002210e8-cc3a-11e6-9be8-d6650f2b26c9.png)


[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: 
bd794f6e-3845-49e5-88cc-a140b24cdea4