### PR TITLE
Achievements migration for 2017/06/16 rollout

### DIFF
--- a/migrations/20170616_achievements.js
+++ b/migrations/20170616_achievements.js
@@ -1,0 +1,114 @@
+var migrationName = '20170616_achievements';
+var authorName = 'Sabe'; // in case script author needs to know when their ...
+var authorUuid = '7f14ed62-5408-4e1b-be83-ada62d504931'; //... own data is done
+
+/*
+ * Updates to achievements for June 16, 2017 biweekly merge
+ * 1. Multiply various collection quest achievements based on difficulty reduction
+ * 2. Award Joined Challenge achievement to those who should have it already
+ */
+
+import monk from 'monk';
+
+var connectionString = 'mongodb://localhost:27017/habitrpg?auto_reconnect=true'; // FOR TEST DATABASE
+var dbUsers = monk(connectionString).get('users', { castIds: false });
+
+function processUsers(lastId) {
+  // specify a query to limit the affected users (empty for all users):
+  var query = {
+    $or: [
+      {'achievements.quests.dilatoryDistress1': {$gt:0}},
+      {'achievements.quests.egg': {$gt:0}},
+      {'achievements.quests.goldenknight1': {$gt:0}},
+      {'achievements.quests.moonstone1': {$gt:0}},
+      {'achievements.quests.vice2': {$gt:0}},
+      {'achievements.challenges': {$exists: true, $ne: []}},
+      {'challenges': {$exists: true, $ne: []}},
+    ],
+  };
+
+  if (lastId) {
+    query._id = {
+      $gt: lastId
+    }
+  }
+
+  dbUsers.find(query, {
+    sort: {_id: 1},
+    limit: 250,
+    fields: [ // specify fields we are interested in to limit retrieved data (empty if we're not reading data):
+      'achievements',
+      'challenges',
+    ],
+  })
+  .then(updateUsers)
+  .catch(function (err) {
+    console.log(err);
+    return exiting(1, 'ERROR! ' + err);
+  });
+}
+
+var progressCount = 1000;
+var count = 0;
+
+function updateUsers (users) {
+  if (!users || users.length === 0) {
+    console.warn('All appropriate users found and modified.');
+    displayData();
+    return;
+  }
+
+  var userPromises = users.map(updateUser);
+  var lastUser = users[users.length - 1];
+
+  return Promise.all(userPromises)
+  .then(function () {
+    processUsers(lastUser._id);
+  });
+}
+
+function updateUser (user) {
+  count++;
+  var set = {'migration': migrationName};
+
+  if (user.challenges.length > 0 || user.achievements.challenges.length > 0) {
+    set['achievements.joinedChallenge'] = true;
+  }
+  if (user.achievements.quests.dilatoryDistress1) {
+    set['achievements.quests.dilatoryDistress1'] = Math.ceil(user.achievements.quests.dilatoryDistress1 * 1.25);
+  }
+  if (user.achievements.quests.egg) {
+    set['achievements.quests.egg'] = Math.ceil(user.achievements.quests.egg * 2.5);
+  }
+  if (user.achievements.quests.goldenknight1) {
+    set['achievements.quests.goldenknight1'] = user.achievements.quests.goldenknight1 * 5;
+  }
+  if (user.achievements.quests.moonstone1) {
+    set['achievements.quests.moonstone1'] = user.achievements.quests.moonstone1 * 5;
+  }
+  if (user.achievements.quests.vice2) {
+    set['achievements.quests.vice2'] = Math.ceil(user.achievements.quests.vice2 * 1.5);
+  }
+
+  dbUsers.update({_id: user._id}, {$set:set});
+
+  if (count % progressCount == 0) console.warn(count + ' ' + user._id);
+  if (user._id == authorUuid) console.warn(authorName + ' processed');
+}
+
+function displayData() {
+  console.warn('\n' + count + ' users processed\n');
+  return exiting(0);
+}
+
+function exiting(code, msg) {
+  code = code || 0; // 0 = success
+  if (code && !msg) { msg = 'ERROR!'; }
+  if (msg) {
+    if (code) { console.error(msg); }
+    else      { console.log(  msg); }
+  }
+  process.exit(code);
+}
+
+module.exports = processUsers;

--- a/website/views/shared/new-stuff.jade
+++ b/website/views/shared/new-stuff.jade
@@ -1,23 +1,52 @@
-h2 6/13/2017 - SEA SLUG PET QUEST AND ALYS CONTRIBUTOR SPOTLIGHT
+h2 6/16/2017 - NEW AUDIO THEMES AND GREETING CARDS, CHALLENGE JOINING ACHIEVEMENT, AND REDUCED COLLECTION QUEST DIFFICULTY
   hr
   tr
     td
