### PR TITLE
Used ajax when canceling from the website

### DIFF
--- a/website/client-old/js/services/paymentServices.js
+++ b/website/client-old/js/services/paymentServices.js
@@ -296,7 +296,7 @@ function($rootScope, User, $http, Content) {
   }
 
   Payments.cancelSubscription = function(config) {
-    if (config && config.group && !confirm(window.env.t('confirmCancelGroupPlan'))) return; 
+    if (config && config.group && !confirm(window.env.t('confirmCancelGroupPlan'))) return;
     if (!confirm(window.env.t('sureCancelSub'))) return;
 
     var group;
@@ -315,11 +315,23 @@ function($rootScope, User, $http, Content) {
       paymentMethod = paymentMethod.toLowerCase();
     }
 
-    var cancelUrl = '/' + paymentMethod + '/subscribe/cancel?_id=' + User.user._id + '&apiToken=' + User.settings.auth.apiToken;
+    var queryParams = {
+      _id: User.user._id,
+      apiToken: User.settings.auth.apiToken,
+      noRedirect: true,
+    };
+
     if (group) {
-      cancelUrl += '&groupId=' + group._id;
+      queryParams.groupId = group._id;
     }
-    window.location.href = cancelUrl;
+
+    var cancelUrl = '/' + paymentMethod + '/subscribe/cancel?' + $.param(queryParams);
+
+    $http.get(cancelUrl)
+      .then(function (success) {
+        alert(window.evn.t('paypalCanceled'));
+        window.location.href = '/';
+      });
   }
 
   Payments.encodeGift = function(uuid, gift) {

--- a/website/common/locales/en/subscriber.json
+++ b/website/common/locales/en/subscriber.json
@@ -166,5 +166,6 @@
     "missingPaymentId": "Missing req.query.paymentId",
     "missingCustomerId": "Missing req.query.customerId",
     "missingPaypalBlock": "Missing req.session.paypalBlock",
-    "missingSubKey": "Missing req.query.sub"
+    "missingSubKey": "Missing req.query.sub",
+    "paypalCanceled": "You subscription has been canceled"
 }

--- a/website/common/locales/en/subscriber.json
+++ b/website/common/locales/en/subscriber.json
@@ -167,5 +167,5 @@
     "missingCustomerId": "Missing req.query.customerId",
     "missingPaypalBlock": "Missing req.session.paypalBlock",
     "missingSubKey": "Missing req.query.sub",
-    "paypalCanceled": "You subscription has been canceled"
+    "paypalCanceled": "Your subscription has been canceled"
 }


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #6401

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

This PR allows forces the payment service to use an ajax call when canceling Paypal from the website rather than using the redirects that are required during the Paypal checkout process.

[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: 
