### PR TITLE
Fixes pressing enter to confirm character choice in IME creates new checklist line

### DIFF
--- a/website/views/shared/tasks/edit/checklist.jade
+++ b/website/views/shared/tasks/edit/checklist.jade
@@ -18,6 +18,6 @@
           //-,ng-blur='saveTask(task,true)')
           span.checklist-icon.glyphicon.glyphicon-resize-vertical
           input(type='text', ng-model='item.text',
-            ui-keyup="{'13':'addChecklistItem(task,$event,$index)','38 40':'navigateChecklist(task,$index,$event)'}")
+            ui-keydown="{'13':'addChecklistItem(task,$event,$index)','38 40':'navigateChecklist(task,$index,$event)'}")
           a(ng-click='removeChecklistItem(task,$event,$index,true)')
             span.glyphicon.glyphicon-trash(tooltip=env.t('delete'))


### PR DESCRIPTION
Fixes #8326 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

I changed the event from "ui-keyup" to "ui-keydown".

First, this issue was happened on OS X El Capitan and macOS Sierra.
The cause of the issue was that Enter pressing event was acquired only for "ui-keyup" **at character conversion**. ("ui-keydown", "ui-keypress" do not work in this case. I think this case should **not** trigger any key-event, including "ui-keyup", like on Windows.)

The behavior of the IME is well explained in that issue by @citrusella.

▼Before
![habitica_bug_report](https://cloud.githubusercontent.com/assets/1789422/21517930/afdd1156-cc97-11e6-8884-be2884f5b074.gif)

▼After
![habitica_bug_report_after](https://cloud.githubusercontent.com/assets/1789422/21563250/0c741362-ce35-11e6-93ce-b55dafb57b20.gif)

[//]: # (Put User ID in here - found in Settings -> API)

Feedback is welcome, thank you.

----
UUID: 1c980e87-ef12-471b-a812-4a020cc226c1
