### PR TITLE
add missing string for mountNowOwned error message

### DIFF
--- a/website/common/locales/en/pets.json
+++ b/website/common/locales/en/pets.json
@@ -71,6 +71,7 @@
     "displayNow": "Display Now",
     "displayLater": "Display Later",
     "petNotOwned": "You do not own this pet.",
+    "mountNotOwned": "You do not own this mount.",
     "earnedCompanion": "With all your productivity, you've earned a new companion. Feed it to make it grow!",
     "feedPet": "Feed <%= article %><%= text %> to your <%= name %>?",
     "useSaddle": "Saddle <%= pet %>?",

--- a/website/server/controllers/api-v3/user.js
+++ b/website/server/controllers/api-v3/user.js
@@ -1095,7 +1095,7 @@ api.hatch = {
  * @apiErrorExample {json} Item not owned or doesn't exist.
  * {"success":false,"error":"NotFound","message":"You do not own this item."}
  * {"success":false,"error":"NotFound","message":"You do not own this pet."}
- * {"success":false,"error":"NotFound","message":"String 'mountNotOwned' not found."}
+ * {"success":false,"error":"NotFound","message":"You do not own this mount."}
  *
  */
 api.equip = {


### PR DESCRIPTION
When you try to equip a mount you don't own, you're supposed to see an error message saying that you don't own it, but that string was never created. This PR creates it.