### PR TITLE
Make responce codes uniform

### DIFF
--- a/website/server/controllers/api-v3/challenges.js
+++ b/website/server/controllers/api-v3/challenges.js
@@ -158,7 +158,7 @@ let api = {};
  * @apiParam (Body) {Boolean} [official=false] Whether or not a challenge is an official Habitica challenge (requires admin)
  * @apiParam (Body) {Number} [challenge.prize=0] Number of gems offered as a prize to challenge winner
  *
- * @apiSuccess {Object} challenge The newly created challenge.
+ * @apiSuccess (201) {Object} challenge The newly created challenge.
  * @apiUse SuccessfulChallengeRequest
  *
  * @apiUse ChallengeSuccessExample

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -83,7 +83,7 @@ let api = {};
  * @apiError (400) {NotAuthorized} partyMustbePrivate Party must have privacy set to private
  * @apiError (400) {NotAuthorized} messageGroupAlreadyInParty
  *
- * @apiSuccess {Object} data The created group (See <a href="https://github.com/HabitRPG/habitica/blob/develop/website/server/models/group.js" target="_blank">/website/server/models/group.js</a>)
+ * @apiSuccess (201) {Object} data The created group (See <a href="https://github.com/HabitRPG/habitica/blob/develop/website/server/models/group.js" target="_blank">/website/server/models/group.js</a>)
  *
  * @apiSuccessExample {json} Private Guild:
  *     HTTP/1.1 200 OK
@@ -174,7 +174,7 @@ api.createGroup = {
  * @apiName CreateGroupPlan
  * @apiGroup Group
  *
- * @apiSuccess {Object} data The created group
+ * @apiSuccess (201) {Object} data The created group
  */
 api.createGroupPlan = {
   method: 'POST',

--- a/website/server/controllers/api-v3/tags.js
+++ b/website/server/controllers/api-v3/tags.js
@@ -30,7 +30,7 @@ let api = {};
  * @apiParamExample {json} Example body:
  * {"name":"practicetag"}
  *
- * @apiSuccess {Object} data The newly created tag
+ * @apiSuccess (201) {Object} data The newly created tag
  *
  * @apiSuccessExample {json} Example return:
  * {"success":true,"data":{"name":"practicetag","id":"8bc0afbf-ab8e-49a4-982d-67a40557ed1a"},"notifications":[]}

--- a/website/server/controllers/api-v3/tasks.js
+++ b/website/server/controllers/api-v3/tasks.js
@@ -86,7 +86,7 @@ let requiredGroupFields = '_id leader tasksOrder name';
  *       "priority":2
  *     }
  *
- * @apiSuccess data An object if a single task was created, otherwise an array of tasks
+ * @apiSuccess (201) data An object if a single task was created, otherwise an array of tasks
  *
  * @apiSuccessExample {json} Success-Response:
  *     {
@@ -203,7 +203,7 @@ api.createUserTasks = {
  * @apiParamExample {json} Request-Example:
  * {"type":"todo","text":"Test API Params"}
  *
- * @apiSuccess data An object if a single task was created, otherwise an array of tasks
+ * @apiSuccess (201) data An object if a single task was created, otherwise an array of tasks
  *
  * @apiSuccessExample {json} Example return:
  * {"success":true,"data":{"text":"Test API Params","type":"todo","notes":"","tags":[],"value":0,"priority":1,"attribute":"str","challenge":{"id":"f23c12f2-5830-4f15-9c36-e17fd729a812"},"group":{"assignedUsers":[],"approval":{"required":false,"approved":false,"requested":false}},"reminders":[],"_id":"4a29874c-0308-417b-a909-2a7d262b49f6","createdAt":"2017-01-13T21:23:05.949Z","updatedAt":"2017-01-13T21:23:05.949Z","checklist":[],"collapseChecklist":false,"completed":false,"id":"4a29874c-0308-417b-a909-2a7d262b49f6"},"notifications":[]}

--- a/website/server/controllers/api-v3/webhook.js
+++ b/website/server/controllers/api-v3/webhook.js
@@ -61,13 +61,13 @@ let api = {};
  *     "url": "http://some-webhook-url.com"
  *   }
  *
- * @apiSuccess {Object} data The created webhook
- * @apiSuccess {UUID} data.id The uuid of the webhook
- * @apiSuccess {String} data.url The url of the webhook
- * @apiSuccess {String} data.label A label for you to keep track of what this webhooks is for
- * @apiSuccess {Boolean} data.enabled Whether the webhook should be sent
- * @apiSuccess {String} data.type The type of the webhook
- * @apiSuccess {Object} data.options The options for the webhook (See examples)
+ * @apiSuccess (201) {Object} data The created webhook
+ * @apiSuccess (201) {UUID} data.id The uuid of the webhook
+ * @apiSuccess (201) {String} data.url The url of the webhook
+ * @apiSuccess (201) {String} data.label A label for you to keep track of what this webhooks is for
+ * @apiSuccess (201) {Boolean} data.enabled Whether the webhook should be sent
+ * @apiSuccess (201) {String} data.type The type of the webhook
+ * @apiSuccess (201) {Object} data.options The options for the webhook (See examples)
  *
  * @apiUse WebhookBodyInvalid
  */


### PR DESCRIPTION
This PR and issue is about #8087 on improving API docs.
Post request return `200 Success` in the documentation, whereas in code and on actual site they return `201 Created`. I've fixed this issue in `tasks.js`, but it should be checked through all other api endpoints. 