### PR TITLE
Group migration fixes

### DIFF
--- a/migrations/groups/habitrpg-jackalopes.js
+++ b/migrations/groups/habitrpg-jackalopes.js
@@ -1,0 +1,46 @@
+var migrationName = 'Jackalopes for Unlimited Subscribers';
+
+/*
+ * This migration will find users with unlimited subscriptions who are also eligible for Jackalope mounts, and award them
+ */
+import Bluebird from 'bluebird';
+
+import { model as Group } from '../../website/server/models/group';
+import { model as User } from '../../website/server/models/user';
+import * as payments from '../../website/server/libs/payments';
+
+async function handOutJackalopes () {
+  let promises = [];
+  let cursor = User.find({
+    'purchased.plan.customerId':'habitrpg',
+  }).cursor();
+
+  cursor.on('data', async function(user) {
+    console.log('User: ' + user._id);
+
+    let groupList = [];
+    if (user.party._id) groupList.push(user.party._id);
+    groupList = groupList.concat(user.guilds);
+
+    let subscribedGroup =
+      await Group.findOne({
+        '_id': {$in: groupList},
+        'purchased.plan.planId': 'group_monthly',
+        'purchased.plan.dateTerminated': null,
+      },
+      {'_id':1}
+    );
+
+    if (subscribedGroup) {
+      User.update({'_id':user._id},{$set:{'items.mounts.Jackalope-RoyalPurple':true}}).exec();
+      promises.push(user.save());
+    }
+  });
+
+  cursor.on('close', async function() {
+    console.log('done');
+    return await Bluebird.all(promises);
+  });
+};
+
+module.exports = handOutJackalopes;

--- a/website/server/libs/amazonPayments.js
+++ b/website/server/libs/amazonPayments.js
@@ -196,11 +196,11 @@ api.cancelSubscription = async function cancelSubscription (options = {}) {
 
   let details = await this.getBillingAgreementDetails({
     AmazonBillingAgreementId: billingAgreementId,
-  }).catch(function (err) {
-    console.log(err);
+  }).catch(function errorCatch (err) {
+    return err;
   });
 
-  let badBAStates = ['Canceled', 'Closed', 'Suspended']
+  let badBAStates = ['Canceled', 'Closed', 'Suspended'];
   if (details && details.BillingAgreementDetails && details.BillingAgreementDetails.BillingAgreementStatus &&
       badBAStates.indexOf(details.BillingAgreementDetails.BillingAgreementStatus.State) === -1) {
     await this.closeBillingAgreement({

--- a/website/server/libs/amazonPayments.js
+++ b/website/server/libs/amazonPayments.js
@@ -196,13 +196,18 @@ api.cancelSubscription = async function cancelSubscription (options = {}) {
 
   let details = await this.getBillingAgreementDetails({
     AmazonBillingAgreementId: billingAgreementId,
+  }).catch(function (err) {
+    console.log(err);
   });
 
-  if (details.BillingAgreementDetails.BillingAgreementStatus.State !== 'Closed') {
+  let badBAStates = ['Canceled', 'Closed', 'Suspended']
+  if (details && details.BillingAgreementDetails && details.BillingAgreementDetails.BillingAgreementStatus &&
+      badBAStates.indexOf(details.BillingAgreementDetails.BillingAgreementStatus.State) === -1) {
     await this.closeBillingAgreement({
       AmazonBillingAgreementId: billingAgreementId,
     });
   }
+
 
   let subscriptionBlock = common.content.subscriptionBlocks[planId];
   let subscriptionLength = subscriptionBlock.months * 30;

--- a/website/server/libs/stripePayments.js
+++ b/website/server/libs/stripePayments.js
@@ -227,8 +227,8 @@ api.cancelSubscription = async function cancelSubscription (options, stripeInc) 
   if (!customerId) throw new NotAuthorized(i18n.t('missingSubscription'));
 
   // @TODO: Handle error response
-  let customer = await stripeApi.customers.retrieve(customerId).catch(function(err) {
-    console.log(err);
+  let customer = await stripeApi.customers.retrieve(customerId).catch(function errorCatch (err) {
+    return err;
   });
   let nextBill = moment().add(30, 'days').unix() * 1000;
 

--- a/website/server/libs/stripePayments.js
+++ b/website/server/libs/stripePayments.js
@@ -1,6 +1,7 @@
 import stripeModule from 'stripe';
 import nconf from 'nconf';
 import cc from 'coupon-code';
+import moment from 'moment';
 
 import {
   BadRequest,
@@ -226,20 +227,27 @@ api.cancelSubscription = async function cancelSubscription (options, stripeInc) 
   if (!customerId) throw new NotAuthorized(i18n.t('missingSubscription'));
 
   // @TODO: Handle error response
-  let customer = await stripeApi.customers.retrieve(customerId);
+  let customer = await stripeApi.customers.retrieve(customerId).catch(function(err) {
+    console.log(err);
+  });
+  let nextBill = moment().add(30, 'days').unix() * 1000;
 
-  let subscription = customer.subscription;
-  if (!subscription && customer.subscriptions) {
-    subscription = customer.subscriptions.data[0];
+  if (customer && (customer.subscription || customer.subscriptions)) {
+    let subscription = customer.subscription;
+    if (!subscription && customer.subscriptions) {
+      subscription = customer.subscriptions.data[0];
+    }
+    await stripeApi.customers.del(customerId);
+
+    if (subscription && subscription.current_period_end) {
+      nextBill = subscription.current_period_end * 1000; // timestamp in seconds
+    }
   }
 
-  if (!subscription) return;
-
-  await stripeApi.customers.del(customerId);
   await payments.cancelSubscription({
     user,
     groupId,
-    nextBill: subscription.current_period_end * 1000, // timestamp in seconds
+    nextBill,
     paymentMethod: this.constants.PAYMENT_METHOD,
   });
 };


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

* Changes the migration used to award individual subscriptions to users in group plans to use a cursor-based stream, to avoid Mongo timeouts.
* Adds more error catches in payment libraries, so cancel operations don't fail out if the subscription is already gone on the payment processor end.
* Adds a migration to award Jackalope mounts to users who ought to qualify for them but are skipped over in current subscription code thanks to their having lifetime subscriptions.

[//]: # (Put User ID in here - found in Settings -> API)