### PR TITLE
Send gem-purchased item data to Amplitude

### DIFF
--- a/test/api/v3/unit/libs/analyticsService.test.js
+++ b/test/api/v3/unit/libs/analyticsService.test.js
@@ -279,6 +279,29 @@ describe('analyticsService', () => {
           rewards: [{_id: 'reward'}],
           balance: 12,
           loginIncentives: 1,
+          background: {
+            blizzard: true,
+          },
+          shirt: {
+            horizon: true,
+          },
+          hair: {
+            base: {
+              1: true,
+            },
+            beard: {
+              3: true,
+            },
+            color: {
+              snowy: true,
+            },
+            mustache: {
+              2: true,
+            },
+          },
+          skin: {
+            snowy: true,
+          },
         };
 
         data.user = user;
@@ -305,6 +328,29 @@ describe('analyticsService', () => {
                 balance: 12,
                 balanceGemAmount: 48,
                 loginIncentives: 1,
+                background: {
+                  blizzard: true,
+                },
+                shirt: {
+                  horizon: true,
+                },
+                hair: {
+                  base: {
+                    1: true,
+                  },
+                  beard: {
+                    3: true,
+                  },
+                  color: {
+                    snowy: true,
+                  },
+                  mustache: {
+                    2: true,
+                  },
+                },
+                skin: {
+                  snowy: true,
+                },
               },
             });
           });
@@ -523,6 +569,29 @@ describe('analyticsService', () => {
           dailys: [{_id: 'daily'}],
           todos: [{_id: 'todo'}],
           rewards: [{_id: 'reward'}],
+          background: {
+            blizzard: true,
+          },
+          shirt: {
+            horizon: true,
+          },
+          hair: {
+            base: {
+              1: true,
+            },
+            beard: {
+              3: true,
+            },
+            color: {
+              snowy: true,
+            },
+            mustache: {
+              2: true,
+            },
+          },
+          skin: {
+            snowy: true,
+          },
         };
 
         data.user = user;
@@ -546,6 +615,29 @@ describe('analyticsService', () => {
                 },
                 contributorLevel: 1,
                 subscription: 'foo-plan',
+                background: {
+                  blizzard: true,
+                },
+                shirt: {
+                  horizon: true,
+                },
+                hair: {
+                  base: {
+                    1: true,
+                  },
+                  beard: {
+                    3: true,
+                  },
+                  color: {
+                    snowy: true,
+                  },
+                  mustache: {
+                    2: true,
+                  },
+                },
+                skin: {
+                  snowy: true,
+                },
               },
             });
           });

--- a/test/api/v3/unit/libs/analyticsService.test.js
+++ b/test/api/v3/unit/libs/analyticsService.test.js
@@ -281,7 +281,7 @@ describe('analyticsService', () => {
           loginIncentives: 1,
           background: {
             blizzard: true,
-            blue: true
+            blue: true,
           },
           shirt: {
             horizon: true,
@@ -305,8 +305,8 @@ describe('analyticsService', () => {
               owned: {
                 armor_special_bardRobes: true,
                 headAccessory_special_foxEars: true,
-              }
-            }
+              },
+            },
           },
           skin: {
             snowy: true,
@@ -346,7 +346,7 @@ describe('analyticsService', () => {
                   color: ['snowy'],
                   mustache: ['2'],
                 },
-                skin: ['snowy']
+                skin: ['snowy'],
               },
             });
           });
