### PR TITLE
use new email template when joining a group plan for customisation of subscription cancellation information

### DIFF
--- a/test/api/v3/unit/libs/amazonPayments.test.js
+++ b/test/api/v3/unit/libs/amazonPayments.test.js
@@ -525,6 +525,7 @@ describe('Amazon Payments', () => {
         nextBill: moment(user.purchased.plan.lastBillingDate).add({ days: subscriptionLength }),
         paymentMethod: amzLib.constants.PAYMENT_METHOD,
         headers,
+        cancellationReason: undefined,
       });
       expectAmazonStubs();
     });
@@ -555,6 +556,7 @@ describe('Amazon Payments', () => {
         nextBill: moment(user.purchased.plan.lastBillingDate).add({ days: subscriptionLength }),
         paymentMethod: amzLib.constants.PAYMENT_METHOD,
         headers,
+        cancellationReason: undefined,
       });
       amzLib.closeBillingAgreement.restore();
     });
@@ -593,6 +595,7 @@ describe('Amazon Payments', () => {
         nextBill: moment(group.purchased.plan.lastBillingDate).add({ days: subscriptionLength }),
         paymentMethod: amzLib.constants.PAYMENT_METHOD,
         headers,
+        cancellationReason: undefined,
       });
       expectAmazonStubs();
     });
@@ -623,6 +626,7 @@ describe('Amazon Payments', () => {
         nextBill: moment(group.purchased.plan.lastBillingDate).add({ days: subscriptionLength }),
         paymentMethod: amzLib.constants.PAYMENT_METHOD,
         headers,
+        cancellationReason: undefined,
       });
       amzLib.closeBillingAgreement.restore();
     });