-      .quest_nudibranch.pull-right
-      h3 New Pet Quest: Sea Slugs!
-      p A leisurely day at the beach takes a turn for the alarming when a bunch of dazzling sea slugs invade a To-Do list! Get the latest pet quest, the <a href='/#/options/inventory/quests'>NowDo Nudibranch</a>, and earn some nifty Nudibranch pets by completing your real-life tasks.
-      p.small.muted by SabreCat, Beffymaroo, Lilith of Alfheim, amadshade, Porrompomperro, and Thiam
+      h3 New Audio Themes!
+      p We've added two new audio themes, both packed full of old-school games nostalgia! Check out Beatscribe's NES Theme and Arashi's Theme, available under the 🔊 icon on the Web site or Settings > Audio Theme in our mobile apps.
+      p.small.muted by Beatscribe and Airu
   tr
     td
-      .promo_contrib_spotlight_alys.pull-left.slight-right-margin
-      h3 Contributor Spotlight: Alys!
-      p We've posted a new <a href='https://habitica.wordpress.com/2017/06/13/contributor-spotlight-alys/' target='_blank'>Contributor Spotlight</a> on the blog! Check out our latest interview with Alys, a Moderator and Blacksmith, to learn more about how she uses Habitica.
-      p.small.muted by Alys, Beffymaroo, and Lemoness
+      .inventory_special_congrats.pull-left.slight-right-margin
+      .inventory_special_getwell.pull-right
+      h3 New Cards: Congratulations and Get Well
+      p Two new greeting cards are available in the <a href='/#/options/inventory/drops'>Market</a>: Congratulations and Get Well cards! For 10 Gold, you can cheer up a party member who's under the weather, or congratulate them on their accomplishments. Do so, and you and the recipient will earn the Caring Confidant or Congratulatory Companion achievement, respectively!
+      p.small.muted Art by McCoyly, tricksy.fox, and Willow the Witty
+      p.small.muted Implemented by Accio Books!
+  tr
+    td
+      .achievement-challenge2x.pull-right
+      h3 Challenge Joining Achievement
+      p Another new Achievement is available: Joined a Challenge! Earn this badge by participating in any Challenge on Habitica, be it an official Habitica challenge, or a Guild or Party challenge. Habiticans currently participating in Challenges or who have won Challenges in the past have already had this Achievement awarded--head to your <a href='/#/options/profile/achievements'>achievements page</a> to see!
+      p.small.muted Art by Vampitch
+      p.small.muted Implemented by Drueth
+  tr
+    td
+      .quest_goldenknight1_testimony.pull-left.slight-right-margin
+      h3 Collection Quest Difficulty Reduced
+      p In response to your feedback, we've reduced the number of items needed to complete several collection quests. "Find the Lair of the Wyrm", "Egg Hunt", "Message in a Bottle", "A Stern Talking-To", and "The Moonstone Chain" have all had their requirements reduced, making it more feasible for small parties to complete them in a timely fashion. If you've felt daunted by these Quests in the past, head to the <a href='/#/options/inventory/quests'>Quest Shop</a> and give them another try!
+      br
+      p If you've already tackled these quests, your extra efforts were not in vain! We've proportionally increased the number of achievements that you received from them.
+      p.small.muted by paulwasit and Lemoness
 
 if menuItem !== 'oldNews'
   hr
   a(href='/static/old-news', target='_blank') Read older news
 
 mixin oldNews
+  h2 6/13/2017 - SEA SLUG PET QUEST AND ALYS CONTRIBUTOR SPOTLIGHT
+    tr
+      td
+        .quest_nudibranch.pull-right
+        h3 New Pet Quest: Sea Slugs!
+        p A leisurely day at the beach takes a turn for the alarming when a bunch of dazzling sea slugs invade a To-Do list! Get the latest pet quest, the <a href='/#/options/inventory/quests'>NowDo Nudibranch</a>, and earn some nifty Nudibranch pets by completing your real-life tasks.
+        p.small.muted by SabreCat, Beffymaroo, Lilith of Alfheim, amadshade, Porrompomperro, and Thiam
+    tr
+      td
+        .promo_contrib_spotlight_alys.pull-left.slight-right-margin
+        h3 Contributor Spotlight: Alys!
+        p We've posted a new <a href='https://habitica.wordpress.com/2017/06/13/contributor-spotlight-alys/' target='_blank'>Contributor Spotlight</a> on the blog! Check out our latest interview with Alys, a Moderator and Blacksmith, to learn more about how she uses Habitica.
+        p.small.muted by Alys, Beffymaroo, and Lemoness
   h2 6/1/2017 - JUNE BACKGROUNDS AND ARMOIRE ITEMS, NEW TAKE THIS CHALLENGE, AND GUILD SPOTLIGHT
     tr
       td


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Adds a migration to bring existing users up to date with changes from #8754 and #8761. Retroactively awards the Joined Challenge achievement to users who are currently members of challenges or who have won challenges in the past (unfortunately, there is no database record of users who joined challenges in the past but did not win them). Also bumps up users' count of achievements for completing collection quests that have been reduced in difficulty, in proportion to how much more difficult the old version of the quests was relative to the new standard.

[//]: # (Put User ID in here - found in Settings -> API)