### PR TITLE
Fix for automatic allocation not persisting #8641

### DIFF
--- a/website/client-old/js/services/userServices.js
+++ b/website/client-old/js/services/userServices.js
@@ -189,7 +189,7 @@ angular.module('habitrpg')
           }
         })
       }
-      
+
       function setUser(updates) {
         for (var key in updates) {
           _.set(user, key, updates[key]);

--- a/website/client-old/js/services/userServices.js
+++ b/website/client-old/js/services/userServices.js
@@ -189,9 +189,7 @@ angular.module('habitrpg')
           }
         })
       }
-
-      //Calling this multiple times rapidly will not persist changes
-      //All changes must either be sent at once, or spaced in time (0.1-0.5 sec)
+      
       function setUser(updates) {
         for (var key in updates) {
           _.set(user, key, updates[key]);

--- a/website/client-old/js/services/userServices.js
+++ b/website/client-old/js/services/userServices.js
@@ -190,6 +190,8 @@ angular.module('habitrpg')
         })
       }
 
+      //Calling this multiple times rapidly will not persist changes
+      //All changes must either be sent at once, or spaced in time (0.1-0.5 sec)
       function setUser(updates) {
         for (var key in updates) {
           _.set(user, key, updates[key]);

--- a/website/views/options/profile/stats.jade
+++ b/website/views/options/profile/stats.jade
@@ -28,7 +28,7 @@ script(id='partials/options.profile.stats.html', type='text/ng-template')
               fieldset.auto-allocate
                 .checkbox
                   label
-                    input(type='checkbox', ng-model='user.preferences.automaticAllocation', ng-change='set({"preferences.automaticAllocation": user.preferences.automaticAllocation?true: false})', ng-click='set({"preferences.allocationMode":"taskbased"})')
+                    input(type='checkbox', ng-model='user.preferences.automaticAllocation', ng-change='set({"preferences.automaticAllocation": user.preferences.automaticAllocation?true: false, "preferences.allocationMode" : "taskbased"})')
                     span.hint(popover-trigger='mouseenter', popover-placement='right', popover=env.t('autoAllocationPop'))=env.t('autoAllocation')
                 form(ng-show='user.preferences.automaticAllocation',style='margin-left:1em')
                   .radio

--- a/website/views/options/profile/stats.jade
+++ b/website/views/options/profile/stats.jade
@@ -28,7 +28,7 @@ script(id='partials/options.profile.stats.html', type='text/ng-template')
               fieldset.auto-allocate
                 .checkbox
                   label
-                    input(type='checkbox', ng-model='user.preferences.automaticAllocation', ng-change='set({"preferences.automaticAllocation": user.preferences.automaticAllocation?true: false, "preferences.allocationMode" : "taskbased"})')
+                    input(type='checkbox', ng-model='user.preferences.automaticAllocation', ng-change='set({"preferences.automaticAllocation": user.preferences.automaticAllocation, "preferences.allocationMode":"taskbased"})')
                     span.hint(popover-trigger='mouseenter', popover-placement='right', popover=env.t('autoAllocationPop'))=env.t('autoAllocation')
                 form(ng-show='user.preferences.automaticAllocation',style='margin-left:1em')
                   .radio


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
https://github.com/HabitRPG/habitica/issues/8641

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
- Changed stats.jade so on selection of Automatic Allocation Checkbox, user preference changes are sent in one request. 
- Commented issue on setUser function

The issue was when Automatic allocation is selected on a user's stats page, the changes are not saved. This issue was caused during an update of lodash from version 3 to 4, the root cause being previously the jade profile saved user.preferences.automaticAllocation and _then_ user.preferences.allocationMode one after the other. Some issue in lodash caused the User object not to persist between each call, so only the final call was saved (In this case automaticAllocation was lost but allocationMode was saved). The fix was to send all the changes at once, so when the Automatic allocation checkbox is selected, autoAllocate _and_ allocMode are both sent at the same time. 

---
UUID: f57bd235-ec21-4357-b5c9-a0536294b285
