### PR TITLE
fix(nextRewardUnlocksIn): Check-in prize message was always plural --…

### DIFF
--- a/website/common/locales/cs/loginincentives.json
+++ b/website/common/locales/cs/loginincentives.json
@@ -1,7 +1,7 @@
 {
   "unlockedReward": "Obdržel/a jsi <%= reward %>",
   "earnedRewardForDevotion": "Získal/a jsi <%= reward %> za snahu zlepšit se ve svém životě.",
-  "nextRewardUnlocksIn": "Your next prize will unlock in <%= numberOfCheckinsLeft %> more check-ins!",
+  "nextRewardUnlocksIn": "Check-ins until your next prize: <%= numberOfCheckinsLeft %>",
   "awesome": "Awesome!",
   "totalCount": "<%= count %> total count",
   "countLeft": "<%= count %> more check-ins until next reward",

--- a/website/common/locales/en/loginIncentives.json
+++ b/website/common/locales/en/loginIncentives.json
@@ -1,7 +1,7 @@
 {
   "unlockedReward": "You have received <%= reward %>",
   "earnedRewardForDevotion": "You have earned a <%= reward %> for being committed to improving your life.",
-  "nextRewardUnlocksIn": "Your next prize will unlock in <%= numberOfCheckinsLeft %> more check-ins!",
+  "nextRewardUnlocksIn": "Check-ins until your next prize: <%= numberOfCheckinsLeft %>",
   "awesome": "Awesome!",
   "totalCount": "<%= count %> total count",
   "countLeft": "<%= count %> more check-ins until next reward",

--- a/website/common/locales/en@pirate/loginincentives.json
+++ b/website/common/locales/en@pirate/loginincentives.json
@@ -1,7 +1,7 @@
 {
   "unlockedReward": "You have received <%= reward %>",
   "earnedRewardForDevotion": "You have earned a <%= reward %> for being committed to improving your life.",
-  "nextRewardUnlocksIn": "Your next prize will unlock in <%= numberOfCheckinsLeft %> more check-ins!",
+  "nextRewardUnlocksIn": "Check-ins until your next prize:  <%= numberOfCheckinsLeft %>",
   "awesome": "Awesome!",
   "totalCount": "<%= count %> total count",
   "countLeft": "<%= count %> more check-ins until next reward",

--- a/website/common/locales/en_GB/loginincentives.json
+++ b/website/common/locales/en_GB/loginincentives.json
@@ -1,7 +1,7 @@
 {
   "unlockedReward": "You have received <%= reward %>",
   "earnedRewardForDevotion": "You have earned a <%= reward %> for being committed to improving your life.",
-  "nextRewardUnlocksIn": "Your next prize will unlock in <%= numberOfCheckinsLeft %> more check-ins!",
+  "nextRewardUnlocksIn": "Check-ins until your next prize: <%= numberOfCheckinsLeft %>",
   "awesome": "Awesome!",
   "totalCount": "<%= count %> total count",
   "countLeft": "<%= count %> more check-ins until next reward",

--- a/website/common/locales/he/loginincentives.json
+++ b/website/common/locales/he/loginincentives.json
@@ -1,7 +1,7 @@
 {
   "unlockedReward": "You have received <%= reward %>",
   "earnedRewardForDevotion": "You have earned a <%= reward %> for being committed to improving your life.",
-  "nextRewardUnlocksIn": "Your next prize will unlock in <%= numberOfCheckinsLeft %> more check-ins!",
+  "nextRewardUnlocksIn": "Check-ins until your next prize: <%= numberOfCheckinsLeft %>",
   "awesome": "Awesome!",
   "totalCount": "<%= count %> total count",
   "countLeft": "<%= count %> more check-ins until next reward",

--- a/website/common/locales/hu/loginincentives.json
+++ b/website/common/locales/hu/loginincentives.json
@@ -1,7 +1,7 @@
 {
   "unlockedReward": "You have received <%= reward %>",
   "earnedRewardForDevotion": "You have earned a <%= reward %> for being committed to improving your life.",
-  "nextRewardUnlocksIn": "Your next prize will unlock in <%= numberOfCheckinsLeft %> more check-ins!",
+  "nextRewardUnlocksIn": "Check-ins until your next prize: <%= numberOfCheckinsLeft %>",
   "awesome": "Awesome!",
   "totalCount": "<%= count %> total count",
   "countLeft": "<%= count %> more check-ins until next reward",

--- a/website/common/locales/id/loginincentives.json
+++ b/website/common/locales/id/loginincentives.json
@@ -1,7 +1,7 @@
 {
   "unlockedReward": "Kamu telah mendapatkan <%= reward %>",
   "earnedRewardForDevotion": "Kamu telah mendapatkan sebuah <%= reward %> karena telah berkomitmen dalam pengembangan diri. ",
-  "nextRewardUnlocksIn": "Your next prize will unlock in <%= numberOfCheckinsLeft %> more check-ins!",
+  "nextRewardUnlocksIn": "Check-ins until your next prize: <%= numberOfCheckinsLeft %>",
   "awesome": "Keren! ",
   "totalCount": "<%= count %> total jumlah",
   "countLeft": "<%= count %> more check-ins until next reward",

--- a/website/common/locales/sk/loginincentives.json
+++ b/website/common/locales/sk/loginincentives.json
@@ -1,7 +1,7 @@
 {
   "unlockedReward": "You have received <%= reward %>",
   "earnedRewardForDevotion": "You have earned a <%= reward %> for being committed to improving your life.",
-  "nextRewardUnlocksIn": "Your next prize will unlock in <%= numberOfCheckinsLeft %> more check-ins!",
+  "nextRewardUnlocksIn": "Check-ins until your next prize: <%= numberOfCheckinsLeft %>",
   "awesome": "Awesome!",
   "totalCount": "<%= count %> total count",
   "countLeft": "<%= count %> more check-ins until next reward",

--- a/website/common/locales/sr/loginincentives.json
+++ b/website/common/locales/sr/loginincentives.json
@@ -1,7 +1,7 @@
 {
   "unlockedReward": "You have received <%= reward %>",
   "earnedRewardForDevotion": "You have earned a <%= reward %> for being committed to improving your life.",
-  "nextRewardUnlocksIn": "Your next prize will unlock in <%= numberOfCheckinsLeft %> more check-ins!",
+  "nextRewardUnlocksIn": "Check-ins until your next prize: <%= numberOfCheckinsLeft %>",
   "awesome": "Awesome!",
   "totalCount": "<%= count %> total count",
   "countLeft": "<%= count %> more check-ins until next reward",

--- a/website/common/locales/sv/loginincentives.json
+++ b/website/common/locales/sv/loginincentives.json
@@ -1,7 +1,7 @@
 {
   "unlockedReward": "Du har fått <%=reward%>",
   "earnedRewardForDevotion": "Du har fått en <%=reward %> eftersom du är \nengagerad i att förbättra ditt liv.",
-  "nextRewardUnlocksIn": "Your next prize will unlock in <%= numberOfCheckinsLeft %> more check-ins!",
+  "nextRewardUnlocksIn": "Check-ins until your next prize: <%= numberOfCheckinsLeft %>",
   "awesome": "Grymt! ",
   "totalCount": "<%= count %> total count",
   "countLeft": "<%= count %> more check-ins until next reward",

--- a/website/common/locales/uk/loginincentives.json
+++ b/website/common/locales/uk/loginincentives.json
@@ -1,7 +1,7 @@
 {
   "unlockedReward": "You have received <%= reward %>",
   "earnedRewardForDevotion": "You have earned a <%= reward %> for being committed to improving your life.",
-  "nextRewardUnlocksIn": "Your next prize will unlock in <%= numberOfCheckinsLeft %> more check-ins!",
+  "nextRewardUnlocksIn": "Check-ins until your next prize: <%= numberOfCheckinsLeft %>",
   "awesome": "Awesome!",
   "totalCount": "<%= count %> total count",
   "countLeft": "<%= count %> more check-ins until next reward",


### PR DESCRIPTION
Fixes #8428

### Changes
[//]: # 

Check-in prize message was always plural -- moving to a non-sentence like structure to fix incorrect grammar.

[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: 
