### PR TITLE
Send group plans subscription message to Slack

### DIFF
--- a/website/server/libs/payments.js
+++ b/website/server/libs/payments.js
@@ -56,9 +56,9 @@ function _dateDiff (earlyDate, lateDate) {
 api.addSubscriptionToGroupUsers = async function addSubscriptionToGroupUsers (group) {
   let members;
   if (group.type === 'guild') {
-    members = await User.find({guilds: group._id}).select('_id purchased').exec();
+    members = await User.find({guilds: group._id}).select('_id purchased auth profile.name').exec();
   } else {
-    members = await User.find({'party._id': group._id}).select('_id purchased').exec();
+    members = await User.find({'party._id': group._id}).select('_id purchased auth profile.name').exec();
   }
 
   let promises = members.map((member) => {

--- a/website/server/libs/payments.js
+++ b/website/server/libs/payments.js
@@ -378,7 +378,8 @@ api.createSubscription = async function createSubscription (data) {
       email: getUserInfo(data.gift.member, ['email']).email,
     } : {},
     paymentMethod: data.paymentMethod,
-    months,
+    months: group ? 1 : months,
+    groupId,
   });
 };
 

--- a/website/server/libs/slack.js
+++ b/website/server/libs/slack.js
@@ -69,6 +69,7 @@ function sendSubscriptionNotification ({
   recipient,
   paymentMethod,
   months,
+  groupId,
 }) {
   if (!SLACK_SUBSCRIPTIONS_URL) {
     return;
@@ -77,6 +78,8 @@ function sendSubscriptionNotification ({
   let timestamp = new Date();
   if (recipient.id) {
     text = `${buyer.name} ${buyer.id} ${buyer.email} bought a ${months}-month gift subscription for ${recipient.name} ${recipient.id} ${recipient.email} using ${paymentMethod} on ${timestamp}`;
+  } else if (groupId) {
+    text = `${buyer.name} ${buyer.id} ${buyer.email} bought a 1-month recurring group-plan for ${groupId} using ${paymentMethod} on ${timestamp}`;
   } else {
     text = `${buyer.name} ${buyer.id} ${buyer.email} bought a ${months}-month recurring subscription using ${paymentMethod} on ${timestamp}`;
   }


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Previously, functionality for sending troubleshooting data to the moderator Slack when users bought subscriptions did not handle group plan subscriptions. Now, if a user purchases a group plan, a message tailored to this situation gets sent. (Note that `group-plan` rather than `group plan` is intentional for easier script parsing of this output.)

[//]: # (Put User ID in here - found in Settings -> API)
