### PR TITLE
Add missing text to buttons on the party / guild invite modal - Fixes #8391

### DIFF
--- a/test/client-old/spec/controllers/groupCtrlSpec.js
+++ b/test/client-old/spec/controllers/groupCtrlSpec.js
@@ -240,6 +240,5 @@ describe('Groups Controller', function() {
   describe.skip("clickMember", function() { });
   describe.skip("removeMember", function() { });
   describe.skip("confirmRemoveMember", function() { });
-  describe.skip("openInviteModal", function() { });
   describe.skip("quickReply", function() { });
 });

--- a/test/client-old/spec/services/groupServicesSpec.js
+++ b/test/client-old/spec/services/groupServicesSpec.js
@@ -170,6 +170,7 @@ describe('groupServices', function() {
   });
 
   it('sets a "sendInviteText" property on a party to "Send Invitations"', function() {
+    var sendInviteText = window.env.t('sendInvitations');
     var party = {
       type: 'party',
       data: {
@@ -177,10 +178,11 @@ describe('groupServices', function() {
       },
     };
     groups.inviteOrStartParty(party);
-    expect(party.sendInviteText).to.eql('Send Invitations');
+    expect(party.sendInviteText).to.eql(sendInviteText);
   });
 
   it('sets a "sendInviteText" proptery on a guild to "Send Invitations +$3.00/month/user"', function() {
+    var sendInviteText = window.env.t('sendInvitations');
     var guild = {
       type: 'guild',
       data: {
@@ -192,8 +194,7 @@ describe('groupServices', function() {
         },
       },
     };
-
     groups.inviteOrStartParty(guild);
-    expect(guild.sendInviteText).to.eql('Send Invitations +$3.00/month/user');
+    expect(guild.sendInviteText).to.eql(sendInviteText + window.env.t('groupAdditionalUserCost'));
   });
 });

--- a/test/client-old/spec/services/groupServicesSpec.js
+++ b/test/client-old/spec/services/groupServicesSpec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 describe('groupServices', function() {
-  var $httpBackend, $http, groups, user;
+  var $httpBackend, $http, groups, user, $rootScope;
   var groupApiUrlPrefix = '/api/v3/groups';
 
   beforeEach(function() {
@@ -13,8 +13,10 @@ describe('groupServices', function() {
       $provide.value('User', {user: user});
     });
 
-    inject(function(_$httpBackend_, Groups, User) {
+    inject(function(_$httpBackend_, _$rootScope_, Groups, User) {
       $httpBackend = _$httpBackend_;
+      $rootScope = _$rootScope_;
+      $rootScope.openModal = function() {}
       groups = Groups;
     });
   });
@@ -165,5 +167,33 @@ describe('groupServices', function() {
       });
 
     $httpBackend.flush()
+  });
+
+  it('sets a "sendInviteText" property on a party to "Send Invitations"', function() {
+    var party = {
+      type: 'party',
+      data: {
+        _id: '1234',
+      },
+    };
+    groups.inviteOrStartParty(party);
+    expect(party.sendInviteText).to.eql('Send Invitations');
+  });
+
+  it('sets a "sendInviteText" proptery on a guild to "Send Invitations +$3.00/month/user"', function() {
+    var guild = {
+      type: 'guild',
+      data: {
+        _id: '12345',
+      },
+      purchased: {
+        plan: {
+          customerId: '123',
+        },
+      },
+    };
+
+    groups.inviteOrStartParty(guild);
+    expect(guild.sendInviteText).to.eql('Send Invitations +$3.00/month/user');
   });
 });

--- a/website/client-old/js/controllers/groupsCtrl.js
+++ b/website/client-old/js/controllers/groupsCtrl.js
@@ -2,6 +2,7 @@
 
 habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '$http', '$q', 'User', 'Members', '$state', 'Notification',
   function($scope, $rootScope, Shared, Groups, $http, $q, User, Members, $state, Notification) {
+    $scope.inviteOrStartParty = Groups.inviteOrStartParty;
     $scope.isMemberOfPendingQuest = function (userid, group) {
       if (!group.quest || !group.quest.members) return false;
       if (group.quest.active) return false; // quest is started, not pending
@@ -118,25 +119,6 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '
       } else {
         $scope.removeMemberData = undefined;
       }
-    };
-
-    $scope.openInviteModal = function (group) {
-      if (group.type !== 'party' && group.type !== 'guild') {
-        return console.log('Invalid group type.')
-      }
-
-      var sendInviteText = window.env.t('sendInvitations');
-      if(group.purchased && group.purchased.plan && group.purchased.plan.customerId) sendInviteText += window.env.t('groupAdditionalUserCost');
-      group.sendInviteText = sendInviteText;
-
-      $rootScope.openModal('invite-' + group.type, {
-        controller:'InviteToGroupCtrl',
-        resolve: {
-          injectedGroup: function(){
-            return group;
-          },
-        }
-      });
     };
 
     $scope.quickReply = function (uid) {

--- a/website/client-old/js/services/groupServices.js
+++ b/website/client-old/js/services/groupServices.js
@@ -220,20 +220,25 @@ angular.module('habitrpg')
 
     function inviteOrStartParty (group) {
       Analytics.track({'hitType':'event','eventCategory':'button','eventAction':'click','eventLabel':'Invite Friends'});
-
-      if (group && group.type === "party" || $location.$$path === "/options/groups/party") {
-       group.type = 'party';
-       group.sendInviteText = window.env.t('sendInvitations')
-
-       $rootScope.openModal('invite-party', {
-         controller:'InviteToGroupCtrl',
-         resolve: {
-           injectedGroup: function(){ return group; }
-         }
-       });
-      } else {
-       $location.path("/options/groups/party");
+      
+      var sendInviteText = window.env.t('sendInvitations');
+      if (group.type !== 'party' && group.type !== 'guild') {
+        $location.path("/options/groups/party");
+        return console.log('Invalid group type.')
       }
+
+      if(group.purchased && group.purchased.plan && group.purchased.plan.customerId) sendInviteText += window.env.t('groupAdditionalUserCost');
+
+      group.sendInviteText = sendInviteText;
+
+      $rootScope.openModal('invite-' + group.type, {
+        controller:'InviteToGroupCtrl',
+        resolve: {
+          injectedGroup: function() {
+            return group;
+          },
+        },
+      });
     }
 
     return {

--- a/website/client-old/js/services/groupServices.js
+++ b/website/client-old/js/services/groupServices.js
@@ -223,6 +223,7 @@ angular.module('habitrpg')
 
       if (group && group.type === "party" || $location.$$path === "/options/groups/party") {
        group.type = 'party';
+       group.sendInviteText = window.env.t('sendInvitations')
 
        $rootScope.openModal('invite-party', {
          controller:'InviteToGroupCtrl',

--- a/website/views/options/social/group.jade
+++ b/website/views/options/social/group.jade
@@ -19,7 +19,7 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
     li
       a(ng-click="groupPanel = 'subscription'", ng-show='group.leader._id === user._id && group.purchased.plan.customerId')=env.t('subscription')
       a(ng-click="groupPanel = 'subscription'", ng-show='group.leader._id === user._id && !group.purchased.plan.customerId')=env.t('upgradeTitle')
-    
+
   .tab-content
     .tab-pane.active
 
@@ -87,7 +87,7 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
             h3.panel-title
               =env.t('members')
               span(ng-if='group.type=="party" && (group.onlineUsers || group.onlineUsers == 0)')= ' (' + env.t('onlineCount', {count: "{{group.onlineUsers}}"}) + ')'
-              button.pull-right.btn.btn-primary(ng-click="openInviteModal(group)")=env.t("inviteFriends")
+              button.pull-right.btn.btn-primary(ng-click="inviteOrStartParty(group)")=env.t("inviteFriends")
 
           .panel-body.modal-fixed-height
             h4(ng-show='::group.memberCount === 1 && group.type === "party"')=env.t('partyEmpty')
@@ -173,10 +173,9 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
           +chatMessages()
           h4(ng-if='group.chat.length < 1 && group.type === "party"')=env.t('partyChatEmpty')
           h4(ng-if='group.chat.length < 1 && group.type === "guild"')=env.t('guildChatEmpty')
-    
+
     group-tasks(ng-show="groupPanel == 'tasks'")
 
     group-approvals(ng-show="groupPanel == 'approvals'", ng-if="group.leader._id === user._id", group="group")
 
     +groupSubscription
-        


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #8391 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
When #8328 was added, the text for the buttons was changed from =env.t('sendInvitations') to the dynamic message influenced by the groupsCtrl {{group.sendInviteText}} which makes sense to show the different button text.

The only problem is that if the button isn't subject to the fee text, then the group has no concept of sendInviteText.

All I did was went to where the group object originates groupService.js and added a default sendInviteText.

## Screenshots!
### Before
<img width="399" alt="screen shot 2017-01-11 at 11 51 44 pm" src="https://cloud.githubusercontent.com/assets/3782604/21878598/f07803fc-d858-11e6-8770-b091732e90f7.png">

### After
<img width="615" alt="screen shot 2017-01-11 at 11 49 57 pm" src="https://cloud.githubusercontent.com/assets/3782604/21878588/d5d80560-d858-11e6-9b07-dcd8910e0685.png">



[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: 29664a36-68e0-4d97-a2b4-9343ebbfa8a6
