### PR TITLE
Fixes task left in odd setting when cancelling editing with ESC / Escape Key; add click outside to close modal #8308 #8321

### DIFF
--- a/website/client-old/js/services/taskServices.js
+++ b/website/client-old/js/services/taskServices.js
@@ -271,7 +271,14 @@ angular.module('habitrpg')
       }
       modalScope.cancelTaskEdit = cancelTaskEdit;
 
-      $rootScope.openModal('task-edit', {scope: modalScope, backdrop: 'static'});
+      $rootScope.openModal('task-edit', {scope: modalScope })
+        .result.catch(() => {
+          cancelTaskEdit(task);
+        });
+
+      // modal.result.catch(function() {
+      //   cancelTaskEdit(task);
+      // });
     }
 
     function cancelTaskEdit(task) {

--- a/website/client-old/js/services/taskServices.js
+++ b/website/client-old/js/services/taskServices.js
@@ -275,10 +275,6 @@ angular.module('habitrpg')
         .result.catch(() => {
           cancelTaskEdit(task);
         });
-
-      // modal.result.catch(function() {
-      //   cancelTaskEdit(task);
-      // });
     }
 
     function cancelTaskEdit(task) {

--- a/website/views/shared/tasks/meta_controls.jade
+++ b/website/views/shared/tasks/meta_controls.jade
@@ -33,18 +33,9 @@
     span.glyphicon.glyphicon-tags(tooltip='{{Shared.appliedTags(user.tags, task.tags)}}', ng-hide='Shared.noTags(task.tags)')
     
     // edit
-    a(ng-hide='task._editing || (checkGroupAccess && !checkGroupAccess(obj))', ng-click='editTask(task, user, Shared.taskClasses(task, user.filters, user.preferences.dayStart, user.lastCron, list.showCompleted, main))', tooltip=env.t('edit'))
+    a(ng-hide='checkGroupAccess && !checkGroupAccess(obj)', ng-click='editTask(task, user, Shared.taskClasses(task, user.filters, user.preferences.dayStart, user.lastCron, list.showCompleted, main))', tooltip=env.t('edit'))
       | &nbsp;
-      span.glyphicon.glyphicon-pencil(ng-hide='task._editing')
-    | &nbsp;
-
-    a(ng-hide='!task._editing', ng-click='cancelTaskEdit(task)', tooltip=env.t('cancel'))
-      span.glyphicon.glyphicon-remove(ng-hide='!task._editing')
-      | &nbsp;
-      
-    // save
-    a(ng-hide='!task._editing', ng-click='saveTask(task)', tooltip=env.t('save'))
-      span.glyphicon.glyphicon-ok(ng-hide='!task._editing')
+      span.glyphicon.glyphicon-pencil
     | &nbsp;
   
     //challenges

--- a/website/views/shared/tasks/task.jade
+++ b/website/views/shared/tasks/task.jade
@@ -5,7 +5,7 @@ li(id='task-{{::task._id}}',
   ng-click='spell && (list.type != "reward") && castEnd(task, "task", $event)',
   ng-show='shouldShow(task, list, user.preferences)',
   popover-trigger='mouseenter', popover-placement="top", popover-append-to-body='{{::modal ? "false":"true"}}',
-  data-popover-html="{{::taskPopover(task) | markdown}}")
+  data-popover-html="{{taskPopover(task)}}")
 
   ng-form(name='taskForm')
     include ./meta_controls

--- a/website/views/shared/tasks/task.jade
+++ b/website/views/shared/tasks/task.jade
@@ -5,7 +5,7 @@ li(id='task-{{::task._id}}',
   ng-click='spell && (list.type != "reward") && castEnd(task, "task", $event)',
   ng-show='shouldShow(task, list, user.preferences)',
   popover-trigger='mouseenter', popover-placement="top", popover-append-to-body='{{::modal ? "false":"true"}}',
-  data-popover-html="{{taskPopover(task)}}")
+  data-popover-html="{{taskPopover(task) | markdown}}")
 
   ng-form(name='taskForm')
     include ./meta_controls


### PR DESCRIPTION
Fixes #8308 
Fixes #8321 

### Changes
Removed backdrop property from openModal, which allows the modal to close when clicked outside the modal area. Then added a call on modal rejection to cancelTaskEdit function, which is called on both pressing ESC and click outside. Finally, as a tidy I removed the old template logic to display cancel/accept icons instead of the edit icon in the task metadata component when editing the task, as these icons no longer have any function.

----
UUID: f301baf5-b41b-44f0-8978-ee3e7764b8e1
