### PR TITLE
Redirection fixes

### DIFF
--- a/test/api/v3/unit/middlewares/redirects.js
+++ b/test/api/v3/unit/middlewares/redirects.js
@@ -1,0 +1,182 @@
+import {
+  generateRes,
+  generateReq,
+  generateNext,
+} from '../../../../helpers/api-unit.helper';
+import nconf from 'nconf';
+import requireAgain from 'require-again';
+
+describe('redirects middleware', () => {
+  let res, req, next;
+  let pathToRedirectsMiddleware = '../../../../../website/server/middlewares/redirects';
+
+  beforeEach(() => {
+    res = generateRes();
+    req = generateReq();
+    next = generateNext();
+  });
+
+  context('forceSSL', () => {
+    it('sends http requests to https', () => {
+      let nconfStub = sandbox.stub(nconf, 'get');
+      nconfStub.withArgs('BASE_URL').returns('https://habitica.com');
+      nconfStub.withArgs('IS_PROD').returns('true');
+      req.header = sandbox.stub().withArgs('x-forwarded-proto').returns('http');
+      req.originalUrl = '/static/front';
+
+      let attachRedirects = requireAgain(pathToRedirectsMiddleware);
+
+      attachRedirects.forceSSL(req, res, next);
+
+      expect(res.redirect).to.be.calledOnce;
+      expect(res.redirect).to.be.calledWith('https://habitica.com/static/front');
+    });
+
+    it('does not redirect https forwarded requests', () => {
+      let nconfStub = sandbox.stub(nconf, 'get');
+      nconfStub.withArgs('BASE_URL').returns('https://habitica.com');
+      nconfStub.withArgs('IS_PROD').returns('true');
+      req.header = sandbox.stub().withArgs('x-forwarded-proto').returns('https');
+      req.originalUrl = '/static/front';
+
+      let attachRedirects = requireAgain(pathToRedirectsMiddleware);
+
+      attachRedirects.forceSSL(req, res, next);
+
+      expect(res.redirect).to.be.notCalled;
+    });
+
+    it('does not redirect outside of production environments', () => {
+      let nconfStub = sandbox.stub(nconf, 'get');
+      nconfStub.withArgs('BASE_URL').returns('https://habitica.com');
+      nconfStub.withArgs('IS_PROD').returns('false');
+      req.header = sandbox.stub().withArgs('x-forwarded-proto').returns('http');
+      req.originalUrl = '/static/front';
+
+      let attachRedirects = requireAgain(pathToRedirectsMiddleware);
+
+      attachRedirects.forceSSL(req, res, next);
+
+      expect(res.redirect).to.be.notCalled;
+    });
+
+    it('does not redirect if base URL is not https', () => {
+      let nconfStub = sandbox.stub(nconf, 'get');
+      nconfStub.withArgs('BASE_URL').returns('http://habitica.com');
+      nconfStub.withArgs('IS_PROD').returns('true');
+      req.header = sandbox.stub().withArgs('x-forwarded-proto').returns('http');
+      req.originalUrl = '/static/front';
+
+      let attachRedirects = requireAgain(pathToRedirectsMiddleware);
+
+      attachRedirects.forceSSL(req, res, next);
+
+      expect(res.redirect).to.be.notCalled;
+    });
+  });
+
+  context('forceHabitica', () => {
+    it('sends requests with differing hostname to base URL host', () => {
+      let nconfStub = sandbox.stub(nconf, 'get');
+      nconfStub.withArgs('BASE_URL').returns('https://habitica.com');
+      nconfStub.withArgs('IGNORE_REDIRECT').returns('false');
+      nconfStub.withArgs('IS_PROD').returns('true');
+      req.hostname = 'www.habitica.com';
+      req.method = 'GET';
+      req.originalUrl = '/static/front';
+      req.url = '/static/front';
+
+      let attachRedirects = requireAgain(pathToRedirectsMiddleware);
+
+      attachRedirects.forceHabitica(req, res, next);
+
+      expect(res.redirect).to.be.calledOnce;
+      expect(res.redirect).to.be.calledWith(301, 'https://habitica.com/static/front');
+    });
+
+    it('does not redirect outside of production environments', () => {
+      let nconfStub = sandbox.stub(nconf, 'get');
+      nconfStub.withArgs('BASE_URL').returns('https://habitica.com');
+      nconfStub.withArgs('IGNORE_REDIRECT').returns('false');
+      nconfStub.withArgs('IS_PROD').returns('false');
+      req.hostname = 'www.habitica.com';
+      req.method = 'GET';
+      req.originalUrl = '/static/front';
+      req.url = '/static/front';
+
+      let attachRedirects = requireAgain(pathToRedirectsMiddleware);
+
+      attachRedirects.forceHabitica(req, res, next);
+
+      expect(res.redirect).to.be.notCalled;
+    });
+
+    it('does not redirect if env is set to ignore redirection', () => {
+      let nconfStub = sandbox.stub(nconf, 'get');
+      nconfStub.withArgs('BASE_URL').returns('https://habitica.com');
+      nconfStub.withArgs('IGNORE_REDIRECT').returns('true');
+      nconfStub.withArgs('IS_PROD').returns('true');
+      req.hostname = 'www.habitica.com';
+      req.method = 'GET';
+      req.originalUrl = '/static/front';
+      req.url = '/static/front';
+
+      let attachRedirects = requireAgain(pathToRedirectsMiddleware);
+
+      attachRedirects.forceHabitica(req, res, next);
+
+      expect(res.redirect).to.be.notCalled;
+    });
+
+    it('does not redirect if request hostname matches base URL host', () => {
+      let nconfStub = sandbox.stub(nconf, 'get');
+      nconfStub.withArgs('BASE_URL').returns('https://habitica.com');
+      nconfStub.withArgs('IGNORE_REDIRECT').returns('false');
+      nconfStub.withArgs('IS_PROD').returns('true');
+      req.hostname = 'habitica.com';
+      req.method = 'GET';
+      req.originalUrl = '/static/front';
+      req.url = '/static/front';
+
+      let attachRedirects = requireAgain(pathToRedirectsMiddleware);
+
+      attachRedirects.forceHabitica(req, res, next);
+
+      expect(res.redirect).to.be.notCalled;
+    });
+
+    it('does not redirect if request is an API URL', () => {
+      let nconfStub = sandbox.stub(nconf, 'get');
+      nconfStub.withArgs('BASE_URL').returns('https://habitica.com');
+      nconfStub.withArgs('IGNORE_REDIRECT').returns('false');
+      nconfStub.withArgs('IS_PROD').returns('true');
+      req.hostname = 'www.habitica.com';
+      req.method = 'GET';
+      req.originalUrl = '/static/front';
+      req.url = '/api/v3/challenges';
+
+      let attachRedirects = requireAgain(pathToRedirectsMiddleware);
+
+      attachRedirects.forceHabitica(req, res, next);
+
+      expect(res.redirect).to.be.notCalled;
+    });
+
+    it('does not redirect if request method is not GET', () => {
+      let nconfStub = sandbox.stub(nconf, 'get');
+      nconfStub.withArgs('BASE_URL').returns('https://habitica.com');
+      nconfStub.withArgs('IGNORE_REDIRECT').returns('false');
+      nconfStub.withArgs('IS_PROD').returns('true');
+      req.hostname = 'www.habitica.com';
+      req.method = 'POST';
+      req.originalUrl = '/static/front';
+      req.url = '/static/front';
+
+      let attachRedirects = requireAgain(pathToRedirectsMiddleware);
+
+      attachRedirects.forceHabitica(req, res, next);
+
+      expect(res.redirect).to.be.notCalled;
+    });
+  });
+});

