### PR TITLE
Validate coupon code for subscriptions fixes #8398

### DIFF
--- a/test/client-old/spec/controllers/settingsCtrlSpec.js
+++ b/test/client-old/spec/controllers/settingsCtrlSpec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 describe('Settings Controller', function () {
-  var rootScope, scope, user, User, ctrl;
+  var rootScope, scope, $httpBackend, user, User, ctrl, Notification;
 
   const actionClickEvent = {
     target: document.createElement('button'),
@@ -29,18 +29,27 @@ describe('Settings Controller', function () {
         releaseBoth: sandbox.stub(),
       };
 
+      Notification = {
+        error: sandbox.stub(),
+        text: sandbox.stub()
+      };
+
+      $provide.value('Notification', Notification);
       $provide.value('User', User);
       $provide.value('Guide', sandbox.stub());
     });
 
-    inject(function(_$rootScope_, _$controller_) {
+    inject(function(_$rootScope_, _$controller_, _$httpBackend_) {
       scope = _$rootScope_.$new();
       rootScope = _$rootScope_;
+      $httpBackend = _$httpBackend_;
+
+      $httpBackend.whenGET(/partials/).respond();
 
       // Load RootCtrl to ensure shared behaviors are loaded
-      _$controller_('RootCtrl',  {$scope: scope, User: User});
+      _$controller_('RootCtrl',  {$scope: scope, User: User, Notification: Notification});
 
-      ctrl = _$controller_('SettingsCtrl', {$scope: scope, User: User});
+      ctrl = _$controller_('SettingsCtrl', {$scope: scope, User: User, Notification: Notification});
     });
   });
 
@@ -278,6 +287,50 @@ describe('Settings Controller', function () {
         expect($.fn.popover).to.be.calledWith('destroy');
         expect($.fn.popover).to.be.called;
         expect($.fn.popover).to.be.calledWith('show');
+      });
+    });
+  });
+
+  context('coupons', function () {
+    describe('coupons', function () {
+      it('something about invalid coupons', function () {
+        $httpBackend
+          .whenPOST('/api/v3/coupons/validate/INVALID_COUPON?userV=undefined')
+          .respond(200, {
+            success: true,
+            data: {
+              valid: false
+            },
+            notifications: [],
+            userV: 'undefined'
+          });
+
+        scope.applyCoupon('INVALID_COUPON');
+
+        $httpBackend.flush();
+
+        expect(Notification.error).to.be.called;
+        expect(Notification.error).to.be.calledWith(env.t('invalidCoupon'), true);
+      });
+
+      it('valid coupons', function () {
+        $httpBackend
+          .whenPOST('/api/v3/coupons/validate/VALID_COUPON?userV=undefined')
+          .respond(200, {
+            success: true,
+            data: {
+              valid: true
+            },
+            notifications: [],
+            userV: 'undefined'
+          });
+
+        scope.applyCoupon('VALID_COUPON');
+
+        $httpBackend.flush();
+
+        expect(Notification.error).to.not.be.called;
+        expect(Notification.text).to.be.calledWith('Coupon applied!');
       });
     });
   });

--- a/test/client-old/spec/controllers/settingsCtrlSpec.js
+++ b/test/client-old/spec/controllers/settingsCtrlSpec.js
@@ -291,9 +291,9 @@ describe('Settings Controller', function () {
     });
   });
 
-  context('coupons', function () {
-    describe('coupons', function () {
-      it('something about invalid coupons', function () {
+  context('Validating coupons', function () {
+    describe('#applyCoupon', function () {
+      it('displays an error when an invalid coupon is applied', function () {
         $httpBackend
           .whenPOST('/api/v3/coupons/validate/INVALID_COUPON?userV=undefined')
           .respond(200, {
@@ -313,7 +313,7 @@ describe('Settings Controller', function () {
         expect(Notification.error).to.be.calledWith(env.t('invalidCoupon'), true);
       });
 
-      it('valid coupons', function () {
+      it('displays an confirmation when a valid coupon is applied', function () {
         $httpBackend
           .whenPOST('/api/v3/coupons/validate/VALID_COUPON?userV=undefined')
           .respond(200, {

--- a/website/client-old/js/controllers/settingsCtrl.js
+++ b/website/client-old/js/controllers/settingsCtrl.js
@@ -269,7 +269,11 @@ habitrpg.controller('SettingsCtrl',
 
     $scope.applyCoupon = function(coupon){
       $http.post(ApiUrl.get() + '/api/v3/coupons/validate/'+coupon)
-      .success(function(){
+      .success(function(res, code){
+        if (!res.data.valid) {
+          Notification.error(env.t('invalidCoupon'), true);
+          return;
+        }
         Notification.text("Coupon applied!");
         var subs = Content.subscriptionBlocks;
         subs["basic_6mo"].discount = true;


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #8398

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

- Added a check to see if the /api/v3/coupons/validate/:coupon is sending back a true or false
- Displays an error if the coupon code is invalid

Didn't add a test for this because it doesn't look like the functions pertaining to coupons are being tested in settingsCtrlSpec.js. Let me know if I should add one.

[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: a3f88ebe-efd8-4ff9-a887-efb5d2522a97
