### PR TITLE
Fix subscriptions ending early - fixes #8600

### DIFF
--- a/test/api/v3/unit/libs/payments.test.js
+++ b/test/api/v3/unit/libs/payments.test.js
@@ -504,6 +504,18 @@ describe('payments/index', () => {
         expect(daysTillTermination).to.be.within(13, 15);
       });
 
+      it('terminates at next billing date even if dateUpdated is prior to now', async () => {
+        data.nextBill = moment().add({ days: 15 });
+        data.user.purchased.plan.dateUpdated = moment().subtract({ days: 10 });
+
+        await api.cancelSubscription(data);
+
+        let now = new Date();
+        let daysTillTermination = moment(user.purchased.plan.dateTerminated).diff(now, 'days');
+
+        expect(daysTillTermination).to.be.within(13, 15);
+      });
+
       it('resets plan.extraMonths', async () => {
         user.purchased.plan.extraMonths = 5;
 

--- a/website/server/libs/payments.js
+++ b/website/server/libs/payments.js
@@ -448,7 +448,7 @@ api.cancelSubscription = async function cancelSubscription (data) {
   let remaining = data.nextBill ? moment(data.nextBill).diff(new Date(), 'days', true) : defaultRemainingDays;
   if (plan.extraMonths < 0) plan.extraMonths = 0;
   let extraDays = Math.ceil(30.5 * plan.extraMonths);
-  let nowStr = `${now.format('MM')}/${moment(plan.dateUpdated).format('DD')}/${now.format('YYYY')}`;
+  let nowStr = `${now.format('MM')}/${now.format('DD')}/${now.format('YYYY')}`;
   let nowStrFormat = 'MM/DD/YYYY';
 
   plan.dateTerminated =


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes https://github.com/HabitRPG/habitica/issues/8600

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Previously, the calculation for a subscription's end date, or `plan.dateTerminated`, was using `plan.dateUpdated`. This would sometimes incorrectly set the wrong termination date if the updated date was earlier than the current date. 

Use “now” for calculation of the subscription end date instead of plan.dateUpdated

[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: fc28e9dc-9c84-4ee3-be6e-b4dffa54f558
