### PR TITLE
modify Market intro for eggs to clarify that quest eggs don't drop

### DIFF
--- a/website/common/locales/en/pets.json
+++ b/website/common/locales/en/pets.json
@@ -42,6 +42,7 @@
     "food": "Food and Saddles",
     "noFood": "You don't have any food or saddles.",
     "dropsExplanation": "Get these items faster with Gems if you don't want to wait for them to drop when completing a task. <a href=\"http://habitica.wikia.com/wiki/Drops\">Learn more about the drop system.</a>",
+    "dropsExplanationEggs": "Spend Gems to get eggs more quickly, if you don't want to wait for standard eggs to drop, or to repeat Quests to earn Quest eggs. <a href=\"http://habitica.wikia.com/wiki/Drops\">Learn more about the drop system.</a>",
     "premiumPotionNoDropExplanation": "Magic Hatching Potions cannot be used on eggs received from Quests. The only way to get Magic Hatching Potions is by buying them below, not from random drops.",
     "beastMasterProgress": "Beast Master Progress",
     "stableBeastMasterProgress": "Beast Master Progress: <%= number %> Pets Found",

--- a/website/common/script/libs/shops.js
+++ b/website/common/script/libs/shops.js
@@ -25,7 +25,7 @@ shops.getMarketCategories = function getMarket (user, language) {
   let eggsCategory = {
     identifier: 'eggs',
     text: i18n.t('eggs', language),
-    notes: i18n.t('dropsExplanation', language),
+    notes: i18n.t('dropsExplanationEggs', language),
   };
 
   eggsCategory.items = sortBy(values(content.questEggs)


### PR DESCRIPTION
In the Market, just above the eggs you can buy, the standard message explaining drops makes it sound like you can get quest eggs in drops.

This PR adds a new string that better explains why you might want to buy eggs.

Lemoness's comments about the new text: https://habitica.slack.com/archives/C02RK7DKF/p1491847171061587?thread_ts=1491779437.902223&cid=C02RK7DKF

![image](https://cloud.githubusercontent.com/assets/1495809/25124678/cd8e081a-246f-11e7-8a02-7340dbd85d40.png)

