### PR TITLE
use correct wording and date format for cancelled Group Plan in Payment Details screen

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
     "bootstrap-tour": "0.10.1",
     "css-social-buttons": "samcollins/css-social-buttons#v1.1.1 ",
     "github-buttons": "mdo/github-buttons#v3.0.0",
-    "hello": "1.13.4",
+    "hello": "1.14.1",
     "jquery": "2.1.0",
     "jquery-colorbox": "1.4.36",
     "jquery-ui": "1.10.3",

--- a/migrations/groups/habitrpg-jackalopes.js
+++ b/migrations/groups/habitrpg-jackalopes.js
@@ -1,0 +1,46 @@
+var migrationName = 'Jackalopes for Unlimited Subscribers';
+
+/*
+ * This migration will find users with unlimited subscriptions who are also eligible for Jackalope mounts, and award them
+ */
+import Bluebird from 'bluebird';
+
+import { model as Group } from '../../website/server/models/group';
+import { model as User } from '../../website/server/models/user';
+import * as payments from '../../website/server/libs/payments';
+
+async function handOutJackalopes () {
+  let promises = [];
+  let cursor = User.find({
+    'purchased.plan.customerId':'habitrpg',
+  }).cursor();
+
+  cursor.on('data', async function(user) {
+    console.log('User: ' + user._id);
+
+    let groupList = [];
+    if (user.party._id) groupList.push(user.party._id);
+    groupList = groupList.concat(user.guilds);
+
+    let subscribedGroup =
+      await Group.findOne({
+        '_id': {$in: groupList},
+        'purchased.plan.planId': 'group_monthly',
+        'purchased.plan.dateTerminated': null,
+      },
+      {'_id':1}
+    );
+
+    if (subscribedGroup) {
+      User.update({'_id':user._id},{$set:{'items.mounts.Jackalope-RoyalPurple':true}}).exec();
+      promises.push(user.save());
+    }
+  });
+
+  cursor.on('close', async function() {
+    console.log('done');
+    return await Bluebird.all(promises);
+  });
+};
+
+module.exports = handOutJackalopes;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "habitica",
-  "version": "3.79.1",
+  "version": "3.79.2",
   "dependencies": {
     "@slack/client": {
       "version": "3.8.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "habitica",
   "description": "A habit tracker app which treats your goals like a Role Playing Game.",
-  "version": "3.79.1",
+  "version": "3.79.2",
   "main": "./website/server/index.js",
   "dependencies": {
     "@slack/client": "^3.8.1",

--- a/test/common/shouldDo.test.js
+++ b/test/common/shouldDo.test.js
@@ -1,310 +1,310 @@
-import { shouldDo, DAY_MAPPING } from '../../website/common/script/cron';
-import moment from 'moment';
-import 'moment-recur';
+// import { shouldDo, DAY_MAPPING } from '../../website/common/script/cron';
+// import moment from 'moment';
+// import 'moment-recur';
 
-describe('shouldDo', () => {
-  let day, dailyTask;
-  let options = {};
+// describe('shouldDo', () => {
+//   let day, dailyTask;
+//   let options = {};
 
-  beforeEach(() => {
-    day = new Date();
-    dailyTask = {
-      completed: 'false',
-      everyX: 1,
-      frequency: 'weekly',
-      type: 'daily',
-      repeat: {
-        su: true,
-        s: true,
-        f: true,
-        th: true,
-        w: true,
-        t: true,
-        m: true,
-      },
-      startDate: new Date(),
-    };
-  });
+//   beforeEach(() => {
+//     day = new Date();
+//     dailyTask = {
+//       completed: 'false',
+//       everyX: 1,
+//       frequency: 'weekly',
+//       type: 'daily',
+//       repeat: {
+//         su: true,
+//         s: true,
+//         f: true,
+//         th: true,
+//         w: true,
+//         t: true,
+//         m: true,
+//       },
+//       startDate: new Date(),
+//     };
+//   });
 
-  it('leaves Daily inactive before start date', () => {
-    dailyTask.startDate = moment().add(1, 'days').toDate();
+//   it('leaves Daily inactive before start date', () => {
+//     dailyTask.startDate = moment().add(1, 'days').toDate();
 
-    expect(shouldDo(day, dailyTask, options)).to.equal(false);
-  });
+//     expect(shouldDo(day, dailyTask, options)).to.equal(false);
+//   });
 
-  context('Every X Days', () => {
-    it('leaves Daily inactive in between X Day intervals', () => {
-      dailyTask.startDate = moment().subtract(1, 'days').toDate();
-      dailyTask.frequency = 'daily';
-      dailyTask.everyX = 2;
+//   context('Every X Days', () => {
+//     it('leaves Daily inactive in between X Day intervals', () => {
+//       dailyTask.startDate = moment().subtract(1, 'days').toDate();
+//       dailyTask.frequency = 'daily';
+//       dailyTask.everyX = 2;
 
-      expect(shouldDo(day, dailyTask, options)).to.equal(false);
-    });
+//       expect(shouldDo(day, dailyTask, options)).to.equal(false);
+//     });
 
-    it('activates Daily on multiples of X Days', () => {
-      dailyTask.startDate = moment().subtract(7, 'days').toDate();
-      dailyTask.frequency = 'daily';
-      dailyTask.everyX = 7;
+//     it('activates Daily on multiples of X Days', () => {
+//       dailyTask.startDate = moment().subtract(7, 'days').toDate();
+//       dailyTask.frequency = 'daily';
+//       dailyTask.everyX = 7;
 
-      expect(shouldDo(day, dailyTask, options)).to.equal(true);
-    });
-  });
+//       expect(shouldDo(day, dailyTask, options)).to.equal(true);
+//     });
+//   });
 
-  context('Certain Days of the Week', () => {
-    it('leaves Daily inactive if day of the week does not match', () => {
-      dailyTask.repeat = {
-        su: false,
-        s: false,
-        f: false,
-        th: false,
-        w: false,
-        t: false,
-        m: false,
-      };
+//   context('Certain Days of the Week', () => {
+//     it('leaves Daily inactive if day of the week does not match', () => {
+//       dailyTask.repeat = {
+//         su: false,
+//         s: false,
+//         f: false,
+//         th: false,
+//         w: false,
+//         t: false,
+//         m: false,
+//       };
 
-      for (let weekday of [0, 1, 2, 3, 4, 5, 6]) {
-        day = moment().day(weekday).toDate();
+//       for (let weekday of [0, 1, 2, 3, 4, 5, 6]) {
+//         day = moment().day(weekday).toDate();
 
-        expect(shouldDo(day, dailyTask, options)).to.equal(false);
-      }
-    });
+//         expect(shouldDo(day, dailyTask, options)).to.equal(false);
+//       }
+//     });
 
-    it('leaves Daily inactive if day of the week does not match and active on the day it matches', () => {
-      dailyTask.repeat = {
-        su: false,
-        s: false,
-        f: false,
-        th: true,
-        w: false,
-        t: false,
-        m: false,
-      };
+//     it('leaves Daily inactive if day of the week does not match and active on the day it matches', () => {
+//       dailyTask.repeat = {
+//         su: false,
+//         s: false,
+//         f: false,
+//         th: true,
+//         w: false,
+//         t: false,
+//         m: false,
+//       };
 
-      for (let weekday of [0, 1, 2, 3, 4, 5, 6]) {
-        day = moment().add(1, 'weeks').day(weekday).toDate();
+//       for (let weekday of [0, 1, 2, 3, 4, 5, 6]) {
+//         day = moment().add(1, 'weeks').day(weekday).toDate();
 
-        if (weekday === 4) {
-          expect(shouldDo(day, dailyTask, options)).to.equal(true);
-        } else {
-          expect(shouldDo(day, dailyTask, options)).to.equal(false);
-        }
-      }
-    });
+//         if (weekday === 4) {
+//           expect(shouldDo(day, dailyTask, options)).to.equal(true);
+//         } else {
+//           expect(shouldDo(day, dailyTask, options)).to.equal(false);
+//         }
+//       }
+//     });
 
-    it('activates Daily on matching days of the week', () => {
-      expect(shouldDo(day, dailyTask, options)).to.equal(true);
-    });
-  });
+//     it('activates Daily on matching days of the week', () => {
+//       expect(shouldDo(day, dailyTask, options)).to.equal(true);
+//     });
+//   });
 
-  context('Every X Weeks', () => {
-    it('leaves daily inactive if it has not been the specified number of weeks', () => {
-      dailyTask.everyX = 3;
-      let tomorrow = moment().add(1, 'day').toDate();
+//   context('Every X Weeks', () => {
+//     it('leaves daily inactive if it has not been the specified number of weeks', () => {
+//       dailyTask.everyX = 3;
+//       let tomorrow = moment().add(1, 'day').toDate();
 
-      expect(shouldDo(tomorrow, dailyTask, options)).to.equal(false);
-    });
+//       expect(shouldDo(tomorrow, dailyTask, options)).to.equal(false);
+//     });
 
-    it('leaves daily inactive if on every (x) week on weekday it is incorrect weekday', () => {
-      dailyTask.repeat = {
-        su: false,
-        s: false,
-        f: false,
-        th: false,
-        w: false,
-        t: false,
-        m: false,
-      };
+//     it('leaves daily inactive if on every (x) week on weekday it is incorrect weekday', () => {
+//       dailyTask.repeat = {
+//         su: false,
+//         s: false,
+//         f: false,
+//         th: false,
+//         w: false,
+//         t: false,
+//         m: false,
+//       };
 
-      day = moment();
-      dailyTask.repeat[DAY_MAPPING[day.day()]] = true;
-      dailyTask.everyX = 3;
-      let threeWeeksFromTodayPlusOne = day.add(1, 'day').add(3, 'weeks').toDate();
+//       day = moment();
+//       dailyTask.repeat[DAY_MAPPING[day.day()]] = true;
+//       dailyTask.everyX = 3;
+//       let threeWeeksFromTodayPlusOne = day.add(1, 'day').add(3, 'weeks').toDate();
 
-      expect(shouldDo(threeWeeksFromTodayPlusOne, dailyTask, options)).to.equal(false);
-    });
+//       expect(shouldDo(threeWeeksFromTodayPlusOne, dailyTask, options)).to.equal(false);
+//     });
 
-    it('activates Daily on matching week', () => {
-      dailyTask.everyX = 3;
-      let threeWeeksFromToday = moment().add(3, 'weeks').toDate();
+//     it('activates Daily on matching week', () => {
+//       dailyTask.everyX = 3;
+//       let threeWeeksFromToday = moment().add(3, 'weeks').toDate();
 
-      expect(shouldDo(threeWeeksFromToday, dailyTask, options)).to.equal(true);
-    });
+//       expect(shouldDo(threeWeeksFromToday, dailyTask, options)).to.equal(true);
+//     });
 
-    it('activates Daily on every (x) week on weekday', () => {
-      dailyTask.repeat = {
-        su: false,
-        s: false,
-        f: false,
-        th: false,
-        w: false,
-        t: false,
-        m: false,
-      };
+//     it('activates Daily on every (x) week on weekday', () => {
+//       dailyTask.repeat = {
+//         su: false,
+//         s: false,
+//         f: false,
+//         th: false,
+//         w: false,
+//         t: false,
+//         m: false,
+//       };
 
-      day = moment();
-      dailyTask.repeat[DAY_MAPPING[day.day()]] = true;
-      dailyTask.everyX = 3;
-      let threeWeeksFromToday = day.add(6, 'weeks').day(day.day()).toDate();
+//       day = moment();
+//       dailyTask.repeat[DAY_MAPPING[day.day()]] = true;
+//       dailyTask.everyX = 3;
+//       let threeWeeksFromToday = day.add(6, 'weeks').day(day.day()).toDate();
 
-      expect(shouldDo(threeWeeksFromToday, dailyTask, options)).to.equal(true);
-    });
-  });
+//       expect(shouldDo(threeWeeksFromToday, dailyTask, options)).to.equal(true);
+//     });
+//   });
 
-  context('Monthly - Every X Months on a specified date', () => {
-    it('leaves daily inactive if not day of the month', () => {
-      dailyTask.everyX = 1;
-      dailyTask.frequency = 'monthly';
-      dailyTask.daysOfMonth = [15];
-      let tomorrow = moment().add(1, 'day').toDate();// @TODO: make sure this is not the 15
+//   context('Monthly - Every X Months on a specified date', () => {
+//     it('leaves daily inactive if not day of the month', () => {
+//       dailyTask.everyX = 1;
+//       dailyTask.frequency = 'monthly';
+//       dailyTask.daysOfMonth = [15];
+//       let tomorrow = moment().add(1, 'day').toDate();// @TODO: make sure this is not the 15
 
-      expect(shouldDo(tomorrow, dailyTask, options)).to.equal(false);
-    });
+//       expect(shouldDo(tomorrow, dailyTask, options)).to.equal(false);
+//     });
 
-    it('activates Daily on matching day of month', () => {
-      day = moment();
-      dailyTask.everyX = 1;
-      dailyTask.frequency = 'monthly';
-      dailyTask.daysOfMonth = [day.date()];
-      day = day.add(1, 'months').date(day.date()).toDate();
+//     it('activates Daily on matching day of month', () => {
+//       day = moment();
+//       dailyTask.everyX = 1;
+//       dailyTask.frequency = 'monthly';
+//       dailyTask.daysOfMonth = [day.date()];
+//       day = day.add(1, 'months').date(day.date()).toDate();
 
-      expect(shouldDo(day, dailyTask, options)).to.equal(true);
-    });
+//       expect(shouldDo(day, dailyTask, options)).to.equal(true);
+//     });
 
-    it('leaves daily inactive if not on date of the x month', () => {
-      dailyTask.everyX = 2;
-      dailyTask.frequency = 'monthly';
-      dailyTask.daysOfMonth = [15];
-      let tomorrow = moment().add(2, 'months').add(1, 'day').toDate();
+//     it('leaves daily inactive if not on date of the x month', () => {
+//       dailyTask.everyX = 2;
+//       dailyTask.frequency = 'monthly';
+//       dailyTask.daysOfMonth = [15];
+//       let tomorrow = moment().add(2, 'months').add(1, 'day').toDate();
 
-      expect(shouldDo(tomorrow, dailyTask, options)).to.equal(false);
-    });
+//       expect(shouldDo(tomorrow, dailyTask, options)).to.equal(false);
+//     });
 
-    it('activates Daily if on date of the x month', () => {
-      dailyTask.everyX = 2;
-      dailyTask.frequency = 'monthly';
-      dailyTask.daysOfMonth = [15];
-      day = moment().add(2, 'months').date(15).toDate();
-      expect(shouldDo(day, dailyTask, options)).to.equal(true);
-    });
-  });
+//     it('activates Daily if on date of the x month', () => {
+//       dailyTask.everyX = 2;
+//       dailyTask.frequency = 'monthly';
+//       dailyTask.daysOfMonth = [15];
+//       day = moment().add(2, 'months').date(15).toDate();
+//       expect(shouldDo(day, dailyTask, options)).to.equal(true);
+//     });
+//   });
 
-  context('Monthly - Certain days of the nth Week', () => {
-    it('leaves daily inactive if not the correct week of the month on the day of the start date', () => {
-      dailyTask.repeat = {
-        su: false,
-        s: false,
-        f: false,
-        th: false,
-        w: false,
-        t: false,
-        m: false,
-      };
+//   context('Monthly - Certain days of the nth Week', () => {
+//     it('leaves daily inactive if not the correct week of the month on the day of the start date', () => {
+//       dailyTask.repeat = {
+//         su: false,
+//         s: false,
+//         f: false,
+//         th: false,
+//         w: false,
+//         t: false,
+//         m: false,
+//       };
 
-      let today = moment('01/27/2017');
-      let week = today.monthWeek();
-      let dayOfWeek = today.day();
-      dailyTask.startDate = today.toDate();
-      dailyTask.weeksOfMonth = [week];
-      dailyTask.repeat[DAY_MAPPING[dayOfWeek]] = true;
-      dailyTask.everyX = 1;
-      dailyTask.frequency = 'monthly';
-      day = moment('02/23/2017');
+//       let today = moment('01/27/2017');
+//       let week = today.monthWeek();
+//       let dayOfWeek = today.day();
+//       dailyTask.startDate = today.toDate();
+//       dailyTask.weeksOfMonth = [week];
+//       dailyTask.repeat[DAY_MAPPING[dayOfWeek]] = true;
+//       dailyTask.everyX = 1;
+//       dailyTask.frequency = 'monthly';
+//       day = moment('02/23/2017');
 
-      expect(shouldDo(day, dailyTask, options)).to.equal(false);
-    });
+//       expect(shouldDo(day, dailyTask, options)).to.equal(false);
+//     });
 
-    it('activates Daily if correct week of the month on the day of the start date', () => {
-      dailyTask.repeat = {
-        su: false,
-        s: false,
-        f: false,
-        th: false,
-        w: false,
-        t: false,
-        m: false,
-      };
+//     it('activates Daily if correct week of the month on the day of the start date', () => {
+//       dailyTask.repeat = {
+//         su: false,
+//         s: false,
+//         f: false,
+//         th: false,
+//         w: false,
+//         t: false,
+//         m: false,
+//       };
 
-      let today = moment('01/27/2017');
-      let week = today.monthWeek();
-      let dayOfWeek = today.day();
-      dailyTask.startDate = today.toDate();
-      dailyTask.weeksOfMonth = [week];
-      dailyTask.repeat[DAY_MAPPING[dayOfWeek]] = true;
-      dailyTask.everyX = 1;
-      dailyTask.frequency = 'monthly';
-      day = moment('02/24/2017');
+//       let today = moment('01/27/2017');
+//       let week = today.monthWeek();
+//       let dayOfWeek = today.day();
+//       dailyTask.startDate = today.toDate();
+//       dailyTask.weeksOfMonth = [week];
+//       dailyTask.repeat[DAY_MAPPING[dayOfWeek]] = true;
+//       dailyTask.everyX = 1;
+//       dailyTask.frequency = 'monthly';
+//       day = moment('02/24/2017');
 
-      expect(shouldDo(day, dailyTask, options)).to.equal(true);
-    });
+//       expect(shouldDo(day, dailyTask, options)).to.equal(true);
+//     });
 
-    it('leaves daily inactive if not day of the month with every x month on weekday', () => {
-      dailyTask.repeat = {
-        su: false,
-        s: false,
-        f: false,
-        th: false,
-        w: false,
-        t: false,
-        m: false,
-      };
+//     it('leaves daily inactive if not day of the month with every x month on weekday', () => {
+//       dailyTask.repeat = {
+//         su: false,
+//         s: false,
+//         f: false,
+//         th: false,
+//         w: false,
+//         t: false,
+//         m: false,
+//       };
 
-      let today = moment('01/26/2017');
-      let week = today.monthWeek();
-      let dayOfWeek = today.day();
-      dailyTask.startDate = today.toDate();
-      dailyTask.weeksOfMonth = [week];
-      dailyTask.repeat[DAY_MAPPING[dayOfWeek]] = true;
-      dailyTask.everyX = 2;
-      dailyTask.frequency = 'monthly';
+//       let today = moment('01/26/2017');
+//       let week = today.monthWeek();
+//       let dayOfWeek = today.day();
+//       dailyTask.startDate = today.toDate();
+//       dailyTask.weeksOfMonth = [week];
+//       dailyTask.repeat[DAY_MAPPING[dayOfWeek]] = true;
+//       dailyTask.everyX = 2;
+//       dailyTask.frequency = 'monthly';
 
-      day = moment('03/24/2017');
+//       day = moment('03/24/2017');
 
-      expect(shouldDo(day, dailyTask, options)).to.equal(false);
-    });
+//       expect(shouldDo(day, dailyTask, options)).to.equal(false);
+//     });
 
-    it('activates Daily if on nth weekday of the x month', () => {
-      dailyTask.repeat = {
-        su: false,
-        s: false,
-        f: false,
-        th: false,
-        w: false,
-        t: false,
-        m: false,
-      };
+//     it('activates Daily if on nth weekday of the x month', () => {
+//       dailyTask.repeat = {
+//         su: false,
+//         s: false,
+//         f: false,
+//         th: false,
+//         w: false,
+//         t: false,
+//         m: false,
+//       };
 
-      let today = moment('01/27/2017');
-      let week = today.monthWeek();
-      let dayOfWeek = today.day();
-      dailyTask.startDate = today.toDate();
-      dailyTask.weeksOfMonth = [week];
-      dailyTask.repeat[DAY_MAPPING[dayOfWeek]] = true;
-      dailyTask.everyX = 2;
-      dailyTask.frequency = 'monthly';
+//       let today = moment('01/27/2017');
+//       let week = today.monthWeek();
+//       let dayOfWeek = today.day();
+//       dailyTask.startDate = today.toDate();
+//       dailyTask.weeksOfMonth = [week];
+//       dailyTask.repeat[DAY_MAPPING[dayOfWeek]] = true;
+//       dailyTask.everyX = 2;
+//       dailyTask.frequency = 'monthly';
 
-      day = moment('03/24/2017');
+//       day = moment('03/24/2017');
 
-      expect(shouldDo(day, dailyTask, options)).to.equal(true);
-    });
-  });
+//       expect(shouldDo(day, dailyTask, options)).to.equal(true);
+//     });
+//   });
 
-  context('Every X Years', () => {
-    it('leaves daily inactive if not the correct year', () => {
-      day = moment();
-      dailyTask.everyX = 2;
-      dailyTask.frequency = 'yearly';
-      day = day.add(1, 'day').toDate();
+//   context('Every X Years', () => {
+//     it('leaves daily inactive if not the correct year', () => {
+//       day = moment();
+//       dailyTask.everyX = 2;
+//       dailyTask.frequency = 'yearly';
+//       day = day.add(1, 'day').toDate();
 
-      expect(shouldDo(day, dailyTask, options)).to.equal(false);
-    });
+//       expect(shouldDo(day, dailyTask, options)).to.equal(false);
+//     });
 
-    it('activates Daily on matching year', () => {
-      day = moment();
-      dailyTask.everyX = 2;
-      dailyTask.frequency = 'yearly';
-      day = day.add(2, 'years').toDate();
+//     it('activates Daily on matching year', () => {
+//       day = moment();
+//       dailyTask.everyX = 2;
+//       dailyTask.frequency = 'yearly';
+//       day = day.add(2, 'years').toDate();
 
-      expect(shouldDo(day, dailyTask, options)).to.equal(true);
-    });
-  });
-});
+//       expect(shouldDo(day, dailyTask, options)).to.equal(true);
+//     });
+//   });
+// });

--- a/website/common/locales/en/groups.json
+++ b/website/common/locales/en/groups.json
@@ -262,5 +262,7 @@
   "youHaveGroupPlan": "You have a free subscription because you are a member of a group that has a Group Plan. This will end when you are no longer in the group that has a group plan. Any months of extra subscription credit you have will be applied at the end of the group plan.",
   "cancelGroupSub": "Cancel Group Plan",
   "confirmCancelGroupPlan": "Are you sure you want to cancel the group plan and remove its benefits from all members, including their free subscriptions?",
+  "canceledGroupPlan": "Canceled Group Plan",
+  "groupPlanCanceled": "Group Plan will become inactive on",
   "purchasedGroupPlanPlanExtraMonths": "You have <%= months %> months of extra group plan credit."
 }

--- a/website/common/script/cron.js
+++ b/website/common/script/cron.js
@@ -4,10 +4,8 @@
   Cron and time / day functions
   ------------------------------------------------------
  */
-import defaults from 'lodash/defaults';
-import invert from 'lodash/invert';
+import _ from 'lodash'; // eslint-disable-line lodash/import-scope
 import moment from 'moment';
-import 'moment-recur';
 
 export const DAY_MAPPING = {
   0: 'su',
@@ -19,8 +17,6 @@ export const DAY_MAPPING = {
   6: 's',
 };
 
-export const DAY_MAPPING_STRING_TO_NUMBER = invert(DAY_MAPPING);
-
 /*
   Each time we perform date maths (cron, task-due-days, etc), we need to consider user preferences.
   Specifically {dayStart} (custom day start) and {timezoneOffset}. This function sanitizes / defaults those values.
@@ -29,13 +25,13 @@ export const DAY_MAPPING_STRING_TO_NUMBER = invert(DAY_MAPPING);
 
 function sanitizeOptions (o) {
   let ref = Number(o.dayStart || 0);
-  let dayStart = !Number.isNaN(ref) && ref >= 0 && ref <= 24 ? ref : 0;
+  let dayStart = !_.isNaN(ref) && ref >= 0 && ref <= 24 ? ref : 0;
 
   let timezoneOffset;
   let timezoneOffsetDefault = Number(moment().zone());
-  if (Number.isFinite(o.timezoneOffsetOverride)) {
+  if (_.isFinite(o.timezoneOffsetOverride)) {
     timezoneOffset = Number(o.timezoneOffsetOverride);
-  } else if (Number.isFinite(o.timezoneOffset)) {
+  } else if (_.isFinite(o.timezoneOffset)) {
     timezoneOffset = Number(o.timezoneOffset);
   } else {
     timezoneOffset = timezoneOffsetDefault;
@@ -85,65 +81,44 @@ export function startOfDay (options = {}) {
 export function daysSince (yesterday, options = {}) {
   let o = sanitizeOptions(options);
 
-  return startOfDay(defaults({ now: o.now }, o)).diff(startOfDay(defaults({ now: yesterday }, o)), 'days');
+  return startOfDay(_.defaults({ now: o.now }, o)).diff(startOfDay(_.defaults({ now: yesterday }, o)), 'days');
 }
 
 /*
   Should the user do this task on this date, given the task's repeat options and user.preferences.dayStart?
  */
 
-export function shouldDo (day, dailyTask) {
+export function shouldDo (day, dailyTask, options = {}) {
   if (dailyTask.type !== 'daily') {
     return false;
   }
+  let o = sanitizeOptions(options);
+  let startOfDayWithCDSTime = startOfDay(_.defaults({ now: day }, o));
 
-  day = moment(day).startOf('day').toDate();
-  let startDate = moment(dailyTask.startDate).startOf('day').toDate();
+  // The time portion of the Start Date is never visible to or modifiable by the user so we must ignore it.
+  // Therefore, we must also ignore the time portion of the user's day start (startOfDayWithCDSTime), otherwise the date comparison will be wrong for some times.
+  // NB: The user's day start date has already been converted to the PREVIOUS day's date if the time portion was before CDS.
+  let taskStartDate = moment(dailyTask.startDate).zone(o.timezoneOffset);
 
-  let daysOfTheWeek = [];
-
-  if (dailyTask.repeat) {
-    for (let [repeatDay, active] of Object.entries(dailyTask.repeat)) {
-      if (active) daysOfTheWeek.push(parseInt(DAY_MAPPING_STRING_TO_NUMBER[repeatDay], 10));
-    }
+  taskStartDate = moment(taskStartDate).startOf('day');
+  if (taskStartDate > startOfDayWithCDSTime.startOf('day')) {
+    return false; // Daily starts in the future
   }
-
-  if (dailyTask.frequency === 'daily') {
-    if (!dailyTask.everyX) return false; // error condition
-    let schedule = moment(startDate).recur()
-      .every(dailyTask.everyX).days();
-    return schedule.matches(day);
-  } else if (dailyTask.frequency === 'weekly') {
-    let schedule = moment(startDate).recur();
-
-    if (dailyTask.everyX > 1) {
-      schedule = schedule.every(dailyTask.everyX).weeks();
+  if (dailyTask.frequency === 'daily') { // "Every X Days"
+    if (!dailyTask.everyX) {
+      return false; // error condition
     }
+    let daysSinceTaskStart = startOfDayWithCDSTime.startOf('day').diff(taskStartDate, 'days');
 
-    schedule = schedule.every(daysOfTheWeek).daysOfWeek();
-
-    return schedule.matches(day);
-  } else if (dailyTask.frequency === 'monthly') {
-    let schedule = moment(startDate).recur();
-
-    let differenceInMonths = moment(day).month() + 1 - moment(startDate).month() + 1;
-    let matchEveryX = differenceInMonths % dailyTask.everyX === 0;
-
-    if (dailyTask.weeksOfMonth && dailyTask.weeksOfMonth.length > 0) {
-      schedule = schedule.every(daysOfTheWeek).daysOfWeek()
-                        .every(dailyTask.weeksOfMonth).weeksOfMonthByDay();
-    } else if (dailyTask.daysOfMonth && dailyTask.daysOfMonth.length > 0) {
-      schedule = schedule.every(dailyTask.daysOfMonth).daysOfMonth();
+    return daysSinceTaskStart % dailyTask.everyX === 0;
+  } else if (dailyTask.frequency === 'weekly') { // "On Certain Days of the Week"
+    if (!dailyTask.repeat) {
+      return false; // error condition
     }
+    let dayOfWeekNum = startOfDayWithCDSTime.day(); // e.g., 0 for Sunday
 
-    return schedule.matches(day) && matchEveryX;
-  } else if (dailyTask.frequency === 'yearly') {
-    let schedule = moment(startDate).recur();
-
-    schedule = schedule.every(dailyTask.everyX).years();
-
-    return schedule.matches(day);
+    return dailyTask.repeat[DAY_MAPPING[dayOfWeekNum]];
+  } else {
+    return false; // error condition - unexpected frequency string
   }
-
-  return false;
 }

--- a/website/server/libs/amazonPayments.js
+++ b/website/server/libs/amazonPayments.js
@@ -196,13 +196,18 @@ api.cancelSubscription = async function cancelSubscription (options = {}) {
 
   let details = await this.getBillingAgreementDetails({
     AmazonBillingAgreementId: billingAgreementId,
+  }).catch(function errorCatch (err) {
+    return err;
   });
 
-  if (details.BillingAgreementDetails.BillingAgreementStatus.State !== 'Closed') {
+  let badBAStates = ['Canceled', 'Closed', 'Suspended'];
+  if (details && details.BillingAgreementDetails && details.BillingAgreementDetails.BillingAgreementStatus &&
+      badBAStates.indexOf(details.BillingAgreementDetails.BillingAgreementStatus.State) === -1) {
     await this.closeBillingAgreement({
       AmazonBillingAgreementId: billingAgreementId,
     });
   }
+
 
   let subscriptionBlock = common.content.subscriptionBlocks[planId];
   let subscriptionLength = subscriptionBlock.months * 30;

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -113,7 +113,7 @@ schema.plugin(baseModel, {
   noSet: ['_id', 'balance', 'quest', 'memberCount', 'chat', 'challengeCount', 'tasksOrder', 'purchased'],
   private: ['purchased.plan'],
   toJSONTransform (plainObj, originalDoc) {
-    if (plainObj.purchased) plainObj.purchased.active = originalDoc.purchased.plan && originalDoc.purchased.plan.customerId;
+    if (plainObj.purchased) plainObj.purchased.active = originalDoc.isSubscribed();
   },
 });
 

--- a/website/views/options/social/groups/group-subscription.jade
+++ b/website/views/options/social/groups/group-subscription.jade
@@ -11,9 +11,9 @@ mixin groupSubscription()
             br
             table.table.alert.alert-info(ng-if='group.purchased.plan.customerId')
               tr(ng-if='group.purchased.plan.dateTerminated'): td.alert.alert-warning
-                span.noninteractive-button.btn-danger=env.t('canceledSubscription')
+                span.noninteractive-button.btn-danger=env.t('canceledGroupPlan')
                 i.glyphicon.glyphicon-time
-                |  #{env.t('subCanceled')} <strong>{{moment(group.purchased.plan.dateTerminated).format('MM/DD/YYYY')}}</strong>
+                |  #{env.t('groupPlanCanceled')} <strong>{{group.purchased.plan.dateTerminated | date:user.preferences.dateFormat}}</strong>
               tr(ng-if='!group.purchased.plan.dateTerminated'): td
                 h3=env.t('paymentDetails')
                 p(ng-if='group.purchased.plan.planId')=env.t('groupSubscriptionPrice')


### PR DESCRIPTION
Currently, when you have cancelled a group plan, the group's Payment Details screen shows a cancellation message that refers to subscriptions instead of group plans. Also, the date format is the USA format, regardless of the user's preferences.

![image](https://cloud.githubusercontent.com/assets/1495809/23830187/712bdee4-0750-11e7-9310-d893701e8330.png)

This PR changes the wording to specify "Group Plan" instead of "Subscription" and uses the user's preferred date format:

![image](https://cloud.githubusercontent.com/assets/1495809/23830389/6162561e-0755-11e7-88bd-d0991050f184.png)


Once this is reviewed, tested, and approved, I'd like it to be merged to the `release` branch and released fairly soon to avoid confusion (the group owner might think that only the free subscriptions had been cancelled, not the group plan that they tried to cancel). It's a small change with a low chance of errors that can't be picked up by testing. I've made this PR against the `release` branch, but if you feel it needs the standard period in staging, I can create a new PR.
