### PR TITLE
Add isDue prop to tasks

### DIFF
--- a/test/api/v3/integration/tasks/GET-tasks_challenge_challengeId.test.js
+++ b/test/api/v3/integration/tasks/GET-tasks_challenge_challengeId.test.js
@@ -61,6 +61,12 @@ describe('GET /tasks/:taskId', () => {
         expect(getTask).to.eql(task);
       });
 
+      it('does not include isDue property', async () => {
+        let getTask = await user.get(`/tasks/${task._id}`);
+
+        expect(getTask.isDue).to.not.exist;
+      });
+
       it('returns error when user is not a member of the challenge', async () => {
         let anotherUser = await generateUser();
 

--- a/test/api/v3/integration/tasks/GET-tasks_id.test.js
+++ b/test/api/v3/integration/tasks/GET-tasks_id.test.js
@@ -34,6 +34,12 @@ describe('GET /tasks/:id', () => {
       expect(getTask).to.eql(task);
     });
 
+    it('includes isDue property', async () => {
+      let getTask = await user.get(`/tasks/${task.alias}`);
+
+      expect(getTask.isDue).to.be.a('boolean');
+    });
+
     // TODO after challenges are implemented
     it('can get active challenge task that user does not own'); // Yes?
   });

--- a/test/api/v3/integration/tasks/GET-tasks_user.test.js
+++ b/test/api/v3/integration/tasks/GET-tasks_user.test.js
@@ -15,6 +15,16 @@ describe('GET /tasks/user', () => {
     expect(tasks.length).to.equal(createdTasks.length + 1); // + 1 because 1 is a default task
   });
 
+  it('includes isDue properties on user tasks', async () => {
+    await user.post('/tasks/user', [{text: 'test habit', type: 'habit'}, {text: 'test todo', type: 'todo'}]);
+    let tasks = await user.get('/tasks/user');
+    expect(tasks.length).to.be.greaterThan(0);
+
+    tasks.forEach((task) => {
+      expect(task.isDue).to.be.a('boolean');
+    });
+  });
+
   it('returns only a type of user\'s tasks if req.query.type is specified', async () => {
     let createdTasks = await user.post('/tasks/user', [
       {text: 'test habit', type: 'habit'},

--- a/test/api/v3/integration/tasks/POST-tasks_id_score_direction.test.js
+++ b/test/api/v3/integration/tasks/POST-tasks_id_score_direction.test.js
@@ -78,6 +78,7 @@ describe('POST /tasks/:id/score/:direction', () => {
       expect(body.user).to.have.all.keys('_id', '_tmp', 'stats');
       expect(body.user.stats).to.have.all.keys('hp', 'mp', 'exp', 'gp', 'lvl', 'class', 'points', 'str', 'con', 'int', 'per', 'buffs', 'training', 'maxHealth', 'maxMP', 'toNextLevel');
       expect(body.task.id).to.eql(task.id);
+      expect(body.task.isDue).to.be.a('boolean');
       expect(body.direction).to.eql('up');
       expect(body.delta).to.be.greaterThan(0);
     });

--- a/test/api/v3/integration/tasks/POST-tasks_user.test.js
+++ b/test/api/v3/integration/tasks/POST-tasks_user.test.js
@@ -301,6 +301,15 @@ describe('POST /tasks/user', () => {
 
       expect(task.alias).to.eql('a_alias012');
     });
+
+    it('includes isDue property in task response', async () => {
+      let task = await user.post('/tasks/user', {
+        text: 'test daily',
+        type: 'daily',
+      });
+
+      expect(task.isDue).to.be.a('boolean');
+    });
   });
 
   context('habits', () => {

--- a/test/api/v3/integration/tasks/PUT-tasks_id.test.js
+++ b/test/api/v3/integration/tasks/PUT-tasks_id.test.js
@@ -295,6 +295,14 @@ describe('PUT /tasks/:id', () => {
 
       expect(fetchedDaily.text).to.eql('saved');
     });
+
+    it('includes isDue property in task response', async () => {
+      let savedDaily = await user.put(`/tasks/${daily._id}`, {
+        text: 'new text',
+      });
+
+      expect(savedDaily.isDue).to.be.a('boolean');
+    });
   });
 
   context('habits', () => {

--- a/test/api/v3/unit/models/task.test.js
+++ b/test/api/v3/unit/models/task.test.js
@@ -5,6 +5,7 @@ import * as Tasks from '../../../../../website/server/models/task';
 import { InternalServerError } from '../../../../../website/server/libs/errors';
 import { each } from 'lodash';
 import { generateHistory } from '../../../../helpers/api-unit.helper.js';
+import shared from '../../../../../website/common';
 
 describe('Task Model', () => {
   let guild, leader, challenge, task;
@@ -165,6 +166,79 @@ describe('Task Model', () => {
   });
 
   describe('Instance Methods', () => {
+    describe('withIsDue', () => {
+      it('returns the doc if task is not owned by the user', () => {
+        let daily = new Tasks.daily({ // eslint-disable-line new-cap
+          text: 'Daily',
+          userId: 'user-id',
+        });
+
+        let dailyObj = daily.withIsDue({
+          _id: 'not-user-id',
+        });
+
+        expect(daily).to.equal(dailyObj);
+      });
+
+      it('does not include isDue if not owned by the user', () => {
+        let daily = new Tasks.daily({ // eslint-disable-line new-cap
+          text: 'Daily',
+          userId: 'user-id',
+        });
+
+        let dailyObj = daily.withIsDue({
+          _id: 'not-user-id',
+        });
+
+        expect(dailyObj.isDue).to.not.exist;
+      });
+
+      it('returns a plain javascript object if task is owned by user', () => {
+        let daily = new Tasks.daily({ // eslint-disable-line new-cap
+          text: 'Daily',
+          userId: 'user-id',
+        });
+
+        let dailyObj = daily.withIsDue({
+          _id: 'user-id',
+        });
+
+        expect(daily).to.not.equal(dailyObj);
+        expect(daily.text).to.equal(dailyObj.text);
+      });
+
+      it('includes an isDue property', () => {
+        let daily = new Tasks.daily({ // eslint-disable-line new-cap
+          text: 'Daily',
+          userId: 'user-id',
+        });
+
+        let dailyObj = daily.withIsDue({
+          _id: 'user-id',
+        });
+
+        expect(dailyObj.isDue).to.be.a('boolean');
+      });
+
+      it('calls shared.shouldDo to calculate isDue', () => {
+        sandbox.spy(shared, 'shouldDo');
+
+        let user = {
+          _id: 'user-id',
+          preferences: {},
+        };
+        let daily = new Tasks.daily({ // eslint-disable-line new-cap
+          text: 'Daily',
+          userId: 'user-id',
+        });
+
+        daily.withIsDue(user);
+
+        expect(shared.shouldDo).to.be.calledOnce;
+        expect(shared.shouldDo).to.be.calledWith(sandbox.match.number, daily, user.preferences);
+      });
+    });
+
     describe('scoreChallengeTask', () => {
     });
 


### PR DESCRIPTION
### Changes

First pass at adding `task.isDue` to tasks. This will make API users (such as the mobile apps) not need to duplicate complex and ever changing shouldDo logic.

We need to have access to the user's preferences when calculating if a daily is do, so, unfortunately, we have to call a method on each route that sends back the user's task object.

Open to suggestions in regard to naming these methods and property.