### PR TITLE
Align doubled achievement popovers

### DIFF
--- a/website/assets/sprites/css/index.css
+++ b/website/assets/sprites/css/index.css
@@ -61,6 +61,10 @@
   padding-right: 0.5em;
 }
 
+.achievement-container {
+  height: 52px;
+}
+
 [class*="Mount_Head_"],
 [class*="Mount_Body_"] {
   margin-top:18px; /* Sprite accommodates 105x123 box */

--- a/website/client-old/css/shared.styl
+++ b/website/client-old/css/shared.styl
@@ -118,3 +118,7 @@ li.spaced
 
 .modal-footer
   border: none
+
+.no-vertical-padding
+  padding-top: 0px
+  padding-bottom: 0px

--- a/website/views/shared/profiles/achievements.jade
+++ b/website/views/shared/profiles/achievements.jade
@@ -1,13 +1,21 @@
 mixin simpleAchiev(achiev)
   - var popoverHtml = '<div class="{{earnedClass}}">{{achiev.title}}<hr>{{achiev.text}}</div>';
+  //- style is used to set a height to prevent duplicate popovers
+  //- (e.g. click vs hover) from appearing out of alignment.
+  //-
+  //- height value from .achievement-unearned2x
   div(ng-init='earnedClass = achiev.earned ? "" : "muted"',
       data-popover-html='#{popoverHtml}',
       popover-placement='{{achievPopoverPlacement}}',
-      popover-append-to-body='{{achievAppendToBody}}')&attributes(attributes)
+      popover-append-to-body='{{achievAppendToBody}}',
+      style='height:52px;')&attributes(attributes)
+    //- padding set to 0 on verticals to combat alignment
+    //- changes due to user-agent stylesheets
     button.pet-button(popover-trigger='mouseenter',
       data-popover-html='#{popoverHtml}',
       popover-placement='{{achievPopoverPlacement}}',
-      popover-append-to-body='{{achievAppendToBody}}')
+      popover-append-to-body='{{achievAppendToBody}}'
+      style='padding-top:0;padding-bottom:0:')
 
       .achievement(ng-class='achiev.icon + "2x"', ng-if='achiev.earned')
         .counter.badge.badge-info.stack-count(ng-if='(achiev.optionalCount)') {{::achiev.optionalCount}}

--- a/website/views/shared/profiles/achievements.jade
+++ b/website/views/shared/profiles/achievements.jade
@@ -1,21 +1,13 @@
 mixin simpleAchiev(achiev)
   - var popoverHtml = '<div class="{{earnedClass}}">{{achiev.title}}<hr>{{achiev.text}}</div>';
-  //- style is used to set a height to prevent duplicate popovers
-  //- (e.g. click vs hover) from appearing out of alignment.
-  //-
-  //- height value from .achievement-unearned2x
-  div(ng-init='earnedClass = achiev.earned ? "" : "muted"',
+  div.achievement-container(ng-init='earnedClass = achiev.earned ? "" : "muted"',
       data-popover-html='#{popoverHtml}',
       popover-placement='{{achievPopoverPlacement}}',
-      popover-append-to-body='{{achievAppendToBody}}',
-      style='height:52px;')&attributes(attributes)
-    //- padding set to 0 on verticals to combat alignment
-    //- changes due to user-agent stylesheets
-    button.pet-button(popover-trigger='mouseenter',
+      popover-append-to-body='{{achievAppendToBody}}')&attributes(attributes)
+    button.pet-button.no-vertical-padding(popover-trigger='mouseenter',
       data-popover-html='#{popoverHtml}',
       popover-placement='{{achievPopoverPlacement}}',
-      popover-append-to-body='{{achievAppendToBody}}'
-      style='padding-top:0;padding-bottom:0:')
+      popover-append-to-body='{{achievAppendToBody}}')
 
       .achievement(ng-class='achiev.icon + "2x"', ng-if='achiev.earned')
         .counter.badge.badge-info.stack-count(ng-if='(achiev.optionalCount)') {{::achiev.optionalCount}}


### PR DESCRIPTION
Continuation of #8511 
Fixes #8510

### Changes
Adjusted heights of the div and button sequence for the achievement visuals to fix an alignment issue that occurs between showing the popover using mouse-over vs click.

Before:

![image](https://user-images.githubusercontent.com/4501321/26908037-e561a21c-4bac-11e7-9597-4b067d8381d1.png)

After:

![image](https://user-images.githubusercontent.com/4501321/26908049-f8b412dc-4bac-11e7-993c-03e1c53b13c5.png)

----
UUID: ff7a63c1-0026-4bc3-9e72-478761ce0021
