### PR TITLE
adjust old Bailey - Shiny Seeds achievement not given to caster - fixes https://github.com/HabitRPG/habitica/issues/8658

### DIFF
--- a/website/views/shared/new-stuff.jade
+++ b/website/views/shared/new-stuff.jade
@@ -45,7 +45,7 @@ mixin oldNews
     tr
       td
         h3 Shiny Seeds
-        p Throw a Shiny Seed at your friends and they will turn into a cheerful flower until their next cron! You can buy the Seeds in the <a href='/#/options/inventory/seasonalshop'>Seasonal Shop</a> for gold. Plus, you and your pal will both receive the Agricultural Friends badge!
+        p Throw a Shiny Seed at your friends and they will turn into a cheerful flower until their next cron! You can buy the Seeds in the <a href='/#/options/inventory/seasonalshop'>Seasonal Shop</a> for gold. Plus, they will receive the Agricultural Friends badge!
         br
         p Don't want to be a flower? Just buy some Petal-Free Potion from your Rewards column to reverse it.
         br


### PR DESCRIPTION
Fixes https://github.com/HabitRPG/habitica/issues/8658

In a recent Bailey message, the information about the Shiny Seeds needs to change to explain that the achievement is not given to the caster.

Lemoness's comments in our admin channel: https://habitica.slack.com/archives/C02RK7DKF/p1492032261365388

![image](https://cloud.githubusercontent.com/assets/1495809/25124462/23aaeaac-246f-11e7-896b-c2be4a4f1ef7.png)
