### PR TITLE
Group Plan bug fix attempt (super broken)

### DIFF
--- a/website/server/libs/payments.js
+++ b/website/server/libs/payments.js
@@ -106,6 +106,23 @@ api.addSubToGroupUser = async function addSubToGroupUser (member, group) {
     },
   };
 
+  plan = member.purchased.plan.toObject();
+
+  _(plan).merge({ // override with these values
+    planId: 'group_plan_auto',
+    customerId: 'group-plan',
+    dateUpdated: today,
+    paymentMethod: 'groupPlan',
+    extraMonths,
+    dateTerminated: null,
+    lastBillingDate: null,
+    owner: member._id,
+  }).defaults({ // allow non-override if a plan was previously used
+    gemsBought: 0,
+    dateCreated: today,
+    mysteryItems: [],
+  }).value();
+
   if (member.isSubscribed()) {
     let memberPlan = member.purchased.plan;
     let customerHasCancelledGroupPlan = memberPlan.customerId === this.constants.GROUP_PLAN_CUSTOMER_ID && !member.hasNotCancelled();
@@ -114,24 +131,9 @@ api.addSubToGroupUser = async function addSubToGroupUser (member, group) {
     if (member.hasNotCancelled()) await member.cancelSubscription();
 
     let today = new Date();
-    plan = member.purchased.plan.toObject();
+    // plan = member.purchased.plan.toObject(); 
     let extraMonths = Number(plan.extraMonths);
     if (plan.dateTerminated) extraMonths += _dateDiff(today, plan.dateTerminated);
-
-    _(plan).merge({ // override with these values
-      planId: 'group_plan_auto',
-      customerId: 'group-plan',
-      dateUpdated: today,
-      paymentMethod: 'groupPlan',
-      extraMonths,
-      dateTerminated: null,
-      lastBillingDate: null,
-      owner: member._id,
-    }).defaults({ // allow non-override if a plan was previously used
-      gemsBought: 0,
-      dateCreated: today,
-      mysteryItems: [],
-    }).value();
   }
 
   member.purchased.plan = plan;


### PR DESCRIPTION
This should fix the issue "when ex-subscriber joins group plan, they lose Mystic Hourglasses and Mystery Items #8643". I am not sure how to test this solution as it involves group plans.

[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes put_issue_url_here

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)



[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: 
