### PR TITLE
Fixes #8227 (buying gems with gold gives two notifications when language is not 'en')

### DIFF
--- a/test/common/ops/purchase.js
+++ b/test/common/ops/purchase.js
@@ -147,6 +147,15 @@ describe('shared.ops.purchase', () => {
       expect(user.stats.gp).to.equal(goldPoints - planGemLimits.convRate);
     });
 
+    it('purchases gems with a different language than the default', () => {
+      let [, message] = purchase(user, {params: {type: 'gems', key: 'gem'}, language: 'de'});
+
+      expect(message).to.equal(i18n.t('plusOneGem', 'de'));
+      expect(user.balance).to.equal(userGemAmount + 0.5);
+      expect(user.purchased.plan.gemsBought).to.equal(2);
+      expect(user.stats.gp).to.equal(goldPoints - planGemLimits.convRate*2);
+    });
+
     it('purchases eggs', () => {
       let type = 'eggs';
       let key = 'Wolf';

--- a/test/common/ops/purchase.js
+++ b/test/common/ops/purchase.js
@@ -153,7 +153,7 @@ describe('shared.ops.purchase', () => {
       expect(message).to.equal(i18n.t('plusOneGem', 'de'));
       expect(user.balance).to.equal(userGemAmount + 0.5);
       expect(user.purchased.plan.gemsBought).to.equal(2);
-      expect(user.stats.gp).to.equal(goldPoints - planGemLimits.convRate*2);
+      expect(user.stats.gp).to.equal(goldPoints - planGemLimits.convRate * 2);
     });
 
     it('purchases eggs', () => {

--- a/website/common/script/ops/purchase.js
+++ b/website/common/script/ops/purchase.js
@@ -57,7 +57,7 @@ module.exports = function purchase (user, req = {}, analytics) {
 
     return [
       _.pick(user, splitWhitespace('stats balance')),
-      i18n.t('plusOneGem'),
+      i18n.t('plusOneGem', req.language),
     ];
   }
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #8227 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

- Added request language to i18n.t call

Previously, two notifications were shown: one with the correct translation, from the return of the purchase function, and one untranslated, from the API call. When the translated string matched the 'en' string (as in 'en_GB' or 'en@pirate'), only one notification was shown. But if both strings were different, two notifications were shown:

<img width="293" alt="captura de pantalla 2017-01-05 a las 20 06 25" src="https://cloud.githubusercontent.com/assets/24368942/21742104/1d926b62-d4e8-11e6-8961-3003627ae577.png">


With this modification, the API call returns the translated string, so both string matches and only one notification is shown. Some examples follow: 

For Spanish:

<img width="390" alt="captura de pantalla 2017-01-07 a las 13 43 16" src="https://cloud.githubusercontent.com/assets/24368942/21741980/5ba34df2-d4e5-11e6-8943-1f52b7bb1fc4.png">

For German:

<img width="392" alt="captura de pantalla 2017-01-07 a las 13 43 46" src="https://cloud.githubusercontent.com/assets/24368942/21742041/bc3c88da-d4e6-11e6-9203-d8f68b687e65.png">

For French:

<img width="390" alt="captura de pantalla 2017-01-07 a las 13 44 11" src="https://cloud.githubusercontent.com/assets/24368942/21742047/da9e9232-d4e6-11e6-9ce0-668bee7dcbb7.png">

For English:

<img width="394" alt="captura de pantalla 2017-01-07 a las 13 44 31" src="https://cloud.githubusercontent.com/assets/24368942/21742034/a2bf5586-d4e6-11e6-9d49-dc216ef66cfd.png">

[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: bbbb9c50-f373-4528-ac4d-c1f9925a611d