### PR TITLE
fix(nextRewardUnlocksIn): Check-in prize message was always plural --…

### DIFF
--- a/website/common/locales/en/loginIncentives.json
+++ b/website/common/locales/en/loginIncentives.json
@@ -1,7 +1,7 @@
 {
   "unlockedReward": "You have received <%= reward %>",
   "earnedRewardForDevotion": "You have earned a <%= reward %> for being committed to improving your life.",
-  "nextRewardUnlocksIn": "Your next prize will unlock in <%= numberOfCheckinsLeft %> more check-ins!",
+  "nextRewardUnlocksIn": "Check-ins until your next prize: <%= numberOfCheckinsLeft %>",
   "awesome": "Awesome!",
   "totalCount": "<%= count %> total count",
   "countLeft": "<%= count %> more check-ins until next reward",

--- a/website/common/locales/en/loginIncentives.json
+++ b/website/common/locales/en/loginIncentives.json
@@ -4,7 +4,7 @@
   "nextRewardUnlocksIn": "Check-ins until your next prize: <%= numberOfCheckinsLeft %>",
   "awesome": "Awesome!",
   "totalCount": "<%= count %> total count",
-  "countLeft": "<%= count %> more check-ins until next reward",
+  "countLeft": "Check-ins until next reward: <%= count %>",
   "incentivesDescription": "When it comes to building habits, consistency is key. Each day you check-in you get closer to a prize.",
   "totalCheckins": "<%= count %> Check-Ins",
   "checkinEarned": "Your Check-In Counter went up!",


### PR DESCRIPTION
Fixes #8428 

### Changes

Check-in prize message was always plural -- moving to a non-sentence like structure to fix incorrect grammar.





[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: 
