### PR TITLE
fix text problems in Community Guidelines; add email variables to jade files; add Press Kit link

### DIFF
--- a/website/common/locales/en/communityGuidelines.json
+++ b/website/common/locales/en/communityGuidelines.json
@@ -70,7 +70,7 @@
     "commGuidePara039": "The Back Corner Guild is a free public space to discuss sensitive subjects, and it is carefully moderated. It is not a place for general discussions or conversations. <strong>The Public Space Guidelines still apply, as do all of the Terms and Conditions.</strong> Just because we are wearing long cloaks and clustering in a corner doesn't mean that anything goes! Now pass me that smoldering candle, will you?",
     "commGuideHeadingTrello": "Trello Boards",
     "commGuidePara040": "<strong>Trello serves as an open forum for suggestions and discussion of site features.</strong> Habitica is ruled by the people in the form of valiant contributors -- we all build the site together. Trello lends structure to our system. Out of consideration for this, <strong>try your best to contain all your thoughts into one comment, instead of commenting many times in a row on the same card. If you think of something new, feel free to edit your original comments.</strong> Please, take pity on those of us who receive a notification for every new comment. Our inboxes can only withstand so much.",
-    "commGuidePara041": "Habitica uses five different Trello boards:",
+    "commGuidePara041": "Habitica uses four different Trello boards:",
     "commGuideList03A": "The <strong>Main Board</strong> is a place to request and vote on site features.",
     "commGuideList03B": "The <strong>Mobile Board</strong> is a place to request and vote on mobile app features.",
     "commGuideList03C": "The <strong>Pixel Art Board</strong> is a place to discuss and submit pixel art.",

--- a/website/views/options/profile/profile.jade
+++ b/website/views/options/profile/profile.jade
@@ -40,7 +40,7 @@ script(id='partials/options.profile.profile.html', type='text/ng-template')
 
       form.col-md-4(ng-show='_editing.profile', ng-submit='save()')
         .alert.alert-info.alert-sm
-          !=env.t("communityGuidelinesWarning")
+          !=env.t("communityGuidelinesWarning", { hrefBlankCommunityManagerEmail : '<a href="mailto:' + env.EMAILS.COMMUNITY_MANAGER_EMAIL + '">' + env.EMAILS.COMMUNITY_MANAGER_EMAIL + '</a>'})
         input.btn.btn-primary(type='submit', value=env.t('save'))
         // TODO use photo-upload instead: https://groups.google.com/forum/?fromgroups=#!topic/derbyjs/xMmADvxBOak
         .form-group

--- a/website/views/options/settings/api.jade
+++ b/website/views/options/settings/api.jade
@@ -8,7 +8,7 @@ script(type='text/ng-template', id='partials/options.settings.api.html')
         pre.prettyprint {{user.id}}
         h6=env.t('APIToken')
         pre.prettyprint {{User.settings.auth.apiToken}}
-        small!=env.t("APITokenWarning")
+        small!=env.t("APITokenWarning", { hrefTechAssistanceEmail : '<a href="mailto:' + env.EMAILS.TECH_ASSISTANCE_EMAIL + '">' + env.EMAILS.TECH_ASSISTANCE_EMAIL + '</a>' })
         br
         h3=env.t('thirdPartyApps')
         ul

--- a/website/views/shared/footer.jade
+++ b/website/views/shared/footer.jade
@@ -37,6 +37,8 @@ footer.footer(ng-controller='FooterCtrl')
           li
             a(href='/static/terms')=env.t('companyTerms')
           li
+            a(href='/static/press-kit')=env.t('presskit')
+          li
             a(href='/static/contact')=env.t('contactUs')
           li
             a(href='/static/merch')=env.t('merch')

--- a/website/views/static/community-guidelines.jade
+++ b/website/views/static/community-guidelines.jade
@@ -28,8 +28,8 @@ block content
       p.pagemeta
         =env.t('lastUpdated')
         |&nbsp;
-        =env.t('February')
-        |&nbsp;28&comma; 2016
+        =env.t('March')
+        |&nbsp;30&comma; 2017
       h2#welcome=env.t('commGuideHeadingWelcome')
       .clearfix
         img.pull-left(src='/community-guidelines-images/intro.png', alt='')


### PR DESCRIPTION
Our super-observant Socialites have reported a few text problems in the Community Guidelines and some broken text containing email addresses (details below). This PR fixes them, and removes Windows line breaks from some of the affected files. It also adds a link to the Press Kit in the footer's Company column, just above Contact Us:

![image](https://cloud.githubusercontent.com/assets/1495809/24491051/c39bee82-1568-11e7-9ccb-bb9abd4c75a4.png)

----

Altariel: **"Minor not really bug but something Report: The Community Guidelines say last updated February 28, 2016, but I thought Bailey told me this morning they were just updated today/yesterday."**

I've updated it to March 30 2017

![image](https://cloud.githubusercontent.com/assets/1495809/24490814/b0b3c962-1567-11e7-867e-4d8488b10973.png)

----

tricksy.fox: **"Super minor, but the new Community Guidelines says "Habitica uses five different Trello boards:" and then only lists four"**

I've changed the text to four.

![image](https://cloud.githubusercontent.com/assets/1495809/24490805/a2e445d2-1567-11e7-8ed1-cbf01f845f5c.png)

----

Can of Lightbulbs and RandomGryffindor: **"When viewing the Profile page, there is now a blue box under the check-in progress bar that reads the following: Error processing the string "communityGuidelinesWarning". Please see Help > Report a Bug."**

Fixed by inserting a variable for COMMUNITY_MANAGER_EMAIL

![image](https://cloud.githubusercontent.com/assets/1495809/24490941/40a5a8b0-1568-11e7-8848-d5bc73dfa56b.png)

----

**The Settings > API page showed `Error processing the string "APITokenWarning"`.** I fixed it by inserting a variable for TECH_ASSISTANCE_EMAIL (the token shown below is for a test account on localhost).

![image](https://cloud.githubusercontent.com/assets/1495809/24490997/8e5b17ca-1568-11e7-9e73-115f7272bd0c.png)
