### PR TITLE
Fixes task left in odd setting when cancelling editing with ESC / Escape Key; add click outside to close modal #8308 #8321

### DIFF
--- a/test/client-old/spec/services/taskServicesSpec.js
+++ b/test/client-old/spec/services/taskServicesSpec.js
@@ -17,7 +17,14 @@ describe('Tasks Service', function() {
       tasks = Tasks;
     });
 
-    rootScope.openModal = function () {};
+    rootScope.openModal = function() {
+      return {
+        result: {
+          then: function() {},
+          catch: function() {},
+        },
+      };
+    };
   });
 
   it('calls get user tasks endpoint', function() {

--- a/website/client-old/js/services/taskServices.js
+++ b/website/client-old/js/services/taskServices.js
@@ -271,7 +271,14 @@ angular.module('habitrpg')
       }
       modalScope.cancelTaskEdit = cancelTaskEdit;
 
-      $rootScope.openModal('task-edit', {scope: modalScope, backdrop: 'static'});
+      $rootScope.openModal('task-edit', {scope: modalScope })
+        .result.catch(() => {
+          cancelTaskEdit(task);
+        });
+
+      // modal.result.catch(function() {
+      //   cancelTaskEdit(task);
+      // });
     }
 
     function cancelTaskEdit(task) {

--- a/website/client-old/js/services/taskServices.js
+++ b/website/client-old/js/services/taskServices.js
@@ -272,13 +272,9 @@ angular.module('habitrpg')
       modalScope.cancelTaskEdit = cancelTaskEdit;
 
       $rootScope.openModal('task-edit', {scope: modalScope })
-        .result.catch(() => {
+        .result.catch(function() {
           cancelTaskEdit(task);
         });
-
-      // modal.result.catch(function() {
-      //   cancelTaskEdit(task);
-      // });
     }
 
     function cancelTaskEdit(task) {

--- a/website/views/shared/tasks/meta_controls.jade
+++ b/website/views/shared/tasks/meta_controls.jade
@@ -33,18 +33,9 @@
     span.glyphicon.glyphicon-tags(tooltip='{{Shared.appliedTags(user.tags, task.tags)}}', ng-hide='Shared.noTags(task.tags)')
     
     // edit
-    a(ng-hide='task._editing || (checkGroupAccess && !checkGroupAccess(obj))', ng-click='editTask(task, user, Shared.taskClasses(task, user.filters, user.preferences.dayStart, user.lastCron, list.showCompleted, main))', tooltip=env.t('edit'))
+    a(ng-hide='checkGroupAccess && !checkGroupAccess(obj)', ng-click='editTask(task, user, Shared.taskClasses(task, user.filters, user.preferences.dayStart, user.lastCron, list.showCompleted, main))', tooltip=env.t('edit'))
       | &nbsp;
-      span.glyphicon.glyphicon-pencil(ng-hide='task._editing')
-    | &nbsp;
-
-    a(ng-hide='!task._editing', ng-click='cancelTaskEdit(task)', tooltip=env.t('cancel'))
-      span.glyphicon.glyphicon-remove(ng-hide='!task._editing')
-      | &nbsp;
-      
-    // save
-    a(ng-hide='!task._editing', ng-click='saveTask(task)', tooltip=env.t('save'))
-      span.glyphicon.glyphicon-ok(ng-hide='!task._editing')
+      span.glyphicon.glyphicon-pencil
     | &nbsp;
   
     //challenges


### PR DESCRIPTION
Fixes #8308
Fixes #8321

### Changes

Removed backdrop property from openModal, which allows the modal to close when clicked outside the modal area. Then added a call on modal rejection to cancelTaskEdit function, which is called on both pressing ESC and click outside. Finally, as a tidy I removed the old template logic to display cancel/accept icons instead of the edit icon in the task metadata component when editing the task, as these icons no longer have any function. I made a small modification to the task service tests' openModal no-op method to ensure the tests continue to pass.

----
UUID: f301baf5-b41b-44f0-8978-ee3e7764b8e1
