### PR TITLE
Reduce wasted space in UI

### DIFF
--- a/website/client-old/css/tasks.styl
+++ b/website/client-old/css/tasks.styl
@@ -646,7 +646,7 @@ form
 // Task filters
 // --------
 .task-filter
-  margin: 1.5em 0 1em 0
+  margin: 1em 0 1em 0
   hrpg-button-bar-mixin($color-tasks)
   @extend $hrpg-button-bar
   width: 100%


### PR DESCRIPTION
Reduce top margins on task filter bar to reduce dead space below 'add multiple' link / make UI more space efficient

Before:
<img width="391" alt="screen shot 2017-06-10 at 1 25 38 am" src="https://user-images.githubusercontent.com/775657/27000347-782521ec-4d7d-11e7-82d2-53f07f69a046.png">

After:
<img width="398" alt="screen shot 2017-06-10 at 1 26 08 am" src="https://user-images.githubusercontent.com/775657/27000348-7d510e24-4d7d-11e7-8b84-12cc39bdfcb1.png">

Could see reducing the spacing even further, but wanted to maintain some spacing for mobile user touches... just seemed like a lot of wasted space on a desktop computer screen (almost the same height as a one-line task!)

User 6a60aecd-4aa9-4365-ae16-6775ad8b9e98
