### PR TITLE
gulp/gulp-transifex-test.js: fixed variable name typo

### DIFF
--- a/gulp/gulp-transifex-test.js
+++ b/gulp/gulp-transifex-test.js
@@ -84,8 +84,8 @@ gulp.task('transifex:malformedStrings', () => {
           let malformedString = `${lang} - ${file} - ${key} - ${translationString}`;
           stringsWithMalformedInterpolations.push(malformedString);
         } else if (englishOccurences.length !== translationOccurences.length && !malformedStringExceptions[key]) {
-          let missingInterploationString = `${lang} - ${file} - ${key} - ${translationString}`;
-          stringsWithIncorrectNumberOfInterpolations.push(missingInterploationString);
+          let missingInterpolationString = `${lang} - ${file} - ${key} - ${translationString}`;
+          stringsWithIncorrectNumberOfInterpolations.push(missingInterpolationString);
         }
       });
     });


### PR DESCRIPTION
Trivial typo fix, noticed while reading the droparticle discussion.
