### PR TITLE
Avoid setting profile name to not found

### DIFF
--- a/test/api/v3/integration/user/PUT-user.test.js
+++ b/test/api/v3/integration/user/PUT-user.test.js
@@ -26,6 +26,32 @@ describe('PUT /user', () => {
       expect(user.preferences.costume).to.eql(true);
       expect(user.stats.hp).to.eql(14);
     });
+
+    it('profile.name cannot be an empty string or null', async () => {
+      await expect(user.put('/user', {
+        'profile.name': ' ', // string should be trimmed
+      })).to.eventually.be.rejected.and.eql({
+        code: 400,
+        error: 'BadRequest',
+        message: 'User validation failed',
+      });
+
+      await expect(user.put('/user', {
+        'profile.name': '',
+      })).to.eventually.be.rejected.and.eql({
+        code: 400,
+        error: 'BadRequest',
+        message: 'User validation failed',
+      });
+
+      await expect(user.put('/user', {
+        'profile.name': null,
+      })).to.eventually.be.rejected.and.eql({
+        code: 400,
+        error: 'BadRequest',
+        message: 'User validation failed',
+      });
+    });
   });
 
   context('Top Level Protected Operations', () => {

--- a/test/api/v3/integration/user/auth/POST-register_local.test.js
+++ b/test/api/v3/integration/user/auth/POST-register_local.test.js
@@ -32,6 +32,7 @@ describe('POST /user/auth/local/register', () => {
       expect(user._id).to.exist;
       expect(user.apiToken).to.exist;
       expect(user.auth.local.username).to.eql(username);
+      expect(user.profile.name).to.eql(username);
     });
 
     it('provides default tags and tasks', async () => {

--- a/test/api/v3/integration/user/auth/POST-user_auth_social.test.js
+++ b/test/api/v3/integration/user/auth/POST-user_auth_social.test.js
@@ -33,7 +33,7 @@ describe('POST /user/auth/social', () => {
 
   describe('facebook', () => {
     before(async () => {
-      let expectedResult = {id: facebookId};
+      let expectedResult = {id: facebookId, displayName: 'a facebook user'};
       sandbox.stub(passport._strategies.facebook, 'userProfile').yields(null, expectedResult);
       network = 'facebook';
     });
@@ -47,6 +47,7 @@ describe('POST /user/auth/social', () => {
       expect(response.apiToken).to.exist;
       expect(response.id).to.exist;
       expect(response.newUser).to.be.true;
+      await expect(getProperty('users', response.id, 'profile.name')).to.eventually.equal('a facebook user');
     });
 
     it('logs an existing user in', async () => {
@@ -88,7 +89,7 @@ describe('POST /user/auth/social', () => {
 
   describe('google', () => {
     before(async () => {
-      let expectedResult = {id: googleId};
+      let expectedResult = {id: googleId, displayName: 'a google user'};
       sandbox.stub(passport._strategies.google, 'userProfile').yields(null, expectedResult);
       network = 'google';
     });
@@ -102,6 +103,7 @@ describe('POST /user/auth/social', () => {
       expect(response.apiToken).to.exist;
       expect(response.id).to.exist;
       expect(response.newUser).to.be.true;
+      await expect(getProperty('users', response.id, 'profile.name')).to.eventually.equal('a google user');
     });
 
     it('logs an existing user in', async () => {

--- a/website/server/models/user/hooks.js
+++ b/website/server/models/user/hooks.js
@@ -131,6 +131,16 @@ function _setProfileName (user) {
   return localUsername || _getFacebookName(user.auth.facebook) || googleUsername || anonymous;
 }
 
+schema.pre('validate', function preValidateUser (next) {
+  // Populate new user with profile name, not running in pre('save') because the field
+  // is required and validation fails if it doesn't exists like for new users
+  if (this.isNew) {
+    this.profile.name = _setProfileName(this);
+  }
+
+  next();
+});
+
 schema.pre('save', true, function preSaveUser (next, done) {
   next();
 
@@ -178,10 +188,8 @@ schema.pre('save', true, function preSaveUser (next, done) {
   if (_.isNaN(this._v) || !_.isNumber(this._v)) this._v = 0;
   this._v++;
 
-  // Populate new users with default content and profile name
+  // Populate new users with default content
   if (this.isNew) {
-    this.profile.name = _setProfileName(this);
-
     _setUpNewUser(this)
       .then(() => done())
       .catch(done);

--- a/website/server/models/user/hooks.js
+++ b/website/server/models/user/hooks.js
@@ -138,10 +138,6 @@ schema.pre('save', true, function preSaveUser (next, done) {
     this.preferences.dayStart = 0;
   }
 
-  if (this.isNew || this.profile.name === '') {
-    this.profile.name = _setProfileName(this);
-  }
-
   // Determines if Beast Master should be awarded
   let beastMasterProgress = shared.count.beastMasterProgress(this.items.pets);
 
@@ -182,8 +178,10 @@ schema.pre('save', true, function preSaveUser (next, done) {
   if (_.isNaN(this._v) || !_.isNumber(this._v)) this._v = 0;
   this._v++;
 
-  // Populate new users with default content
+  // Populate new users with default content and profile name
   if (this.isNew) {
+    this.profile.name = _setProfileName(this);
+
     _setUpNewUser(this)
       .then(() => done())
       .catch(done);

--- a/website/server/models/user/hooks.js
+++ b/website/server/models/user/hooks.js
@@ -138,10 +138,6 @@ schema.pre('save', true, function preSaveUser (next, done) {
     this.preferences.dayStart = 0;
   }
 
-  if (!this.profile.name) {
-    this.profile.name = _setProfileName(this);
-  }
-
   // Determines if Beast Master should be awarded
   let beastMasterProgress = shared.count.beastMasterProgress(this.items.pets);
 
@@ -182,8 +178,10 @@ schema.pre('save', true, function preSaveUser (next, done) {
   if (_.isNaN(this._v) || !_.isNumber(this._v)) this._v = 0;
   this._v++;
 
-  // Populate new users with default content
+  // Populate new users with default content and set profile name
   if (this.isNew) {
+    this.profile.name = _setProfileName(this);
+
     _setUpNewUser(this)
       .then(() => done())
       .catch(done);

--- a/website/server/models/user/hooks.js
+++ b/website/server/models/user/hooks.js
@@ -138,6 +138,10 @@ schema.pre('save', true, function preSaveUser (next, done) {
     this.preferences.dayStart = 0;
   }
 
+  if (this.isNew || this.profile.name === '') {
+    this.profile.name = _setProfileName(this);
+  }
+
   // Determines if Beast Master should be awarded
   let beastMasterProgress = shared.count.beastMasterProgress(this.items.pets);
 
@@ -178,10 +182,8 @@ schema.pre('save', true, function preSaveUser (next, done) {
   if (_.isNaN(this._v) || !_.isNumber(this._v)) this._v = 0;
   this._v++;
 
-  // Populate new users with default content and set profile name
+  // Populate new users with default content
   if (this.isNew) {
-    this.profile.name = _setProfileName(this);
-
     _setUpNewUser(this)
       .then(() => done())
       .catch(done);

--- a/website/server/models/user/hooks.js
+++ b/website/server/models/user/hooks.js
@@ -134,7 +134,7 @@ function _setProfileName (user) {
 schema.pre('validate', function preValidateUser (next) {
   // Populate new user with profile name, not running in pre('save') because the field
   // is required and validation fails if it doesn't exists like for new users
-  if (this.isNew) {
+  if (this.isNew && !this.profile.name) {
     this.profile.name = _setProfileName(this);
   }
 

--- a/website/server/models/user/schema.js
+++ b/website/server/models/user/schema.js
@@ -472,7 +472,11 @@ let schema = new Schema({
   profile: {
     blurb: String,
     imageUrl: String,
-    name: String,
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+    },
   },
   stats: {
     hp: {type: Number, default: shared.maxHealth},


### PR DESCRIPTION
The `profile name not found` bug happens when the user is loaded without the `profile` part: when the user is saved the code check for existence of `profile.name` and if it cannot find it (even if it exists but has not been loaded) it set it to (in order): username, google and fb profile names and at last fallbacks to `profile name not found`.

This PR makes sure the `profile.name` always exists by adding a required validator on it that prevents it to be set to an empty string and only set the profile name automatically when the user is created.
