### PR TITLE
use correct wording and date format for cancelled Group Plan in Payment Details screen

### DIFF
--- a/website/common/locales/en/groups.json
+++ b/website/common/locales/en/groups.json
@@ -262,5 +262,7 @@
   "youHaveGroupPlan": "You have a free subscription because you are a member of a group that has a Group Plan. This will end when you are no longer in the group that has a group plan. Any months of extra subscription credit you have will be applied at the end of the group plan.",
   "cancelGroupSub": "Cancel Group Plan",
   "confirmCancelGroupPlan": "Are you sure you want to cancel the group plan and remove its benefits from all members, including their free subscriptions?",
+  "canceledGroupPlan": "Canceled Group Plan",
+  "groupPlanCanceled": "Group Plan will become inactive on",
   "purchasedGroupPlanPlanExtraMonths": "You have <%= months %> months of extra group plan credit."
 }

--- a/website/views/options/social/groups/group-subscription.jade
+++ b/website/views/options/social/groups/group-subscription.jade
@@ -11,9 +11,9 @@ mixin groupSubscription()
             br
             table.table.alert.alert-info(ng-if='group.purchased.plan.customerId')
               tr(ng-if='group.purchased.plan.dateTerminated'): td.alert.alert-warning
-                span.noninteractive-button.btn-danger=env.t('canceledSubscription')
+                span.noninteractive-button.btn-danger=env.t('canceledGroupPlan')
                 i.glyphicon.glyphicon-time
-                |  #{env.t('subCanceled')} <strong>{{moment(group.purchased.plan.dateTerminated).format('MM/DD/YYYY')}}</strong>
+                |  #{env.t('groupPlanCanceled')} <strong>{{group.purchased.plan.dateTerminated | date:user.preferences.dateFormat}}</strong>
               tr(ng-if='!group.purchased.plan.dateTerminated'): td
                 h3=env.t('paymentDetails')
                 p(ng-if='group.purchased.plan.planId')=env.t('groupSubscriptionPrice')


### PR DESCRIPTION
Currently, when you have cancelled a group plan, the group's Payment Details screen shows a cancellation message that refers to subscriptions instead of group plans. Also, the date format is the USA format, regardless of the user's preferences.

![image](https://cloud.githubusercontent.com/assets/1495809/23830187/712bdee4-0750-11e7-9310-d893701e8330.png)

This PR changes the wording to specify "Group Plan" instead of "Subscription" and uses the user's preferred date format:

![image](https://cloud.githubusercontent.com/assets/1495809/23830389/6162561e-0755-11e7-88bd-d0991050f184.png)


Once this is reviewed, tested, and approved, if possible, I'd like it to be merged to the `release` branch and released fairly soon to avoid confusion (the group owner might think that only the free subscriptions had been cancelled, not the group plan that they tried to cancel). It's a small change with a low chance of errors that can't be picked up by testing.