### PR TITLE
Fix allowing users to quit challenges after leaving party: fixes https://github.com/HabitRPG/habitica/issues/8693

### DIFF
--- a/website/server/controllers/api-v3/challenges.js
+++ b/website/server/controllers/api-v3/challenges.js
@@ -343,8 +343,8 @@ api.leaveChallenge = {
     let challenge = await Challenge.findOne({ _id: req.params.challengeId }).exec();
     if (!challenge) throw new NotFound(res.t('challengeNotFound'));
 
-    //Prevented users from leaving challenge after quitting party.
-    //let group = await Group.getGroup({user, groupId: challenge.group, fields: '_id type privacy'});
+   // Prevented users from leaving challenge after quitting party.
+   // let group = await Group.getGroup({user, groupId: challenge.group, fields: '_id type privacy'});
    // if (!group || !challenge.canView(user, group)) throw new NotFound(res.t('challengeNotFound'));
 
     if (!challenge.isMember(user)) throw new NotAuthorized(res.t('challengeMemberNotFound'));

--- a/website/server/controllers/api-v3/challenges.js
+++ b/website/server/controllers/api-v3/challenges.js
@@ -343,8 +343,9 @@ api.leaveChallenge = {
     let challenge = await Challenge.findOne({ _id: req.params.challengeId }).exec();
     if (!challenge) throw new NotFound(res.t('challengeNotFound'));
 
-    let group = await Group.getGroup({user, groupId: challenge.group, fields: '_id type privacy'});
-    if (!group || !challenge.canView(user, group)) throw new NotFound(res.t('challengeNotFound'));
+    //Prevented users from leaving challenge after quitting party.
+    //let group = await Group.getGroup({user, groupId: challenge.group, fields: '_id type privacy'});
+   // if (!group || !challenge.canView(user, group)) throw new NotFound(res.t('challengeNotFound'));
 
     if (!challenge.isMember(user)) throw new NotAuthorized(res.t('challengeMemberNotFound'));
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes https://github.com/HabitRPG/habitica/issues/8693

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Two lines commented out in challenges.js (347 and 348) which prevented the user from leaving a challenge after leaving the party.  Due to the discussed potential security risk found on the URL, I left the code commented out in case there was a need to alter to deal with the security issue at a later time.
If user chooses to keep tasks when leaving challenge, the challenge will automatically disappear from page.  If they remove the tasks, the challenge will stay - with 'leave' turned to 'join' (which doesn't work), and will be gone upon refresh.

[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: 348b9f3a-83ef-4865-b4d1-8f64870c9734