--- a/test/api/v3/unit/libs/payments.test.js
+++ b/test/api/v3/unit/libs/payments.test.js
@@ -16,6 +16,7 @@ describe('payments/index', () => {
   beforeEach(async () => {
     user = new User();
     user.profile.name = 'sender';
+    await user.save();
 
     group = generateGroup({
       name: 'test group',

--- a/test/api/v3/unit/libs/payments/group-plans/group-payments-cancel.test.js
+++ b/test/api/v3/unit/libs/payments/group-plans/group-payments-cancel.test.js
@@ -138,7 +138,7 @@ describe('Canceling a subscription for group', () => {
     ]);
   });
 
-  it('prevents non group leader from manging subscription', async () => {
+  it('prevents non group leader from managing subscription', async () => {
     let groupMember = new User();
     data.user = groupMember;
     data.groupId = group._id;

--- a/test/api/v3/unit/libs/payments/group-plans/group-payments-create.test.js
+++ b/test/api/v3/unit/libs/payments/group-plans/group-payments-create.test.js
@@ -14,6 +14,11 @@ import {
 } from '../../../../../../helpers/api-unit.helper.js';
 
 describe('Purchasing a group plan for group', () => {
+  const EMAIL_TEMPLATE_SUBSCRIPTION_TYPE_GOOGLE = 'Google_subscription';
+  const EMAIL_TEMPLATE_SUBSCRIPTION_TYPE_IOS = 'iOS_subscription';
+  const EMAIL_TEMPLATE_SUBSCRIPTION_TYPE_NORMAL = 'normal_subscription';
+  const EMAIL_TEMPLATE_SUBSCRIPTION_TYPE_NONE = 'no_subscription';
+
   let plan, group, user, data;
   let stripe = stripeModule('test');
   let groupLeaderName = 'sender';
@@ -176,7 +181,7 @@ describe('Purchasing a group plan for group', () => {
     expect(sender.sendTxn.firstCall.args[2]).to.eql([
       {name: 'LEADER', content: user.profile.name},
       {name: 'GROUP_NAME', content: group.name},
-      {name: 'PREVIOUS_SUBSCRIPTION_TYPE', content: 'none'},
+      {name: 'PREVIOUS_SUBSCRIPTION_TYPE', content: EMAIL_TEMPLATE_SUBSCRIPTION_TYPE_NONE},
     ]);
     // confirm that the other email sent is appropriate:
     expect(sender.sendTxn.secondCall.args[0]._id).to.equal(group.leader);
@@ -202,7 +207,7 @@ describe('Purchasing a group plan for group', () => {
     expect(sender.sendTxn.firstCall.args[2]).to.eql([
       {name: 'LEADER', content: user.profile.name},
       {name: 'GROUP_NAME', content: group.name},
-      {name: 'PREVIOUS_SUBSCRIPTION_TYPE', content: 'normal'},
+      {name: 'PREVIOUS_SUBSCRIPTION_TYPE', content: EMAIL_TEMPLATE_SUBSCRIPTION_TYPE_NORMAL},
     ]);
     // confirm that the other email sent is not a cancel-subscription email:
     expect(sender.sendTxn.secondCall.args[0]._id).to.equal(group.leader);
@@ -236,7 +241,7 @@ describe('Purchasing a group plan for group', () => {
     expect(sender.sendTxn.firstCall.args[2]).to.eql([
       {name: 'LEADER', content: user.profile.name},
       {name: 'GROUP_NAME', content: group.name},
-      {name: 'PREVIOUS_SUBSCRIPTION_TYPE', content: 'normal'},
+      {name: 'PREVIOUS_SUBSCRIPTION_TYPE', content: EMAIL_TEMPLATE_SUBSCRIPTION_TYPE_NORMAL},
     ]);
     // confirm that the other email sent is not a cancel-subscription email:
     expect(sender.sendTxn.secondCall.args[0]._id).to.equal(group.leader);
@@ -273,7 +278,7 @@ describe('Purchasing a group plan for group', () => {
     expect(sender.sendTxn.firstCall.args[2]).to.eql([
       {name: 'LEADER', content: user.profile.name},
       {name: 'GROUP_NAME', content: group.name},
-      {name: 'PREVIOUS_SUBSCRIPTION_TYPE', content: 'normal'},
+      {name: 'PREVIOUS_SUBSCRIPTION_TYPE', content: EMAIL_TEMPLATE_SUBSCRIPTION_TYPE_NORMAL},
     ]);
     // confirm that the other email sent is not a cancel-subscription email:
     expect(sender.sendTxn.secondCall.args[0]._id).to.equal(group.leader);
@@ -308,7 +313,7 @@ describe('Purchasing a group plan for group', () => {
     expect(sender.sendTxn.args[1][2]).to.eql([
       {name: 'LEADER', content: groupLeaderName},
       {name: 'GROUP_NAME', content: groupName},
-      {name: 'PREVIOUS_SUBSCRIPTION_TYPE', content: 'Google'},
+      {name: 'PREVIOUS_SUBSCRIPTION_TYPE', content: EMAIL_TEMPLATE_SUBSCRIPTION_TYPE_GOOGLE},
     ]);
     expect(sender.sendTxn.args[2][0]._id).to.equal(group.leader);
     expect(sender.sendTxn.args[2][1]).to.equal('group-member-join');
@@ -341,7 +346,7 @@ describe('Purchasing a group plan for group', () => {
     expect(sender.sendTxn.args[1][2]).to.eql([
       {name: 'LEADER', content: groupLeaderName},
       {name: 'GROUP_NAME', content: groupName},
-      {name: 'PREVIOUS_SUBSCRIPTION_TYPE', content: 'iOS'},
+      {name: 'PREVIOUS_SUBSCRIPTION_TYPE', content: EMAIL_TEMPLATE_SUBSCRIPTION_TYPE_IOS},
     ]);
     expect(sender.sendTxn.args[2][0]._id).to.equal(group.leader);
     expect(sender.sendTxn.args[2][1]).to.equal('group-member-join');

--- a/test/api/v3/unit/libs/paypalPayments.test.js
+++ b/test/api/v3/unit/libs/paypalPayments.test.js
@@ -447,6 +447,7 @@ describe('Paypal Payments', ()  => {
         groupId,
         paymentMethod: 'Paypal',
         nextBill: nextBillingDate,
+        cancellationReason: undefined,
       });
     });
 
@@ -464,6 +465,7 @@ describe('Paypal Payments', ()  => {
         groupId: group._id,
         paymentMethod: 'Paypal',
         nextBill: nextBillingDate,
+        cancellationReason: undefined,
       });
     });
   });

--- a/test/api/v3/unit/libs/stripePayments.test.js
+++ b/test/api/v3/unit/libs/stripePayments.test.js
@@ -683,6 +683,7 @@ describe('Stripe Payments', () => {
           groupId: undefined,
           nextBill: currentPeriodEndTimeStamp * 1000, // timestamp in seconds
           paymentMethod: 'Stripe',
+          cancellationReason: undefined,
         });
       });
 
@@ -702,6 +703,7 @@ describe('Stripe Payments', () => {
           groupId,
           nextBill: currentPeriodEndTimeStamp * 1000, // timestamp in seconds
           paymentMethod: 'Stripe',
+          cancellationReason: undefined,
         });
       });
     });

--- a/website/server/libs/amazonPayments.js
+++ b/website/server/libs/amazonPayments.js
@@ -161,11 +161,12 @@ api.checkout = async function checkout (options = {}) {
  * @param  options.user  The user object who is canceling
  * @param  options.groupId  The id of the group that is canceling
  * @param  options.headers  The request headers
+ * @param  options.cancellationReason  A text string to control the email template used
  *
  * @return undefined
  */
 api.cancelSubscription = async function cancelSubscription (options = {}) {
-  let {user, groupId, headers, reason} = options; // TODO add `reason` to the other payment-specific cancelSubscription functions
+  let {user, groupId, headers, cancellationReason} = options;
 
   let billingAgreementId;
   let planId;
@@ -218,7 +219,7 @@ api.cancelSubscription = async function cancelSubscription (options = {}) {
     nextBill: moment(lastBillingDate).add({ days: subscriptionLength }),
     paymentMethod: this.constants.PAYMENT_METHOD,
     headers,
-    reason, // TODO add `reason` to the other payment-specific cancelSubscription functions
+    cancellationReason,
   });
 };
 

--- a/website/server/libs/amazonPayments.js
+++ b/website/server/libs/amazonPayments.js
@@ -165,7 +165,7 @@ api.checkout = async function checkout (options = {}) {
  * @return undefined
  */
 api.cancelSubscription = async function cancelSubscription (options = {}) {
-  let {user, groupId, headers} = options;
+  let {user, groupId, headers, reason} = options; // TODO add `reason` to the other payment-specific cancelSubscription functions
 
   let billingAgreementId;
   let planId;
@@ -218,6 +218,7 @@ api.cancelSubscription = async function cancelSubscription (options = {}) {
     nextBill: moment(lastBillingDate).add({ days: subscriptionLength }),
     paymentMethod: this.constants.PAYMENT_METHOD,
     headers,
+    reason, // TODO add `reason` to the other payment-specific cancelSubscription functions
   });
 };
 

--- a/website/server/libs/amazonPayments.js
+++ b/website/server/libs/amazonPayments.js
@@ -161,7 +161,7 @@ api.checkout = async function checkout (options = {}) {
  * @param  options.user  The user object who is canceling
  * @param  options.groupId  The id of the group that is canceling
  * @param  options.headers  The request headers
- * @param  options.cancellationReason  A text string to control the email template used
+ * @param  options.cancellationReason  A text string to control sending an email
  *
  * @return undefined
  */

--- a/website/server/libs/payments.js
+++ b/website/server/libs/payments.js
@@ -131,7 +131,7 @@ api.addSubToGroupUser = async function addSubToGroupUser (member, group) {
 
     if ((ignorePaymentPlan || ignoreCustomerId) && !customerHasCancelledGroupPlan) return;
 
-    if (member.hasNotCancelled()) await member.cancelSubscription();
+    if (member.hasNotCancelled()) await member.cancelSubscription({reason:'joined_group_plan'}); // TODO make joined_group_plan a CONST
 
     let today = new Date();
     plan = member.purchased.plan.toObject();
@@ -414,7 +414,7 @@ api.cancelSubscription = async function cancelSubscription (data) {
   let emailType = 'cancel-subscription';
   let emailMergeData = [];
 
-  //  If we are buying a group subscription
+  //  If we are cancelling a group subscription
   if (data.groupId) {
     let groupFields = basicGroupFields.concat(' purchased');
     group = await Group.getGroup({user: data.user, groupId: data.groupId, populateLeader: false, groupFields});
@@ -435,6 +435,7 @@ api.cancelSubscription = async function cancelSubscription (data) {
     await this.cancelGroupUsersSubscription(group);
   } else {
     plan = data.user.purchased.plan;
+    if (data.reason && data.reason === 'joined_group_plan') emailType = 'move-subscription-to-free-group-plan'; // TODO email template requires RECIPIENT_NAME and GROUP_NAME
   }
 
   let customerId = plan.customerId;

--- a/website/server/libs/payments.js
+++ b/website/server/libs/payments.js
@@ -20,7 +20,7 @@ import {
 import slack from './slack';
 
 const TECH_ASSISTANCE_EMAIL = nconf.get('EMAILS:TECH_ASSISTANCE_EMAIL');
-
+const JOINED_GROUP_PLAN = 'joined group plan';
 let api = {};
 
 api.constants = {
@@ -131,7 +131,7 @@ api.addSubToGroupUser = async function addSubToGroupUser (member, group) {
 
     if ((ignorePaymentPlan || ignoreCustomerId) && !customerHasCancelledGroupPlan) return;
 
-    if (member.hasNotCancelled()) await member.cancelSubscription({reason:'joined_group_plan'}); // TODO make joined_group_plan a CONST
+    if (member.hasNotCancelled()) await member.cancelSubscription({cancellationReason: JOINED_GROUP_PLAN});
 
     let today = new Date();
     plan = member.purchased.plan.toObject();
@@ -435,7 +435,7 @@ api.cancelSubscription = async function cancelSubscription (data) {
     await this.cancelGroupUsersSubscription(group);
   } else {
     plan = data.user.purchased.plan;
-    if (data.reason && data.reason === 'joined_group_plan') emailType = 'move-subscription-to-free-group-plan'; // TODO email template requires RECIPIENT_NAME and GROUP_NAME
+    if (data.cancellationReason && data.cancellationReason === JOINED_GROUP_PLAN) emailType = 'move-subscription-to-free-group-plan'; // TODO email template requires RECIPIENT_NAME and GROUP_NAME
   }
 
   let customerId = plan.customerId;

--- a/website/server/libs/payments.js
+++ b/website/server/libs/payments.js
@@ -21,6 +21,7 @@ import slack from './slack';
 
 const TECH_ASSISTANCE_EMAIL = nconf.get('EMAILS:TECH_ASSISTANCE_EMAIL');
 const JOINED_GROUP_PLAN = 'joined group plan';
+
 let api = {};
 
 api.constants = {

--- a/website/server/libs/paypalPayments.js
+++ b/website/server/libs/paypalPayments.js
@@ -176,8 +176,18 @@ api.subscribeSuccess = async function subscribeSuccess (options = {}) {
   });
 };
 
+/**
+ * Cancel a PayPal Subscription
+ *
+ * @param  options
+ * @param  options.user  The user object who is canceling
+ * @param  options.groupId  The id of the group that is canceling
+ * @param  options.cancellationReason  A text string to control the email template used
+ *
+ * @return undefined
+ */
 api.subscribeCancel = async function subscribeCancel (options = {}) {
-  let {groupId, user} = options;
+  let {groupId, user, cancellationReason} = options;
 
   let customerId;
   if (groupId) {
@@ -212,6 +222,7 @@ api.subscribeCancel = async function subscribeCancel (options = {}) {
     groupId,
     paymentMethod: this.constants.PAYMENT_METHOD,
     nextBill: nextBillingDate,
+    cancellationReason,
   });
 };
 

--- a/website/server/libs/paypalPayments.js
+++ b/website/server/libs/paypalPayments.js
@@ -182,7 +182,7 @@ api.subscribeSuccess = async function subscribeSuccess (options = {}) {
  * @param  options
  * @param  options.user  The user object who is canceling
  * @param  options.groupId  The id of the group that is canceling
- * @param  options.cancellationReason  A text string to control the email template used
+ * @param  options.cancellationReason  A text string to control sending an email
  *
  * @return undefined
  */

--- a/website/server/libs/stripePayments.js
+++ b/website/server/libs/stripePayments.js
@@ -198,7 +198,7 @@ api.editSubscription = async function editSubscription (options, stripeInc) {
  * @param  options
  * @param  options.user  The user object who is purchasing
  * @param  options.groupId  The id of the group purchasing a subscription
- * @param  options.cancellationReason  A text string to control the email template used
+ * @param  options.cancellationReason  A text string to control sending an email
  *
  * @return undefined
  */

--- a/website/server/libs/stripePayments.js
+++ b/website/server/libs/stripePayments.js
@@ -198,11 +198,12 @@ api.editSubscription = async function editSubscription (options, stripeInc) {
  * @param  options
  * @param  options.user  The user object who is purchasing
  * @param  options.groupId  The id of the group purchasing a subscription
+ * @param  options.cancellationReason  A text string to control the email template used
  *
  * @return undefined
  */
 api.cancelSubscription = async function cancelSubscription (options, stripeInc) {
-  let {groupId, user} = options;
+  let {groupId, user, cancellationReason} = options;
   let customerId;
 
   // @TODO: We need to mock this, but curently we don't have correct Dependency Injection. And the Stripe Api doesn't seem to be a singleton?
@@ -252,6 +253,7 @@ api.cancelSubscription = async function cancelSubscription (options, stripeInc) 
     groupId,
     nextBill,
     paymentMethod: this.constants.PAYMENT_METHOD,
+    cancellationReason,
   });
 };
 

--- a/website/server/models/user/methods.js
+++ b/website/server/models/user/methods.js
@@ -105,6 +105,17 @@ schema.methods.addComputedStatsToJSONObj = function addComputedStatsToUserJSONOb
   return statsObject;
 };
 
+/**
+ * Cancels a subscription.
+ *
+ * @param  options
+ * @param  options.user  The user object who is purchasing
+ * @param  options.groupId  The id of the group purchasing a subscription
+ * @param  options.headers  The request headers (only for Amazon subscriptions)
+ * @param  options.cancellationReason  A text string to control sending an email
+ *
+ * @return a Promise from api.cancelSubscription()
+ */
 // @TODO: There is currently a three way relation between the user, payment methods and the payment helper
 // This creates some odd Dependency Injection issues. To counter that, we use the user as the third layer
 // To negotiate between the payment providers and the payment helper (which probably has too many responsiblities)
@@ -121,6 +132,7 @@ schema.methods.cancelSubscription = async function cancelSubscription (options =
   } else if (plan.paymentMethod === paypalPayments.constants.PAYMENT_METHOD) {
     return await paypalPayments.subscribeCancel(options);
   }
+  // Android and iOS subscriptions cannot be cancelled by Habitica.
 
   return await payments.cancelSubscription(options);
 };

--- a/website/server/models/user/methods.js
+++ b/website/server/models/user/methods.js
@@ -110,16 +110,17 @@ schema.methods.addComputedStatsToJSONObj = function addComputedStatsToUserJSONOb
 // To negotiate between the payment providers and the payment helper (which probably has too many responsiblities)
 // In summary, currently is is best practice to use this method to cancel a user subscription, rather than calling the
 // payment helper.
-schema.methods.cancelSubscription = async function cancelSubscription () {
+schema.methods.cancelSubscription = async function cancelSubscription (options = {}) {
   let plan = this.purchased.plan;
 
+  options.user = this;
   if (plan.paymentMethod === amazonPayments.constants.PAYMENT_METHOD) {
-    return await amazonPayments.cancelSubscription({user: this});
+    return await amazonPayments.cancelSubscription(options);
   } else if (plan.paymentMethod === stripePayments.constants.PAYMENT_METHOD) {
-    return await stripePayments.cancelSubscription({user: this});
+    return await stripePayments.cancelSubscription(options);
   } else if (plan.paymentMethod === paypalPayments.constants.PAYMENT_METHOD) {
-    return await paypalPayments.subscribeCancel({user: this});
+    return await paypalPayments.subscribeCancel(options);
   }
 
-  return await payments.cancelSubscription({user: this});
+  return await payments.cancelSubscription(options);
 };


### PR DESCRIPTION
This PR makes various changes related to sending emails when subscriptions are cancelled and/or group plans are created / joined:

- Adds the `cancellationReason` option to the cancelSubscription() / subscribeCancel() functions to pass information through to the code that controls what kind of email is sent when a user's subscription is cancelled.
- Uses that option to prevent sending of a subscription cancellation email when a user's subscription is replaced by the free subscription from a group plan.
- Adds the `PREVIOUS_SUBSCRIPTION_TYPE` Mandril "conditional merge tag" to the config for the email that the user receives when they join a group plan (the `group-plan-join` template). This allows the email template to give the user precise information about what has happened to their previous subscription. (The plain-text Mandrill template for that email is included below for comparison.)
- Uses that conditional merge tag to make the `group-plan-join` email tell the user to cancel their own iOS / Android subscription.
- Adjusts the text that is sent to an admin when the user has an iOS / Android subscription since the admin no longer needs to email instructions to the user.
- Fixes typos in comments and test descriptions; makes other small text changes for consistency.

For reference, below is the plain-text version of the Mandrill template for the `group-plan-join` email.

```
Dear *|RECIPIENT_NAME|*,

We just wanted to let you know that *|LEADER|* has enrolled you in the group "*|GROUP_NAME|*"!

As a member of a premium group plan, you'll have access to the following benefits:
- Access to the group's shared task dashboard and chatroom
- The ability to claim a task that you're working on
- The ability to be notified when a task has been assigned to you
- The ability to see which tasks have been assigned to other group members
- An exclusive Jackalope Mount for your avatar
- A free subscription with all the normal subscription benefits!

*|IF:PREVIOUS_SUBSCRIPTION_TYPE=normal_subscription|*
Since you were already an awesome subscriber, we wanted to let you know that we've switched your existing subscription over to a free Group Plan subscription and cancelled your ongoing payments. Don't worry, your benefits for consecutive subscriptions will seamlessly transfer over, and any unused subscription credits will be saved for your use if you leave the group plan.

*|ELSEIF:PREVIOUS_SUBSCRIPTION_TYPE=Google_subscription|*
Since you were already an awesome subscriber through Google Play, there's an extra action that you'll need to take to get your free subscription. Habitica can't automatically cancel your preexisting subscription for you, so you'll need to:
- go to the "My apps &amp; games" > "Subscriptions" section of the Google Play Store app to cancel your subscription.
- respond to this email so we know to set you up with your free subscription. Don't worry, your benefits for consecutive subscriptions will seamlessly transfer over, and any unused subscription credits will be saved for your use if you leave the group plan!

*|ELSEIF:PREVIOUS_SUBSCRIPTION_TYPE=iOS_subscription|*
Since you were already an awesome subscriber through the App Store, there's an extra action that you'll need to take to get your free subscription. Habitica can't automatically cancel your preexisting subscription for you, so you'll need to follow Apple's official instructions at https://support.apple.com/en-us/HT202039 and then respond to this email so we know to set you up with your free subscription. Don't worry, your benefits for consecutive subscriptions will seamlessly transfer over, and any unused subscription credits will be saved for your use if you leave the group plan!

*|ELSEIF:PREVIOUS_SUBSCRIPTION_TYPE=lifetime_free_subscription|*
Because you already had a lifetime free subscription, your subscription has not been changed.

*|ELSEIF:PREVIOUS_SUBSCRIPTION_TYPE=unknown_type_of_subscription|*
Due to the nature of your subscription, it has not been changed. Please reply to this email to ask for futher details.

*|END:IF|*
More benefits will be available in the future as we continue to develop Group Plans. Definitely feel free to reach out if you have any feedback!

Warmly,
{etc}
```