--- a/test/api/v3/unit/middlewares/redirects.js
+++ b/test/api/v3/unit/middlewares/redirects.js
@@ -152,7 +152,7 @@ describe('redirects middleware', () => {
       nconfStub.withArgs('IS_PROD').returns(true);
       req.hostname = 'www.habitica.com';
       req.method = 'GET';
-      req.originalUrl = '/static/front';
+      req.originalUrl = '/api/v3/challenges';
       req.url = '/api/v3/challenges';
 
       let attachRedirects = requireAgain(pathToRedirectsMiddleware);

--- a/test/api/v3/unit/middlewares/redirects.js
+++ b/test/api/v3/unit/middlewares/redirects.js
@@ -20,7 +20,7 @@ describe('redirects middleware', () => {
     it('sends http requests to https', () => {
       let nconfStub = sandbox.stub(nconf, 'get');
       nconfStub.withArgs('BASE_URL').returns('https://habitica.com');
-      nconfStub.withArgs('IS_PROD').returns('true');
+      nconfStub.withArgs('IS_PROD').returns(true);
       req.header = sandbox.stub().withArgs('x-forwarded-proto').returns('http');
       req.originalUrl = '/static/front';
 
@@ -35,7 +35,7 @@ describe('redirects middleware', () => {
     it('does not redirect https forwarded requests', () => {
       let nconfStub = sandbox.stub(nconf, 'get');
       nconfStub.withArgs('BASE_URL').returns('https://habitica.com');
-      nconfStub.withArgs('IS_PROD').returns('true');
+      nconfStub.withArgs('IS_PROD').returns(true);
       req.header = sandbox.stub().withArgs('x-forwarded-proto').returns('https');
       req.originalUrl = '/static/front';
 
@@ -49,7 +49,7 @@ describe('redirects middleware', () => {
     it('does not redirect outside of production environments', () => {
       let nconfStub = sandbox.stub(nconf, 'get');
       nconfStub.withArgs('BASE_URL').returns('https://habitica.com');
-      nconfStub.withArgs('IS_PROD').returns('false');
+      nconfStub.withArgs('IS_PROD').returns(false);
       req.header = sandbox.stub().withArgs('x-forwarded-proto').returns('http');
       req.originalUrl = '/static/front';
 
@@ -63,7 +63,7 @@ describe('redirects middleware', () => {
     it('does not redirect if base URL is not https', () => {
       let nconfStub = sandbox.stub(nconf, 'get');
       nconfStub.withArgs('BASE_URL').returns('http://habitica.com');
-      nconfStub.withArgs('IS_PROD').returns('true');
+      nconfStub.withArgs('IS_PROD').returns(true);
       req.header = sandbox.stub().withArgs('x-forwarded-proto').returns('http');
       req.originalUrl = '/static/front';
 
@@ -80,7 +80,7 @@ describe('redirects middleware', () => {
       let nconfStub = sandbox.stub(nconf, 'get');
       nconfStub.withArgs('BASE_URL').returns('https://habitica.com');
       nconfStub.withArgs('IGNORE_REDIRECT').returns('false');
-      nconfStub.withArgs('IS_PROD').returns('true');
+      nconfStub.withArgs('IS_PROD').returns(true);
       req.hostname = 'www.habitica.com';
       req.method = 'GET';
       req.originalUrl = '/static/front';
@@ -98,7 +98,7 @@ describe('redirects middleware', () => {
       let nconfStub = sandbox.stub(nconf, 'get');
       nconfStub.withArgs('BASE_URL').returns('https://habitica.com');
       nconfStub.withArgs('IGNORE_REDIRECT').returns('false');
-      nconfStub.withArgs('IS_PROD').returns('false');
+      nconfStub.withArgs('IS_PROD').returns(false);
       req.hostname = 'www.habitica.com';
       req.method = 'GET';
       req.originalUrl = '/static/front';
@@ -115,7 +115,7 @@ describe('redirects middleware', () => {
       let nconfStub = sandbox.stub(nconf, 'get');
       nconfStub.withArgs('BASE_URL').returns('https://habitica.com');
       nconfStub.withArgs('IGNORE_REDIRECT').returns('true');
-      nconfStub.withArgs('IS_PROD').returns('true');
+      nconfStub.withArgs('IS_PROD').returns(true);
       req.hostname = 'www.habitica.com';
       req.method = 'GET';
       req.originalUrl = '/static/front';
@@ -132,7 +132,7 @@ describe('redirects middleware', () => {
       let nconfStub = sandbox.stub(nconf, 'get');
       nconfStub.withArgs('BASE_URL').returns('https://habitica.com');
       nconfStub.withArgs('IGNORE_REDIRECT').returns('false');
-      nconfStub.withArgs('IS_PROD').returns('true');
+      nconfStub.withArgs('IS_PROD').returns(true);
       req.hostname = 'habitica.com';
       req.method = 'GET';
       req.originalUrl = '/static/front';
@@ -149,7 +149,7 @@ describe('redirects middleware', () => {
       let nconfStub = sandbox.stub(nconf, 'get');
       nconfStub.withArgs('BASE_URL').returns('https://habitica.com');
       nconfStub.withArgs('IGNORE_REDIRECT').returns('false');
-      nconfStub.withArgs('IS_PROD').returns('true');
+      nconfStub.withArgs('IS_PROD').returns(true);
       req.hostname = 'www.habitica.com';
       req.method = 'GET';
       req.originalUrl = '/static/front';
@@ -166,7 +166,7 @@ describe('redirects middleware', () => {
       let nconfStub = sandbox.stub(nconf, 'get');
       nconfStub.withArgs('BASE_URL').returns('https://habitica.com');
       nconfStub.withArgs('IGNORE_REDIRECT').returns('false');
-      nconfStub.withArgs('IS_PROD').returns('true');
+      nconfStub.withArgs('IS_PROD').returns(true);
       req.hostname = 'www.habitica.com';
       req.method = 'POST';
       req.originalUrl = '/static/front';

--- a/test/helpers/api-unit.helper.js
+++ b/test/helpers/api-unit.helper.js
@@ -30,16 +30,17 @@ export function generateChallenge (options = {}) {
 
 export function generateRes (options = {}) {
   let defaultRes = {
-    render: sandbox.stub(),
-    send: sandbox.stub(),
-    status: sandbox.stub().returnsThis(),
-    sendStatus: sandbox.stub().returnsThis(),
     json: sandbox.stub(),
     locals: {
       user: generateUser(options.localsUser),
       group: generateGroup(options.localsGroup),
     },
+    redirect: sandbox.stub(),
+    render: sandbox.stub(),
+    send: sandbox.stub(),
+    sendStatus: sandbox.stub().returnsThis(),
     set: sandbox.stub(),
+    status: sandbox.stub().returnsThis(),
     t (string) {
       return i18n.t(string);
     },

--- a/website/server/middlewares/redirects.js
+++ b/website/server/middlewares/redirects.js
@@ -1,8 +1,11 @@
 import nconf from 'nconf';
 
-const IS_PROD = nconf.get('IS_PROD');
-const IGNORE_REDIRECT = nconf.get('IGNORE_REDIRECT');
+const IS_PROD = nconf.get('IS_PROD') === 'true';
+const IGNORE_REDIRECT = nconf.get('IGNORE_REDIRECT') === 'true';
 const BASE_URL = nconf.get('BASE_URL');
+
+let baseUrlSplit = BASE_URL.split('//');
+const BASE_URL_HOST = baseUrlSplit[1];
 
 function isHTTP (req) {
   return ( // eslint-disable-line no-extra-parens
@@ -13,15 +16,8 @@ function isHTTP (req) {
   );
 }
 
-function isProxied (req) {
-  return ( // eslint-disable-line no-extra-parens
-    req.header('x-habitica-lb') &&
-    req.header('x-habitica-lb') === 'Yes'
-  );
-}
-
 export function forceSSL (req, res, next) {
-  if (isHTTP(req) && !isProxied(req)) {
+  if (isHTTP(req)) {
     return res.redirect(BASE_URL + req.originalUrl);
   }
 
@@ -35,7 +31,7 @@ function nonApiUrl (req) {
 }
 
 export function forceHabitica (req, res, next) {
-  if (IS_PROD && !IGNORE_REDIRECT && !isProxied(req) && nonApiUrl(req)) {
+  if (IS_PROD && !IGNORE_REDIRECT && req.hostname !== BASE_URL_HOST && nonApiUrl(req) && req.method === 'GET') {
     return res.redirect(301, BASE_URL + req.url);
   }
 

--- a/website/server/middlewares/redirects.js
+++ b/website/server/middlewares/redirects.js
@@ -1,6 +1,6 @@
 import nconf from 'nconf';
 
-const IS_PROD = nconf.get('IS_PROD') === 'true';
+const IS_PROD = nconf.get('IS_PROD');
 const IGNORE_REDIRECT = nconf.get('IGNORE_REDIRECT') === 'true';
 const BASE_URL = nconf.get('BASE_URL');
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

**Previously**, the `redirects` middleware treated the `IGNORE_REDIRECT` environment variable as a Boolean. When retrieved in environments like Heroku, however, this variable is a string; therefore, `redirects` always acted as if redirection was ignored in these scenarios. That caused some undesirable behavior, such as users encountering the login page when given a www.habitica.com link, even if they were properly logged in to habitica.com.

**Now**, when `redirects` looks up `IGNORE_REDIRECT`, it correctly converts it to a Boolean by checking for the `'true'` string, allowing for redirection to proceed as expected.

---

**Previously**, Habitica used an extra load balancing layer to handle the habitrpg.com to habitica.com transition that needed to be accounted for in the `redirects` middleware.

**Now**, that architecture layer is no longer in use (see instead https://github.com/HabitRPG/habitrpg-redirect), so the checks for it in `redirects` have been removed.

---

**Previously**, the `redirects` middleware did not distinguish between request methods, despite Express `res.redirect` only being applicable to `GET` requests.

**Now**, `redirects` does not attempt to act on requests using methods other than `GET`.

---

**Previously**, the `redirects` middleware had no unit tests.

**Now**, tests have been added covering the current logic.

[//]: # (Put User ID in here - found in Settings -> API)