### PR TITLE
adjust gem gift modal to encourage reporting players who beg for gems

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -94,8 +94,8 @@
     },
     "ITUNES_SHARED_SECRET": "aaaabbbbccccddddeeeeffff00001111",
     "EMAILS" : {
-        "COMMUNITY_MANAGER_EMAIL" : "community@example.com",
-        "TECH_ASSISTANCE_EMAIL" : "tech@example.com",
-        "PRESS_ENQUIRY_EMAIL" : "press@example.com"
+        "COMMUNITY_MANAGER_EMAIL" : "leslie@habitica.com",
+        "TECH_ASSISTANCE_EMAIL" : "admin@habitica.com",
+        "PRESS_ENQUIRY_EMAIL" : "leslie@habitica.com"
     }
 }

--- a/website/common/locales/en/groups.json
+++ b/website/common/locales/en/groups.json
@@ -155,6 +155,7 @@
   "sendGiftPurchase": "Purchase",
   "sendGiftMessagePlaceholder": "Personal message (optional)",
   "sendGiftSubscription": "<%= months %> Month(s): $<%= price %> USD",
+  "gemGiftsAreOptional": "Please note that Habitica will never require you to gift gems to other players. Begging people for gems is a <strong>violation of the Community Guidelines</strong>, and all such instances should be reported to <%= hrefTechAssistanceEmail %>.",
   "battleWithFriends": "Battle Monsters With Friends",
   "startPartyWithFriends": "Start a Party with your friends!",
   "startAParty": "Start a Party",

--- a/website/views/shared/modals/members.jade
+++ b/website/views/shared/modals/members.jade
@@ -79,6 +79,9 @@ script(type='text/ng-template', id='modals/send-gift.html')
             .btn-group
               a.btn.btn-default(ng-class="{active:gift.gems.fromBalance}", ng-click="gift.gems.fromBalance=true")=env.t('sendGiftFromBalance')
               a.btn.btn-default(ng-class="{active:!gift.gems.fromBalance}", ng-click="gift.gems.fromBalance=false")=env.t('sendGiftPurchase')
+        .row
+          .col-md-12
+            p.small.muted!=env.t('gemGiftsAreOptional', { hrefTechAssistanceEmail : '<a href="mailto:' + env.EMAILS.TECH_ASSISTANCE_EMAIL + '">' + env.EMAILS.TECH_ASSISTANCE_EMAIL + '</a>'})
 
     .panel.panel-default(class="{{gift.type=='subscription' ? 'panel-primary' : 'transparent'}}", ng-click='gift.type="subscription"')
       .panel-heading=env.t('subscription')


### PR DESCRIPTION
This PR adds a message to the gem gift modal to state that gem gifting is never required and that begging is a violation of the guidelines and should be reported.

It is something that the mods and @lemoness and @veeeeeee were discussing after we discovered that a player had harassed others into giving him gems. Some of the players had thought that giving gems was mandatory to join his party.

I'll be asking the mods for feedback so don't merge yet (I'm also happy to take feedback from the other admins of course).

In the screenshot below, the only new thing is the grey message just below the "From Balance" and "Purchase" buttons.
 
![image](https://cloud.githubusercontent.com/assets/1495809/24396713/7946ad40-13e7-11e7-9def-def3c796c0db.png)

This PR also changes the config.json.example file to replace the example email addresses with the real ones. This allows us to easily tell from local install screenshots whether the correct address variable has been used. I can't see any disadvantage to it - emails aren't sent from local installs, and even if they ever are for a specific testing purpose, I think the benefit of seeing the correct address in screenshots outweighs the small inconvenience from occasional test email spam.