### PR TITLE
Improve suspended account message & logic

### DIFF
--- a/website/client-old/js/config.js
+++ b/website/client-old/js/config.js
@@ -81,11 +81,20 @@ angular.module('habitrpg')
           if (!mobileApp) // skip mobile for now
             $rootScope.$broadcast('responseError', "The site has been updated and the page needs to refresh. The last action has not been recorded, please refresh and try again.");
 
-        } else if (response.data && response.data.code && response.data.code === 'ACCOUNT_SUSPENDED') {
-          confirm(response.data.err);
-          localStorage.clear();
-          window.location.href = mobileApp ? '/app/login' : '/logout'; //location.reload()
-
+        } else if (response.data && response.data.error && response.data.error === 'AccountSuspended') {
+          $rootScope.openModal('account-suspended', { controller : ['$scope', function($scope) {
+            let jadeArgs = JSON.parse(response.data.message);
+            $scope.managerEmail = jadeArgs["communityManagerEmail"];
+            $scope.userId = jadeArgs["userId"];
+            $scope.userName = jadeArgs["userName"];
+            }]
+          }).result.then(function(data) {
+            localStorage.clear();
+            window.location.href = mobileApp ? '/app/login' : '/logout'; //location.reload()
+          }, function(err) {
+            localStorage.clear();
+            window.location.href = mobileApp ? '/app/login' : '/logout'; //location.reload()
+          });
         // 400 range
         } else if (response.status < 400) {
           // never triggered because we're in responseError

--- a/website/client-old/js/services/alertServices.js
+++ b/website/client-old/js/services/alertServices.js
@@ -6,10 +6,10 @@
     .factory('Alert', alertFactory);
 
   alertFactory.$inject = [
-    '$window'
+    '$window', '$modal'
   ];
 
-  function alertFactory($window) {
+  function alertFactory($window, $modal) {
 
     function authErrorAlert(data, status, headers, config) {
       if (status === 0) {
@@ -17,6 +17,14 @@
       } else if (status === 400 && data.errors && _.isArray(data.errors)) { // bad requests
         data.errors.forEach(function (err) {
           $window.alert(err.message);
+        });
+      } else if (data.error === 'AccountSuspended') {
+        $modal.open({ templateUrl: 'modals/account-suspended.html', controller : ['$scope', function($scope) {
+            let jadeArgs = JSON.parse(data.message);
+            $scope.managerEmail = jadeArgs["communityManagerEmail"];
+            $scope.userId = jadeArgs["userId"];
+            $scope.userName = jadeArgs["userName"];
+          }]
         });
       } else if (!!data && !!data.error) {
         $window.alert(data.message);

--- a/website/common/locales/en/front.json
+++ b/website/common/locales/en/front.json
@@ -259,7 +259,7 @@
     "passwordResetEmailHtml": "If you requested a password reset for <strong><%= username %></strong> on Habitica, <a href=\"<%= passwordResetLink %>\">click here</a> to set a new one. The link will expire after 24 hours.<br/><br>If you haven't requested a password reset, please ignore this email.",
     "invalidLoginCredentialsLong": "Uh-oh - your username or password is incorrect.\n- Make sure your username or email is typed correctly.\n- You may have signed up with Facebook, not email. Double-check by trying Facebook login.\n- If you forgot your password, click \"Forgot Password\".",
     "invalidCredentials": "There is no account that uses those credentials.",
-    "accountSuspended": "Account has been suspended, please contact <%= communityManagerEmail %> with your User ID \"<%= userId %>\" for assistance.",
+    "accountSuspended": "  This account, Profile Name \"<%= userName %>\", User ID \"<%= userId %>\", has been blocked for breaking the <a href=\"https://habitica.com/static/community-guidelines\">Community Guidelines</a> or <a href=\"https://habitica.com/static/terms\">Terms of Service</a>. For details or to ask to be unblocked, please email Lemoness at <a href=\"mailto:<%= communityManagerEmail %>\"><%= communityManagerEmail %></a> or ask your parent or guardian to email her. Please copy your Profile Name and User ID into the email.",
     "unsupportedNetwork": "This network is not currently supported.",
     "cantDetachSocial": "Account lacks another authentication method; can't detach this authentication method.",
     "onlySocialAttachLocal": "Local authentication can be added to only a social account.",

--- a/website/common/script/libs/errors.js
+++ b/website/common/script/libs/errors.js
@@ -23,6 +23,12 @@ export class NotAuthorized extends CustomError {
   }
 }
 
+export class AccountSuspended extends NotAuthorized {
+  constructor (customMessage) {
+    super(customMessage);
+  }
+}
+
 export class BadRequest extends CustomError {
   constructor (customMessage) {
     super();

--- a/website/server/controllers/api-v3/auth.js
+++ b/website/server/controllers/api-v3/auth.js
@@ -6,6 +6,7 @@ import {
   authWithHeaders,
 } from '../../middlewares/auth';
 import {
+  AccountSuspended,
   NotAuthorized,
   BadRequest,
   NotFound,
@@ -187,7 +188,7 @@ api.registerLocal = {
 };
 
 function _loginRes (user, req, res) {
-  if (user.auth.blocked) throw new NotAuthorized(res.t('accountSuspended', {communityManagerEmail: COMMUNITY_MANAGER_EMAIL, userId: user._id}));
+  if (user.auth.blocked) throw new AccountSuspended(JSON.stringify({communityManagerEmail: COMMUNITY_MANAGER_EMAIL, userId: user._id, userName: user.profile.name}));
   return res.respond(200, {id: user._id, apiToken: user.apiToken, newUser: user.newUser || false});
 }
 

--- a/website/server/libs/errors.js
+++ b/website/server/libs/errors.js
@@ -16,6 +16,19 @@ export const CustomError = common.errors.CustomError;
 export const NotAuthorized = common.errors.NotAuthorized;
 
 /**
+ * @apiDefine AccountSuspended
+ * @apiError AccountSuspended The client is not authorized to make this request because the habitica user is blocked.
+ *
+ * @apiErrorExample Error-Response:
+ *     HTTP/1.1 401 Unauthorized
+ *     {
+ *       "error": "AccountSuspended",
+ *       "message": "{"communityManagerEmail":"COMMUNITY_MANAGER_EMAIL","userId":"USER_ID","userName":"USERNAME"}"
+ *     }
+ */
+export const AccountSuspended = common.errors.AccountSuspended;
+
+/**
  * @apiDefine BadRequest
  * @apiError BadRequest The request wasn't formatted correctly.
  *

--- a/website/server/middlewares/auth.js
+++ b/website/server/middlewares/auth.js
@@ -1,5 +1,6 @@
 import {
   NotAuthorized,
+  AccountSuspended,
 } from '../libs/errors';
 import {
   model as User,
@@ -29,7 +30,7 @@ export function authWithHeaders (optional = false) {
     .exec()
     .then((user) => {
       if (!user) throw new NotAuthorized(res.t('invalidCredentials'));
-      if (user.auth.blocked) throw new NotAuthorized(res.t('accountSuspended', {communityManagerEmail: COMMUNITY_MANAGER_EMAIL, userId: user._id}));
+      if (user.auth.blocked) throw new AccountSuspended(JSON.stringify({communityManagerEmail: COMMUNITY_MANAGER_EMAIL, userId: user._id, userName: user.profile.name}));
 
       res.locals.user = user;
 

--- a/website/views/shared/modals/account-suspended.jade
+++ b/website/views/shared/modals/account-suspended.jade
@@ -1,0 +1,4 @@
+script(id='modals/account-suspended.html', type='text/ng-template')
+  .modal-content(style='min-width:28em')
+    .modal-body.text-center
+      p!=env.t("accountSuspended", { communityManagerEmail : '{{managerEmail}}', userName : '{{userName}}', userId : '{{userId}}' })

--- a/website/views/shared/modals/index.jade
+++ b/website/views/shared/modals/index.jade
@@ -1,3 +1,4 @@
+include ./account-suspended.jade
 include ./message-modal
 include ./achievements
 include ./reroll

--- a/website/views/static/front.jade
+++ b/website/views/static/front.jade
@@ -45,6 +45,7 @@ html(ng-app='habitrpg', ng-controller='RootCtrl')
     include ./login-modal
     include ../shared/avatar/index
     include ../shared/mixins
+    include ../shared/modals/account-suspended
     include ../shared/modals/members
 
     noscript.banner= env.t('jsDisabledHeadingFull')


### PR DESCRIPTION
As per the issues below, my pr modifies the "accountSuspended" message as well as some of the code that handles the logic for suspended accounts.

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #8636, #8672

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Before, when a user was logged in but became blocked, refreshing the page would cause the website to stall on the loading screen (issue I opened was #8672).  There was logic to handle a suspended account, but it was outdated I think.  I added a new class AccountSuspended since there seemed to be no easier/maintainable way to distinguish it from a generic NotAuthorized error on the client (only properties were success, name, and message).

Now, when a user is logged in but blocked, the modal shows.  After it is dismissed, the user is logged out.  If the user refreshes the page while the modal is showing, the modal still shows with the loading screen in the background (logged out upon dismissing the modal).

Old error notification:
![old_error](https://cloud.githubusercontent.com/assets/1495809/24584117/b27e6640-17a5-11e7-8991-09da96b34dfa.png)

New modal screenshot (I used an odd account name to make sure user input was escaped):
![modal_message](https://cloud.githubusercontent.com/assets/5566652/25299935/ed73644e-26b9-11e7-94d7-46ec273a21a8.PNG)

I need to write tests of course (frontend & backend), but I figured that I'd open the pull request for your feedback before starting work on them.  Hope this helps!

Sidenote: 'npm test' doesn't work due to linting (Windows 10 line ending errors and vue.js errors).  Also, when skipping linting several other tests fail; I can give you screenshots & more information later.  

----
UUID: 54d0305c-fbc0-4fe8-a941-948204625f08
