### PR TITLE
Prevented ios and android subs from being upgrade to group plans

### DIFF
--- a/test/api/v3/unit/libs/payments/group-plans/group-payments-create.test.js
+++ b/test/api/v3/unit/libs/payments/group-plans/group-payments-create.test.js
@@ -603,6 +603,64 @@ describe('Purchasing a subscription for group', () => {
     expect(updatedUser.purchased.plan.dateCreated).to.exist;
   });
 
+  it('does not modify a user with an Google subscription', async () => {
+    plan.customerId = 'random';
+    plan.paymentMethod = api.constants.GOOGLE_PAYMENT_METHOD;
+
+    let recipient = new User();
+    recipient.profile.name = 'recipient';
+    recipient.purchased.plan = plan;
+    recipient.guilds.push(group._id);
+    await recipient.save();
+
+    user.guilds.push(group._id);
+    await user.save();
+    data.groupId = group._id;
+
+    await api.createSubscription(data);
+
+    let updatedUser = await User.findById(recipient._id).exec();
+
+    expect(updatedUser.purchased.plan.planId).to.eql('basic_3mo');
+    expect(updatedUser.purchased.plan.customerId).to.eql('random');
+    expect(updatedUser.purchased.plan.dateUpdated).to.exist;
+    expect(updatedUser.purchased.plan.gemsBought).to.eql(0);
+    expect(updatedUser.purchased.plan.paymentMethod).to.eql(api.constants.GOOGLE_PAYMENT_METHOD);
+    expect(updatedUser.purchased.plan.extraMonths).to.eql(0);
+    expect(updatedUser.purchased.plan.dateTerminated).to.eql(null);
+    expect(updatedUser.purchased.plan.lastBillingDate).to.exist;
+    expect(updatedUser.purchased.plan.dateCreated).to.exist;
+  });
+
+  it('does not modify a user with an iOS subscription', async () => {
+    plan.customerId = 'random';
+    plan.paymentMethod = api.constants.IOS_PAYMENT_METHOD;
+
+    let recipient = new User();
+    recipient.profile.name = 'recipient';
+    recipient.purchased.plan = plan;
+    recipient.guilds.push(group._id);
+    await recipient.save();
+
+    user.guilds.push(group._id);
+    await user.save();
+    data.groupId = group._id;
+
+    await api.createSubscription(data);
+
+    let updatedUser = await User.findById(recipient._id).exec();
+
+    expect(updatedUser.purchased.plan.planId).to.eql('basic_3mo');
+    expect(updatedUser.purchased.plan.customerId).to.eql('random');
+    expect(updatedUser.purchased.plan.dateUpdated).to.exist;
+    expect(updatedUser.purchased.plan.gemsBought).to.eql(0);
+    expect(updatedUser.purchased.plan.paymentMethod).to.eql(api.constants.IOS_PAYMENT_METHOD);
+    expect(updatedUser.purchased.plan.extraMonths).to.eql(0);
+    expect(updatedUser.purchased.plan.dateTerminated).to.eql(null);
+    expect(updatedUser.purchased.plan.lastBillingDate).to.exist;
+    expect(updatedUser.purchased.plan.dateCreated).to.exist;
+  });
+
   it('updates a user with a cancelled but active group subscription', async () => {
     plan.key = 'basic_earned';
     plan.customerId = api.constants.GROUP_PLAN_CUSTOMER_ID;

--- a/test/api/v3/unit/libs/payments/group-plans/group-payments-create.test.js
+++ b/test/api/v3/unit/libs/payments/group-plans/group-payments-create.test.js
@@ -603,7 +603,7 @@ describe('Purchasing a subscription for group', () => {
     expect(updatedUser.purchased.plan.dateCreated).to.exist;
   });
 
-  it('does not modify a user with an Google subscription', async () => {
+  it('does not modify a user with a Google subscription', async () => {
     plan.customerId = 'random';
     plan.paymentMethod = api.constants.GOOGLE_PAYMENT_METHOD;
 

--- a/website/server/libs/payments.js
+++ b/website/server/libs/payments.js
@@ -19,9 +19,7 @@ import {
 } from './errors';
 import slack from './slack';
 
-const FLAG_REPORT_EMAILS = nconf.get('FLAG_REPORT_EMAIL').split(',').map((email) => {
-  return { email, canSend: true };
-});
+const TECH_ASSISTANCE_EMAIL = nconf.get('EMAILS:TECH_ASSISTANCE_EMAIL');
 
 let api = {};
 
@@ -30,7 +28,7 @@ api.constants = {
   GROUP_PLAN_CUSTOMER_ID: 'group-plan',
   GROUP_PLAN_PAYMENT_METHOD: 'Group Plan',
   GOOGLE_PAYMENT_METHOD: 'Google',
-  IOS_PAYMENT_METHOD: 'ios', // @TODO: replace with correct payment method
+  IOS_PAYMENT_METHOD: 'Apple',
 };
 
 function revealMysteryItems (user) {
@@ -121,11 +119,13 @@ api.addSubToGroupUser = async function addSubToGroupUser (member, group) {
     let ignoreCustomerId = customerIdsToIgnore.indexOf(memberPlan.customerId) !== -1;
 
     if (ignorePaymentPlan) {
-      txnEmail(FLAG_REPORT_EMAILS, 'invalid-payment-cancel', [
-        {name: 'USERNAME', content: member.auth.local.username},
+      txnEmail(FLAG_REPORT_EMAILS, 'admin-user-subscription-details', [
+        {name: 'PROFILE_NAME', content: member.profile.name},
         {name: 'UUID', content: member._id},
         {name: 'EMAIL', content: member.auth.local.email},
         {name: 'PAYMENT_METHOD', content: memberPlan.paymentMethod},
+        {name: 'PURCHASED_PLAN', content: JSON.stringify(memberPlan)},
+        {name: 'ACTION_NEEDED', content: 'User has joined group plan. Tell them to cancel subscription then give them free sub.'},
       ]);
     }
 

--- a/website/server/libs/payments.js
+++ b/website/server/libs/payments.js
@@ -119,10 +119,10 @@ api.addSubToGroupUser = async function addSubToGroupUser (member, group) {
     let ignoreCustomerId = customerIdsToIgnore.indexOf(memberPlan.customerId) !== -1;
 
     if (ignorePaymentPlan) {
-      txnEmail(FLAG_REPORT_EMAILS, 'admin-user-subscription-details', [
+      txnEmail(TECH_ASSISTANCE_EMAIL, 'admin-user-subscription-details', [
         {name: 'PROFILE_NAME', content: member.profile.name},
         {name: 'UUID', content: member._id},
-        {name: 'EMAIL', content: member.auth.local.email},
+        {name: 'EMAIL', content: getUserInfo(member, ['email']).email},
         {name: 'PAYMENT_METHOD', content: memberPlan.paymentMethod},
         {name: 'PURCHASED_PLAN', content: JSON.stringify(memberPlan)},
         {name: 'ACTION_NEEDED', content: 'User has joined group plan. Tell them to cancel subscription then give them free sub.'},

--- a/website/server/libs/payments.js
+++ b/website/server/libs/payments.js
@@ -24,6 +24,8 @@ api.constants = {
   UNLIMITED_CUSTOMER_ID: 'habitrpg', // Users with the customerId have an unlimted free subscription
   GROUP_PLAN_CUSTOMER_ID: 'group-plan',
   GROUP_PLAN_PAYMENT_METHOD: 'Group Plan',
+  GOOGLE_PAYMENT_METHOD: 'Google',
+  IOS_PAYMENT_METHOD: 'ios', // @TODO: replace with correct payment method
 };
 
 function revealMysteryItems (user) {
@@ -77,6 +79,7 @@ api.addSubscriptionToGroupUsers = async function addSubscriptionToGroupUsers (gr
  */
 api.addSubToGroupUser = async function addSubToGroupUser (member, group) {
   let customerIdsToIgnore = [this.constants.GROUP_PLAN_CUSTOMER_ID, this.constants.UNLIMITED_CUSTOMER_ID];
+  let paymentMethodsToIgnore = [this.constants.GOOGLE_PAYMENT_METHOD, this.constants.IOS_PAYMENT_METHOD];
 
   let data = {
     user: {},
@@ -109,7 +112,18 @@ api.addSubToGroupUser = async function addSubToGroupUser (member, group) {
   if (member.isSubscribed()) {
     let memberPlan = member.purchased.plan;
     let customerHasCancelledGroupPlan = memberPlan.customerId === this.constants.GROUP_PLAN_CUSTOMER_ID && !member.hasNotCancelled();
-    if (customerIdsToIgnore.indexOf(memberPlan.customerId) !== -1 && !customerHasCancelledGroupPlan) return;
+    let ignorePaymentPlan = paymentMethodsToIgnore.indexOf(memberPlan.paymentMethod) !== -1;
+    let ignoreCustomerId = customerIdsToIgnore.indexOf(memberPlan.customerId) !== -1;
+
+    // @TODO: send email to admin
+    if (ignorePaymentPlan) {
+      // txnEmail(data.user, 'group-member-joining', [
+      //   {name: 'LEADER', content: leader.profile.name},
+      //   {name: 'GROUP_NAME', content: group.name},
+      // ]);
+    }
+
+    if ((ignorePaymentPlan || ignoreCustomerId) && !customerHasCancelledGroupPlan) return;
 
     if (member.hasNotCancelled()) await member.cancelSubscription();
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes put_issue_url_here

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Currently, we can not cancel iOS and Android subscriptions from our API, so we will prevent them from being overridden during Group Plan purchases. 

[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: 
