### PR TITLE
Mods blocking - when adjusting a previously-blocked user, do not cause them to rest in the inn

### DIFF
--- a/test/api/v3/integration/hall/PUT-hall_heores_heroId.test.js
+++ b/test/api/v3/integration/hall/PUT-hall_heores_heroId.test.js
@@ -40,13 +40,14 @@ describe('PUT /heroes/:heroId', () => {
     });
   });
 
-  it('updates contributor level, balance, ads, blocked', async () => {
+  it('change contributor level, balance, ads', async () => {
     let hero = await generateUser();
+    let prevBlockState = hero.auth.blocked;
+    let prevSleepState = hero.preferences.sleep;
     let heroRes = await user.put(`/hall/heroes/${hero._id}`, {
       balance: 3,
       contributor: {level: 1},
       purchased: {ads: true},
-      auth: {blocked: true},
     });
 
     // test response
@@ -61,16 +62,45 @@ describe('PUT /heroes/:heroId', () => {
     expect(heroRes.balance).to.equal(3 + 0.75); // 3+0.75 for first contrib level
     expect(heroRes.contributor.level).to.equal(1);
     expect(heroRes.purchased.ads).to.equal(true);
-    expect(heroRes.auth.blocked).to.equal(true);
     // test hero values
     await hero.sync();
     expect(hero.balance).to.equal(3 + 0.75); // 3+0.75 for first contrib level
     expect(hero.contributor.level).to.equal(1);
     expect(hero.purchased.ads).to.equal(true);
-    expect(hero.auth.blocked).to.equal(true);
-    expect(hero.preferences.sleep).to.equal(true);
+    expect(hero.auth.blocked).to.equal(prevBlockState);
+    expect(hero.preferences.sleep).to.equal(prevSleepState);
     expect(hero.notifications.length).to.equal(1);
     expect(hero.notifications[0].type).to.equal('NEW_CONTRIBUTOR_LEVEL');
+  });
+
+  it('block a user', async () => {
+    let hero = await generateUser();
+    let heroRes = await user.put(`/hall/heroes/${hero._id}`, {
+      auth: {blocked: true},
+      preferences: {sleep: true},
+    });
+
+    // test response values
+    expect(heroRes.auth.blocked).to.equal(true);
+    // test hero values
+    await hero.sync();
+    expect(hero.auth.blocked).to.equal(true);
+    expect(hero.preferences.sleep).to.equal(true);
+  });
+
+  it('unblock a user', async () => {
+    let hero = await generateUser();
+    let prevSleepState = hero.preferences.sleep;
+    let heroRes = await user.put(`/hall/heroes/${hero._id}`, {
+      auth: {blocked: false},
+    });
+
+    // test response values
+    expect(heroRes.auth.blocked).to.equal(false);
+    // test hero values
+    await hero.sync();
+    expect(hero.auth.blocked).to.equal(false);
+    expect(hero.preferences.sleep).to.equal(prevSleepState);
   });
 
   it('updates chatRevoked flag', async () => {

--- a/website/server/controllers/api-v3/hall.js
+++ b/website/server/controllers/api-v3/hall.js
@@ -177,9 +177,12 @@ api.updateHero = {
       _.set(hero, updateData.itemPath, updateData.itemVal); // Sanitization at 5c30944 (deemed unnecessary)
     }
 
-    if (updateData.auth && _.isBoolean(updateData.auth.blocked)) {
+    if (updateData.auth && updateData.auth.blocked === true) {
       hero.auth.blocked = updateData.auth.blocked;
       hero.preferences.sleep = true; // when blocking, have them rest at an inn to prevent damage
+    }
+    if (updateData.auth && updateData.auth.blocked === false) {
+      hero.auth.blocked = false;
     }
     if (updateData.flags && _.isBoolean(updateData.flags.chatRevoked)) hero.flags.chatRevoked = updateData.flags.chatRevoked;
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes https://github.com/HabitRPG/habitica/issues/8254

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Changed the logic for moderators updating user accounts so that previously blocked users are not put to sleep.
Changed three tests to reflect this:
- change contributor level, balance, ads: No longer checks blocking at the same time. Checks if block/sleep haven't been changed.
- block a user: checks that users are blocked and asleep
- unblock a user: checks that users are unblocked and don't changed sleep state

[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: e48c8f5d-6ec9-49a0-9713-354447be2d17
