### PR TITLE
minor text changes: Shield-Hand Item; space in quest completion modal; Rebirth clarification

### DIFF
--- a/website/common/locales/en/gear.json
+++ b/website/common/locales/en/gear.json
@@ -988,7 +988,7 @@
   "offhandCapitalized": "Shield-Hand Item",
 
   "shieldBase0Text": "No Shield-Hand Equipment",
-  "shieldBase0Notes": "No shield or second weapon.",
+  "shieldBase0Notes": "No shield or shield-hand item.",
 
   "shieldWarrior1Text": "Wooden Shield",
   "shieldWarrior1Notes": "Round shield of thick wood. Increases Constitution by <%= con %>.",

--- a/website/common/locales/en/questsContent.json
+++ b/website/common/locales/en/questsContent.json
@@ -80,7 +80,7 @@
 
   "questVice3Text": "Vice, Part 3: Vice Awakens",
   "questVice3Notes": "After much effort, your party has discovered Vice's lair. The hulking monster eyes your party with distaste. As shadows swirl around you, a voice whispers through your head, \"More foolish citizens of Habitica come to stop me? Cute. You'd have been wise not to come.\" The scaly titan rears back its head and prepares to attack. This is your chance! Give it everything you've got and defeat Vice once and for all!",
-  "questVice3Completion": "The shadows dissipate from the cavern and a steely silence falls. My word, you've done it! You have defeated Vice! You and your party may finally breath a sigh of relief. Enjoy your victory, brave Habiteers, but take the lessons you've learned from battling Vice and move forward. There are still Habits to be done and potentially worse evils to conquer!",
+  "questVice3Completion": "The shadows dissipate from the cavern and a steely silence falls. My word, you've done it! You have defeated Vice! You and your party may finally breathe a sigh of relief. Enjoy your victory, brave Habiteers, but take the lessons you've learned from battling Vice and move forward. There are still Habits to be done and potentially worse evils to conquer!",
   "questVice3Boss": "Vice, the Shadow Wyrm",
   "questVice3DropWeaponSpecial2": "Stephen Weber's Shaft of the Dragon",
   "questVice3DropDragonEgg": "Dragon (Egg)",

--- a/website/common/locales/en/questsContent.json
+++ b/website/common/locales/en/questsContent.json
@@ -504,7 +504,7 @@
   "questStoikalmCalamity3Completion": "You subdue the Icicle Drake Queen, giving Lady Glaciate time to shatter the glowing bracelets. The Queen stiffens in apparent mortification, then quickly covers it with a haughty pose. \"Feel free to remove these extraneous items,\" she says. \"I'm afraid they simply don't fit our decor.\"<br><br>\"Also, you stole them,\" @Beffymaroo says. \"By summoning monsters from the earth.\"<br><br>The Icicle Drake Queen looks miffed. \"Take it up with that wretched bracelet saleswoman,\" she says. \"It's Tzina you want. I was essentially unaffiliated.\"<br><br>Lady Glaciate claps you on the arm. \"You did well today,\" she says, handing you a spear and a horn from the pile. \"Be proud.\"",
   "questStoikalmCalamity3Boss": "Icicle Drake Queen",
   "questStoikalmCalamity3DropBlueCottonCandy": "Blue Cotton Candy (Food)",
-  "questStoikalmCalamity3DropShield": "Mammoth Rider's Horn (Shield)",
+  "questStoikalmCalamity3DropShield": "Mammoth Rider's Horn (Shield-Hand Item)",
   "questStoikalmCalamity3DropWeapon": "Mammoth Rider Spear (Weapon)",
 
   "questGuineaPigText": "The Guinea Pig Gang",

--- a/website/common/locales/en/questsContent.json
+++ b/website/common/locales/en/questsContent.json
@@ -452,7 +452,7 @@
 
   "questMoon1Text": "Lunar Battle, Part 1: Find the Mysterious Shards",
   "questMoon1Notes": "Habiticans have been distracted from their tasks by something strange: twisted shards of stone are appearing across the land. Worried, @Starsystemic the Seer summons you to her tower. She says, \"I've been reading alarming omens about these shards, which have been blighting the land and driving hardworking Habiticans to distraction. I can track the source, but first I'll need to examine the shards. Can you bring some to me?\"",
