### PR TITLE
Added fix to correctly check if object is sub group for all users

### DIFF
--- a/website/views/shared/tasks/edit/advanced_options.jade
+++ b/website/views/shared/tasks/edit/advanced_options.jade
@@ -10,7 +10,7 @@ div(ng-if='::task.type!="reward"')
     input.form-control(ng-model='task._edit.alias' type='text' placeholder=env.t('taskAliasPlaceholder'))
 
   fieldset.option-group.advanced-option(ng-show="task._edit._advanced")
-    group-tasks-actions(ng-if="obj.purchased && obj.purchased.plan && obj.purchased.plan.customerId", task='task', group='obj')
+    group-tasks-actions(ng-if="!obj.auth && obj.purchased && obj.purchased.active", task='task', group='obj')
 
   div(ng-show='task._edit._advanced')
     div(ng-if='::task.type == "daily"')

--- a/website/views/shared/tasks/meta_controls.jade
+++ b/website/views/shared/tasks/meta_controls.jade
@@ -20,7 +20,7 @@
 
   // Icons only available if you own the tasks (aka, hidden from challenge stats)
   span(ng-if='!obj._locked')
-    group-task-meta-actions(ng-if="!obj.auth && obj.purchased && obj.purchased.plan && obj.purchased.plan.customerId", task='task', group='obj')
+    group-task-meta-actions(ng-if="!obj.auth && obj.purchased && obj.purchased.active", task='task', group='obj')
     
     a(ng-click='pushTask(task,$index,"top")', tooltip=env.t('pushTaskToTop'), ng-class="{'push-down': ctrlPressed}")
       span(ng-hide="ctrlPressed").glyphicon.glyphicon-open


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes put_issue_url_here

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
The purchase object is private, but there is a non private field to show non leader users if a guild is subscribed. This should restore the group meta options for all users. 


[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: 
