### PR TITLE
Fix character values - do not allow values less than 1 - fixes #8512

### DIFF
--- a/test/client-old/spec/controllers/settingsCtrlSpec.js
+++ b/test/client-old/spec/controllers/settingsCtrlSpec.js
@@ -18,6 +18,7 @@ describe('Settings Controller', function () {
         releaseMounts: sandbox.stub(),
         releaseBoth: sandbox.stub(),
         setCustomDayStart: sandbox.stub(),
+        restore: sandbox.stub(),
         user: user
       };
 
@@ -27,6 +28,7 @@ describe('Settings Controller', function () {
         releasePets: sandbox.stub(),
         releaseMounts: sandbox.stub(),
         releaseBoth: sandbox.stub(),
+        restore: sandbox.stub(),
       };
 
       Notification = {
@@ -331,6 +333,44 @@ describe('Settings Controller', function () {
 
         expect(Notification.error).to.not.be.called;
         expect(Notification.text).to.be.calledWith('Coupon applied!');
+      });
+    });
+  });
+
+  context('Fixing character values', function () {
+    describe('#restore', function () {
+      it('updates character values only when valid values are entered', function () {
+        scope.restoreValues = {
+          stats: {
+            hp: -1,
+            exp: -1,
+            gp: -1,
+            lvl: 0,
+            mp: -1,
+          },
+          achievements: {
+            streak: -1,
+          },
+        };
+        scope.restore();
+        expect(User.set).to.not.be.called;
+      });
+
+      it('doesn\'t update character values when invalid values are entered', function () {
+        scope.restoreValues = {
+          stats: {
+            hp: 0,
+            exp: 0,
+            gp: 0,
+            lvl: 1,
+            mp: 0,
+          },
+          achievements: {
+            streak: 0,
+          },
+        };
+        scope.restore();
+        expect(User.set).to.be.called;
       });
     });
   });

