### PR TITLE
add mountText for all drop eggs and quest eggs - partial fix for https://github.com/HabitRPG/habitica/issues/5419 

### DIFF
--- a/website/common/script/content/eggs.js
+++ b/website/common/script/content/eggs.js
@@ -28,6 +28,7 @@ function hasQuestAchievementFunction (key) {
 let drops = {
   Wolf: {
     text: t('dropEggWolfText'),
+    mountText: t('dropEggWolfMountText'),
     adjective: t('dropEggWolfAdjective'),
   },
   TigerCub: {
@@ -47,18 +48,22 @@ let drops = {
   },
   Fox: {
     text: t('dropEggFoxText'),
+    mountText: t('dropEggFoxMountText'),
     adjective: t('dropEggFoxAdjective'),
   },
   FlyingPig: {
     text: t('dropEggFlyingPigText'),
+    mountText: t('dropEggFlyingPigMountText'),
     adjective: t('dropEggFlyingPigAdjective'),
   },
   Dragon: {
     text: t('dropEggDragonText'),
+    mountText: t('dropEggDragonMountText'),
     adjective: t('dropEggDragonAdjective'),
   },
   Cactus: {
     text: t('dropEggCactusText'),
+    mountText: t('dropEggCactusMountText'),
     adjective: t('dropEggCactusAdjective'),
   },
   BearCub: {
@@ -71,66 +76,78 @@ let drops = {
 let quests = {
   Gryphon: {
     text: t('questEggGryphonText'),
+    mountText: t('questEggGryphonMountText'),
     adjective: t('questEggGryphonAdjective'),
     canBuy: hasQuestAchievementFunction('gryphon'),
   },
   Hedgehog: {
     text: t('questEggHedgehogText'),
+    mountText: t('questEggHedgehogMountText'),
     adjective: t('questEggHedgehogAdjective'),
     canBuy: hasQuestAchievementFunction('hedgehog'),
   },
   Deer: {
     text: t('questEggDeerText'),
+    mountText: t('questEggDeerMountText'),
     adjective: t('questEggDeerAdjective'),
     canBuy: hasQuestAchievementFunction('ghost_stag'),
   },
   Egg: {
     text: t('questEggEggText'),
-    adjective: t('questEggEggAdjective'),
     mountText: t('questEggEggMountText'),
+    adjective: t('questEggEggAdjective'),
   },
   Rat: {
     text: t('questEggRatText'),
+    mountText: t('questEggRatMountText'),
     adjective: t('questEggRatAdjective'),
     canBuy: hasQuestAchievementFunction('rat'),
   },
   Octopus: {
     text: t('questEggOctopusText'),
+    mountText: t('questEggOctopusMountText'),
     adjective: t('questEggOctopusAdjective'),
     canBuy: hasQuestAchievementFunction('octopus'),
   },
   Seahorse: {
     text: t('questEggSeahorseText'),
+    mountText: t('questEggSeahorseMountText'),
     adjective: t('questEggSeahorseAdjective'),
     canBuy: hasQuestAchievementFunction('dilatory_derby'),
   },
   Parrot: {
     text: t('questEggParrotText'),
+    mountText: t('questEggParrotMountText'),
     adjective: t('questEggParrotAdjective'),
     canBuy: hasQuestAchievementFunction('harpy'),
   },
   Rooster: {
     text: t('questEggRoosterText'),
+    mountText: t('questEggRoosterMountText'),
     adjective: t('questEggRoosterAdjective'),
     canBuy: hasQuestAchievementFunction('rooster'),
   },
   Spider: {
     text: t('questEggSpiderText'),
+    mountText: t('questEggSpiderMountText'),
     adjective: t('questEggSpiderAdjective'),
     canBuy: hasQuestAchievementFunction('spider'),
   },
   Owl: {
     text: t('questEggOwlText'),
+    mountText: t('questEggOwlMountText'),
     adjective: t('questEggOwlAdjective'),
     canBuy: hasQuestAchievementFunction('owl'),
   },
   Penguin: {
     text: t('questEggPenguinText'),
+    mountText: t('questEggPenguinMountText'),
     adjective: t('questEggPenguinAdjective'),
     canBuy: hasQuestAchievementFunction('penguin'),
   },
   TRex: {
     text: t('questEggTRexText'),
+    mountText: t('questEggTRexMountText'),
     adjective: t('questEggTRexAdjective'),
     canBuy (user) {
       let questAchievements = user.achievements.quests;
@@ -143,51 +160,61 @@ let quests = {
   },
   Rock: {
     text: t('questEggRockText'),
+    mountText: t('questEggRockMountText'),
     adjective: t('questEggRockAdjective'),
     canBuy: hasQuestAchievementFunction('rock'),
   },
   Bunny: {
     text: t('questEggBunnyText'),
+    mountText: t('questEggBunnyMountText'),
     adjective: t('questEggBunnyAdjective'),
     canBuy: hasQuestAchievementFunction('bunny'),
   },
   Slime: {
     text: t('questEggSlimeText'),
+    mountText: t('questEggSlimeMountText'),
     adjective: t('questEggSlimeAdjective'),
     canBuy: hasQuestAchievementFunction('slime'),
   },
   Sheep: {
     text: t('questEggSheepText'),
+    mountText: t('questEggSheepMountText'),
     adjective: t('questEggSheepAdjective'),
     canBuy: hasQuestAchievementFunction('sheep'),
   },
   Cuttlefish: {
     text: t('questEggCuttlefishText'),
+    mountText: t('questEggCuttlefishMountText'),
     adjective: t('questEggCuttlefishAdjective'),
     canBuy: hasQuestAchievementFunction('kraken'),
   },
   Whale: {
     text: t('questEggWhaleText'),
+    mountText: t('questEggWhaleMountText'),
     adjective: t('questEggWhaleAdjective'),
     canBuy: hasQuestAchievementFunction('whale'),
   },
   Cheetah: {
     text: t('questEggCheetahText'),
+    mountText: t('questEggCheetahMountText'),
     adjective: t('questEggCheetahAdjective'),
     canBuy: hasQuestAchievementFunction('cheetah'),
   },
   Horse: {
     text: t('questEggHorseText'),
+    mountText: t('questEggHorseMountText'),
     adjective: t('questEggHorseAdjective'),
     canBuy: hasQuestAchievementFunction('horse'),
   },
   Frog: {
     text: t('questEggFrogText'),
+    mountText: t('questEggFrogMountText'),
     adjective: t('questEggFrogAdjective'),
     canBuy: hasQuestAchievementFunction('frog'),
   },
   Snake: {
     text: t('questEggSnakeText'),
+    mountText: t('questEggSnakeMountText'),
     adjective: t('questEggSnakeAdjective'),
     canBuy: hasQuestAchievementFunction('snake'),
   },
@@ -199,81 +226,97 @@ let quests = {
   },
   Sabretooth: {
     text: t('questEggSabretoothText'),
+    mountText: t('questEggSabretoothMountText'),
     adjective: t('questEggSabretoothAdjective'),
     canBuy: hasQuestAchievementFunction('sabretooth'),
   },
   Monkey: {
     text: t('questEggMonkeyText'),
+    mountText: t('questEggMonkeyMountText'),
     adjective: t('questEggMonkeyAdjective'),
     canBuy: hasQuestAchievementFunction('monkey'),
   },
   Snail: {
     text: t('questEggSnailText'),
+    mountText: t('questEggSnailMountText'),
     adjective: t('questEggSnailAdjective'),
     canBuy: hasQuestAchievementFunction('snail'),
   },
   Falcon: {
     text: t('questEggFalconText'),
+    mountText: t('questEggFalconMountText'),
     adjective: t('questEggFalconAdjective'),
     canBuy: hasQuestAchievementFunction('falcon'),
   },
   Treeling: {
     text: t('questEggTreelingText'),
+    mountText: t('questEggTreelingMountText'),
     adjective: t('questEggTreelingAdjective'),
     canBuy: hasQuestAchievementFunction('treeling'),
   },
   Axolotl: {
     text: t('questEggAxolotlText'),
+    mountText: t('questEggAxolotlMountText'),
     adjective: t('questEggAxolotlAdjective'),
     canBuy: hasQuestAchievementFunction('axolotl'),
   },
   Turtle: {
     text: t('questEggTurtleText'),
+    mountText: t('questEggTurtleMountText'),
     adjective: t('questEggTurtleAdjective'),
     canBuy: hasQuestAchievementFunction('turtle'),
   },
   Armadillo: {
     text: t('questEggArmadilloText'),
+    mountText: t('questEggArmadilloMountText'),
     adjective: t('questEggArmadilloAdjective'),
     canBuy: hasQuestAchievementFunction('armadillo'),
   },
   Cow: {
     text: t('questEggCowText'),
+    mountText: t('questEggCowMountText'),
     adjective: t('questEggCowAdjective'),
     canBuy: hasQuestAchievementFunction('cow'),
   },
   Beetle: {
     text: t('questEggBeetleText'),
+    mountText: t('questEggBeetleMountText'),
     adjective: t('questEggBeetleAdjective'),
     canBuy: hasQuestAchievementFunction('beetle'),
   },
   Ferret: {
     text: t('questEggFerretText'),
+    mountText: t('questEggFerretMountText'),
     adjective: t('questEggFerretAdjective'),
     canBuy: hasQuestAchievementFunction('ferret'),
   },
   Sloth: {
     text: t('questEggSlothText'),
+    mountText: t('questEggSlothMountText'),
     adjective: t('questEggSlothAdjective'),
     canBuy: hasQuestAchievementFunction('sloth'),
   },
   Triceratops: {
     text: t('questEggTriceratopsText'),
+    mountText: t('questEggTriceratopsMountText'),
     adjective: t('questEggTriceratopsAdjective'),
     canBuy: hasQuestAchievementFunction('triceratops'),
   },
   GuineaPig: {
     text: t('questEggGuineaPigText'),
+    mountText: t('questEggGuineaPigMountText'),
     adjective: t('questEggGuineaPigAdjective'),
     canBuy: hasQuestAchievementFunction('guineapig'),
   },
   Peacock: {
     text: t('questEggPeacockText'),
+    mountText: t('questEggPeacockMountText'),
     adjective: t('questEggPeacockAdjective'),
     canBuy: hasQuestAchievementFunction('peacock'),
   },
   Butterfly: {
     text: t('questEggButterflyText'),
+    mountText: t('questEggButterflyMountText'),
     adjective: t('questEggButterflyAdjective'),
     canBuy: hasQuestAchievementFunction('butterfly'),
   },


### PR DESCRIPTION
This adjusts the drops content data so that mountText is supplied for all eggs. 

This has some benefits for English (e.g., we can ride Butterfly mounts instead of Caterpillar mounts.

It has more benefits for the other languages where pet and mount often have different names. I'ts a partial(?) fix for https://github.com/HabitRPG/habitica/issues/5419. After this PR is live, I'll go through that issue to see if there's anything left to do for it and/or ask the Linguists about it.

I've checked that all those added mountText strings do exist in locales/en/content.json

![image](https://cloud.githubusercontent.com/assets/1495809/25124378/e26f6ec8-246e-11e7-8c29-6117c95c91d5.png)


