### PR TITLE
Add test for GET /shops/backgrounds

### DIFF
--- a/test/api/v3/integration/shops/GET-shops_backgrounds.test.js
+++ b/test/api/v3/integration/shops/GET-shops_backgrounds.test.js
@@ -1,0 +1,25 @@
+import {
+  generateUser,
+  translate as t,
+} from '../../../../helpers/api-integration/v3';
+
+describe('GET /shops/backgrounds', () => {
+  let user;
+
+  beforeEach(async () => {
+    user = await generateUser();
+  });
+
+  it('returns a valid shop object', async () => {
+    let shop = await user.get('/shops/backgrounds');
+    expect(shop.identifier).to.equal('backgroundShop');
+    expect(shop.text).to.eql(t('backgroundShop'));
+    expect(shop.notes).to.eql(t('backgroundShopText'));
+    expect(shop.imageName).to.equal('background_shop');
+    expect(shop.sets).to.be.an('array');
+
+    let sets = shop.sets.map(set => set.identifier);
+    expect(sets).to.include('incentiveBackgrounds');
+    expect(sets).to.include('backgrounds062014');
+  });
+});


### PR DESCRIPTION
### Changes

[Coveralls](https://coveralls.io/builds/11756782/source?filename=website%2Fserver%2Fcontrollers%2Fapi-v3%2Fshops.js) showed this endpoint as uncovered. I tried to use the same testing strategy as the other endpoints.

Please let me know if I did this right!

----
UUID: 74e5e6f8-cb86-45c3-a993-872cfc407094

