### PR TITLE
Group Approvals Formatting - Fix #8677

### DIFF
--- a/website/client-old/js/components/groupApprovals/groupApprovalsController.js
+++ b/website/client-old/js/components/groupApprovals/groupApprovalsController.js
@@ -9,7 +9,7 @@ habitrpg.controller('GroupApprovalsCtrl', ['$scope', 'Tasks',
     };
 
     $scope.approvalTitle = function (approval) {
-      return env.t('approvalTitle', {text: approval.text, userName: approval.userId.profile.name});
+      return env.t('approvalTitle', {type: approval.type, text: approval.text, userName: approval.userId.profile.name});
     };
 
     $scope.refreshApprovals = function () {

--- a/website/common/locales/en/groups.json
+++ b/website/common/locales/en/groups.json
@@ -227,7 +227,7 @@
   "yourTaskHasBeenApproved": "Your task \"<%= taskText %>\" has been approved",
   "userHasRequestedTaskApproval": "<%= user %> has requested task approval for <%= taskName %>",
   "approve": "Approve",
-  "approvalTitle": "<%= text %> for user: <%= userName %>",
+  "approvalTitle": "<%= userName %> has completed <%= type %>: \"<%= text %>\"",
   "confirmTaskApproval": "Do you want to reward <%= username %> for completing this task?",
   "groupSubscriptionPrice": "$9 every month + $3 a month for every additional group member",
   "groupAdditionalUserCost": " +$3.00/month/user",

--- a/website/views/options/social/groups/group-tasks-approvals.jade
+++ b/website/views/options/social/groups/group-tasks-approvals.jade
@@ -9,5 +9,19 @@ script(type='text/ng-template', id='partials/groups.tasks.approvals.html')
   .panel-group(ng-repeat="approval in group.approvals")
     .panel.panel-default
       .panel-heading
-        span {{approvalTitle(approval)}}
-        a.btn.btn-sm.btn-success.pull-right(ng-click="approve(approval.group.taskId, approval.userId._id, approval.userId.profile.name, $index)")=env.t('approve')
+        span 
+          markdown(text = "approvalTitle(approval)")
+          a.btn.btn-sm.btn-success.pull-right(ng-click="approve(approval.group.taskId, approval.userId._id, approval.userId.profile.name, $index)")=env.t('approve')
+
+
+ // *ALTERNATIVE SOLUTION-puts text in one column and the approve button in the other 
+ // div
+ //   .container(style="width:100%")
+ //     .panel-group(ng-repeat="approval in group.approvals")
+ //       div
+ //         .row
+ //           .panel.panel-default.col-lg-11
+ //             .panel-heading
+ //               markdown(text ="approvalTitle(approval)")
+ //           .col-lg-1
+ //             a.btn.btn-md.btn-success.align-right(style="margin-top:4px")(ng-click="approve(approval.group.taskId, approval.userId._id, approval.userId.profile.name, $index)")=env.t('approve')

--- a/website/views/options/social/groups/group-tasks-approvals.jade
+++ b/website/views/options/social/groups/group-tasks-approvals.jade
@@ -10,18 +10,7 @@ script(type='text/ng-template', id='partials/groups.tasks.approvals.html')
     .panel.panel-default
       .panel-heading
         span 
-          markdown(text = "approvalTitle(approval)")
-          a.btn.btn-sm.btn-success.pull-right(ng-click="approve(approval.group.taskId, approval.userId._id, approval.userId.profile.name, $index)")=env.t('approve')
+          div(style='padding: 1rem 1rem 2rem 2rem;')
+            markdown.pull-left(text = "approvalTitle(approval)")
+            a.btn.btn-sm.btn-success.pull-right(ng-click="approve(approval.group.taskId, approval.userId._id, approval.userId.profile.name, $index)")=env.t('approve')
 
-
- // *ALTERNATIVE SOLUTION-puts text in one column and the approve button in the other 
- // div
- //   .container(style="width:100%")
- //     .panel-group(ng-repeat="approval in group.approvals")
- //       div
- //         .row
- //           .panel.panel-default.col-lg-11
- //             .panel-heading
- //               markdown(text ="approvalTitle(approval)")
- //           .col-lg-1
- //             a.btn.btn-md.btn-success.align-right(style="margin-top:4px")(ng-click="approve(approval.group.taskId, approval.userId._id, approval.userId.profile.name, $index)")=env.t('approve')


### PR DESCRIPTION
[//]: # (https://github.com/HabitRPG/habitica/issues/8677)
Fixes https://github.com/HabitRPG/habitica/issues/8677

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
This fix aims to do three things on the Group Plans Task Approval List:

1. Indicate the task type for which the member of the party is requesting approval.
2. Differentiate between the username and the task using quotation marks
3. Render markdown and emojis in the task title

This issue also mentions this bug "For Habits, it's also not possible to tell if the member clicked the plus or minus button, which is important to know for correctly approving it. It should state whether plus or minus was clicked." However, @Alys notes that it may not be possible to solve this bug until #8676 is fixed. So we did not attempt to fix that bug in this pull request.

In order to solve these bugs, we had to modify the groups.json file to add in the task "type." But to be able to access the task "type", we had to modify the _groupApprovalsController.js_ file and add in `type: approval.type`. Both of these changes happened in the first commit.

In the second commit, we needed to add the markdown tags on the group-tasks-approvals.jade file so that any markdown or emoji used in the task titles would be rendered correctly on the Group Plans Task Approval List page. 

Here is what the original Group Plans Task Approval List looked like:
![7e0787b4-235a-11e7-8669-81b358be06c9](https://cloud.githubusercontent.com/assets/3806031/26707097/217dea7c-46f7-11e7-9a8b-8a07a1ad4d53.png)


Here is what it looks like with the changes (option 1)
![option1](https://cloud.githubusercontent.com/assets/3806031/26707122/468806f4-46f7-11e7-8b5d-75f32ff95142.png)


**^Note:** I realize that the Approve button is slightly below where it should be and there's a strange white space added to the task block element. We tried various things to fix it and the only thing we could come up with was this (option 2):
![option2](https://cloud.githubusercontent.com/assets/3806031/26707152/7dfb45ec-46f7-11e7-8079-0e7d8b92c8d2.png)
^The code to display it formatted as so(option 2) is included in the file group-tasks-approvals.jade but commented out (see below). I was told in the Aspiring Blacksmiths' Guild to submit a pull request and ask for guidance on how to solve this formatting issue.


[//]: # (b686be6c-6db5-42c5-b4de-92ae66031411)

----
UUID: b686be6c-6db5-42c5-b4de-92ae66031411  - @jjprevite
and UUID: e5026bf1-acca-437f-a5f7-8cc738b74f02  - @razzlen

This issue was the work of both myself and @razzlepdx (her Github username). It was our first time contributing to an opensource project so we wanted to work on it together, thanks to the encouragement from Habitica user @AccioBooks!!

If possible, we would like to credit our party and group- FCW or Future Coding Wizards. Although only @razzlen and myself worked on this issue, we represent a Habitica party who are all learning to code and contribute to opensource projects which include myself, @razzlen, @Nyaemal Hrruna and @seereuben.