### PR TITLE
Test /api/v3/tasks/unlink-all and unlink-one

### DIFF
--- a/test/api/v3/integration/tasks/POST-tasks_unlink-all_challengeId.test.js
+++ b/test/api/v3/integration/tasks/POST-tasks_unlink-all_challengeId.test.js
@@ -1,7 +1,6 @@
 import {
   generateUser,
   generateGroup,
-  createAndPopulateGroup,
   generateChallenge,
   translate as t,
 } from '../../../../helpers/api-integration/v3';

--- a/test/api/v3/integration/tasks/POST-tasks_unlink-all_challengeId.test.js
+++ b/test/api/v3/integration/tasks/POST-tasks_unlink-all_challengeId.test.js
@@ -1,0 +1,113 @@
+import {
+  generateUser,
+  generateGroup,
+  createAndPopulateGroup,
+  generateChallenge,
+  translate as t,
+} from '../../../../helpers/api-integration/v3';
+
+describe('POST /tasks/unlink-all/:challengeId', () => {
+  let user;
+  let guild;
+  let challenge;
+  let tasksToTest = {
+    habit: {
+      text: 'test habit',
+      type: 'habit',
+      up: false,
+      down: true,
+    },
+    todo: {
+      text: 'test todo',
+      type: 'todo',
+    },
+    daily: {
+      text: 'test daily',
+      type: 'daily',
+      frequency: 'daily',
+      everyX: 5,
+      startDate: new Date(),
+    },
+    reward: {
+      text: 'test reward',
+      type: 'reward',
+    },
+  };
+
+  beforeEach(async () => {
+    user = await generateUser();
+    guild = await generateGroup(user);
+    challenge = await generateChallenge(user, guild);
+  });
+
+  it('fails if no keep query', async () => {
+    try {
+      await user.post(`/tasks/unlink-all/${challenge._id}`);
+    } catch (err) {
+      expect(err).to.eql({
+        code: 400,
+        error: 'BadRequest',
+        message: t('invalidReqParams'),
+      });
+    }
+  });
+
+  it('fails if invalid challenge id', async () => {
+    try {
+      await user.post('/tasks/unlink-all/123?keep=remove-all');
+    } catch (err) {
+      expect(err).to.eql({
+        code: 400,
+        error: 'BadRequest',
+        message: t('invalidReqParams'),
+      });
+    }
+  });
+
+  it('fails on an unbroken challenge', async () => {
+    await user.post(`/tasks/challenge/${challenge._id}`, tasksToTest.daily);
+    await expect(user.post(`/tasks/unlink-all/${challenge._id}?keep=remove-all`))
+    .to.eventually.be.rejected.and.eql({
+      code: 400,
+      error: 'BadRequest',
+      message: t('cantOnlyUnlinkChalTask'),
+    });
+  });
+
+  it('unlinks all tasks from a challenge and deletes them on keep=remove-all', async () => {
+    const daily = await user.post(`/tasks/challenge/${challenge._id}`, tasksToTest.daily);
+    await user.post(`/tasks/challenge/${challenge._id}`, tasksToTest.habit);
+    await user.post(`/tasks/challenge/${challenge._id}`, tasksToTest.reward);
+    await user.post(`/tasks/challenge/${challenge._id}`, tasksToTest.todo);
+    await user.del(`/challenges/${challenge._id}`);
+    const response = await user.post(`/tasks/unlink-all/${challenge._id}?keep=remove-all`);
+    expect(response).to.eql({});
+
+    await expect(user.get(`/tasks/${daily._id}`)).to.eventually.be.rejected.and.eql({
+      code: 404,
+      error: 'NotFound',
+      message: t('taskNotFound'),
+    });
+  });
+
+  it.only('unlinks a task from a challenge on keep=keep-all', async () => {
+    /*
+      NOTE: I expected keep-all to preserve the tasks, but if I try to GET them by _id afterwards they are gone
+      Is this intended behavior? What is keep-all supposed to do?
+      From what I can tell the tasks are gone for this user
+    */
+    const { groupLeader, group, members } = await createAndPopulateGroup({ members: 1 });
+    const [follower] = members;
+    const newChallenge = await generateChallenge(groupLeader, group);
+    const thisTask = await groupLeader.post(`/tasks/challenge/${newChallenge._id}`, tasksToTest.daily);
+
+    // This gives:  Only the challenge leader can delete it.
+    await groupLeader.del(`/challenges/${challenge._id}`);
+    /*
+    const response = await groupLeader.post(`/tasks/unlink-all/${challenge._id}?keep=keep-all`);
+    expect(response).to.eql({});
+    const keptTask = await follower.get(`/tasks/${thisTask._id}`);
+    console.log(keptTask); */
+    // expect(response).to.eql({});
+  });
+});

