### PR TITLE
Allow leaving a challenge without having access to the challenge - fixes #8693

### DIFF
--- a/test/api/README.md
+++ b/test/api/README.md
@@ -38,19 +38,20 @@ One caveat. If you have a severe syntax error in your files, the tests may fail 
 $ gulp test:api:safe
 ```
 
-If you'd like to run the tests individually and inspect the output from the server, in one pane you can run:
+If you'd like to run selected tests and inspect the output from the server, in one pane you can run:
 
 ```bash
 $ gulp test:nodemon
 ```
 
-And run your tests in another pane:
+Wait for it to get to `info: Connected with Mongoose` and then leave it running. Run your tests in another pane:
 
 ```bash
-$ mocha path/to/file.js
+# Run a single test
+$ mocha test/SUBDIRECTORY/NAME_OF_TEST.js --require ./test/helpers/start-server
 
-# Mark a test with the `.only` attribute
-$ mocha
+# Run all tests in a subdirectory
+$ mocha test/SUBDIRECTORY --recursive --require ./test/helpers/start-server
 ```
 
 ## Structure

--- a/website/server/controllers/api-v3/challenges.js
+++ b/website/server/controllers/api-v3/challenges.js
@@ -190,9 +190,6 @@ api.leaveChallenge = {
     let challenge = await Challenge.findOne({ _id: req.params.challengeId }).exec();
     if (!challenge) throw new NotFound(res.t('challengeNotFound'));
 
-    let group = await Group.getGroup({user, groupId: challenge.group, fields: '_id type privacy'});
-    if (!group || !challenge.canView(user, group)) throw new NotFound(res.t('challengeNotFound'));
-
     if (!challenge.isMember(user)) throw new NotAuthorized(res.t('challengeMemberNotFound'));
 
     // Unlink challenge's tasks from user's tasks and save the challenge


### PR DESCRIPTION
(e.g. after leaving a party or guild)

[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes https://github.com/HabitRPG/habitica/issues/8693

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
* Exactly as @Alys described in the issue description; removed getting the challenge group and checking that the group exists, since the user might not have access.
* Note that the `challenge.canView(user, group)` check that is also removed is redundant, since that will return true if `challenge.isMember(user)` is true, and that's the next check anyways.


[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: b58c50cd-d497-4f53-88a6-69f076ea1114

(Seemed fitting that since I reported the bug in the first place in the Report a Bug guild, I should finally get around to setting up my dev env to fix it.)