### PR TITLE
Fixed subscription popup too narrow in Japanese

### DIFF
--- a/website/client-old/css/menu.styl
+++ b/website/client-old/css/menu.styl
@@ -178,6 +178,8 @@
     hrpg-button-color-mixin(lighten($color-toolbar,32.8%))
 .toolbar-subscribe-button, .toolbar-controls .toolbar-subscribe-button
   @extend $hrpg-button
+  button
+    min-width: 130px
 @media screen and (max-width: $xs-max-screen-width)
   .toolbar-toggle
     display: none


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #8581 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
The best approach to resolve the problem I found was to add a minimum width to the subscription button. I hope its okay.

Before:
![Image of bug](http://i.imgur.com/upJiQvF.jpg)

Now:
![Image of fix](http://i.imgur.com/KOLRMB0.png)

[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: 203f208a-e0f0-4442-bf16-d4f19e553e8a
