### PR TITLE
Fixes on-hover notes on tasks do not update after you edit the notes, until a sync occurs

### DIFF
--- a/website/views/shared/tasks/task.jade
+++ b/website/views/shared/tasks/task.jade
@@ -5,7 +5,7 @@ li(id='task-{{::task._id}}',
   ng-click='spell && (list.type != "reward") && castEnd(task, "task", $event)',
   ng-show='shouldShow(task, list, user.preferences)',
   popover-trigger='mouseenter', popover-placement="top", popover-append-to-body='{{::modal ? "false":"true"}}',
-  data-popover-html="{{::taskPopover(task) | markdown}}")
+  data-popover-html="{{taskPopover(task)}}")
 
   ng-form(name='taskForm')
     include ./meta_controls

--- a/website/views/shared/tasks/task.jade
+++ b/website/views/shared/tasks/task.jade
@@ -5,7 +5,7 @@ li(id='task-{{::task._id}}',
   ng-click='spell && (list.type != "reward") && castEnd(task, "task", $event)',
   ng-show='shouldShow(task, list, user.preferences)',
   popover-trigger='mouseenter', popover-placement="top", popover-append-to-body='{{::modal ? "false":"true"}}',
-  data-popover-html="{{taskPopover(task)}}")
+  data-popover-html="{{taskPopover(task) | markdown}}")
 
   ng-form(name='taskForm')
     include ./meta_controls


### PR DESCRIPTION
Fixes #8352 

### Changes
I removed the one-time-binding syntax from the logic that displays notes, this one-time-binding meant the notes' value was only being computed at initialisation and sync, not reflecting local updates to the task data.

----
UUID: f301baf5-b41b-44f0-8978-ee3e7764b8e1
