### PR TITLE
Add 'balanceGemAmount' to Amplitude #8057

### DIFF
--- a/test/api/v3/unit/libs/analyticsService.test.js
+++ b/test/api/v3/unit/libs/analyticsService.test.js
@@ -303,7 +303,7 @@ describe('analyticsService', () => {
                 contributorLevel: 1,
                 subscription: 'foo-plan',
                 balance: 12,
-                balanceGemAmount: 3,
+                balanceGemAmount: 48,
                 loginIncentives: 1,
               },
             });

--- a/test/api/v3/unit/libs/analyticsService.test.js
+++ b/test/api/v3/unit/libs/analyticsService.test.js
@@ -303,6 +303,7 @@ describe('analyticsService', () => {
                 contributorLevel: 1,
                 subscription: 'foo-plan',
                 balance: 12,
+                balanceGemAmount: 3,
                 loginIncentives: 1,
               },
             });

--- a/test/client-old/spec/services/analyticsServicesSpec.js
+++ b/test/client-old/spec/services/analyticsServicesSpec.js
@@ -194,6 +194,7 @@ describe('Analytics Service', function () {
           rewards: 1
         };
         expectedProperties.balance = 12;
+        expectedProperties.balanceGemAmount = 3;
 
         beforeEach(function() {
           user._id = 'unique-user-id';
@@ -243,7 +244,8 @@ describe('Analytics Service', function () {
             habits: 1,
             rewards: 1
           },
-          balance: 12
+          balance: 12,
+          balanceGemAmount: 3
         };
 
         beforeEach(function() {

--- a/test/client-old/spec/services/analyticsServicesSpec.js
+++ b/test/client-old/spec/services/analyticsServicesSpec.js
@@ -194,7 +194,7 @@ describe('Analytics Service', function () {
           rewards: 1
         };
         expectedProperties.balance = 12;
-        expectedProperties.balanceGemAmount = 3;
+        expectedProperties.balanceGemAmount = 48;
 
         beforeEach(function() {
           user._id = 'unique-user-id';
@@ -245,7 +245,7 @@ describe('Analytics Service', function () {
             rewards: 1
           },
           balance: 12,
-          balanceGemAmount: 3
+          balanceGemAmount: 48
         };
 
         beforeEach(function() {

--- a/website/client-old/js/services/analyticsServices.js
+++ b/website/client-old/js/services/analyticsServices.js
@@ -129,6 +129,7 @@
     }
 
     properties.balance = user.balance;
+    properties.balanceGemAmount = properties.balance / 4;
 
     properties.tutorialComplete = user.flags && user.flags.tour && user.flags.tour.intro === -2;
     if (user.habits && user.dailys && user.todos && user.rewards) {

--- a/website/client-old/js/services/analyticsServices.js
+++ b/website/client-old/js/services/analyticsServices.js
@@ -129,7 +129,7 @@
     }
 
     properties.balance = user.balance;
-    properties.balanceGemAmount = properties.balance / 4;
+    properties.balanceGemAmount = properties.balance * 4;
 
     properties.tutorialComplete = user.flags && user.flags.tour && user.flags.tour.intro === -2;
     if (user.habits && user.dailys && user.todos && user.rewards) {

--- a/website/server/libs/analyticsService.js
+++ b/website/server/libs/analyticsService.js
@@ -68,6 +68,7 @@ let _formatUserData = (user) => {
   }
 
   properties.balance = user.balance;
+  properties.balanceGemAmount = properties.balance / 4;
 
   properties.tutorialComplete = user.flags && user.flags.tour && user.flags.tour.intro === -2;
 

--- a/website/server/libs/analyticsService.js
+++ b/website/server/libs/analyticsService.js
@@ -68,7 +68,7 @@ let _formatUserData = (user) => {
   }
 
   properties.balance = user.balance;
-  properties.balanceGemAmount = properties.balance / 4;
+  properties.balanceGemAmount = properties.balance * 4;
 
   properties.tutorialComplete = user.flags && user.flags.tour && user.flags.tour.intro === -2;
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #8057

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
- Added a 'balanceGemAmount' property
- ~~'balanceGemAmount' is equal to the 'balance' property divided by 4~~
- 'balanceGemAmount' is equal to the 'balance' property times by 4
- Added a check for the correct 'balanceGemAmount' in api unit test and client-old services test


[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: a3f88ebe-efd8-4ff9-a887-efb5d2522a97
