### PR TITLE
fix bug that prevented sending of emails to admin addresses

### DIFF
--- a/website/server/controllers/api-v3/user.js
+++ b/website/server/controllers/api-v3/user.js
@@ -329,7 +329,7 @@ api.deleteUser = {
     await user.remove();
 
     if (feedback) {
-      txnEmail(TECH_ASSISTANCE_EMAIL, 'admin-feedback', [
+      txnEmail({email: TECH_ASSISTANCE_EMAIL}, 'admin-feedback', [
         {name: 'PROFILE_NAME', content: user.profile.name},
         {name: 'UUID', content: user._id},
         {name: 'EMAIL', content: getUserInfo(user, ['email']).email},

--- a/website/server/libs/payments.js
+++ b/website/server/libs/payments.js
@@ -134,7 +134,7 @@ api.addSubToGroupUser = async function addSubToGroupUser (member, group) {
     let ignoreCustomerId = customerIdsToIgnore.indexOf(memberPlan.customerId) !== -1;
 
     if (ignorePaymentPlan) {
-      txnEmail(TECH_ASSISTANCE_EMAIL, 'admin-user-subscription-details', [
+      txnEmail({email: TECH_ASSISTANCE_EMAIL}, 'admin-user-subscription-details', [
         {name: 'PROFILE_NAME', content: member.profile.name},
         {name: 'UUID', content: member._id},
         {name: 'EMAIL', content: getUserInfo(member, ['email']).email},


### PR DESCRIPTION
Emails from the new feature to send feedback on account deletion haven't been getting through because the `sendTxn` / `txnEmail` call had a wrong parameter. 

This PR fixes that, and also fixes the same bug in a feature that sends emails to admins about certain subscription problems.

Admin slack discussion: https://habitica.slack.com/archives/C02V10HPE/p1498049915383928