### PR TITLE
Limit party size to 30 members

### DIFF
--- a/test/api/v3/integration/groups/GET-groups_groupId_invites.test.js
+++ b/test/api/v3/integration/groups/GET-groups_groupId_invites.test.js
@@ -63,15 +63,17 @@ describe('GET /groups/:groupId/invites', () => {
   });
 
   it('returns only first 30 invites', async () => {
-    let group = await generateGroup(user, {type: 'party', name: generateUUID()});
+    let leader = await generateUser({balance: 4});
+    let group = await generateGroup(leader, {type: 'guild', privacy: 'public', name: generateUUID()});
+
     let invitesToGenerate = [];
     for (let i = 0; i < 31; i++) {
       invitesToGenerate.push(generateUser());
     }
     let generatedInvites = await Promise.all(invitesToGenerate);
-    await user.post(`/groups/${group._id}/invite`, {uuids: generatedInvites.map(invite => invite._id)});
+    await leader.post(`/groups/${group._id}/invite`, {uuids: generatedInvites.map(invite => invite._id)});
 
-    let res = await user.get('/groups/party/invites');
+    let res = await leader.get(`/groups/${group._id}/invites`);
     expect(res.length).to.equal(30);
     res.forEach(member => {
       expect(member).to.have.all.keys(['_id', 'id', 'profile']);

--- a/test/api/v3/integration/groups/POST-groups_invite.test.js
+++ b/test/api/v3/integration/groups/POST-groups_invite.test.js
@@ -331,7 +331,7 @@ describe('Post /groups/:groupId/invite', () => {
       let generatedInvites = await Promise.all(invitesToGenerate);
       // Invite users
       expect(await inviter.post(`/groups/${group._id}/invite`, {
-        uuids: generatedInvites.map(invite => invite._id)
+        uuids: generatedInvites.map(invite => invite._id),
       }))
       .to.be.an('array');
     });
@@ -435,7 +435,7 @@ describe('Post /groups/:groupId/invite', () => {
       let generatedInvites = await Promise.all(invitesToGenerate);
       // Invite users
       expect(await inviter.post(`/groups/${party._id}/invite`, {
-        uuids: generatedInvites.map(invite => invite._id)
+        uuids: generatedInvites.map(invite => invite._id),
       }))
       .to.be.an('array');
     });
@@ -449,7 +449,7 @@ describe('Post /groups/:groupId/invite', () => {
       let generatedInvites = await Promise.all(invitesToGenerate);
       // Invite users
       await expect(inviter.post(`/groups/${party._id}/invite`, {
-        uuids: generatedInvites.map(invite => invite._id)
+        uuids: generatedInvites.map(invite => invite._id),
       }))
       .to.eventually.be.rejected.and.eql({
         code: 400,

--- a/test/api/v3/integration/groups/POST-groups_invite.test.js
+++ b/test/api/v3/integration/groups/POST-groups_invite.test.js
@@ -322,6 +322,20 @@ describe('Post /groups/:groupId/invite', () => {
       });
     });
 
+    it('allow 30+ members in a guild', async () => {
+      let invitesToGenerate = [];
+      // Generate 30 users to invite (30 + leader = 31 members)
+      for (let i = 0; i < PARTY_LIMIT_MEMBERS; i++) {
+        invitesToGenerate.push(generateUser());
+      }
+      let generatedInvites = await Promise.all(invitesToGenerate);
+      // Invite users
+      expect(await inviter.post(`/groups/${group._id}/invite`, {
+        uuids: generatedInvites.map(invite => invite._id)
+      }))
+      .to.be.an('array');
+    });
+
     // @TODO: Add this after we are able to mock the group plan route
     xit('returns an error when a non-leader invites to a group plan', async () => {
       let userToInvite = await generateUser();
@@ -423,7 +437,7 @@ describe('Post /groups/:groupId/invite', () => {
       expect(await inviter.post(`/groups/${party._id}/invite`, {
         uuids: generatedInvites.map(invite => invite._id)
       }))
-      .to.be.a('array');
+      .to.be.an('array');
     });
 
     it('do not allow 30+ members in a party', async () => {

--- a/test/api/v3/integration/groups/POST-groups_invite.test.js
+++ b/test/api/v3/integration/groups/POST-groups_invite.test.js
@@ -420,15 +420,10 @@ describe('Post /groups/:groupId/invite', () => {
       }
       let generatedInvites = await Promise.all(invitesToGenerate);
       // Invite users
-      await inviter.post(`/groups/${party._id}/invite`, {
+      expect(await inviter.post(`/groups/${party._id}/invite`, {
         uuids: generatedInvites.map(invite => invite._id)
-      });
-      // Users accept invites
-      for (let i = 0; i < PARTY_LIMIT_MEMBERS - 1; i++) {
-        await generatedInvites[i].post(`/groups/${party._id}/join`);
-      }
-      // Verify the number of members
-      expect((await inviter.get(`/groups/${party._id}`)).memberCount).to.equal(PARTY_LIMIT_MEMBERS);
+      }))
+      .to.be.a('array');
     });
 
     it('do not allow 30+ members in a party', async () => {
@@ -438,7 +433,7 @@ describe('Post /groups/:groupId/invite', () => {
         invitesToGenerate.push(generateUser());
       }
       let generatedInvites = await Promise.all(invitesToGenerate);
-      // Invite users - must fail
+      // Invite users
       await expect(inviter.post(`/groups/${party._id}/invite`, {
         uuids: generatedInvites.map(invite => invite._id)
       }))

--- a/test/api/v3/integration/groups/POST-groups_invite.test.js
+++ b/test/api/v3/integration/groups/POST-groups_invite.test.js
@@ -322,7 +322,7 @@ describe('Post /groups/:groupId/invite', () => {
       });
     });
 
-    it('allow 30+ members in a guild', async () => {
+    it('allows 30+ members in a guild', async () => {
       let invitesToGenerate = [];
       // Generate 30 users to invite (30 + leader = 31 members)
       for (let i = 0; i < PARTY_LIMIT_MEMBERS; i++) {
@@ -332,8 +332,7 @@ describe('Post /groups/:groupId/invite', () => {
       // Invite users
       expect(await inviter.post(`/groups/${group._id}/invite`, {
         uuids: generatedInvites.map(invite => invite._id),
-      }))
-      .to.be.an('array');
+      })).to.be.an('array');
     });
 
     // @TODO: Add this after we are able to mock the group plan route
@@ -426,7 +425,7 @@ describe('Post /groups/:groupId/invite', () => {
       expect((await userToInvite.get('/user')).invitations.party.id).to.equal(party._id);
     });
 
-    it('allow 30 members in a party', async () => {
+    it('allows 30 members in a party', async () => {
       let invitesToGenerate = [];
       // Generate 29 users to invite (29 + leader = 30 members)
       for (let i = 0; i < PARTY_LIMIT_MEMBERS - 1; i++) {
@@ -436,11 +435,10 @@ describe('Post /groups/:groupId/invite', () => {
       // Invite users
       expect(await inviter.post(`/groups/${party._id}/invite`, {
         uuids: generatedInvites.map(invite => invite._id),
-      }))
-      .to.be.an('array');
+      })).to.be.an('array');
     });
 
-    it('do not allow 30+ members in a party', async () => {
+    it('does not allow 30+ members in a party', async () => {
       let invitesToGenerate = [];
       // Generate 30 users to invite (30 + leader = 31 members)
       for (let i = 0; i < PARTY_LIMIT_MEMBERS; i++) {

--- a/test/api/v3/unit/models/group.test.js
+++ b/test/api/v3/unit/models/group.test.js
@@ -537,7 +537,7 @@ describe('Group Model', () => {
         expect(res.t).to.be.calledWith('canOnlyInviteMaxInvites', {maxInvites: INVITES_LIMIT });
       });
 
-      it('does not throw error if number of invites matches max invite limit', () => {
+      it('does not throw error if number of invites matches max invite limit', async () => {
         let uuids = [];
         let emails = [];
 
@@ -546,47 +546,47 @@ describe('Group Model', () => {
           emails.push(`user-${i}@example.com`);
         }
 
-        expect(function () {
-          Group.validateInvitations(uuids, emails, res);
+        expect(async function () {
+          await Group.validateInvitations(uuids, emails, res);
         }).to.not.throw();
       });
 
 
-      it('does not throw an error if only user ids are passed in', () => {
-        expect(function () {
-          Group.validateInvitations(['user-id', 'user-id2'], null, res);
-        }).to.not.throw();
-
-        expect(res.t).to.not.be.called;
-      });
-
-      it('does not throw an error if only emails are passed in', () => {
-        expect(function () {
-          Group.validateInvitations(null, ['user1@example.com', 'user2@example.com'], res);
+      it('does not throw an error if only user ids are passed in', async () => {
+        expect(async function () {
+          await Group.validateInvitations(['user-id', 'user-id2'], null, res);
         }).to.not.throw();
 
         expect(res.t).to.not.be.called;
       });
 
-      it('does not throw an error if both uuids and emails are passed in', () => {
-        expect(function () {
-          Group.validateInvitations(['user-id', 'user-id2'], ['user1@example.com', 'user2@example.com'], res);
+      it('does not throw an error if only emails are passed in', async () => {
+        expect(async function () {
+          await Group.validateInvitations(null, ['user1@example.com', 'user2@example.com'], res);
         }).to.not.throw();
 
         expect(res.t).to.not.be.called;
       });
 
-      it('does not throw an error if uuids are passed in and emails are an empty array', () => {
-        expect(function () {
-          Group.validateInvitations(['user-id', 'user-id2'], [], res);
+      it('does not throw an error if both uuids and emails are passed in', async () => {
+        expect(async function () {
+          await Group.validateInvitations(['user-id', 'user-id2'], ['user1@example.com', 'user2@example.com'], res);
         }).to.not.throw();
 
         expect(res.t).to.not.be.called;
       });
 
-      it('does not throw an error if emails are passed in and uuids are an empty array', () => {
-        expect(function () {
-          Group.validateInvitations([], ['user1@example.com', 'user2@example.com'], res);
+      it('does not throw an error if uuids are passed in and emails are an empty array', async () => {
+        expect(async function () {
+          await Group.validateInvitations(['user-id', 'user-id2'], [], res);
+        }).to.not.throw();
+
+        expect(res.t).to.not.be.called;
+      });
+
+      it('does not throw an error if emails are passed in and uuids are an empty array', async () => {
+        expect(async function () {
+          await Group.validateInvitations([], ['user1@example.com', 'user2@example.com'], res);
         }).to.not.throw();
 
         expect(res.t).to.not.be.called;

--- a/test/api/v3/unit/models/group.test.js
+++ b/test/api/v3/unit/models/group.test.js
@@ -546,49 +546,33 @@ describe('Group Model', () => {
           emails.push(`user-${i}@example.com`);
         }
 
-        expect(async function () {
-          await Group.validateInvitations(uuids, emails, res);
-        }).to.not.throw();
+        await Group.validateInvitations(uuids, emails, res);
+        expect(res.t).to.not.be.called;
       });
 
 
       it('does not throw an error if only user ids are passed in', async () => {
-        expect(async function () {
-          await Group.validateInvitations(['user-id', 'user-id2'], null, res);
-        }).to.not.throw();
-
+        await Group.validateInvitations(['user-id', 'user-id2'], null, res);
         expect(res.t).to.not.be.called;
       });
 
       it('does not throw an error if only emails are passed in', async () => {
-        expect(async function () {
-          await Group.validateInvitations(null, ['user1@example.com', 'user2@example.com'], res);
-        }).to.not.throw();
-
+        await Group.validateInvitations(null, ['user1@example.com', 'user2@example.com'], res);
         expect(res.t).to.not.be.called;
       });
 
       it('does not throw an error if both uuids and emails are passed in', async () => {
-        expect(async function () {
-          await Group.validateInvitations(['user-id', 'user-id2'], ['user1@example.com', 'user2@example.com'], res);
-        }).to.not.throw();
-
+        await Group.validateInvitations(['user-id', 'user-id2'], ['user1@example.com', 'user2@example.com'], res);
         expect(res.t).to.not.be.called;
       });
 
       it('does not throw an error if uuids are passed in and emails are an empty array', async () => {
-        expect(async function () {
-          await Group.validateInvitations(['user-id', 'user-id2'], [], res);
-        }).to.not.throw();
-
+        await Group.validateInvitations(['user-id', 'user-id2'], [], res);
         expect(res.t).to.not.be.called;
       });
 
       it('does not throw an error if emails are passed in and uuids are an empty array', async () => {
-        expect(async function () {
-          await Group.validateInvitations([], ['user1@example.com', 'user2@example.com'], res);
-        }).to.not.throw();
-
+        await Group.validateInvitations([], ['user1@example.com', 'user2@example.com'], res);
         expect(res.t).to.not.be.called;
       });
     });

--- a/test/api/v3/unit/models/group.test.js
+++ b/test/api/v3/unit/models/group.test.js
@@ -460,73 +460,67 @@ describe('Group Model', () => {
         };
       });
 
-      it('throws an error if no uuids or emails are passed in', (done) => {
+      it('throws an error if no uuids or emails are passed in', async () => {
         try {
           Group.validateInvitations(null, null, res);
         } catch (err) {
           expect(err).to.be.an.instanceof(BadRequest);
           expect(res.t).to.be.calledOnce;
           expect(res.t).to.be.calledWith('canOnlyInviteEmailUuid');
-          done();
         }
       });
 
-      it('throws an error if only uuids are passed in, but they are not an array', (done) => {
+      it('throws an error if only uuids are passed in, but they are not an array', async () => {
         try {
           Group.validateInvitations({ uuid: 'user-id'}, null, res);
         } catch (err) {
           expect(err).to.be.an.instanceof(BadRequest);
           expect(res.t).to.be.calledOnce;
           expect(res.t).to.be.calledWith('uuidsMustBeAnArray');
-          done();
         }
       });
 
-      it('throws an error if only emails are passed in, but they are not an array', (done) => {
+      it('throws an error if only emails are passed in, but they are not an array', async () => {
         try {
           Group.validateInvitations(null, { emails: 'user@example.com'}, res);
         } catch (err) {
           expect(err).to.be.an.instanceof(BadRequest);
           expect(res.t).to.be.calledOnce;
           expect(res.t).to.be.calledWith('emailsMustBeAnArray');
-          done();
         }
       });
 
-      it('throws an error if emails are not passed in, and uuid array is empty', (done) => {
+      it('throws an error if emails are not passed in, and uuid array is empty', async () => {
         try {
           Group.validateInvitations([], null, res);
         } catch (err) {
           expect(err).to.be.an.instanceof(BadRequest);
           expect(res.t).to.be.calledOnce;
           expect(res.t).to.be.calledWith('inviteMissingUuid');
-          done();
         }
       });
 
-      it('throws an error if uuids are not passed in, and email array is empty', (done) => {
+      it('throws an error if uuids are not passed in, and email array is empty', async () => {
         try {
           Group.validateInvitations(null, [], res);
         } catch (err) {
           expect(err).to.be.an.instanceof(BadRequest);
           expect(res.t).to.be.calledOnce;
           expect(res.t).to.be.calledWith('inviteMissingEmail');
-          done();
         }
       });
 
-      it('throws an error if uuids and emails are passed in as empty arrays', (done) => {
+      it('throws an error if uuids and emails are passed in as empty arrays', async () => {
         try {
           Group.validateInvitations([], [], res);
         } catch (err) {
           expect(err).to.be.an.instanceof(BadRequest);
           expect(res.t).to.be.calledOnce;
           expect(res.t).to.be.calledWith('inviteMustNotBeEmpty');
-          done();
         }
       });
 
-      it('throws an error if total invites exceed max invite constant', (done) => {
+      it('throws an error if total invites exceed max invite constant', async () => {
         let uuids = [];
         let emails = [];
 
@@ -543,7 +537,6 @@ describe('Group Model', () => {
           expect(err).to.be.an.instanceof(BadRequest);
           expect(res.t).to.be.calledOnce;
           expect(res.t).to.be.calledWith('canOnlyInviteMaxInvites', {maxInvites: INVITES_LIMIT });
-          done();
         }
       });
 

--- a/test/api/v3/unit/models/group.test.js
+++ b/test/api/v3/unit/models/group.test.js
@@ -461,63 +461,63 @@ describe('Group Model', () => {
       });
 
       it('throws an error if no uuids or emails are passed in', async () => {
-        try {
-          Group.validateInvitations(null, null, res);
-        } catch (err) {
-          expect(err).to.be.an.instanceof(BadRequest);
-          expect(res.t).to.be.calledOnce;
-          expect(res.t).to.be.calledWith('canOnlyInviteEmailUuid');
-        }
+        await expect(Group.validateInvitations(null, null, res)).to.eventually.be.rejected.and.eql({
+          httpCode: 400,
+          message: 'Bad request.',
+          name: 'BadRequest',
+        });
+        expect(res.t).to.be.calledOnce;
+        expect(res.t).to.be.calledWith('canOnlyInviteEmailUuid');
       });
 
       it('throws an error if only uuids are passed in, but they are not an array', async () => {
-        try {
-          Group.validateInvitations({ uuid: 'user-id'}, null, res);
-        } catch (err) {
-          expect(err).to.be.an.instanceof(BadRequest);
-          expect(res.t).to.be.calledOnce;
-          expect(res.t).to.be.calledWith('uuidsMustBeAnArray');
-        }
+        await expect(Group.validateInvitations({ uuid: 'user-id'}, null, res)).to.eventually.be.rejected.and.eql({
+          httpCode: 400,
+          message: 'Bad request.',
+          name: 'BadRequest',
+        });
+        expect(res.t).to.be.calledOnce;
+        expect(res.t).to.be.calledWith('uuidsMustBeAnArray');
       });
 
       it('throws an error if only emails are passed in, but they are not an array', async () => {
-        try {
-          Group.validateInvitations(null, { emails: 'user@example.com'}, res);
-        } catch (err) {
-          expect(err).to.be.an.instanceof(BadRequest);
-          expect(res.t).to.be.calledOnce;
-          expect(res.t).to.be.calledWith('emailsMustBeAnArray');
-        }
+        await expect(Group.validateInvitations(null, { emails: 'user@example.com'}, res)).to.eventually.be.rejected.and.eql({
+          httpCode: 400,
+          message: 'Bad request.',
+          name: 'BadRequest',
+        });
+        expect(res.t).to.be.calledOnce;
+        expect(res.t).to.be.calledWith('emailsMustBeAnArray');
       });
 
       it('throws an error if emails are not passed in, and uuid array is empty', async () => {
-        try {
-          Group.validateInvitations([], null, res);
-        } catch (err) {
-          expect(err).to.be.an.instanceof(BadRequest);
-          expect(res.t).to.be.calledOnce;
-          expect(res.t).to.be.calledWith('inviteMissingUuid');
-        }
+        await expect(Group.validateInvitations([], null, res)).to.eventually.be.rejected.and.eql({
+          httpCode: 400,
+          message: 'Bad request.',
+          name: 'BadRequest',
+        });
+        expect(res.t).to.be.calledOnce;
+        expect(res.t).to.be.calledWith('inviteMissingUuid');
       });
 
       it('throws an error if uuids are not passed in, and email array is empty', async () => {
-        try {
-          Group.validateInvitations(null, [], res);
-        } catch (err) {
-          expect(err).to.be.an.instanceof(BadRequest);
-          expect(res.t).to.be.calledOnce;
-          expect(res.t).to.be.calledWith('inviteMissingEmail');
-        }
+        await expect(Group.validateInvitations(null, [], res)).to.eventually.be.rejected.and.eql({
+          httpCode: 400,
+          message: 'Bad request.',
+          name: 'BadRequest',
+        });
+        expect(res.t).to.be.calledOnce;
+        expect(res.t).to.be.calledWith('inviteMissingEmail');
       });
 
       it('throws an error if uuids and emails are passed in as empty arrays', async () => {
-        try {
-          Group.validateInvitations([], [], res);
-        } catch (err) {
-          expect(err).to.be.an.instanceof(BadRequest);
-          expect(res.t).to.be.calledOnce;
-          expect(res.t).to.be.calledWith('inviteMustNotBeEmpty');
-        }
+        await expect(Group.validateInvitations([], [], res)).to.eventually.be.rejected.and.eql({
+          httpCode: 400,
+          message: 'Bad request.',
+          name: 'BadRequest',
+        });
+        expect(res.t).to.be.calledOnce;
+        expect(res.t).to.be.calledWith('inviteMustNotBeEmpty');
       });
 
       it('throws an error if total invites exceed max invite constant', async () => {
@@ -531,13 +531,13 @@ describe('Group Model', () => {
 
         uuids.push('one-more-uuid'); // to put it over the limit
 
-        try {
-          Group.validateInvitations(uuids, emails, res);
-        } catch (err) {
-          expect(err).to.be.an.instanceof(BadRequest);
-          expect(res.t).to.be.calledOnce;
-          expect(res.t).to.be.calledWith('canOnlyInviteMaxInvites', {maxInvites: INVITES_LIMIT });
-        }
+        await expect(Group.validateInvitations(uuids, emails, res)).to.eventually.be.rejected.and.eql({
+          httpCode: 400,
+          message: 'Bad request.',
+          name: 'BadRequest',
+        });
+        expect(res.t).to.be.calledOnce;
+        expect(res.t).to.be.calledWith('canOnlyInviteMaxInvites', {maxInvites: INVITES_LIMIT });
       });
 
       it('does not throw error if number of invites matches max invite limit', () => {

--- a/test/api/v3/unit/models/group.test.js
+++ b/test/api/v3/unit/models/group.test.js
@@ -4,9 +4,6 @@ import validator from 'validator';
 import { sleep } from '../../../../helpers/api-unit.helper';
 import { model as Group, INVITES_LIMIT } from '../../../../../website/server/models/group';
 import { model as User } from '../../../../../website/server/models/user';
-import {
-  BadRequest,
- } from '../../../../../website/server/libs/errors';
 import { quests as questScrolls } from '../../../../../website/common/script/content';
 import { groupChatReceivedWebhook } from '../../../../../website/server/libs/webhook';
 import * as email from '../../../../../website/server/libs/email';

--- a/website/client-old/js/controllers/groupsCtrl.js
+++ b/website/client-old/js/controllers/groupsCtrl.js
@@ -2,6 +2,8 @@
 
 habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '$http', '$q', 'User', 'Members', '$state', 'Notification',
   function($scope, $rootScope, Shared, Groups, $http, $q, User, Members, $state, Notification) {
+    $scope.PARTY_LIMIT_MEMBERS = Shared.constants.PARTY_LIMIT_MEMBERS;
+
     $scope.inviteOrStartParty = Groups.inviteOrStartParty;
     $scope.isMemberOfPendingQuest = function (userid, group) {
       if (!group.quest || !group.quest.members) return false;

--- a/website/common/locales/en/groups.json
+++ b/website/common/locales/en/groups.json
@@ -202,6 +202,7 @@
   "uuidsMustBeAnArray": "User ID invites must be an array.",
   "emailsMustBeAnArray": "Email address invites must be an array.",
   "canOnlyInviteMaxInvites": "You can only invite \"<%= maxInvites %>\" at a time",
+  "partyExceedsMembersLimit": "Party size is limited to <%= maxMembersParty %> members",
   "onlyCreatorOrAdminCanDeleteChat": "Not authorized to delete this message!",
   "onlyGroupLeaderCanEditTasks": "Not authorized to manage tasks!",
   "onlyGroupTasksCanBeAssigned": "Only group tasks can be assigned",

--- a/website/common/locales/en/groups.json
+++ b/website/common/locales/en/groups.json
@@ -135,7 +135,7 @@
   "leaderOnlyChallenges": "Only group leader can create challenges",
   "sendGift": "Send Gift",
   "inviteFriends": "Invite Friends",
-  "partyMembersInfo": "Your party currently has <%= memberCount %> members, and <%= invitationCount %> pending invitations. The limit of members in a party is <%= limitMembers %>. Invitations above this limit cannot be sent.",
+  "partyMembersInfo": "Your party currently has <%= memberCount %> members and <%= invitationCount %> pending invitations. The limit of members in a party is <%= limitMembers %>. Invitations above this limit cannot be sent.",
   "inviteByEmail": "Invite by Email",
   "inviteByEmailExplanation": "If a friend joins Habitica via your email, they'll automatically be invited to your party!",
   "inviteFriendsNow": "Invite Friends Now",

--- a/website/common/locales/en/groups.json
+++ b/website/common/locales/en/groups.json
@@ -135,7 +135,7 @@
   "leaderOnlyChallenges": "Only group leader can create challenges",
   "sendGift": "Send Gift",
   "inviteFriends": "Invite Friends",
-  "partyMembersInfo": "Your party currently have <%= memberCount %> members, and <%= invitationCount %> pending invitations. The limit of members in a party is <%= limitMembers %>. Invitations above this limit cannot be sent.",
+  "partyMembersInfo": "Your party currently has <%= memberCount %> members, and <%= invitationCount %> pending invitations. The limit of members in a party is <%= limitMembers %>. Invitations above this limit cannot be sent.",
   "inviteByEmail": "Invite by Email",
   "inviteByEmailExplanation": "If a friend joins Habitica via your email, they'll automatically be invited to your party!",
   "inviteFriendsNow": "Invite Friends Now",

--- a/website/common/locales/en/groups.json
+++ b/website/common/locales/en/groups.json
@@ -135,6 +135,7 @@
   "leaderOnlyChallenges": "Only group leader can create challenges",
   "sendGift": "Send Gift",
   "inviteFriends": "Invite Friends",
+  "partyMembersInfo": "Your party currently have <%= memberCount %> members. The limit of members in a party is <%= limitMembers %>. Invitations above this limit cannot be sent.",
   "inviteByEmail": "Invite by Email",
   "inviteByEmailExplanation": "If a friend joins Habitica via your email, they'll automatically be invited to your party!",
   "inviteFriendsNow": "Invite Friends Now",

--- a/website/common/locales/en/groups.json
+++ b/website/common/locales/en/groups.json
@@ -135,7 +135,7 @@
   "leaderOnlyChallenges": "Only group leader can create challenges",
   "sendGift": "Send Gift",
   "inviteFriends": "Invite Friends",
-  "partyMembersInfo": "Your party currently have <%= memberCount %> members. The limit of members in a party is <%= limitMembers %>. Invitations above this limit cannot be sent.",
+  "partyMembersInfo": "Your party currently have <%= memberCount %> members, and <%= invitationCount %> pending invitations. The limit of members in a party is <%= limitMembers %>. Invitations above this limit cannot be sent.",
   "inviteByEmail": "Invite by Email",
   "inviteByEmailExplanation": "If a friend joins Habitica via your email, they'll automatically be invited to your party!",
   "inviteFriendsNow": "Invite Friends Now",

--- a/website/common/script/constants.js
+++ b/website/common/script/constants.js
@@ -14,4 +14,4 @@ export const SUPPORTED_SOCIAL_NETWORKS = [
 
 export const GUILDS_PER_PAGE = 30; // number of guilds to return per page when using pagination
 
-export const PARTY_LIMIT_MEMBERS = 5;
+export const PARTY_LIMIT_MEMBERS = 30;

--- a/website/common/script/constants.js
+++ b/website/common/script/constants.js
@@ -13,3 +13,5 @@ export const SUPPORTED_SOCIAL_NETWORKS = [
 ];
 
 export const GUILDS_PER_PAGE = 30; // number of guilds to return per page when using pagination
+
+export const PARTY_LIMIT_MEMBERS = 5;

--- a/website/common/script/index.js
+++ b/website/common/script/index.js
@@ -27,6 +27,7 @@ import {
   LARGE_GROUP_COUNT_MESSAGE_CUTOFF,
   SUPPORTED_SOCIAL_NETWORKS,
   GUILDS_PER_PAGE,
+  PARTY_LIMIT_MEMBERS,
 } from './constants';
 
 api.constants = {
@@ -34,6 +35,7 @@ api.constants = {
   LARGE_GROUP_COUNT_MESSAGE_CUTOFF,
   SUPPORTED_SOCIAL_NETWORKS,
   GUILDS_PER_PAGE,
+  PARTY_LIMIT_MEMBERS
 };
 // TODO Move these under api.constants
 api.maxLevel = MAX_LEVEL;

--- a/website/common/script/index.js
+++ b/website/common/script/index.js
@@ -35,7 +35,7 @@ api.constants = {
   LARGE_GROUP_COUNT_MESSAGE_CUTOFF,
   SUPPORTED_SOCIAL_NETWORKS,
   GUILDS_PER_PAGE,
-  PARTY_LIMIT_MEMBERS
+  PARTY_LIMIT_MEMBERS,
 };
 // TODO Move these under api.constants
 api.maxLevel = MAX_LEVEL;

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -1069,7 +1069,6 @@ api.inviteToGroup = {
 
     // If party, check the limit of members
     if (group.type === 'party') {
-      let partyLimitMembers = 5;
       let memberCount = 0;
 
       // Counting the members that already joined the party
@@ -1088,8 +1087,8 @@ api.inviteToGroup = {
       if (emails)
         memberCount += emails.length;
 
-      if (memberCount > partyLimitMembers)
-        throw new BadRequest(res.t('partyExceedsMembersLimit', {maxMembersParty: partyLimitMembers}));
+      if (memberCount > common.constants.PARTY_LIMIT_MEMBERS)
+        throw new BadRequest(res.t('partyExceedsMembersLimit', {maxMembersParty: common.constants.PARTY_LIMIT_MEMBERS}));
     }
 
     Group.validateInvitations(uuids, emails, res);

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -1083,8 +1083,8 @@ api.inviteToGroup = {
         .find(query)
         .select('_id')
         .exec();
-
       memberCount += groupInvites.length;
+      
       // Counting the members that are going to be invited by email and uuids
       if (uuids) {
         memberCount += uuids.length;

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -1067,37 +1067,7 @@ api.inviteToGroup = {
     let uuids = req.body.uuids;
     let emails = req.body.emails;
 
-    Group.validateInvitations(uuids, emails, res);
-
-    // If party, check the limit of members
-    if (group.type === 'party') {
-      let memberCount = 0;
-
-      // Counting the members that already joined the party
-      memberCount += group.memberCount;
-
-      // Count how many invitations currently exist in the party
-      let query = {};
-      query['invitations.party.id'] = group._id;
-      let groupInvites = await User
-        .find(query)
-        .select('_id')
-        .exec();
-      memberCount += groupInvites.length;
-      
-      // Counting the members that are going to be invited by email and uuids
-      if (uuids) {
-        memberCount += uuids.length;
-      }
-
-      if (emails) {
-        memberCount += emails.length;
-      }
-
-      if (memberCount > common.constants.PARTY_LIMIT_MEMBERS) {
-        throw new BadRequest(res.t('partyExceedsMembersLimit', {maxMembersParty: common.constants.PARTY_LIMIT_MEMBERS}));
-      }
-    }
+    await Group.validateInvitations(uuids, emails, group, res);
 
     let results = [];
 

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -1082,11 +1082,12 @@ api.inviteToGroup = {
         .exec();
       memberCount += groupInvites.length;
       // Counting the members that are going to be invited by email and uuids
-      if (uuids)
+      if (uuids) {
         memberCount += uuids.length;
-      if (emails)
+      }
+      if (emails) {
         memberCount += emails.length;
-
+      }
       if (memberCount > common.constants.PARTY_LIMIT_MEMBERS)
         throw new BadRequest(res.t('partyExceedsMembersLimit', {maxMembersParty: common.constants.PARTY_LIMIT_MEMBERS}));
     }

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -1067,7 +1067,7 @@ api.inviteToGroup = {
     let uuids = req.body.uuids;
     let emails = req.body.emails;
 
-    await Group.validateInvitations(uuids, emails, group, res);
+    await Group.validateInvitations(uuids, emails, res, group);
 
     let results = [];
 

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -1069,13 +1069,19 @@ api.inviteToGroup = {
 
     // If party, check the limit of members
     if (group.type === 'party') {
-      let partyLimitMembers = 2;
+      let partyLimitMembers = 5;
       let memberCount = 0;
 
       // Counting the members that already joined the party
       memberCount += group.memberCount;
-      //@TODO Count how many invitations currently exist in the party
-
+      // Count how many invitations currently exist in the party
+      let query = {};
+      query['invitations.party.id'] = group._id;
+      let groupInvites = await User
+        .find(query)
+        .select('_id')
+        .exec();
+      memberCount += groupInvites.length;
       // Counting the members that are going to be invited by email and uuids
       if (uuids)
         memberCount += uuids.length;

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -1067,12 +1067,15 @@ api.inviteToGroup = {
     let uuids = req.body.uuids;
     let emails = req.body.emails;
 
+    Group.validateInvitations(uuids, emails, res);
+
     // If party, check the limit of members
     if (group.type === 'party') {
       let memberCount = 0;
 
       // Counting the members that already joined the party
       memberCount += group.memberCount;
+
       // Count how many invitations currently exist in the party
       let query = {};
       query['invitations.party.id'] = group._id;
@@ -1080,19 +1083,21 @@ api.inviteToGroup = {
         .find(query)
         .select('_id')
         .exec();
+
       memberCount += groupInvites.length;
       // Counting the members that are going to be invited by email and uuids
       if (uuids) {
         memberCount += uuids.length;
       }
+
       if (emails) {
         memberCount += emails.length;
       }
-      if (memberCount > common.constants.PARTY_LIMIT_MEMBERS)
-        throw new BadRequest(res.t('partyExceedsMembersLimit', {maxMembersParty: common.constants.PARTY_LIMIT_MEMBERS}));
-    }
 
-    Group.validateInvitations(uuids, emails, res);
+      if (memberCount > common.constants.PARTY_LIMIT_MEMBERS) {
+        throw new BadRequest(res.t('partyExceedsMembersLimit', {maxMembersParty: common.constants.PARTY_LIMIT_MEMBERS}));
+      }
+    }
 
     let results = [];
 

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -300,7 +300,7 @@ schema.statics.toJSONCleanChat = function groupToJSONCleanChat (group, user) {
  * @param  res  Express res object for use with translations
  * @throws BadRequest An error describing the issue with the invitations
  */
-schema.statics.validateInvitations = async function getInvitationError (uuids, emails, group, res) {
+schema.statics.validateInvitations = async function getInvitationError (uuids, emails, res, group = null) {
   let uuidsIsArray = Array.isArray(uuids);
   let emailsIsArray = Array.isArray(emails);
   let emptyEmails = emailsIsArray && emails.length < 1;
@@ -341,7 +341,7 @@ schema.statics.validateInvitations = async function getInvitationError (uuids, e
   }
 
   // If party, check the limit of members
-  if (group.type === 'party') {
+  if (group && group.type === 'party') {
     let memberCount = 0;
 
     // Counting the members that already joined the party

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -350,11 +350,8 @@ schema.statics.validateInvitations = async function getInvitationError (uuids, e
     // Count how many invitations currently exist in the party
     let query = {};
     query['invitations.party.id'] = group._id;
-    let groupInvites = await User
-      .find(query)
-      .select('_id')
-      .exec();
-    memberCount += groupInvites.length;
+    let groupInvites = await User.count(query).exec();
+    memberCount += groupInvites;
 
     // Counting the members that are going to be invited by email and uuids
     memberCount += totalInvites;

--- a/website/views/options/social/group.jade
+++ b/website/views/options/social/group.jade
@@ -89,7 +89,7 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
               span(ng-if='group.type=="party" && (group.onlineUsers || group.onlineUsers == 0)')= ' (' + env.t('onlineCount', {count: "{{group.onlineUsers}}"}) + ')'
               button.pull-right.btn.btn-primary(ng-click="inviteOrStartParty(group)")=env.t("inviteFriends")
           .panel-heading
-            p(ng-if='group.type=="party"')=env.t('partyMembersInfo', {memberCount: "{{group.memberCount}}", limitMembers:"30"})
+            p(ng-if='group.type=="party"')=env.t('partyMembersInfo', {memberCount: "{{group.memberCount}}", invitationCount:"{{group.invites.length}}", limitMembers:"30"})
 
           .panel-body.modal-fixed-height
             h4(ng-show='::group.memberCount === 1 && group.type === "party"')=env.t('partyEmpty')

--- a/website/views/options/social/group.jade
+++ b/website/views/options/social/group.jade
@@ -89,7 +89,7 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
               span(ng-if='group.type=="party" && (group.onlineUsers || group.onlineUsers == 0)')= ' (' + env.t('onlineCount', {count: "{{group.onlineUsers}}"}) + ')'
               button.pull-right.btn.btn-primary(ng-click="inviteOrStartParty(group)")=env.t("inviteFriends")
           .panel-heading
-            p(ng-if='group.type=="party"')=env.t('partyMembersInfo', {memberCount: "{{group.memberCount}}", invitationCount:"{{group.invites.length}}", limitMembers:"30"})
+            p(ng-if='group.type=="party"')=env.t('partyMembersInfo', {memberCount: "{{group.memberCount}}", invitationCount:"{{group.invites.length}}", limitMembers:"{{PARTY_LIMIT_MEMBERS}}"})
 
           .panel-body.modal-fixed-height
             h4(ng-show='::group.memberCount === 1 && group.type === "party"')=env.t('partyEmpty')

--- a/website/views/options/social/group.jade
+++ b/website/views/options/social/group.jade
@@ -87,7 +87,7 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
             h3.panel-title
               =env.t('members')
               span(ng-if='group.type=="party" && (group.onlineUsers || group.onlineUsers == 0)')= ' (' + env.t('onlineCount', {count: "{{group.onlineUsers}}"}) + ')'
-              button.pull-right.btn.btn-primary(ng-click="inviteOrStartParty(group)")=env.t("inviteFriends")
+              button.pull-right.btn.btn-primary(ng-if='group.type=="party" && group.memberCount + group.invites.length < PARTY_LIMIT_MEMBERS' ng-click="inviteOrStartParty(group)")=env.t("inviteFriends")
           .panel-heading
             p(ng-if='group.type=="party"')=env.t('partyMembersInfo', {memberCount: "{{group.memberCount}}", invitationCount:"{{group.invites.length}}", limitMembers:"{{PARTY_LIMIT_MEMBERS}}"})
 

--- a/website/views/options/social/group.jade
+++ b/website/views/options/social/group.jade
@@ -88,6 +88,8 @@ a.pull-right.gem-wallet(ng-if='group.type!="party"', popover-trigger='mouseenter
               =env.t('members')
               span(ng-if='group.type=="party" && (group.onlineUsers || group.onlineUsers == 0)')= ' (' + env.t('onlineCount', {count: "{{group.onlineUsers}}"}) + ')'
               button.pull-right.btn.btn-primary(ng-click="inviteOrStartParty(group)")=env.t("inviteFriends")
+          .panel-heading
+            p(ng-if='group.type=="party"')=env.t('partyMembersInfo', {memberCount: "{{group.memberCount}}", limitMembers:"30"})
 
           .panel-body.modal-fixed-height
             h4(ng-show='::group.memberCount === 1 && group.type === "party"')=env.t('partyEmpty')


### PR DESCRIPTION
_note from Alys to Alys: when notifying the wiki editors about this new feature, include this: https://github.com/HabitRPG/habitica/pull/8589#issuecomment-289715055_

----

[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #8561 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
To-do list:
- [x] Add a field that will contain the information about the current number of members in the party and the limit
- [x] Create a global variable with the maximum value of members in a party
- [x] Hide the button when the limit is reached
- [x] Enforce the limit in the server (API) considering:
  - [x] Current number of members
  - [x] Current pending invitations in the party
  - [x] Number of emails and UUIDs provided for invitations
- [x] Create tests to prove that the limit:
  - [x] Applies to parties
  - [x] Does not apply to guilds

### Current results
Party with 29 members, and trying to invite more 2:

![Invite2](http://i.imgur.com/T4ssO51.png?1)

Result (notification with error):

![Error](http://i.imgur.com/2u9vEwW.png?1)

After inviting only one (button to invite is hidden):

![Invited1](http://i.imgur.com/aNXmv4Z.png?1)

[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: 203f208a-e0f0-4442-bf16-d4f19e553e8a