-  "questMoon1Completion": "@Starststemic disappears into her tower to examine the shards you gathered. \"This may be more complicated than we feared,\" says @Beffymaroo, her trusted assistant. \"It will take us some time to discover the cause. Keep checking in every day, and when we know more, we'll send you the next quest scroll.\"",
+  "questMoon1Completion": "@Starsystemic disappears into her tower to examine the shards you gathered. \"This may be more complicated than we feared,\" says @Beffymaroo, her trusted assistant. \"It will take us some time to discover the cause. Keep checking in every day, and when we know more, we'll send you the next quest scroll.\"",
   "questMoon1CollectShards": "Lunar Shards",
   "questMoon1DropHeadgear": "Lunar Warrior Helm (Headgear)",
 

--- a/website/common/locales/en/rebirth.json
+++ b/website/common/locales/en/rebirth.json
@@ -21,7 +21,7 @@
     "rebirthOrb": "Used an Orb of Rebirth to start over after attaining Level <%= level %>.",
     "rebirthOrb100": "Used an Orb of Rebirth to start over after attaining Level 100 or higher.",
     "rebirthOrbNoLevel": "Used an Orb of Rebirth to start over.",
-    "rebirthPop": "Begin a new character at Level 1 while retaining achievements, collectibles, equipment, and tasks with history.",
+    "rebirthPop": "Restart your character at Level 1 while retaining achievements, collectibles, equipment, and tasks with history.",
     "rebirthName": "Orb of Rebirth",
     "reborn": "Reborn, max level <%= reLevel %>",
     "confirmReborn": "Are you sure?",

--- a/website/views/shared/modals/quests.jade
+++ b/website/views/shared/modals/quests.jade
@@ -24,7 +24,7 @@ mixin questInfo
 
 script(type='text/ng-template', id='modals/questCompleted.html')
   .modal-header
-    h4 "{{::Content.quests[user.party.quest.completed].text()}}"
+    h4 "{{::Content.quests[user.party.quest.completed].text()}}"&nbsp;
       =env.t('completed')
   .modal-body
     .col-centered(ng-class='::Content.quests[user.party.quest.completed].completion() ? "pull-right-sm" : ""', class='quest_{{user.party.quest.completed}}')

--- a/website/views/shared/new-stuff.jade
+++ b/website/views/shared/new-stuff.jade
@@ -34,7 +34,7 @@ mixin oldNews
         h3 Group Plan Managers
         p Want other people in your <a href='/#/options/groups/group-plans'>Group Plan</a> to help you assign and approve tasks? Now the Group Plan Leader can assign Group Managers as well! Managers have the ability to assign and approve all tasks, although only leaders can adjust the Group info and payment options.
         br
-        p To add Managers to your Group Plan, just edit the Group Plan by clicking on the pencil icon, and select the people that you want to be Managers from the drop-down menu. We hope that this helps you be more efficient and productive!
+        p To add Managers to your Group Plan, just edit the group by clicking on the edit button, and select the people that you want to be Managers from the drop-down menu. We hope that this helps you be more efficient and productive!
         br
         p Don't forget, there are lots of benefits to being in a Group Plan! In addition to all the extra productivity tools, all members of a Group Plan get free subscriptions, and their very own Jackalope mounts! Be sure to <a href='/#/options/groups/group-plans'>check them out if you haven't already</a>.
         p.small.muted by TheHollidayInn


### PR DESCRIPTION
This makes unrelated changes but they're all so small I didn't think they were worth their own PRs. Each is in its own commit if you want to review them separately.

### replace Shield with Shield-Hand Item where appropriate for consistency and clarity

For example, previously, this Horn was referred to as just a shield, which it isn't. We use "Shield-Hand Item" elsewhere in similar situations.
![delete](https://cloud.githubusercontent.com/assets/1495809/25124081/f5361ba2-246d-11e7-8966-0d9a1642ac9f.png)


### add space in quest completion modal heading between name of quest and "Completed!"

Previously, the quest name and "Completed" were touching. Now they aren't.

![image](https://cloud.githubusercontent.com/assets/1495809/25127833/bba6521e-247a-11e7-84fb-44861a3b6f9c.png)


