### PR TITLE
Issue 8432: Incentives Progress Fix

### DIFF
--- a/test/client-old/spec/controllers/userCtrlSpec.js
+++ b/test/client-old/spec/controllers/userCtrlSpec.js
@@ -1,0 +1,37 @@
+'use strict';
+
+describe('User Controller', function() {
+  var $rootScope, shared, scope, user, User, ctrl, content;
+
+  beforeEach(function() {
+    user = specHelper.newUser();
+    User = {
+      user: user
+    };
+
+    module(function($provide) {
+      $provide.value('User', User);
+      $provide.value('Guide', {});
+    });
+
+    inject(function($rootScope, $controller, Shared, Content){
+      scope = $rootScope.$new();
+      Shared.wrap(user);
+      shared = Shared;
+      content = Content
+      $controller('RootCtrl',  {$scope: scope, User: User, Shared: Shared});
+      ctrl = $controller('UserCtrl', {$scope: scope, User: User});
+    });
+  });
+
+  describe.only('getProgressDisplay', function() {
+    it('should return initial progress', function() {
+      sinon.stub(content, 'loginIncentives').onFirstCall().returns({
+        prevRewardKey: 0,
+        nextRewardKey: 1
+      });
+      var actual = scope.getProgressDisplay();
+      expect(actual).to.eql('');
+    });
+  });
+});

--- a/test/client-old/spec/controllers/userCtrlSpec.js
+++ b/test/client-old/spec/controllers/userCtrlSpec.js
@@ -27,30 +27,29 @@ describe.only('User Controller', function() {
     inject(function($rootScope, $controller, User, Content) {
       scope = $rootScope.$new();
       content = Content;
-      $window = {
-        env: {
-          t: sandbox.stub(),
-        },
-      };
-      $controller('RootCtrl', { $scope: scope, $window: $window, User: User});
+      $controller('RootCtrl', { $scope: scope, User: User});
       ctrl = $controller('UserCtrl', { $scope: scope, User: User, $window: $window});
     });
   });
 
   describe('getProgressDisplay', function() {
+
+    beforeEach(() => {
+      sandbox.stub(window.env, 't');
+      window.env.t.onFirstCall().returns('Progress until next');
+    });
+
     it('should return initial progress', function() {
-      $window.env.t.onFirstCall().returns('');
       scope.profile.loginIncentives = 0;
       content.loginIncentives = [{
         nextRewardAt: 1,
         reward: true
       }];
       var actual = scope.getProgressDisplay();
-      expect(actual.trim()).to.eql('0/1');
+      expect(actual.trim()).to.eql('Progress until next 0/1');
     });
 
     it('should return progress between next reward and current reward', function() {
-      $window.env.t.onFirstCall().returns('');
       scope.profile.loginIncentives = 1;
       content.loginIncentives = [{
         nextRewardAt: 1,
@@ -64,7 +63,7 @@ describe.only('User Controller', function() {
         nextRewardAt: 3
       }];
       var actual = scope.getProgressDisplay();
-      expect(actual.trim()).to.eql('0/1');
+      expect(actual.trim()).to.eql('Progress until next 0/1');
     });
   });
 });

