### PR TITLE
Show task alias advanced option for Rewards - fixes #8668

### DIFF
--- a/website/views/shared/tasks/edit/advanced_options.jade
+++ b/website/views/shared/tasks/edit/advanced_options.jade
@@ -1,4 +1,4 @@
-div(ng-if='(task.type !== "reward") || (!obj.auth && obj.purchased && obj.purchased.active)')
+div(ng-if='(task.type !== "reward") || task.userId || (!obj.auth && obj.purchased && obj.purchased.active)')
   button.advanced-options-toggle.option-title.mega(type='button',
     ng-class='{active: task._edit._advanced}',
     ng-click='task._edit._advanced = !task._edit._advanced', tooltip=env.t('expandCollapse'))


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes https://github.com/HabitRPG/habitica/issues/8668

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

This has got to be one of my shortest PRs ever:
* Show advanced options when editing a task if the task alias form entry should be shown
* No tests because I couldn't find examples of any that describe how task modals should look; please let me know if I've missed something!

Screenshots:

**Editing reward in task list:**

![editing reward in task list](http://imgur.com/CH3pwC7m.png)

**Editing reward while editing challenge:**

![editing reward in challenge](http://imgur.com/5CNkJGhm.png)

**Editing reward while editing private group tasks:**

![editing reward in private group](http://imgur.com/AMsOjYFm.png)

[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: b58c50cd-d497-4f53-88a6-69f076ea1114