@@ -567,7 +567,7 @@ describe('analyticsService', () => {
           rewards: [{_id: 'reward'}],
           background: {
             blizzard: true,
-            blue: true
+            blue: true,
           },
           shirt: {
             horizon: true,
@@ -591,8 +591,8 @@ describe('analyticsService', () => {
               owned: {
                 armor_special_bardRobes: true,
                 headAccessory_special_foxEars: true,
-              }
-            }
+              },
+            },
           },
           skin: {
             snowy: true,

--- a/test/api/v3/unit/libs/analyticsService.test.js
+++ b/test/api/v3/unit/libs/analyticsService.test.js
@@ -281,6 +281,7 @@ describe('analyticsService', () => {
           loginIncentives: 1,
           background: {
             blizzard: true,
+            blue: true
           },
           shirt: {
             horizon: true,
@@ -298,6 +299,14 @@ describe('analyticsService', () => {
             mustache: {
               2: true,
             },
+          },
+          items: {
+            gear: {
+              owned: {
+                armor_special_bardRobes: true,
+                headAccessory_special_foxEars: true,
+              }
+            }
           },
           skin: {
             snowy: true,
@@ -328,29 +337,16 @@ describe('analyticsService', () => {
                 balance: 12,
                 balanceGemAmount: 48,
                 loginIncentives: 1,
-                background: {
-                  blizzard: true,
-                },
-                shirt: {
-                  horizon: true,
-                },
+                animalEars: ['headAccessory_special_foxEars'],
+                background: ['blizzard'],
+                shirt: ['horizon'],
                 hair: {
-                  base: {
-                    1: true,
-                  },
-                  beard: {
-                    3: true,
-                  },
-                  color: {
-                    snowy: true,
-                  },
-                  mustache: {
-                    2: true,
-                  },
+                  base: ['1'],
+                  beard: ['3'],
+                  color: ['snowy'],
+                  mustache: ['2'],
                 },
-                skin: {
-                  snowy: true,
-                },
+                skin: ['snowy']
               },
             });
           });
@@ -571,6 +567,7 @@ describe('analyticsService', () => {
           rewards: [{_id: 'reward'}],
           background: {
             blizzard: true,
+            blue: true
           },
           shirt: {
             horizon: true,
@@ -588,6 +585,14 @@ describe('analyticsService', () => {
             mustache: {
               2: true,
             },
+          },
+          items: {
+            gear: {
+              owned: {
+                armor_special_bardRobes: true,
+                headAccessory_special_foxEars: true,
+              }
+            }
           },
           skin: {
             snowy: true,
@@ -615,29 +620,16 @@ describe('analyticsService', () => {
                 },
                 contributorLevel: 1,
                 subscription: 'foo-plan',
-                background: {
-                  blizzard: true,
-                },
-                shirt: {
-                  horizon: true,
-                },
+                animalEars: ['headAccessory_special_foxEars'],
+                background: ['blizzard'],
+                shirt: ['horizon'],
                 hair: {
-                  base: {
-                    1: true,
-                  },
-                  beard: {
-                    3: true,
-                  },
-                  color: {
-                    snowy: true,
-                  },
-                  mustache: {
-                    2: true,
-                  },
+                  base: ['1'],
+                  beard: ['3'],
+                  color: ['snowy'],
+                  mustache: ['2'],
                 },
-                skin: {
-                  snowy: true,
-                },
+                skin: ['snowy'],
               },
             });
           });

--- a/test/api/v3/unit/libs/analyticsService.test.js
+++ b/test/api/v3/unit/libs/analyticsService.test.js
@@ -271,7 +271,35 @@ describe('analyticsService', () => {
         let user = {
           stats,
           contributor: { level: 1 },
-          purchased: { plan: { planId: 'foo-plan' } },
+          purchased: {
+            plan: {
+              planId: 'foo-plan',
+            },
+            background: {
+              blizzard: true,
+              blue: true,
+            },
+            shirt: {
+              horizon: true,
+            },
+            hair: {
+              base: {
+                1: true,
+              },
+              beard: {
+                3: true,
+              },
+              color: {
+                snowy: true,
+              },
+              mustache: {
+                2: true,
+              },
+            },
+            skin: {
+              snowy: true,
+            },
+          },
           flags: {tour: {intro: -2}},
           habits: [{_id: 'habit'}],
           dailys: [{_id: 'daily'}],
@@ -279,27 +307,6 @@ describe('analyticsService', () => {
           rewards: [{_id: 'reward'}],
           balance: 12,
           loginIncentives: 1,
-          background: {
-            blizzard: true,
-            blue: true,
-          },
-          shirt: {
-            horizon: true,
-          },
-          hair: {
-            base: {
-              1: true,
-            },
-            beard: {
-              3: true,
-            },
-            color: {
-              snowy: true,
-            },
-            mustache: {
-              2: true,
-            },
-          },
           items: {
             gear: {
               owned: {
@@ -308,9 +315,7 @@ describe('analyticsService', () => {
               },
             },
           },
-          skin: {
-            snowy: true,
-          },
+
         };
 
         data.user = user;
@@ -337,16 +342,18 @@ describe('analyticsService', () => {
                 balance: 12,
                 balanceGemAmount: 48,
                 loginIncentives: 1,
-                animalEars: ['headAccessory_special_foxEars'],
-                background: ['blizzard'],
-                shirt: ['horizon'],
-                hair: {
-                  base: ['1'],
-                  beard: ['3'],
-                  color: ['snowy'],
-                  mustache: ['2'],
+                gemPurchased: {
+                  animalEars: ['headAccessory_special_foxEars'],
+                  background: ['blizzard'],
+                  shirt: ['horizon'],
+                  hair: {
+                    base: ['1'],
+                    beard: ['3'],
+                    color: ['snowy'],
+                    mustache: ['2'],
+                  },
+                  skin: ['snowy'],
                 },
-                skin: ['snowy'],
               },
             });
           });
@@ -559,33 +566,40 @@ describe('analyticsService', () => {
         let user = {
           stats,
           contributor: { level: 1 },
-          purchased: { plan: { planId: 'foo-plan' } },
+          purchased: {
+            plan: {
+              planId: 'foo-plan',
+            },
+            background: {
+              blizzard: true,
+              blue: true,
+            },
+            shirt: {
+              horizon: true,
+            },
+            hair: {
+              base: {
+                1: true,
+              },
+              beard: {
+                3: true,
+              },
+              color: {
+                snowy: true,
+              },
+              mustache: {
+                2: true,
+              },
+            },
+            skin: {
+              snowy: true,
+            },
+          },
           flags: {tour: {intro: -2}},
           habits: [{_id: 'habit'}],
           dailys: [{_id: 'daily'}],
           todos: [{_id: 'todo'}],
           rewards: [{_id: 'reward'}],
-          background: {
-            blizzard: true,
-            blue: true,
-          },
-          shirt: {
-            horizon: true,
-          },
-          hair: {
-            base: {
-              1: true,
-            },
-            beard: {
-              3: true,
-            },
-            color: {
-              snowy: true,
-            },
-            mustache: {
-              2: true,
-            },
-          },
           items: {
             gear: {
               owned: {
@@ -593,9 +607,6 @@ describe('analyticsService', () => {
                 headAccessory_special_foxEars: true,
               },
             },
-          },
-          skin: {
-            snowy: true,
           },
         };
 
@@ -620,16 +631,18 @@ describe('analyticsService', () => {
                 },
                 contributorLevel: 1,
                 subscription: 'foo-plan',
-                animalEars: ['headAccessory_special_foxEars'],
-                background: ['blizzard'],
-                shirt: ['horizon'],
-                hair: {
-                  base: ['1'],
-                  beard: ['3'],
-                  color: ['snowy'],
-                  mustache: ['2'],
+                gemPurchased: {
+                  animalEars: ['headAccessory_special_foxEars'],
+                  background: ['blizzard'],
+                  shirt: ['horizon'],
+                  hair: {
+                    base: ['1'],
+                    beard: ['3'],
+                    color: ['snowy'],
+                    mustache: ['2'],
+                  },
+                  skin: ['snowy'],
                 },
-                skin: ['snowy'],
               },
             });
           });

--- a/test/client-old/spec/services/analyticsServicesSpec.js
+++ b/test/client-old/spec/services/analyticsServicesSpec.js
@@ -193,16 +193,17 @@ describe('Analytics Service', function () {
         };
         expectedProperties.balance = 12;
         expectedProperties.balanceGemAmount = 48;
-        expectedProperties.animalEars = ['headAccessory_special_foxEars'];
-        expectedProperties.background = ['blizzard'];
-        expectedProperties.shirt = ['horizon'];
-        expectedProperties.hair = {
+        expectedProperties.gemPurchased = {};
+        expectedProperties.gemPurchased.animalEars = ['headAccessory_special_foxEars'];
+        expectedProperties.gemPurchased.background = ['blizzard'];
+        expectedProperties.gemPurchased.shirt = ['horizon'];
+        expectedProperties.gemPurchased.hair = {
           base: ['1'],
           beard: ['3'],
           color: ['snowy'],
           mustache: ['2'],
         };
-        expectedProperties.skin = ['snowy'];
+        expectedProperties.gemPurchased.skin = ['snowy'];
 
         beforeEach(function() {
           user._id = 'unique-user-id';
@@ -218,11 +219,11 @@ describe('Analytics Service', function () {
           user.todos = [{_id: 'todo'}];
           user.rewards = [{_id: 'reward'}];
           user.balance = 12;
-          user.background = {
+          user.purchased.background = {
             blizzard: true,
             blue: true,
           };
-          user.hair = {
+          user.purchased.hair = {
             base: {
               1: true,
             },
@@ -240,10 +241,10 @@ describe('Analytics Service', function () {
             armor_special_bardRobes: true,
             headAccessory_special_foxEars: true,
           };
-          user.shirt = {
+          user.purchased.shirt = {
             horizon: true,
           };
-          user.skin = {
+          user.purchased.skin = {
             snowy: true,
           };
 
@@ -278,20 +279,22 @@ describe('Analytics Service', function () {
             todos: 1,
             dailys: 1,
             habits: 1,
-            rewards: 1
+            rewards: 1,
           },
           balance: 12,
           balanceGemAmount: 48,
-          background: ['blizzard'],
-          shirt: ['horizon'],
-          hair: {
-            base: ['1'],
-            beard: ['3'],
-            color: ['snowy'],
-            mustache: ['2'],
+          gemPurchased: {
+            background: ['blizzard'],
+            shirt: ['horizon'],
+            hair: {
+              base: ['1'],
+              beard: ['3'],
+              color: ['snowy'],
+              mustache: ['2'],
+            },
+            skin: ['snowy'],
+            animalEars: ['headAccessory_special_foxEars'],
           },
-          skin: ['snowy'],
-          animalEars: ['headAccessory_special_foxEars'],
         };
 
         beforeEach(function() {
@@ -310,11 +313,11 @@ describe('Analytics Service', function () {
           user.todos = [{_id: 'todo'}];
           user.rewards = [{_id: 'reward'}];
           user.balance = 12;
-          user.background = {
+          user.purchased.background = {
             blizzard: true,
             blue: true,
           };
-          user.hair = {
+          user.purchased.hair = {
             base: {
               1: true,
             },
@@ -332,10 +335,10 @@ describe('Analytics Service', function () {
             armor_special_bardRobes: true,
             headAccessory_special_foxEars: true,
           };
-          user.shirt = {
+          user.purchased.shirt = {
             horizon: true,
           };
-          user.skin = {
+          user.purchased.skin = {
             snowy: true,
           };
 

--- a/test/client-old/spec/services/analyticsServicesSpec.js
+++ b/test/client-old/spec/services/analyticsServicesSpec.js
@@ -26,14 +26,22 @@ describe('Analytics Service', function () {
     describe('register', function() {
 
       beforeEach(function() {
-        sandbox.stub(window, 'fbq');
+        sandbox.stub(amplitude, 'setUserId');
+        sandbox.stub(window, 'ga');
       });
 
-      it('records a registration event on Facebook', function() {
+      it('sets up user with Amplitude', function() {
         analytics.register();
         clock.tick();
-        expect(fbq).to.have.been.calledOnce;
-        expect(fbq).to.have.been.calledWith('track', 'CompleteRegistration');
+        expect(amplitude.setUserId).to.have.been.calledOnce;
+        expect(amplitude.setUserId).to.have.been.calledWith(user._id);
+      });
+
+      it('sets up user with Google Analytics', function() {
+        analytics.register();
+        clock.tick();
+        expect(ga).to.have.been.calledOnce;
+        expect(ga).to.have.been.calledWith('set', {userId: user._id});
       });
     });
 
@@ -66,7 +74,6 @@ describe('Analytics Service', function () {
       beforeEach(function() {
         sandbox.stub(amplitude, 'logEvent');
         sandbox.stub(window, 'ga');
-        sandbox.stub(window, 'fbq');
       });
 
       context('successful tracking', function() {
@@ -105,15 +112,6 @@ describe('Analytics Service', function () {
 
           expect(ga).to.have.been.calledOnce;
           expect(ga).to.have.been.calledWith('send', properties);
-        });
-
-        it('tracks a page view with Facebook', function() {
-          var properties = {'hitType':'pageview','eventCategory':'behavior','eventAction':'tasks'};
-          analytics.track(properties);
-          clock.tick();
-
-          expect(fbq).to.have.been.calledOnce;
-          expect(fbq).to.have.been.calledWith('track', 'PageView');
         });
       });
 
@@ -191,33 +189,20 @@ describe('Analytics Service', function () {
           habits: 1,
           dailys: 1,
           todos: 1,
-          rewards: 1,
+          rewards: 1
         };
         expectedProperties.balance = 12;
         expectedProperties.balanceGemAmount = 48;
-        expectedProperties.background = {
-          blizzard: true,
-        };
-        expectedProperties.shirt = {
-          horizon: true,
-        };
+        expectedProperties.animalEars = ['headAccessory_special_foxEars'];
+        expectedProperties.background = ['blizzard'];
+        expectedProperties.shirt = ['horizon'];
         expectedProperties.hair = {
-          base: {
-            1: true,
-          },
-          beard: {
-            3: true,
-          },
-          color: {
-            snowy: true,
-          },
-          mustache: {
-            2: true,
-          },
+          base: ['1'],
+          beard: ['3'],
+          color: ['snowy'],
+          mustache: ['2'],
         };
-        expectedProperties.skin = {
-          snowy: true,
-        };
+        expectedProperties.skin = ['snowy'];
 
         beforeEach(function() {
           user._id = 'unique-user-id';
@@ -235,9 +220,7 @@ describe('Analytics Service', function () {
           user.balance = 12;
           user.background = {
             blizzard: true,
-          };
-          user.shirt = {
-            horizon: true,
+            blue: true,
           };
           user.hair = {
             base: {
@@ -252,6 +235,13 @@ describe('Analytics Service', function () {
             mustache: {
               2: true,
             },
+          };
+          user.items.gear.owned = {
+            armor_special_bardRobes: true,
+            headAccessory_special_foxEars: true,
+          };
+          user.shirt = {
+            horizon: true,
           };
           user.skin = {
             snowy: true,
@@ -288,33 +278,20 @@ describe('Analytics Service', function () {
             todos: 1,
             dailys: 1,
             habits: 1,
-            rewards: 1,
+            rewards: 1
           },
           balance: 12,
           balanceGemAmount: 48,
-          background: {
-            blizzard: true,
-          },
-          shirt: {
-            horizon: true,
-          },
+          background: ['blizzard'],
+          shirt: ['horizon'],
           hair: {
-            base: {
-              1: true,
-            },
-            beard: {
-              3: true,
-            },
-            color: {
-              snowy: true,
-            },
-            mustache: {
-              2: true,
-            },
+            base: ['1'],
+            beard: ['3'],
+            color: ['snowy'],
+            mustache: ['2'],
           },
-          skin: {
-            snowy: true,
-          },
+          skin: ['snowy'],
+          animalEars: ['headAccessory_special_foxEars'],
         };
 
         beforeEach(function() {
@@ -335,9 +312,7 @@ describe('Analytics Service', function () {
           user.balance = 12;
           user.background = {
             blizzard: true,
-          };
-          user.shirt = {
-            horizon: true,
+            blue: true,
           };
           user.hair = {
             base: {
@@ -352,6 +327,13 @@ describe('Analytics Service', function () {
             mustache: {
               2: true,
             },
+          };
+          user.items.gear.owned = {
+            armor_special_bardRobes: true,
+            headAccessory_special_foxEars: true,
+          };
+          user.shirt = {
+            horizon: true,
           };
           user.skin = {
             snowy: true,

--- a/test/client-old/spec/services/analyticsServicesSpec.js
+++ b/test/client-old/spec/services/analyticsServicesSpec.js
@@ -26,22 +26,14 @@ describe('Analytics Service', function () {
     describe('register', function() {
 
       beforeEach(function() {
-        sandbox.stub(amplitude, 'setUserId');
-        sandbox.stub(window, 'ga');
+        sandbox.stub(window, 'fbq');
       });
 
-      it('sets up user with Amplitude', function() {
+      it('records a registration event on Facebook', function() {
         analytics.register();
         clock.tick();
-        expect(amplitude.setUserId).to.have.been.calledOnce;
-        expect(amplitude.setUserId).to.have.been.calledWith(user._id);
-      });
-
-      it('sets up user with Google Analytics', function() {
-        analytics.register();
-        clock.tick();
-        expect(ga).to.have.been.calledOnce;
-        expect(ga).to.have.been.calledWith('set', {userId: user._id});
+        expect(fbq).to.have.been.calledOnce;
+        expect(fbq).to.have.been.calledWith('track', 'CompleteRegistration');
       });
     });
 
@@ -74,6 +66,7 @@ describe('Analytics Service', function () {
       beforeEach(function() {
         sandbox.stub(amplitude, 'logEvent');
         sandbox.stub(window, 'ga');
+        sandbox.stub(window, 'fbq');
       });
 
       context('successful tracking', function() {
@@ -112,6 +105,15 @@ describe('Analytics Service', function () {
 
           expect(ga).to.have.been.calledOnce;
           expect(ga).to.have.been.calledWith('send', properties);
+        });
+
+        it('tracks a page view with Facebook', function() {
+          var properties = {'hitType':'pageview','eventCategory':'behavior','eventAction':'tasks'};
+          analytics.track(properties);
+          clock.tick();
+
+          expect(fbq).to.have.been.calledOnce;
+          expect(fbq).to.have.been.calledWith('track', 'PageView');
         });
       });
 
@@ -189,10 +191,33 @@ describe('Analytics Service', function () {
           habits: 1,
           dailys: 1,
           todos: 1,
-          rewards: 1
+          rewards: 1,
         };
         expectedProperties.balance = 12;
         expectedProperties.balanceGemAmount = 48;
+        expectedProperties.background = {
+          blizzard: true,
+        };
+        expectedProperties.shirt = {
+          horizon: true,
+        };
+        expectedProperties.hair = {
+          base: {
+            1: true,
+          },
+          beard: {
+            3: true,
+          },
+          color: {
+            snowy: true,
+          },
+          mustache: {
+            2: true,
+          },
+        };
+        expectedProperties.skin = {
+          snowy: true,
+        };
 
         beforeEach(function() {
           user._id = 'unique-user-id';
@@ -208,6 +233,29 @@ describe('Analytics Service', function () {
           user.todos = [{_id: 'todo'}];
           user.rewards = [{_id: 'reward'}];
           user.balance = 12;
+          user.background = {
+            blizzard: true,
+          };
+          user.shirt = {
+            horizon: true,
+          };
+          user.hair = {
+            base: {
+              1: true,
+            },
+            beard: {
+              3: true,
+            },
+            color: {
+              snowy: true,
+            },
+            mustache: {
+              2: true,
+            },
+          };
+          user.skin = {
+            snowy: true,
+          };
 
           analytics.updateUser(properties);
           clock.tick();
@@ -240,10 +288,33 @@ describe('Analytics Service', function () {
             todos: 1,
             dailys: 1,
             habits: 1,
-            rewards: 1
+            rewards: 1,
           },
           balance: 12,
-          balanceGemAmount: 48
+          balanceGemAmount: 48,
+          background: {
+            blizzard: true,
+          },
+          shirt: {
+            horizon: true,
+          },
+          hair: {
+            base: {
+              1: true,
+            },
+            beard: {
+              3: true,
+            },
+            color: {
+              snowy: true,
+            },
+            mustache: {
+              2: true,
+            },
+          },
+          skin: {
+            snowy: true,
+          },
         };
 
         beforeEach(function() {
@@ -262,6 +333,29 @@ describe('Analytics Service', function () {
           user.todos = [{_id: 'todo'}];
           user.rewards = [{_id: 'reward'}];
           user.balance = 12;
+          user.background = {
+            blizzard: true,
+          };
+          user.shirt = {
+            horizon: true,
+          };
+          user.hair = {
+            base: {
+              1: true,
+            },
+            beard: {
+              3: true,
+            },
+            color: {
+              snowy: true,
+            },
+            mustache: {
+              2: true,
+            },
+          };
+          user.skin = {
+            snowy: true,
+          };
 
           analytics.updateUser();
           clock.tick();

--- a/website/client-old/js/services/analyticsServices.js
+++ b/website/client-old/js/services/analyticsServices.js
@@ -32,6 +32,17 @@
       }, window['ga'].l = 1 * new Date();
     ga('create', window.env.GA_ID, user ? {'userId': user._id} : undefined);
 
+    // Facebook
+    var n = window.fbq = function() {
+      n.callMethod ? n.callMethod.apply(n, arguments) : n.queue.push(arguments)
+    };
+    if (!window._fbq) window._fbq = n;
+    n.push = n;
+    n.loaded = !0;
+    n.version = '2.0';
+    n.queue = [];
+    fbq('init', window.env.FACEBOOK_ANALYTICS);
+
     function loadScripts() {
       setTimeout(function() {
         // Amplitude
@@ -45,16 +56,22 @@
         // Google Analytics
         var a = document.createElement('script');
         var m = document.getElementsByTagName('script')[0];
-        a.async = 1;
+        a.async = true;
         a.src = '//www.google-analytics.com/analytics.js';
         m.parentNode.insertBefore(a, m);
+
+        // Facebook
+        var t = document.createElement('script');
+        var f = document.getElementsByTagName('script')[0];
+        t.async = true;
+        t.src = 'https://connect.facebook.net/en_US/fbevents.js';
+        f.parentNode.insertBefore(t, f);
       });
     }
 
     function register() {
       setTimeout(function() {
-        amplitude.setUserId(user._id);
-        ga('set', {'userId':user._id});
+        fbq('track', 'CompleteRegistration');
       });
     }
 
@@ -72,6 +89,9 @@
 
         amplitude.logEvent(properties.eventAction,properties);
         ga('send',properties);
+        if(properties.hitType === 'pageview') {
+          fbq('track', 'PageView');
+        }
       });
     }
 
@@ -110,6 +130,11 @@
 
     properties.balance = user.balance;
     properties.balanceGemAmount = properties.balance * 4;
+
+    properties.background = user.background;
+    properties.shirt = user.shirt;
+    properties.hair = user.hair;
+    properties.skin = user.skin;
 
     properties.tutorialComplete = user.flags && user.flags.tour && user.flags.tour.intro === -2;
     if (user.habits && user.dailys && user.todos && user.rewards) {

--- a/website/client-old/js/services/analyticsServices.js
+++ b/website/client-old/js/services/analyticsServices.js
@@ -145,10 +145,10 @@
 
     // gem-purchased items
     properties.animalEars = _filterAnimalEars(user.items.gear.owned);
-    properties.background = _filterBackgrounds(user.background);
-    properties.hair = _formatHair(user.hair);
-    properties.shirt = Object.keys(user.shirt);
-    properties.skin = Object.keys(user.skin);
+    properties.background = user.background ? _filterBackgrounds(user.background) : [];
+    properties.hair = user.hair ? _formatHair(user.hair) : {};
+    properties.shirt = user.shirt ? Object.keys(user.shirt) : [];
+    properties.skin = user.skin ? Object.keys(user.skin) : [];
 
     properties.tutorialComplete = user.flags && user.flags.tour && user.flags.tour.intro === -2;
     if (user.habits && user.dailys && user.todos && user.rewards) {

--- a/website/client-old/js/services/analyticsServices.js
+++ b/website/client-old/js/services/analyticsServices.js
@@ -143,12 +143,17 @@
     properties.balance = user.balance;
     properties.balanceGemAmount = properties.balance * 4;
 
-    // gem-purchased items
-    properties.animalEars = _filterAnimalEars(user.items.gear.owned);
-    properties.background = user.background ? _filterBackgrounds(user.background) : [];
-    properties.hair = user.hair ? _formatHair(user.hair) : {};
-    properties.shirt = user.shirt ? Object.keys(user.shirt) : [];
-    properties.skin = user.skin ? Object.keys(user.skin) : [];
+    properties.gemPurchased = {};
+    if (user.items && user.items.gear && user.items.gear.owned) {
+      properties.gemPurchased.animalEars = _filterAnimalEars(user.items.gear.owned);
+    }
+
+    if (user.purchased) {
+      properties.gemPurchased.background = user.purchased.background ? _filterBackgrounds(user.purchased.background) : [];
+      properties.gemPurchased.hair = user.purchased.hair ? _formatHair(user.purchased.hair) : {};
+      properties.gemPurchased.shirt = user.purchased.shirt ? Object.keys(user.purchased.shirt) : [];
+      properties.gemPurchased.skin = user.purchased.skin ? Object.keys(user.purchased.skin) : [];
+    }
 
     properties.tutorialComplete = user.flags && user.flags.tour && user.flags.tour.intro === -2;
     if (user.habits && user.dailys && user.todos && user.rewards) {

--- a/website/client-old/js/services/analyticsServices.js
+++ b/website/client-old/js/services/analyticsServices.js
@@ -112,9 +112,9 @@
     // filter out gem-purchased backgrounds from backgrounds
     function _filterBackgrounds (owned) {
       // current free backgrounds
-      var free = ['blue', 'green', 'purple', 'red', 'yellow'];
+      var freeBackgrounds = Object.keys(window.habitrpgShared.content.backgrounds.incentiveBackgrounds);
       return Object.keys(owned).reduce(function(purchased, background) {
-        if (!free.includes(background)) {
+        if (!freeBackgrounds.includes(background)) {
           purchased.push(background);
         }
         return purchased;

--- a/website/client-old/js/services/analyticsServices.js
+++ b/website/client-old/js/services/analyticsServices.js
@@ -32,17 +32,6 @@
       }, window['ga'].l = 1 * new Date();
     ga('create', window.env.GA_ID, user ? {'userId': user._id} : undefined);
 
-    // Facebook
-    var n = window.fbq = function() {
-      n.callMethod ? n.callMethod.apply(n, arguments) : n.queue.push(arguments)
-    };
-    if (!window._fbq) window._fbq = n;
-    n.push = n;
-    n.loaded = !0;
-    n.version = '2.0';
-    n.queue = [];
-    fbq('init', window.env.FACEBOOK_ANALYTICS);
-
     function loadScripts() {
       setTimeout(function() {
         // Amplitude
@@ -56,22 +45,16 @@
         // Google Analytics
         var a = document.createElement('script');
         var m = document.getElementsByTagName('script')[0];
-        a.async = true;
+        a.async = 1;
         a.src = '//www.google-analytics.com/analytics.js';
         m.parentNode.insertBefore(a, m);
-
-        // Facebook
-        var t = document.createElement('script');
-        var f = document.getElementsByTagName('script')[0];
-        t.async = true;
-        t.src = 'https://connect.facebook.net/en_US/fbevents.js';
-        f.parentNode.insertBefore(t, f);
       });
     }
 
     function register() {
       setTimeout(function() {
-        fbq('track', 'CompleteRegistration');
+        amplitude.setUserId(user._id);
+        ga('set', {'userId':user._id});
       });
     }
 
@@ -89,9 +72,6 @@
 
         amplitude.logEvent(properties.eventAction,properties);
         ga('send',properties);
-        if(properties.hitType === 'pageview') {
-          fbq('track', 'PageView');
-        }
       });
     }
 
@@ -118,6 +98,38 @@
   }
 
   function _gatherUserStats(user, properties) {
+    // filter out animal ears from owned items
+    function _filterAnimalEars (owned) {
+      var animalEarsRegEx = new RegExp('headAccessory_special_[a-z]+Ears', 'g');
+      return Object.keys(owned).reduce(function(animalEars, item) {
+        if (item.match(animalEarsRegEx)) {
+          animalEars.push(item);
+        }
+        return animalEars;
+      }, []);
+    }
+
+    // filter out gem-purchased backgrounds from backgrounds
+    function _filterBackgrounds (owned) {
+      // current free backgrounds
+      var free = ['blue', 'green', 'purple', 'red', 'yellow'];
+      return Object.keys(owned).reduce(function(purchased, background) {
+        if (!free.includes(background)) {
+          purchased.push(background);
+        }
+        return purchased;
+      }, []);
+    }
+
+    // format hair purchases
+    function _formatHair (hair) {
+      var purchased = {};
+      Object.keys(hair).forEach(function(style) {
+        purchased[style] = Object.keys(hair[style]);
+      });
+      return purchased;
+    }
+
     if (user._id) properties.UUID = user._id;
     if (user.stats) {
       properties.Class = user.stats.class;
@@ -131,10 +143,12 @@
     properties.balance = user.balance;
     properties.balanceGemAmount = properties.balance * 4;
 
-    properties.background = user.background;
-    properties.shirt = user.shirt;
-    properties.hair = user.hair;
-    properties.skin = user.skin;
+    // gem-purchased items
+    properties.animalEars = _filterAnimalEars(user.items.gear.owned);
+    properties.background = _filterBackgrounds(user.background);
+    properties.hair = _formatHair(user.hair);
+    properties.shirt = Object.keys(user.shirt);
+    properties.skin = Object.keys(user.skin);
 
     properties.tutorialComplete = user.flags && user.flags.tour && user.flags.tour.intro === -2;
     if (user.habits && user.dailys && user.todos && user.rewards) {

--- a/website/server/libs/analyticsService.js
+++ b/website/server/libs/analyticsService.js
@@ -72,6 +72,11 @@ let _formatUserData = (user) => {
   properties.balance = user.balance;
   properties.balanceGemAmount = properties.balance * 4;
 
+  properties.background = user.background;
+  properties.shirt = user.shirt;
+  properties.hair = user.hair;
+  properties.skin = user.skin;
+
   properties.tutorialComplete = user.flags && user.flags.tour && user.flags.tour.intro === -2;
 
   if (user.habits && user.dailys && user.todos && user.rewards) {

--- a/website/server/libs/analyticsService.js
+++ b/website/server/libs/analyticsService.js
@@ -73,9 +73,9 @@ let _formatUserData = (user) => {
   // filter out gem-purchased backgrounds from backgrounds
   function _filterBackgrounds (owned) {
     // current free backgrounds
-    const free = ['blue', 'green', 'purple', 'red', 'yellow'];
+    const freeBackgrounds = Object.keys(Content.backgrounds.incentiveBackgrounds);
     return Object.keys(owned).reduce((purchased, background) => {
-      if (!free.includes(background)) {
+      if (!freeBackgrounds.includes(background)) {
         purchased.push(background);
       }
       return purchased;

--- a/website/server/libs/analyticsService.js
+++ b/website/server/libs/analyticsService.js
@@ -107,10 +107,10 @@ let _formatUserData = (user) => {
 
   // gem-purchased items
   properties.animalEars = _filterAnimalEars(user.items.gear.owned);
-  properties.background = _filterBackgrounds(user.background);
-  properties.hair = _formatHair(user.hair);
-  properties.shirt = Object.keys(user.shirt);
-  properties.skin = Object.keys(user.skin);
+  properties.background = user.background ? _filterBackgrounds(user.background) : [];
+  properties.hair = user.hair ? _formatHair(user.hair) : {};
+  properties.shirt = user.shirt ? Object.keys(user.shirt) : [];
+  properties.skin = user.skin ? Object.keys(user.skin) : [];
 
   properties.tutorialComplete = user.flags && user.flags.tour && user.flags.tour.intro === -2;
 

--- a/website/server/libs/analyticsService.js
+++ b/website/server/libs/analyticsService.js
@@ -57,7 +57,40 @@ let _lookUpItemName = (itemKey) => {
   return itemName;
 };
 
+
 let _formatUserData = (user) => {
+  // filter out animal ears from owned items
+  function _filterAnimalEars (owned) {
+    var animalEarsRegEx = new RegExp('headAccessory_special_[a-z]+Ears', 'g');
+    return Object.keys(owned).reduce(function(animalEars, item) {
+      if (item.match(animalEarsRegEx)) {
+        animalEars.push(item);
+      }
+      return animalEars;
+    }, []);
+  }
+
+  // filter out gem-purchased backgrounds from backgrounds
+  function _filterBackgrounds (owned) {
+    // current free backgrounds
+    const free = ['blue', 'green', 'purple', 'red', 'yellow'];
+    return Object.keys(owned).reduce((purchased, background) => {
+      if (!free.includes(background)) {
+        purchased.push(background);
+      }
+      return purchased;
+    }, []);
+  }
+
+  // format hair purchases
+  function _formatHair (hair) {
+    const purchased = {};
+    Object.keys(hair).forEach((style) => {
+      purchased[style] = Object.keys(hair[style]);
+    });
+    return purchased;
+  }
+
   let properties = {};
 
   if (user.stats) {
@@ -72,10 +105,12 @@ let _formatUserData = (user) => {
   properties.balance = user.balance;
   properties.balanceGemAmount = properties.balance * 4;
 
-  properties.background = user.background;
-  properties.shirt = user.shirt;
-  properties.hair = user.hair;
-  properties.skin = user.skin;
+  // gem-purchased items
+  properties.animalEars = _filterAnimalEars(user.items.gear.owned);
+  properties.background = _filterBackgrounds(user.background);
+  properties.hair = _formatHair(user.hair);
+  properties.shirt = Object.keys(user.shirt);
+  properties.skin = Object.keys(user.skin);
 
   properties.tutorialComplete = user.flags && user.flags.tour && user.flags.tour.intro === -2;
 

--- a/website/server/libs/analyticsService.js
+++ b/website/server/libs/analyticsService.js
@@ -61,8 +61,8 @@ let _lookUpItemName = (itemKey) => {
 let _formatUserData = (user) => {
   // filter out animal ears from owned items
   function _filterAnimalEars (owned) {
-    var animalEarsRegEx = new RegExp('headAccessory_special_[a-z]+Ears', 'g');
-    return Object.keys(owned).reduce(function(animalEars, item) {
+    const animalEarsRegEx = new RegExp('headAccessory_special_[a-z]+Ears', 'g');
+    return Object.keys(owned).reduce((animalEars, item) => {
       if (item.match(animalEarsRegEx)) {
         animalEars.push(item);
       }

--- a/website/server/libs/analyticsService.js
+++ b/website/server/libs/analyticsService.js
@@ -105,12 +105,18 @@ let _formatUserData = (user) => {
   properties.balance = user.balance;
   properties.balanceGemAmount = properties.balance * 4;
 
-  // gem-purchased items
-  properties.animalEars = _filterAnimalEars(user.items.gear.owned);
-  properties.background = user.background ? _filterBackgrounds(user.background) : [];
-  properties.hair = user.hair ? _formatHair(user.hair) : {};
-  properties.shirt = user.shirt ? Object.keys(user.shirt) : [];
-  properties.skin = user.skin ? Object.keys(user.skin) : [];
+
+  properties.gemPurchased = {};
+  if (user.items && user.items.gear && user.items.gear.owned) {
+    properties.gemPurchased.animalEars = _filterAnimalEars(user.items.gear.owned);
+  }
+
+  if (user.purchased) {
+    properties.gemPurchased.background = user.purchased.background ? _filterBackgrounds(user.purchased.background) : [];
+    properties.gemPurchased.hair = user.purchased.hair ? _formatHair(user.purchased.hair) : {};
+    properties.gemPurchased.shirt = user.purchased.shirt ? Object.keys(user.purchased.shirt) : [];
+    properties.gemPurchased.skin = user.purchased.skin ? Object.keys(user.purchased.skin) : [];
+  }
 
   properties.tutorialComplete = user.flags && user.flags.tour && user.flags.tour.intro === -2;
 


### PR DESCRIPTION
### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
- In the analytics services files, sends the user's animal ears, backgrounds, shirts, skins, and hairs to Amplitude
- Added tests for the above
- Added two filter functions: One removes the plain backgrounds and only sends gem-purchased backgrounds to Amplitude. The other filters out animal ears from `items.gear.owned` to send to Amplitude.
- Added a function to format hair purchases, see below for an example.
- Gem-purchased items are sent to Amplitude in arrays, so something like this:
```javascript
{
  // ...
  animalEars: [ 'headAccessory_special_foxEars' ],
  background: [ 'blizzard' ],
  // hair is sent as an object of arrays:
  hair: {
    base: [ '1' ],
    beard: [ '3' ],
    color: [ 'snowy' ],
    mustache: [ '2' ],
  },
  shirt: [ 'horizon' ],
  skin: [ 'snowy' ]
  // ...
}
```

EDIT (2017-04-29): The filter function that removes free backgrounds from being sent to Amplitude now grabs them from the common backgrounds.js file.

[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: a3f88ebe-efd8-4ff9-a887-efb5d2522a97