--- a/test/client-old/spec/controllers/userCtrlSpec.js
+++ b/test/client-old/spec/controllers/userCtrlSpec.js
@@ -1,55 +1,70 @@
 'use strict';
 
 describe.only('User Controller', function() {
-  var $rootScope, shared, scope, user, User, ctrl, content, achievement;
+  var $rootScope, $window, User, shared, scope, ctrl, content;
 
   beforeEach(function() {
-    user = specHelper.newUser({
-      balance: 4,
-      items: {
-        gear: { owned: {} },
-        eggs: { Cactus: 1 },
-        hatchingPotions: { Base: 1 },
-        food: { Meat: 1 },
-        pets: {},
-        mounts: {}
-      },
-      flags: {
-        armoireEnabled: true
-      },
-      preferences: {
-        suppressModals: {}
-      },
-      purchased: {
-        plan: {
-          mysteryItems: [],
+    module(function ($provide) {
+      var user = specHelper.newUser();
+      User = {user: user}
+      $provide.value('Guide', sandbox.stub());
+      $provide.value('User', User);
+      $provide.value('Achievement', sandbox.stub());
+      $provide.value('Social', sandbox.stub());
+      $provide.value('Shared', {
+        achievements: {
+          getAchievementsForProfile: sandbox.stub()
         },
-      },
+        shops: {
+          getBackgroundShopSets: sandbox.stub()
+        }
+      });
+      $provide.value('Content', {
+        loginIncentives: sandbox.stub()
+      })
     });
 
-    User = {
-      user: user
-    };
-
-    inject(function($rootScope, $controller, Shared, User, Achievement, Guide) {
+    inject(function($rootScope, $controller, User, Content) {
       scope = $rootScope.$new();
-      Shared.wrap(user);
-      shared = Shared;
-      achievement = Achievement;
-      User.setUser(user);
-      $controller('RootCtrl',  {$scope: scope, User: User, Guide: Guide});
-      ctrl = $controller('UserCtrl', {$scope: scope, User: User, Guide: Guide});
+      content = Content;
+      $window = {
+        env: {
+          t: sandbox.stub(),
+        },
+      };
+      $controller('RootCtrl', { $scope: scope, $window: $window, User: User});
+      ctrl = $controller('UserCtrl', { $scope: scope, User: User, $window: $window});
     });
   });
 
-  describe.only('getProgressDisplay', function() {
+  describe('getProgressDisplay', function() {
     it('should return initial progress', function() {
-      sinon.stub(content, 'loginIncentives').onFirstCall().returns({
-        prevRewardKey: 0,
-        nextRewardKey: 1
-      });
+      $window.env.t.onFirstCall().returns('');
+      scope.profile.loginIncentives = 0;
+      content.loginIncentives = [{
+        nextRewardAt: 1,
+        reward: true
+      }];
       var actual = scope.getProgressDisplay();
-      expect(actual).to.eql('');
+      expect(actual.trim()).to.eql('0/1');
+    });
+
+    it('should return progress between next reward and current reward', function() {
+      $window.env.t.onFirstCall().returns('');
+      scope.profile.loginIncentives = 1;
+      content.loginIncentives = [{
+        nextRewardAt: 1,
+        reward: true
+      }, {
+        prevRewardAt: 0,
+        nextRewardAt: 2,
+        reward: true
+      }, {
+        prevRewardAt: 1,
+        nextRewardAt: 3
+      }];
+      var actual = scope.getProgressDisplay();
+      expect(actual.trim()).to.eql('0/1');
     });
   });
 });

--- a/test/client-old/spec/controllers/userCtrlSpec.js
+++ b/test/client-old/spec/controllers/userCtrlSpec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-describe.only('User Controller', function() {
+describe('User Controller', function() {
   var $rootScope, $window, User, shared, scope, ctrl, content;
 
   beforeEach(function() {

--- a/test/client-old/spec/controllers/userCtrlSpec.js
+++ b/test/client-old/spec/controllers/userCtrlSpec.js
@@ -1,26 +1,44 @@
 'use strict';
 
-describe('User Controller', function() {
-  var $rootScope, shared, scope, user, User, ctrl, content;
+describe.only('User Controller', function() {
+  var $rootScope, shared, scope, user, User, ctrl, content, achievement;
 
   beforeEach(function() {
-    user = specHelper.newUser();
+    user = specHelper.newUser({
+      balance: 4,
+      items: {
+        gear: { owned: {} },
+        eggs: { Cactus: 1 },
+        hatchingPotions: { Base: 1 },
+        food: { Meat: 1 },
+        pets: {},
+        mounts: {}
+      },
+      flags: {
+        armoireEnabled: true
+      },
+      preferences: {
+        suppressModals: {}
+      },
+      purchased: {
+        plan: {
+          mysteryItems: [],
+        },
+      },
+    });
+
     User = {
       user: user
     };
 
-    module(function($provide) {
-      $provide.value('User', User);
-      $provide.value('Guide', {});
-    });
-
-    inject(function($rootScope, $controller, Shared, Content){
+    inject(function($rootScope, $controller, Shared, User, Achievement, Guide) {
       scope = $rootScope.$new();
       Shared.wrap(user);
       shared = Shared;
-      content = Content
-      $controller('RootCtrl',  {$scope: scope, User: User, Shared: Shared});
-      ctrl = $controller('UserCtrl', {$scope: scope, User: User});
+      achievement = Achievement;
+      User.setUser(user);
+      $controller('RootCtrl',  {$scope: scope, User: User, Guide: Guide});
+      ctrl = $controller('UserCtrl', {$scope: scope, User: User, Guide: Guide});
     });
   });
 

--- a/website/client-old/js/controllers/userCtrl.js
+++ b/website/client-old/js/controllers/userCtrl.js
@@ -1,6 +1,6 @@
 "use strict";
 
-habitrpg.controller("UserCtrl", ['$rootScope', '$scope', '$location', 'User', '$http', '$state', 'Guide', 'Shared', 'Content', 'Stats', 'Social', 'Costume',
+habitrpg.controller('UserCtrl', ['$rootScope', '$scope', '$location', 'User', '$http', '$state', 'Guide', 'Shared', 'Content', 'Stats', 'Social', 'Costume',
   function($rootScope, $scope, $location, User, $http, $state, Guide, Shared, Content, Stats, Social, Costume) {
     $scope.profile = User.user;
 

--- a/website/client-old/js/controllers/userCtrl.js
+++ b/website/client-old/js/controllers/userCtrl.js
@@ -96,6 +96,8 @@ habitrpg.controller("UserCtrl", ['$rootScope', '$scope', '$location', 'User', '$
       if (!currentLoginDay) return env.t('moreIncentivesComingSoon');
       var nextRewardAt = currentLoginDay.nextRewardAt;
       if (!nextRewardAt) return env.t('moreIncentivesComingSoon');
+      // if we are on a reward day, let's show progress relative to this
+      if (currentLoginDay.reward) currentLoginDay.prevRewardKey = $scope.profile.loginIncentives;
       if (!currentLoginDay.prevRewardKey) currentLoginDay.prevRewardKey = 0;
       return env.t('checkinProgressTitle') + ' ' + ($scope.profile.loginIncentives - currentLoginDay.prevRewardKey) + '/' + (nextRewardAt - currentLoginDay.prevRewardKey);
     };

--- a/website/client-old/js/controllers/userCtrl.js
+++ b/website/client-old/js/controllers/userCtrl.js
@@ -93,6 +93,7 @@ habitrpg.controller('UserCtrl', ['$rootScope', '$scope', '$location', 'User', '$
 
     $scope.getProgressDisplay = function () {
       var currentLoginDay = Content.loginIncentives[$scope.profile.loginIncentives];
+      console.log('CURRENT DAY', currentLoginDay);
       if (!currentLoginDay) return env.t('moreIncentivesComingSoon');
       var nextRewardAt = currentLoginDay.nextRewardAt;
       if (!nextRewardAt) return env.t('moreIncentivesComingSoon');

--- a/website/client-old/js/controllers/userCtrl.js
+++ b/website/client-old/js/controllers/userCtrl.js
@@ -93,7 +93,6 @@ habitrpg.controller('UserCtrl', ['$rootScope', '$scope', '$location', 'User', '$
 
     $scope.getProgressDisplay = function () {
       var currentLoginDay = Content.loginIncentives[$scope.profile.loginIncentives];
-      console.log('CURRENT DAY', currentLoginDay);
       if (!currentLoginDay) return env.t('moreIncentivesComingSoon');
       var nextRewardAt = currentLoginDay.nextRewardAt;
       if (!nextRewardAt) return env.t('moreIncentivesComingSoon');

--- a/website/common/script/content/loginIncentives.js
+++ b/website/common/script/content/loginIncentives.js
@@ -226,7 +226,7 @@ module.exports = function getLoginIncentives (api) {
     },
   };
 
-  // Add refence link to next reward and add filler days so we have a map to refernce the next reward from any day
+  // Add reference link to next reward and add filler days so we have a map to reference the next reward from any day
   // We could also, use a list, but then we would be cloning each of the rewards.
   // Create a new array if we want the loginIncentives to be immutable in the future
   let nextRewardKey;


### PR DESCRIPTION
Issue #8432 

### Changes
The `loginIncentives.js` file describes a keyed map of rewards, detailing the `prevAward` and `nextAward`. Using the number of consecutive logins as the key, the map was able to be searched to determine *when* the next rewards would be and *when* the previous award was. 

On the profile page, if you had just received a reward, this calculation did not take into consideration if the current login was issuing a reward; therefore it was displaying values of `5/10` instead of `0/5`. 

While I believe there could be a better data structure to store the rewards, for now the fix, adds a conditional to ensure that if the given login received an award, then it is accounted for during the progress component.

The fix also fixed up typos found during investigation.

----
UUID: 4df45790-08ba-4e11-8fcd-0d56c3343cd1

