### PR TITLE
Automatically add a 'two handed' suffix (#8441)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ test/client-old/spec/mocks/translations.js
 .elasticbeanstalk/*
 !.elasticbeanstalk/*.cfg.yml
 !.elasticbeanstalk/*.global.yml
+/nbproject/private/

--- a/website/client-old/js/controllers/inventoryCtrl.js
+++ b/website/client-old/js/controllers/inventoryCtrl.js
@@ -365,6 +365,12 @@ habitrpg.controller("InventoryCtrl",
       }
     };
 
+    $scope.twoHandedNotes = function (item) {
+      if (item.twoHanded) {
+        return window.env.t('twoHandedItem');
+      }
+    };
+
     $scope.hasAllTimeTravelerItems = function() {
       return ($scope.hasAllTimeTravelerItemsOfType('mystery') &&
         $scope.hasAllTimeTravelerItemsOfType('pets') &&

--- a/website/common/locales/en/gear.json
+++ b/website/common/locales/en/gear.json
@@ -4,6 +4,7 @@
   "klass": "Class",
   "groupBy": "Group By <%= type %>",
   "classBonus": "(This item matches your class, so it gets an additional 1.5 stat multiplier.)",
+  "twoHandedItem": "Two-handed item.",
 
   "weapon": "weapon",
   "weaponCapitalized" : "Weapon",
@@ -101,7 +102,7 @@
   "weaponSpecialSkiText": "Ski-sassin Pole",
   "weaponSpecialSkiNotes": "A weapon capable of destroying hordes of enemies! It also helps the user make very nice parallel turns. Increases Strength by <%= str %>. Limited Edition 2013-2014 Winter Gear.",
   "weaponSpecialCandycaneText": "Candy Cane Staff",
-  "weaponSpecialCandycaneNotes": "A powerful mage's staff. Powerfully DELICIOUS, we mean! Two-handed weapon. Increases Intelligence by <%= int %> and Perception by <%= per %>. Limited Edition 2013-2014 Winter Gear.",
+  "weaponSpecialCandycaneNotes": "A powerful mage's staff. Powerfully DELICIOUS, we mean! Increases Intelligence by <%= int %> and Perception by <%= per %>. Limited Edition 2013-2014 Winter Gear.",
   "weaponSpecialSnowflakeText": "Snowflake Wand",
   "weaponSpecialSnowflakeNotes": "This wand sparkles with unlimited healing power. Increases Intelligence by <%= int %>. Limited Edition 2013-2014 Winter Gear.",
 

--- a/website/views/options/inventory/equipment.jade
+++ b/website/views/options/inventory/equipment.jade
@@ -26,7 +26,7 @@ mixin equipmentButton(type)
       button.customize-option(class='shop_{{::item.key}}',
         ng-class='{selectableInventory: user.items.gear.#{type}[item.type] == item.key}',
         ng-click='equip(item.key, "#{type}")',
-        popover='{{::item.notes()}} {{::classBonusNotes(item)}}', popover-title='{{::item.text()}}',
+        popover='{{::item.notes()}} {{::classBonusNotes(item)}} {{::twoHandedNotes(item)}}', popover-title='{{::item.text()}}',
         popover-trigger='mouseenter', popover-placement='right',
         popover-append-to-body='true')
 


### PR DESCRIPTION
…ded weapons (similar to the class bonus suffix).

[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes https://github.com/HabitRPG/habitica/issues/8441

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Items with the `twoHanded` property will now automatically have the suffix "Two-handed item" appended to their description on the Equipment page.  

[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: 