--- a/test/api/v3/integration/tasks/POST-tasks_unlink-all_challengeId.test.js
+++ b/test/api/v3/integration/tasks/POST-tasks_unlink-all_challengeId.test.js
@@ -40,27 +40,21 @@ describe('POST /tasks/unlink-all/:challengeId', () => {
   });
 
   it('fails if no keep query', async () => {
-    try {
-      await user.post(`/tasks/unlink-all/${challenge._id}`);
-    } catch (err) {
-      expect(err).to.eql({
-        code: 400,
-        error: 'BadRequest',
-        message: t('invalidReqParams'),
-      });
-    }
+    await expect(user.post(`/tasks/unlink-all/${challenge._id}`))
+    .to.eventually.be.rejected.and.eql({
+      code: 400,
+      error: 'BadRequest',
+      message: t('invalidReqParams'),
+    });
   });
 
   it('fails if invalid challenge id', async () => {
-    try {
-      await user.post('/tasks/unlink-all/123?keep=remove-all');
-    } catch (err) {
-      expect(err).to.eql({
-        code: 400,
-        error: 'BadRequest',
-        message: t('invalidReqParams'),
-      });
-    }
+    await expect(user.post('/tasks/unlink-all/123?keep=remove-all'))
+    .to.eventually.be.rejected.and.eql({
+      code: 400,
+      error: 'BadRequest',
+      message: t('invalidReqParams'),
+    });
   });
 
   it('fails on an unbroken challenge', async () => {

--- a/test/api/v3/integration/tasks/POST-tasks_unlink-one_taskId.test.js
+++ b/test/api/v3/integration/tasks/POST-tasks_unlink-one_taskId.test.js
@@ -1,0 +1,42 @@
+import {
+  generateUser,
+  generateGroup,
+  generateChallenge,
+  translate as t,
+} from '../../../../helpers/api-integration/v3';
+
+describe('POST /tasks/unlink-one/:taskId', () => {
+  let user;
+  let guild;
+  let challenge;
+  let tasksToTest = {
+    habit: {
+      text: 'test habit',
+      type: 'habit',
+      up: false,
+      down: true,
+    },
+    todo: {
+      text: 'test todo',
+      type: 'todo',
+    },
+    daily: {
+      text: 'test daily',
+      type: 'daily',
+      frequency: 'daily',
+      everyX: 5,
+      startDate: new Date(),
+    },
+    reward: {
+      text: 'test reward',
+      type: 'reward',
+    },
+  };
+
+  beforeEach(async () => {
+    user = await generateUser();
+    guild = await generateGroup(user);
+    challenge = await generateChallenge(user, guild);
+  });
+
+});

--- a/test/api/v3/integration/tasks/POST-tasks_unlink-one_taskId.test.js
+++ b/test/api/v3/integration/tasks/POST-tasks_unlink-one_taskId.test.js
@@ -4,6 +4,7 @@ import {
   generateChallenge,
   translate as t,
 } from '../../../../helpers/api-integration/v3';
+import { v4 as generateUUID } from 'uuid';
 
 describe('POST /tasks/unlink-one/:taskId', () => {
   let user;
@@ -39,4 +40,71 @@ describe('POST /tasks/unlink-one/:taskId', () => {
     challenge = await generateChallenge(user, guild);
   });
 
+  it('fails if no keep query', async () => {
+    const daily = await user.post(`/tasks/challenge/${challenge._id}`, tasksToTest.daily);
+    await expect(user.post(`/tasks/unlink-one/${daily._id}`))
+    .to.eventually.be.rejected.and.eql({
+      code: 400,
+      error: 'BadRequest',
+      message: t('invalidReqParams'),
+    });
+  });
+
+  it('fails if invalid task id', async () => {
+    await expect(user.post('/tasks/unlink-one/123?keep=remove'))
+    .to.eventually.be.rejected.and.eql({
+      code: 400,
+      error: 'BadRequest',
+      message: t('invalidReqParams'),
+    });
+  });
+
+  it('fails on task not found', async () => {
+    await expect(user.post(`/tasks/unlink-one/${generateUUID()}?keep=keep`))
+    .to.eventually.be.rejected.and.eql({
+      code: 404,
+      error: 'NotFound',
+      message: t('taskNotFound'),
+    });
+  });
+
+  it('fails on task unlinked to challenge', async () => {
+    let daily = await user.post('/tasks/user', tasksToTest.daily);
+    await expect(user.post(`/tasks/unlink-one/${daily._id}?keep=keep`))
+    .to.eventually.be.rejected.and.eql({
+      code: 400,
+      error: 'BadRequest',
+      message: t('cantOnlyUnlinkChalTask'),
+    });
+  });
+
+  it('fails on unbroken challenge', async () => {
+    await user.post(`/tasks/challenge/${challenge._id}`, tasksToTest.daily);
+    let [daily] = await user.get('/tasks/user');
+    await expect(user.post(`/tasks/unlink-one/${daily._id}?keep=keep`))
+    .to.eventually.be.rejected.and.eql({
+      code: 400,
+      error: 'BadRequest',
+      message: t('cantOnlyUnlinkChalTask'),
+    });
+  });
+
+  it('unlinks a task from a challenge and saves it on keep=keep', async () => {
+    await user.post(`/tasks/challenge/${challenge._id}`, tasksToTest.daily);
+    let [, daily] = await user.get('/tasks/user');
+    await user.del(`/challenges/${challenge._id}`);
+    await user.post(`/tasks/unlink-one/${daily._id}?keep=keep`);
+    [, daily] = await user.get('/tasks/user');
+    expect(daily.challenge).to.eql({});
+  });
+
+  it('unlinks a task from a challenge and deletes it on keep=remove', async () => {
+    await user.post(`/tasks/challenge/${challenge._id}`, tasksToTest.daily);
+    let [, daily] = await user.get('/tasks/user');
+    await user.del(`/challenges/${challenge._id}`);
+    await user.post(`/tasks/unlink-one/${daily._id}?keep=remove`);
+    const tasks = await user.get('/tasks/user');
+    // Only the default task should remain
+    expect(tasks.length).to.eql(1);
+  });
 });


### PR DESCRIPTION
Fixes [#7274](https://github.com/HabitRPG/habitica/issues/7274)

### Changes
Added tests for /api/v3/tasks/unlink-all and unlink-one.

I haven't figured out how to generate a reliable coverage report locally, but the one I did showed a 10% coverage increase on /website/server/controllers/api-v3/tasks.js. If I've left something uncovered please let me know and I can add more tests.

----
UUID: 74e5e6f8-cb86-45c3-a993-872cfc407094
