### PR TITLE
Keep existing Mystery Items and Hourglasses when adding to group - fixes 8643

### DIFF
--- a/test/api/v3/unit/libs/payments.test.js
+++ b/test/api/v3/unit/libs/payments.test.js
@@ -653,5 +653,32 @@ describe('payments/index', () => {
 
       expect(updatedUser.items.pets['Jackalope-RoyalPurple']).to.eql(5);
     });
+
+    it('saves previously unused Mystery Items and Hourglasses for an expired subscription', async () => {
+      let planExpirationDate = new Date();
+      planExpirationDate.setDate(planExpirationDate.getDate() - 2);
+      let mysteryItem = 'item';
+      let mysteryItems = [mysteryItem];
+      let consecutive = {
+        trinkets: 3,
+      };
+
+      // set expired plan with unused items
+      plan.mysteryItems = mysteryItems;
+      plan.consecutive = consecutive;
+      plan.dateCreated = planExpirationDate;
+      plan.dateTerminated = planExpirationDate;
+      plan.customerId = null;
+
+      user.purchased.plan = plan;
+
+      await user.save();
+      await api.addSubToGroupUser(user, group);
+
+      let updatedUser = await User.findById(user._id).exec();
+
+      expect(updatedUser.purchased.plan.mysteryItems[0]).to.eql(mysteryItem);
+      expect(updatedUser.purchased.plan.consecutive.trinkets).to.equal(consecutive.trinkets);
+    });
   });
 });

--- a/website/client/components/inventory/item.vue
+++ b/website/client/components/inventory/item.vue
@@ -37,7 +37,7 @@ export default {
       type: Object,
     },
     itemContentClass: {
-      type: String
+      type: String,
     },
     selected: {
       type: Boolean,

--- a/website/server/libs/payments.js
+++ b/website/server/libs/payments.js
@@ -112,8 +112,8 @@ api.addSubToGroupUser = async function addSubToGroupUser (member, group) {
     },
   };
 
+  let memberPlan = member.purchased.plan;
   if (member.isSubscribed()) {
-    let memberPlan = member.purchased.plan;
     let customerHasCancelledGroupPlan = memberPlan.customerId === this.constants.GROUP_PLAN_CUSTOMER_ID && !member.hasNotCancelled();
     let ignorePaymentPlan = paymentMethodsToIgnore.indexOf(memberPlan.paymentMethod) !== -1;
     let ignoreCustomerId = customerIdsToIgnore.indexOf(memberPlan.customerId) !== -1;
@@ -153,6 +153,10 @@ api.addSubToGroupUser = async function addSubToGroupUser (member, group) {
       mysteryItems: [],
     }).value();
   }
+
+  // save unused hourglass and mystery items
+  plan.consecutive.trinkets = memberPlan.consecutive.trinkets;
+  plan.mysteryItems = memberPlan.mysteryItems;
 
   member.purchased.plan = plan;
   member.items.mounts['Jackalope-RoyalPurple'] = true;


### PR DESCRIPTION
[//]: # (https://github.com/HabitRPG/habitica/issues/8643)
Fixes https://github.com/HabitRPG/habitica/issues/8643

### Changes

If a user's subscription expires (gift or self-purchase), and they join a paid group, their existing unopened Mystery Items or unopened Mystery Hourglasses will no longer be overwritten.

Modified addSubToGroupUser to save existing mysteryItems and trinket values
Added unit test in payments.test.js


----
UUID: fc28e9dc-9c84-4ee3-be6e-b4dffa54f558
