### PR TITLE
Use backticks in 'quest started' system message

### DIFF
--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -554,7 +554,7 @@ schema.methods.startQuest = async function startQuest (user) {
         });
     });
   });
-  this.sendChat(`Your quest, ${quest.text('en')}, has started.`, null, {
+  this.sendChat(`\`Your quest, ${quest.text('en')}, has started.\``, null, {
     participatingMembers: this.getParticipatingQuestMembers().join(', '),
   });
 };


### PR DESCRIPTION
Fixes #8445

[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

### Problem

All automated system messages in party chat are written with backticks to format as a `<code>` HTML element. Except the message to signify a quest starting, which is unfortunately quite inconsistent.

![](https://cloud.githubusercontent.com/assets/5641207/22169171/06f55024-df27-11e6-89db-e1cac1d16dc8.png)

### Solution

Make it match the other messages! Format with backticks.

<img width="599" alt="screen shot 2017-02-21 at 9 38 37 pm" src="https://cloud.githubusercontent.com/assets/12753198/23194795/387b4886-f87e-11e6-8cb5-68ddce0e92bf.png">


[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: bd794f6e-3845-49e5-88cc-a140b24cdea4
