### PR TITLE
Restrict users from getting back from death

### DIFF
--- a/test/common/ops/buyHealthPotion.js
+++ b/test/common/ops/buyHealthPotion.js
@@ -76,5 +76,20 @@ describe('shared.ops.buyHealthPotion', () => {
         done();
       }
     });
+
+    it('does not purchase if hp is zero', (done) => {
+      user.stats.hp = 0;
+      user.stats.gp = 40;
+      try {
+        buyHealthPotion(user);
+      } catch (err) {
+        expect(err).to.be.an.instanceof(NotAuthorized);
+        expect(err.message).to.equal(i18n.t('messageHealthAlreadyMin'));
+        expect(user.stats.hp).to.eql(0);
+        expect(user.stats.gp).to.eql(40);
+
+        done();
+      }
+    });
   });
 });

--- a/test/common/ops/buyHealthPotion.js
+++ b/test/common/ops/buyHealthPotion.js
@@ -77,7 +77,7 @@ describe('shared.ops.buyHealthPotion', () => {
       }
     });
 
-    it('does not purchase if hp is zero', (done) => {
+    it('does not allow potion purchases when hp is zero', (done) => {
       user.stats.hp = 0;
       user.stats.gp = 40;
       try {
@@ -86,6 +86,21 @@ describe('shared.ops.buyHealthPotion', () => {
         expect(err).to.be.an.instanceof(NotAuthorized);
         expect(err.message).to.equal(i18n.t('messageHealthAlreadyMin'));
         expect(user.stats.hp).to.eql(0);
+        expect(user.stats.gp).to.eql(40);
+
+        done();
+      }
+    });
+
+    it('does not allow potion purchases when hp is negative', (done) => {
+      user.stats.hp = -8;
+      user.stats.gp = 40;
+      try {
+        buyHealthPotion(user);
+      } catch (err) {
+        expect(err).to.be.an.instanceof(NotAuthorized);
+        expect(err.message).to.equal(i18n.t('messageHealthAlreadyMin'));
+        expect(user.stats.hp).to.eql(-8);
         expect(user.stats.gp).to.eql(40);
 
         done();

--- a/website/common/locales/en/messages.json
+++ b/website/common/locales/en/messages.json
@@ -31,7 +31,7 @@
   "messageAlreadyPurchasedGear": "You purchased this gear in the past, but do not currently own it. You can buy it again in the rewards column on the tasks page.",
   "messageAlreadyOwnGear": "You already own this item. Equip it by going to the equipment page.",
   "messageHealthAlreadyMax": "You already have maximum health.",
-  "messageHealthAlreadyMin": "You already have the minimum health.",
+  "messageHealthAlreadyMin": "Oh no! You have already run out of health so it's too late to buy a health potion, but don't worry - you can revive!",
 
   "armoireEquipment": "<%= image %> You found a piece of rare Equipment in the Armoire: <%= dropText %>! Awesome!",
   "armoireFood": "<%= image %> You rummage in the Armoire and find <%= dropArticle %><%= dropText %>. What's that doing in here?",

--- a/website/common/locales/en/messages.json
+++ b/website/common/locales/en/messages.json
@@ -31,6 +31,7 @@
   "messageAlreadyPurchasedGear": "You purchased this gear in the past, but do not currently own it. You can buy it again in the rewards column on the tasks page.",
   "messageAlreadyOwnGear": "You already own this item. Equip it by going to the equipment page.",
   "messageHealthAlreadyMax": "You already have maximum health.",
+  "messageHealthAlreadyMin": "You already have the minimum health.",
 
   "armoireEquipment": "<%= image %> You found a piece of rare Equipment in the Armoire: <%= dropText %>! Awesome!",
   "armoireFood": "<%= image %> You rummage in the Armoire and find <%= dropArticle %><%= dropText %>. What's that doing in here?",

--- a/website/common/locales/en@pirate/messages.json
+++ b/website/common/locales/en@pirate/messages.json
@@ -30,7 +30,6 @@
     "messageAlreadyPurchasedGear": "Ye purchased this gear in th' past, but do not currently own it. Ye can buy it again in th' rewards column on th' tasks page.",
     "messageAlreadyOwnGear": "Ye already own this item. Equip it by going to th' equipment page.",
     "messageHealthAlreadyMax": "You already have maximum health.",
-    "messageHealthAlreadyMin": "You already have the minimum health.",
     "armoireEquipment": "<%= image %> Ye found a piece of rare Equipment in th' Armoire: <%= dropText %>! Awesome!",
     "armoireFood": "<%= image %> Ye rummage in the Armoire an' find <%= dropArticle %><%= dropText %>. What's tha' doin' in here?",
     "armoireExp": "Ye wrestle wi' th' Armoire an' gain Experience. Take that!",

--- a/website/common/locales/en@pirate/messages.json
+++ b/website/common/locales/en@pirate/messages.json
@@ -30,6 +30,7 @@
     "messageAlreadyPurchasedGear": "Ye purchased this gear in th' past, but do not currently own it. Ye can buy it again in th' rewards column on th' tasks page.",
     "messageAlreadyOwnGear": "Ye already own this item. Equip it by going to th' equipment page.",
     "messageHealthAlreadyMax": "You already have maximum health.",
+    "messageHealthAlreadyMin": "You already have the minimum health.",
     "armoireEquipment": "<%= image %> Ye found a piece of rare Equipment in th' Armoire: <%= dropText %>! Awesome!",
     "armoireFood": "<%= image %> Ye rummage in the Armoire an' find <%= dropArticle %><%= dropText %>. What's tha' doin' in here?",
     "armoireExp": "Ye wrestle wi' th' Armoire an' gain Experience. Take that!",

--- a/website/common/locales/es/messages.json
+++ b/website/common/locales/es/messages.json
@@ -30,6 +30,7 @@
     "messageAlreadyPurchasedGear": "Compraste este equipo en el pasado, pero no lo tienes actualmente. Puedes comprarlo de nuevo en la columna de recompensas de la página de tareas.",
     "messageAlreadyOwnGear": "Ya posees este objeto. Para equiparlo has de ir a la página de equipo.",
     "messageHealthAlreadyMax": "Ya tienes el máximo de salud.",
+    "messageHealthAlreadyMin": "Ya tienes el mínimo de salud.",
     "armoireEquipment": "<%= image %> Has encontrado un objeto de equipamiento raro en  el armario: <%= dropText %>! ¡Genial!",
     "armoireFood": "<%= image %> Hurgas en el Ropero y encuentras <%= dropArticle %><%= dropText %>. ¿Qué hace eso aquí?",
     "armoireExp": "Luchas con el Ropero y ganas Experiencia. ¡Toma eso!",

--- a/website/common/locales/es/messages.json
+++ b/website/common/locales/es/messages.json
@@ -30,7 +30,6 @@
     "messageAlreadyPurchasedGear": "Compraste este equipo en el pasado, pero no lo tienes actualmente. Puedes comprarlo de nuevo en la columna de recompensas de la página de tareas.",
     "messageAlreadyOwnGear": "Ya posees este objeto. Para equiparlo has de ir a la página de equipo.",
     "messageHealthAlreadyMax": "Ya tienes el máximo de salud.",
-    "messageHealthAlreadyMin": "Ya tienes el mínimo de salud.",
     "armoireEquipment": "<%= image %> Has encontrado un objeto de equipamiento raro en  el armario: <%= dropText %>! ¡Genial!",
     "armoireFood": "<%= image %> Hurgas en el Ropero y encuentras <%= dropArticle %><%= dropText %>. ¿Qué hace eso aquí?",
     "armoireExp": "Luchas con el Ropero y ganas Experiencia. ¡Toma eso!",

--- a/website/common/locales/es_419/messages.json
+++ b/website/common/locales/es_419/messages.json
@@ -30,7 +30,6 @@
     "messageAlreadyPurchasedGear": "Compraste este equipamiento antes, pero no lo posees actualmente. Lo puedes volver a comprar en la columna de recompensas en la página de tareas.",
     "messageAlreadyOwnGear": "Ya posees este artículo. Equípalo desde la página de equipamiento.",
     "messageHealthAlreadyMax": "Tu salud ya se encuentra en el nivel máximo.",
-    "messageHealthAlreadyMin": "Tu salud ya se encuentra en el nivel mínimo.",
     "armoireEquipment": "<%= image %> Hallaste una pieza de Equipamiento raro en el Armario: ¡<%= dropText %>! ¡Genial!",
     "armoireFood": "<%= image %> Hurgas en el Armario y encuentras <%= dropArticle %><%= dropText %>. ¿Que hacía eso ahí?",
     "armoireExp": "Luchas con el Armario y ganas Experiencia. ¡Toma esto!",

--- a/website/common/locales/es_419/messages.json
+++ b/website/common/locales/es_419/messages.json
@@ -30,6 +30,7 @@
     "messageAlreadyPurchasedGear": "Compraste este equipamiento antes, pero no lo posees actualmente. Lo puedes volver a comprar en la columna de recompensas en la página de tareas.",
     "messageAlreadyOwnGear": "Ya posees este artículo. Equípalo desde la página de equipamiento.",
     "messageHealthAlreadyMax": "Tu salud ya se encuentra en el nivel máximo.",
+    "messageHealthAlreadyMin": "Tu salud ya se encuentra en el nivel mínimo.",
     "armoireEquipment": "<%= image %> Hallaste una pieza de Equipamiento raro en el Armario: ¡<%= dropText %>! ¡Genial!",
     "armoireFood": "<%= image %> Hurgas en el Armario y encuentras <%= dropArticle %><%= dropText %>. ¿Que hacía eso ahí?",
     "armoireExp": "Luchas con el Armario y ganas Experiencia. ¡Toma esto!",

--- a/website/common/script/ops/buyHealthPotion.js
+++ b/website/common/script/ops/buyHealthPotion.js
@@ -19,7 +19,7 @@ module.exports = function buyHealthPotion (user, req = {}, analytics) {
     throw new NotAuthorized(i18n.t('messageHealthAlreadyMax', req.language));
   }
 
-  if (user.stats.hp == 0) {
+  if (user.stats.hp <= 0) {
     throw new NotAuthorized(i18n.t('messageHealthAlreadyMin', req.language));
   }
 

--- a/website/common/script/ops/buyHealthPotion.js
+++ b/website/common/script/ops/buyHealthPotion.js
@@ -19,6 +19,10 @@ module.exports = function buyHealthPotion (user, req = {}, analytics) {
     throw new NotAuthorized(i18n.t('messageHealthAlreadyMax', req.language));
   }
 
+  if (user.stats.hp == 0) {
+    throw new NotAuthorized(i18n.t('messageHealthAlreadyMin', req.language));
+  }
+
   user.stats.hp += 15;
   if (user.stats.hp > 50) {
     user.stats.hp = 50;


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)
fixes #8807

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
This is related to the following issue https://github.com/HabitRPG/habitica/issues/8807

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Add a health validation check so the API doesn't allow users to buy a potion when they're dead (zero health)


[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: a5c6dfde-5305-4e41-98f8-264a1405868a
