### PR TITLE
Fix Gem purchase validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "habitica-markdown": "^1.3.0",
     "html-webpack-plugin": "^2.8.1",
     "image-size": "~0.3.2",
-    "in-app-purchase": "^1.1.6",
+    "in-app-purchase": "github:bkalaldeh/in-app-purchase#3e61c1fa1453692e757f3f455bb50acad2a4b1e9",
     "jade": "~1.11.0",
     "jquery": "https://registry.npmjs.org/jquery/-/jquery-3.1.1.tgz",
     "js2xmlparser": "~1.0.0",

--- a/website/server/libs/inAppPurchases.js
+++ b/website/server/libs/inAppPurchases.js
@@ -7,6 +7,8 @@ import Bluebird from 'bluebird';
 // const CONNECTION_FAILED = 6778002;
 // const PURCHASE_EXPIRED = 6778003;
 
+// We are using this PR instead of the main release: https://github.com/voltrue2/in-app-purchase/pull/74
+// Reason: Without the PR, the library attempts to validate IAP products as subscriptions and fails.
 iap.config({
   // This is the path to the directory containing iap-sanbox/iap-live files
   googlePublicKeyPath: nconf.get('IAP_GOOGLE_KEYDIR'),


### PR DESCRIPTION
The library broke when we added Play store API validation. This switches it to use a PR that fixes this issue.