### PR TITLE
Bug in Challenge: when editing any task that edit will save instantly instead of awaiting Save or Cancel

### DIFF
--- a/website/common/locales/en/challenge.json
+++ b/website/common/locales/en/challenge.json
@@ -43,6 +43,7 @@
     "exportChallengeCSV": "Export to CSV",
     "selectGroup": "Please select group",
     "challengeCreated": "Challenge created",
+    "challengeTaskMessage": "When you add a new task, it will be immediately saved to the challenge and given to all participants. Clicking the cancel button above will not revert your change.",
     "sureDelCha": "Are you sure you want to delete this challenge?",
     "sureDelChaTavern": "Are you sure you want to delete this challenge? Your gems will not be refunded.",
     "removeTasks": "Remove Tasks",

--- a/website/views/shared/tasks/index.jade
+++ b/website/views/shared/tasks/index.jade
@@ -7,7 +7,7 @@ include ./task-list
 include ./task
 
 script(id='templates/habitrpg-tasks.html', type="text/ng-template")
-  .tasks-lists.container-fluid    
+  .tasks-lists.container-fluid
     .row
       .col-sm-6.col-md-3(
         ng-repeat='list in lists',
@@ -15,14 +15,14 @@ script(id='templates/habitrpg-tasks.html', type="text/ng-template")
         .task-column(class='{{::list.type}}s')
           include ./task_view/graph
           h2.task-column_title(class='{{::list.type}}-title') {{::list.header}}
-          h5.tasks-warning When you add a new task, it will be immediately saved to the challenge and given to all participants. Clicking the cancel button above will not revert your change.
+          h5.tasks-message=env.t('challengeTaskMessage')
 
           include ./task_view/help
 
           .todos-chart(ng-if='::list.type == "todo"', ng-show='charts.todos')
 
           include ./task_view/add_new
-          
+
           alert.alert-warning.dailiesRestingInInn(ng-if='list.type == "daily" && user.preferences.sleep && !$state.includes("options.social.challenges")')
             i.glyphicon.glyphicon-warning-sign &nbsp;
             =env.t('dailiesRestingInInn')

--- a/website/views/shared/tasks/index.jade
+++ b/website/views/shared/tasks/index.jade
@@ -7,22 +7,22 @@ include ./task-list
 include ./task
 
 script(id='templates/habitrpg-tasks.html', type="text/ng-template")
-  .tasks-lists.container-fluid
+  .tasks-lists.container-fluid    
     .row
       .col-sm-6.col-md-3(
         ng-repeat='list in lists',
         ng-class='::{ "rewards-module": list.type==="reward", "new-row-sm": list.type==="todo" }')
         .task-column(class='{{::list.type}}s')
           include ./task_view/graph
-
           h2.task-column_title(class='{{::list.type}}-title') {{::list.header}}
+          h5.tasks-warning Warning: Adding a new task will get saved automatically and clicking the cancel button above will not revert any changes.
 
           include ./task_view/help
 
           .todos-chart(ng-if='::list.type == "todo"', ng-show='charts.todos')
 
           include ./task_view/add_new
-
+          
           alert.alert-warning.dailiesRestingInInn(ng-if='list.type == "daily" && user.preferences.sleep && !$state.includes("options.social.challenges")')
             i.glyphicon.glyphicon-warning-sign &nbsp;
             =env.t('dailiesRestingInInn')

--- a/website/views/shared/tasks/index.jade
+++ b/website/views/shared/tasks/index.jade
@@ -15,7 +15,7 @@ script(id='templates/habitrpg-tasks.html', type="text/ng-template")
         .task-column(class='{{::list.type}}s')
           include ./task_view/graph
           h2.task-column_title(class='{{::list.type}}-title') {{::list.header}}
-          h5.tasks-warning Warning: Adding a new task will get saved automatically and clicking the cancel button above will not revert any changes.
+          h5.tasks-warning When you add a new task, it will be immediately saved to the challenge and given to all participants. Clicking the cancel button above will not revert your change.
 
           include ./task_view/help
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: #8540 
Partial fix for https://github.com/HabitRPG/habitica/issues/8540

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
When a user creates a new challenge they are able to edit any of the above fields (title, description). However, if they add or make changes to the tasks below (habits, dailies, todos, and rewards) those changes will save instantly and clicking the cancel button will have no effect in discarding them because the "+" button does its own functionality when clicking it it will make a POST. The easiest fix to this problem was to add a warning message. That warning message is placed inside all the task templates warning users right away that adding any new task will get saved automatically and clicking the cancel button above will not revert any changes.   

![screen shot 2017-05-10 at 9 55 18 am](https://cloud.githubusercontent.com/assets/22210582/25910980/1710d1c2-3567-11e7-82fa-72447ca55660.png)

[//]: # (Put User ID in here - found in Settings -> API)
fda98da6-862b-4583-80ef-5ab81671875e
----
UUID: 
