### PR TITLE
remove "Habitica - Gamify Your Life" video from Press Kit

### DIFF
--- a/website/views/static/press-kit.jade
+++ b/website/views/static/press-kit.jade
@@ -22,9 +22,6 @@ block content
     p
       a.btn.btn-lg.btn-success(href='/presskit/presskit.zip') presskit.zip
 
-  h2= env.t('pkVideo')
-  | <iframe width="560" height="315" src="https://www.youtube.com/embed/hgdeJnSili0" frameborder="0" allowfullscreen></iframe>
-
   -
     var imgs = {
       'Promo': [


### PR DESCRIPTION
As requested by @lemoness:

- removes embedded youtube video from press kit page
- removes "Habitica - Gamify Your Life.mp4" from presskit.zip

Can someone on a Windows machine test the new zip file? I modified and tested on Linux.

Press Kit page before this PR:

![image](https://cloud.githubusercontent.com/assets/1495809/24271439/e99d7a32-1064-11e7-818c-0f1588887504.png)


Press Kit page after this PR:

![image](https://cloud.githubusercontent.com/assets/1495809/24271462/fc886ca6-1064-11e7-97cb-a6620c9f9b37.png)