--- a/test/client-old/spec/controllers/settingsCtrlSpec.js
+++ b/test/client-old/spec/controllers/settingsCtrlSpec.js
@@ -18,7 +18,6 @@ describe('Settings Controller', function () {
         releaseMounts: sandbox.stub(),
         releaseBoth: sandbox.stub(),
         setCustomDayStart: sandbox.stub(),
-        restore: sandbox.stub(),
         user: user
       };
 
@@ -28,7 +27,6 @@ describe('Settings Controller', function () {
         releasePets: sandbox.stub(),
         releaseMounts: sandbox.stub(),
         releaseBoth: sandbox.stub(),
-        restore: sandbox.stub(),
       };
 
       Notification = {
@@ -339,36 +337,28 @@ describe('Settings Controller', function () {
 
   context('Fixing character values', function () {
     describe('#restore', function () {
+      var blankRestoreValues = {
+        stats: {
+          hp: 0,
+          exp: 0,
+          gp: 0,
+          lvl: 0,
+          mp: 0,
+        },
+        achievements: {
+          streak: 0,
+        },
+      };
+
       it('doesn\'t update character values when level is less than 1', function () {
-        scope.restoreValues = {
-          stats: {
-            hp: 0,
-            exp: 0,
-            gp: 0,
-            lvl: 0,
-            mp: 0,
-          },
-          achievements: {
-            streak: 0,
-          },
-        };
+        scope.restoreValues = blankRestoreValues;
         scope.restore();
         expect(User.set).to.not.be.called;
       });
 
       it('updates character values when level is at least 1', function () {
-        scope.restoreValues = {
-          stats: {
-            hp: 0,
-            exp: 0,
-            gp: 0,
-            lvl: 1,
-            mp: 0,
-          },
-          achievements: {
-            streak: 0,
-          },
-        };
+        scope.restoreValues = blankRestoreValues;
+        scope.restoreValues.stats.lvl = 1;
         scope.restore();
         expect(User.set).to.be.called;
       });

--- a/test/client-old/spec/controllers/settingsCtrlSpec.js
+++ b/test/client-old/spec/controllers/settingsCtrlSpec.js
@@ -339,24 +339,24 @@ describe('Settings Controller', function () {
 
   context('Fixing character values', function () {
     describe('#restore', function () {
-      it('updates character values only when valid values are entered', function () {
+      it('doesn\'t update character values when level is less than 1', function () {
         scope.restoreValues = {
           stats: {
-            hp: -1,
-            exp: -1,
-            gp: -1,
+            hp: 0,
+            exp: 0,
+            gp: 0,
             lvl: 0,
-            mp: -1,
+            mp: 0,
           },
           achievements: {
-            streak: -1,
+            streak: 0,
           },
         };
         scope.restore();
         expect(User.set).to.not.be.called;
       });
 
-      it('doesn\'t update character values when invalid values are entered', function () {
+      it('updates character values when level is at least 1', function () {
         scope.restoreValues = {
           stats: {
             hp: 0,

--- a/website/client-old/js/controllers/settingsCtrl.js
+++ b/website/client-old/js/controllers/settingsCtrl.js
@@ -2,8 +2,8 @@
 
 // Make user and settings available for everyone through root scope.
 habitrpg.controller('SettingsCtrl',
-  ['$scope', 'User', '$rootScope', '$http', 'ApiUrl', 'Guide', '$location', '$timeout', 'Content', 'Notification', 'Shared', 'Social', '$compile',
-  function($scope, User, $rootScope, $http, ApiUrl, Guide, $location, $timeout, Content, Notification, Shared, Social, $compile) {
+  ['$scope', 'User', '$rootScope', '$http', 'ApiUrl', 'Guide', '$location', '$modalStack', '$timeout', 'Content', 'Notification', 'Shared', 'Social', '$compile',
+  function($scope, User, $rootScope, $http, ApiUrl, Guide, $location, $modalStack, $timeout, Content, Notification, Shared, Social, $compile) {
     var RELEASE_ANIMAL_TYPES = {
       pets: 'releasePets',
       mounts: 'releaseMounts',
@@ -164,14 +164,17 @@ habitrpg.controller('SettingsCtrl',
     $scope.restore = function(){
       var stats = $scope.restoreValues.stats,
         achievements = $scope.restoreValues.achievements;
-      User.set({
-        "stats.hp": stats.hp,
-        "stats.exp": stats.exp,
-        "stats.gp": stats.gp,
-        "stats.lvl": stats.lvl,
-        "stats.mp": stats.mp,
-        "achievements.streak": achievements.streak
-      });
+      if (_validateValues(stats, achievements)) {
+        User.set({
+          'stats.hp': stats.hp,
+          'stats.exp': stats.exp,
+          'stats.gp': stats.gp,
+          'stats.lvl': stats.lvl,
+          'stats.mp': stats.mp,
+          'achievements.streak': achievements.streak
+        });
+        $modalStack.dismissAll();
+      }
     }
 
     $scope.reset = function(){
@@ -345,6 +348,16 @@ habitrpg.controller('SettingsCtrl',
       }
 
       return +nextCron.format('x');
+    }
+
+    function _validateValues(stats, achievements) {
+      if (stats.hp < 0 || stats.exp < 0 ||
+          stats.gp < 0 || stats.lvl < 1 ||
+          stats.mp < 0 || achievements.streak < 0) {
+        Notification.error(env.t('invalidValue'), true);
+        return false;
+      }
+      return true;
     }
   }
 ]);

--- a/website/client-old/js/controllers/settingsCtrl.js
+++ b/website/client-old/js/controllers/settingsCtrl.js
@@ -164,17 +164,21 @@ habitrpg.controller('SettingsCtrl',
     $scope.restore = function(){
       var stats = $scope.restoreValues.stats,
         achievements = $scope.restoreValues.achievements;
-      if (_validateValues(stats.lvl)) {
-        User.set({
-          'stats.hp': stats.hp,
-          'stats.exp': stats.exp,
-          'stats.gp': stats.gp,
-          'stats.lvl': stats.lvl,
-          'stats.mp': stats.mp,
-          'achievements.streak': achievements.streak
-        });
-        $modalStack.dismissAll();
+
+      if (stats.lvl < 1) {
+        Notification.error(env.t('invalidLevel'), true);
+        return;
       }
+
+      User.set({
+        'stats.hp': stats.hp,
+        'stats.exp': stats.exp,
+        'stats.gp': stats.gp,
+        'stats.lvl': stats.lvl,
+        'stats.mp': stats.mp,
+        'achievements.streak': achievements.streak
+      });
+      $modalStack.dismissAll();
     }
 
     $scope.reset = function(){
@@ -348,14 +352,6 @@ habitrpg.controller('SettingsCtrl',
       }
 
       return +nextCron.format('x');
-    }
-
-    function _validateValues(level) {
-      if (level < 1) {
-        Notification.error(env.t('invalidLevel'), true);
-        return false;
-      }
-      return true;
     }
   }
 ]);

--- a/website/client-old/js/controllers/settingsCtrl.js
+++ b/website/client-old/js/controllers/settingsCtrl.js
@@ -164,7 +164,7 @@ habitrpg.controller('SettingsCtrl',
     $scope.restore = function(){
       var stats = $scope.restoreValues.stats,
         achievements = $scope.restoreValues.achievements;
-      if (_validateValues(stats, achievements)) {
+      if (_validateValues(stats.lvl)) {
         User.set({
           'stats.hp': stats.hp,
           'stats.exp': stats.exp,
@@ -350,11 +350,9 @@ habitrpg.controller('SettingsCtrl',
       return +nextCron.format('x');
     }
 
-    function _validateValues(stats, achievements) {
-      if (stats.hp < 0 || stats.exp < 0 ||
-          stats.gp < 0 || stats.lvl < 1 ||
-          stats.mp < 0 || achievements.streak < 0) {
-        Notification.error(env.t('invalidValue'), true);
+    function _validateValues(level) {
+      if (level < 1) {
+        Notification.error(env.t('invalidLevel'), true);
         return false;
       }
       return true;

--- a/website/common/locales/en/settings.json
+++ b/website/common/locales/en/settings.json
@@ -26,6 +26,7 @@
     "showBaileyPop": "Bring Bailey the Town Crier out of hiding so you can review past news.",
     "fixVal": "Fix Character Values",
     "fixValPop": "Manually change values like Health, Level, and Gold.",
+    "invalidValue": "Invalid value: Level must be 1 or greater. All other values must be 0 or greater.",
     "enableClass": "Enable Class System",
     "enableClassPop": "You opted out of the class system initially. Would you like now to opt-in?",
     "classTourPop": "Show the tour for using the class system.",

--- a/website/common/locales/en/settings.json
+++ b/website/common/locales/en/settings.json
@@ -26,7 +26,7 @@
     "showBaileyPop": "Bring Bailey the Town Crier out of hiding so you can review past news.",
     "fixVal": "Fix Character Values",
     "fixValPop": "Manually change values like Health, Level, and Gold.",
-    "invalidValue": "Invalid value: Level must be 1 or greater. All other values must be 0 or greater.",
+    "invalidLevel": "Invalid value: Level must be 1 or greater.",
     "enableClass": "Enable Class System",
     "enableClassPop": "You opted out of the class system initially. Would you like now to opt-in?",
     "classTourPop": "Show the tour for using the class system.",

--- a/website/server/models/user/schema.js
+++ b/website/server/models/user/schema.js
@@ -494,7 +494,7 @@ let schema = new Schema({
     mp: {type: Number, default: 10},
     exp: {type: Number, default: 0},
     gp: {type: Number, default: 0},
-    lvl: {type: Number, default: 1},
+    lvl: {type: Number, default: 1, min: 1},
 
     // Class System
     class: {type: String, enum: ['warrior', 'rogue', 'wizard', 'healer'], default: 'warrior', required: true},

--- a/website/views/shared/modals/settings.jade
+++ b/website/views/shared/modals/settings.jade
@@ -55,7 +55,7 @@ script(type='text/ng-template', id='modals/restore.html')
       a.btn.btn-sm.btn-warning(ng-controller='FooterCtrl', ng-click='addMissedDay(1)')=env.t('triggerDay')
   .modal-footer
     button.btn.btn-default(ng-click='$close()')=env.t('discardChanges')
-    button.btn.btn-primary(ng-click='restore(); $close();')=env.t('saveAndClose')
+    button.btn.btn-primary(ng-click='restore()')=env.t('saveAndClose')
 
 script(type='text/ng-template', id='modals/delete.html')
   .modal-header


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #8512 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
- ~~Display an error message if invalid character values are entered in the 'fix character values' section~~
- ~~I put an invalidValue message in the en locale settings.json file that says: "Invalid value: Level must be 1 or greater. All other values must be 0 or greater."~~
  - ~~Let me know if this should be modified. This was what I have as a general message to display, rather than displaying a separate message depending on which values are invalid.~~
- Display an error message if a level less than 1 is entered in the 'fix character values' section
- Fix character values modal only closes when the user clicks on 'save and close' and the entered values are valid (can still be closed if they hit the 'cancel' button)

![levelerror](https://cloud.githubusercontent.com/assets/11846752/23712057/883f7ece-03d6-11e7-8f82-30e56a035b5b.png)

[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: a3f88ebe-efd8-4ff9-a887-efb5d2522a97
