### PR TITLE
Fix home column style on medium screen widths fixes #8372

### DIFF
--- a/website/client-old/css/helpers.styl
+++ b/website/client-old/css/helpers.styl
@@ -62,7 +62,7 @@
   .pull-right-lg
     float: right
 
-// Making sure that the To-Dos tab always flow right on medium screens.
+// Making sure that the To-Dos tab always flow right on small screens.
 @media (min-width: $sm-min-screen-width) and (max-width: $sm-max-screen-width)
-  .new-row-md
+  .new-row-sm
     clear: left

--- a/website/views/shared/tasks/index.jade
+++ b/website/views/shared/tasks/index.jade
@@ -6,7 +6,7 @@ include ./task_view/mixins
 script(id='templates/habitrpg-tasks.html', type="text/ng-template")
   .tasks-lists.container-fluid
     .row
-      .col-sm-6.col-md-3(ng-repeat='list in lists', ng-class='::{ "rewards-module": list.type==="reward", "new-row-md": list.type==="todo" }')
+      .col-sm-6.col-md-3(ng-repeat='list in lists', ng-class='::{ "rewards-module": list.type==="reward", "new-row-sm": list.type==="todo" }')
         .task-column(class='{{::list.type}}s')
 
           include ./task_view/graph

--- a/website/views/shared/tasks/index.jade
+++ b/website/views/shared/tasks/index.jade
@@ -6,7 +6,7 @@ include ./task_view/mixins
 script(id='templates/habitrpg-tasks.html', type="text/ng-template")
   .tasks-lists.container-fluid
     .row
-      .col-sm-3(ng-repeat='list in lists', ng-class='::{ "rewards-module": list.type==="reward", "new-row-md": list.type==="todo" }')
+      .col-sm-6.col-md-3(ng-repeat='list in lists', ng-class='::{ "rewards-module": list.type==="reward", "new-row-md": list.type==="todo" }')
         .task-column(class='{{::list.type}}s')
 
           include ./task_view/graph


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes https://github.com/HabitRPG/habitica/issues/8372

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Problems:
- Only xs screens got special treatment, meaning small screens were hard to read
- The "To-Do" column would force a `clear: left`. With `.col-sm-3`, this meant only half of the screen real estate was getting used on certain screen sizes.

Solutions:
- Changed home screen columns to `.col-sm-6.col-md-3` to improve readability
- Updated name of `.new-row-md` helper to `.new-row-sm` for clarity

The `.new-row-md` helper as defined in `helpers.styl` refers to medium columns, but gets applied to small ones so I renamed it. This may have been where some of the confusion came from that resulted in a weird line break on medium screens.

![columnstylefix](https://cloud.githubusercontent.com/assets/412362/21752085/93d1816c-d58f-11e6-9fc5-5fb292bba9ed.gif)


[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: 8328bef9-115c-4c0f-a6bc-8b00e1ca8b6b

