### PR TITLE
Fixes #8315 - Background of task editing modal is white if you double-click the task

### DIFF
--- a/website/client-old/js/controllers/tasksCtrl.js
+++ b/website/client-old/js/controllers/tasksCtrl.js
@@ -77,7 +77,7 @@ habitrpg.controller("TasksCtrl", ['$scope', '$rootScope', '$location', 'User','N
       if (task._editing) {
         $scope.saveTask(task);
       } else {
-        $scope.editTask(task, User.user);
+        $scope.editTask(task, User.user, Shared.taskClasses(task, [], User.user.preferences.dayStart));
       }
     }
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes https://github.com/HabitRPG/habitica/issues/8315

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

When tasks were double-clicked, task-editing modals would not be given the correct HTML class names, and would therefore use the wrong CSS. This would cause the modals to render with a flat white background, as seen here:

![habitica_task_wrong](https://cloud.githubusercontent.com/assets/798619/21668662/99ffba22-d2c9-11e6-9a71-cfd382633400.png)

This is due to the editTask() function being called without the expected taskStatus parameter (see website/client-old/js/controllers/taskCtrl.js:L80). This parameter should be a list of class names as generated by the taskClasses() function exported by website/common/script/libs/taskClasses.js.

This fix simply calls taskClasses(), passing the result directly to editTask(). Most of the parameters to taskClasses() are left as their defaults, since few of them appear to be relevant to rendering the task editing modal. This displays the modal with the appropriate CSS, as seen in this image which shows a task that has been opened with a double-click after the fix has been applied

![habitica_task_right](https://cloud.githubusercontent.com/assets/798619/21668669/a124d76a-d2c9-11e6-9bbc-44a2c6eb2848.png)

[//]: # 

----
UUID: a654bd1f-e925-438b-8d98-9ac4462b973f 
