### PR TITLE
Subscription end date should format according to user's preference

### DIFF
--- a/website/views/options/settings/subscription.jade
+++ b/website/views/options/settings/subscription.jade
@@ -12,7 +12,7 @@ script(id='partials/options.settings.subscription.html',type='text/ng-template',
           tr(ng-if='user.purchased.plan.dateTerminated'): td.alert.alert-warning
             span.noninteractive-button.btn-danger=env.t('canceledSubscription')
             i.glyphicon.glyphicon-time
-            |  #{env.t('subCanceled')} <strong>{{moment(user.purchased.plan.dateTerminated).format('MM/DD/YYYY')}}</strong>
+            |  #{env.t('subCanceled')} <strong>{{user.purchased.plan.dateTerminated | date:user.preferences.dateFormat}}</strong>
           tr(ng-if='!user.purchased.plan.dateTerminated'): td
             h4=env.t('subscribed')
             p(ng-if='user.purchased.plan.planId')=env.t('purchasedPlanId', {price: '{{Content.subscriptionBlocks[user.purchased.plan.planId].price}}', months: '{{Content.subscriptionBlocks[user.purchased.plan.planId].months}}', plan: '{{user.purchased.plan.paymentMethod}}'})


### PR DESCRIPTION
Fixes #8506 

### Problem
On the Settings > Subscription page, a canceled subscription's end date is always formatted `MM/dd/yyyy`, even when the user's preferred date format differs.

### Solution
Use the user's chosen date format instead of hard-coding the USA format.

<img width="501" alt="screen shot 2017-02-26 at 5 27 34 pm" src="https://cloud.githubusercontent.com/assets/12753198/23344353/04865f4c-fc49-11e6-9484-21195b4c3247.png">

### Details
I've used the Angular date filter to format the subscription's `dateTerminated` by `user.preferences.dateFormat`

----
UUID: bd794f6e-3845-49e5-88cc-a140b24cdea4
