### PR TITLE
travis: don't pollute the log with npm output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ before_install:
   - $CXX --version
   - npm install -g npm@4
   - if [ $REQUIRES_SERVER ]; then sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10; echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list; sudo apt-get update; sudo apt-get install mongodb-org-server; fi
+install:
+  - npm install &> npm.install.log || (cat npm.install.log; false)
 before_script:
   - npm run test:build
   - cp config.json.example config.json


### PR DESCRIPTION
npm install causes about 7k lines of output. While travis folds that out of view almost immediately, it means not all tests fit into its web view, so you have to look at the raw log, with no color info. This should alleviate the problem and probably insignificantly speed up the install itself.