### PR TITLE
Task edit screen changes [fixes #8474]

### DIFF
--- a/website/client-old/css/tasks.styl
+++ b/website/client-old/css/tasks.styl
@@ -552,7 +552,6 @@ form
       &:last-of-type
         margin-right: 0
   .repeat-days
-    padding-bottom: 1em
     li
       button
         min-width: 2.5em
@@ -563,11 +562,6 @@ form
     @extend $hrpg-button
   h2#task-edit-title
     margin-top: 1em
-
-// Dailies
-.dailies
-  .repeat-weekly
-    padding-bottom: 1em
 
 // Habits – task button styles (+ -)
 .habits

--- a/website/views/shared/tasks/edit/advanced_options.jade
+++ b/website/views/shared/tasks/edit/advanced_options.jade
@@ -25,16 +25,6 @@ div(ng-if='(task.type !== "reward") || (!obj.auth && obj.purchased && obj.purcha
 
       hr
 
-      .form-group
-        legend.option-title=env.t('repeat')
-        select.form-control(ng-model='task._edit.frequency', ng-disabled='!canEdit(task)')
-          option(value='weekly')=env.t('repeatWeek')
-          option(value='daily')=env.t('repeatDays')
-
-      include ./dailies/repeat_options
-
-      hr
-
   fieldset.option-group.advanced-option(ng-show="task._edit._advanced")
 
     legend.option-title

--- a/website/views/shared/tasks/edit/dailies/repeat_options.jade
+++ b/website/views/shared/tasks/edit/dailies/repeat_options.jade
@@ -1,3 +1,9 @@
+.form-group
+  legend.option-title=env.t('repeat')
+  select.form-control(ng-model='task._edit.frequency', ng-disabled='!canEdit(task)')
+    option(value='weekly')=env.t('repeatWeek')
+    option(value='daily')=env.t('repeatDays')
+
 legend.option-title
   span.hint(popover-trigger='mouseenter', popover-title=env.t('repeatHelpTitle'),
     popover='{{env.t(task._edit.frequency + "RepeatHelpContent")}}')=env.t('repeatEvery')
@@ -9,7 +15,7 @@ ng-form.form-group(name='everyX', ng-if='task._edit.frequency=="daily"')
     span.input-group-addon {{task._edit.everyX == 1 ? env.t('day') : env.t('days')}}
 
 // If frequency is weekly
-.form-group(ng-if='task._edit.frequency=="weekly"')
+ng-form.form-group(ng-if='task._edit.frequency=="weekly"')
   ul.repeat-days
     // note, does not use data-toggle="buttons-checkbox" - it would interfere with our own click binding
     mixin dayOfWeek(day, num)

--- a/website/views/shared/tasks/edit/index.jade
+++ b/website/views/shared/tasks/edit/index.jade
@@ -7,7 +7,7 @@ div(ng-if='task._editing')
 
     br
 
-    h2#task-edit-title
+    h3#task-edit-title
       markdown(text="task._edit.text")
 
     // Broken Challenge
@@ -60,8 +60,6 @@ div(ng-if='task._editing')
         include ./advanced_options
       
       .col-md-12
-        hr
-        
         .save-close
           button(type='submit', ng-click='saveTask(task,false,true); $close()')=env.t('saveAndClose')
         .save-close

--- a/website/views/shared/tasks/edit/text_notes.jade
+++ b/website/views/shared/tasks/edit/text_notes.jade
@@ -4,4 +4,4 @@ fieldset.option-group
 
 fieldset.option-group
   label.option-title=env.t('extraNotes')
-  textarea.form-control.task-extra-notes(rows='3', ng-model='task._edit.notes')
+  textarea.form-control.task-extra-notes(rows='5', ng-model='task._edit.notes')


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
fixes https://github.com/HabitRPG/habitica/issues/8474

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Small UI tweaks to the existing edit modal for tasks, specifically affecting dailies.
- Reduced the font size of the title at the top (about halfway between its original size and the size of the other text in the modal)
- Moved the `repeat` option from the advanced options menu to the main menu, and removed the reduntant `repeat every` option from the advanced options menu
- Increased the height of the `extra notes` option by 2 lines
- Removed some excessive padding - specifically below the `repeat every` option and above the `save & close` and `cancel` buttons

#### Current behaviour:
![Current behaviour](https://cloud.githubusercontent.com/assets/1495809/22615747/803c73ba-eae7-11e6-81fb-a5aa5dcac974.png)

#### New behaviour:
![New behaviour](https://cloud.githubusercontent.com/assets/6353492/22630158/65e52d46-ebc2-11e6-9b3c-73dd8e3d3ac6.png)

[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: 5a346bdd-96fc-4d5d-9105-b20480b056b5