### PR TITLE
Groups can prevent members from getting gems

### DIFF
--- a/test/api/v3/integration/user/POST-user_purchase.test.js
+++ b/test/api/v3/integration/user/POST-user_purchase.test.js
@@ -1,5 +1,6 @@
 import {
   generateUser,
+  createAndPopulateGroup,
   translate as t,
 } from '../../../../helpers/api-integration/v3';
 
@@ -30,5 +31,71 @@ describe('POST /user/purchase/:type/:key', () => {
     await user.sync();
 
     expect(user.items[type][key]).to.equal(1);
+  });
+
+  it('can convert gold to gems if subscribed', async () => {
+    let oldBalance = user.balance;
+    await user.update({
+      'purchased.plan.customerId': 'group-plan',
+      'stats.gp': 1000,
+    });
+    await user.post('/user/purchase/gems/gem');
+    await user.sync();
+    expect(user.balance).to.equal(oldBalance + 0.25);
+  });
+
+  it('leader can convert gold to gems even if the group plan prevents it', async () => {
+    let { group, groupLeader } = await createAndPopulateGroup({
+      groupDetails: {
+        name: 'test',
+        type: 'guild',
+        privacy: 'private',
+      },
+    });
+    await group.update({
+      'leaderOnly.getGems': true,
+      'purchased.plan.customerId': 123,
+    });
+    await groupLeader.sync();
+    let oldBalance = groupLeader.balance;
+
+    await groupLeader.update({
+      'purchased.plan.customerId': 'group-plan',
+      'stats.gp': 1000,
+    });
+    await groupLeader.post('/user/purchase/gems/gem');
+
+    await groupLeader.sync();
+    expect(groupLeader.balance).to.equal(oldBalance + 0.25);
+  });
+
+  it('cannot convert gold to gems if the group plan prevents it', async () => {
+    let { group, members } = await createAndPopulateGroup({
+      groupDetails: {
+        name: 'test',
+        type: 'guild',
+        privacy: 'private',
+      },
+      members: 1,
+    });
+    await group.update({
+      'leaderOnly.getGems': true,
+      'purchased.plan.customerId': 123,
+    });
+    let oldBalance = members[0].balance;
+
+    await members[0].update({
+      'purchased.plan.customerId': 'group-plan',
+      'stats.gp': 1000,
+    });
+    await expect(members[0].post('/user/purchase/gems/gem'))
+      .to.eventually.be.rejected.and.eql({
+        code: 401,
+        error: 'NotAuthorized',
+        message: t('groupPolicyCannotGetGems'),
+      });
+
+    await members[0].sync();
+    expect(members[0].balance).to.equal(oldBalance);
   });
 });

--- a/test/api/v3/unit/libs/amazonPayments.test.js
+++ b/test/api/v3/unit/libs/amazonPayments.test.js
@@ -134,18 +134,17 @@ describe('Amazon Payments', () => {
 
     it('should gift gems', async () => {
       let receivingUser = new User();
-      receivingUser.save();
+      await receivingUser.save();
       let gift = {
         type: 'gems',
+        uuid: receivingUser._id,
         gems: {
           amount: 16,
-          uuid: receivingUser._id,
         },
       };
       amount = 16 / 4;
       await amzLib.checkout({gift, user, orderReferenceId, headers});
 
-      gift.member = receivingUser;
       expect(paymentBuyGemsStub).to.be.calledOnce;
       expect(paymentBuyGemsStub).to.be.calledWith({
         user,

--- a/test/api/v3/unit/libs/applePayments.test.js
+++ b/test/api/v3/unit/libs/applePayments.test.js
@@ -57,7 +57,20 @@ describe('Apple Payments', ()  => {
         });
     });
 
+    it('errors if the user cannot purchase gems', async () => {
+      sinon.stub(user, 'canGetGems').returnsPromise().resolves(false);
+      await expect(applePayments.verifyGemPurchase(user, receipt, headers))
+        .to.eventually.be.rejected.and.to.eql({
+          httpCode: 401,
+          name: 'NotAuthorized',
+          message: i18n.t('groupPolicyCannotGetGems'),
+        });
+
+      user.canGetGems.restore();
+    });
+
     it('purchases gems', async () => {
+      sinon.stub(user, 'canGetGems').returnsPromise().resolves(true);
       await applePayments.verifyGemPurchase(user, receipt, headers);
 
       expect(iapSetupStub).to.be.calledOnce;
@@ -74,6 +87,8 @@ describe('Apple Payments', ()  => {
         amount: 5.25,
         headers,
       });
+      expect(user.canGetGems).to.be.calledOnce;
+      user.canGetGems.restore();
     });
   });
 

--- a/test/api/v3/unit/libs/googlePayments.test.js
+++ b/test/api/v3/unit/libs/googlePayments.test.js
@@ -63,7 +63,21 @@ describe('Google Payments', ()  => {
         });
     });
 
+    it('should throw an error if user cannot purchase gems', async () => {
+      sinon.stub(user, 'canGetGems').returnsPromise().resolves(false);
+
+      await expect(googlePayments.verifyGemPurchase(user, receipt, signature, headers))
+        .to.eventually.be.rejected.and.to.eql({
+          httpCode: 401,
+          name: 'NotAuthorized',
+          message: i18n.t('groupPolicyCannotGetGems'),
+        });
+
+      user.canGetGems.restore();
+    });
+
     it('purchases gems', async () => {
+      sinon.stub(user, 'canGetGems').returnsPromise().resolves(true);
       await googlePayments.verifyGemPurchase(user, receipt, signature, headers);
 
       expect(iapSetupStub).to.be.calledOnce;
@@ -82,6 +96,8 @@ describe('Google Payments', ()  => {
         amount: 5.25,
         headers,
       });
+      expect(user.canGetGems).to.be.calledOnce;
+      user.canGetGems.restore();
     });
   });
 

--- a/test/api/v3/unit/libs/paypalPayments.test.js
+++ b/test/api/v3/unit/libs/paypalPayments.test.js
@@ -87,6 +87,17 @@ describe('Paypal Payments', ()  => {
       });
     });
 
+    it('should error if the user cannot get gems', async () => {
+      let user = new User();
+      sinon.stub(user, 'canGetGems').returnsPromise().resolves(false);
+
+      await expect(paypalPayments.checkout({user})).to.eventually.be.rejected.and.to.eql({
+        httpCode: 401,
+        message: i18n.t('groupPolicyCannotGetGems'),
+        name: 'NotAuthorized',
+      });
+    });
+
     it('creates a link for gifting gems', async () => {
       let receivingUser = new User();
       await receivingUser.save();

--- a/test/api/v3/unit/libs/paypalPayments.test.js
+++ b/test/api/v3/unit/libs/paypalPayments.test.js
@@ -61,7 +61,7 @@ describe('Paypal Payments', ()  => {
     });
 
     it('creates a link for gem purchases', async () => {
-      let link = await paypalPayments.checkout();
+      let link = await paypalPayments.checkout({user: new User()});
 
       expect(paypalPaymentCreateStub).to.be.calledOnce;
       expect(paypalPaymentCreateStub).to.be.calledWith(getPaypalCreateOptions('Habitica Gems', 5.00));
@@ -89,11 +89,12 @@ describe('Paypal Payments', ()  => {
 
     it('creates a link for gifting gems', async () => {
       let receivingUser = new User();
+      await receivingUser.save();
       let gift = {
         type: 'gems',
+        uuid: receivingUser._id,
         gems: {
           amount: 16,
-          uuid: receivingUser._id,
         },
       };
 

--- a/test/api/v3/unit/libs/stripePayments.test.js
+++ b/test/api/v3/unit/libs/stripePayments.test.js
@@ -75,8 +75,29 @@ describe('Stripe Payments', () => {
       });
     });
 
+
+    it('should error if user cannot get gems', async () => {
+      gift = undefined;
+      sinon.stub(user, 'canGetGems').returnsPromise().resolves(false);
+
+      await expect(stripePayments.checkout({
+        token,
+        user,
+        gift,
+        groupId,
+        email,
+        headers,
+        coupon,
+      }, stripe)).to.eventually.be.rejected.and.to.eql({
+        httpCode: 401,
+        message: i18n.t('groupPolicyCannotGetGems'),
+        name: 'NotAuthorized',
+      });
+    });
+
     it('should purchase gems', async () => {
       gift = undefined;
+      sinon.stub(user, 'canGetGems').returnsPromise().resolves(true);
 
       await stripePayments.checkout({
         token,
@@ -102,6 +123,8 @@ describe('Stripe Payments', () => {
         paymentMethod: 'Stripe',
         gift,
       });
+      expect(user.canGetGems).to.be.calledOnce;
+      user.canGetGems.restore();
     });
 
     it('should gift gems', async () => {

--- a/test/api/v3/unit/libs/stripePayments.test.js
+++ b/test/api/v3/unit/libs/stripePayments.test.js
@@ -106,12 +106,12 @@ describe('Stripe Payments', () => {
 
     it('should gift gems', async () => {
       let receivingUser = new User();
-      receivingUser.save();
+      await receivingUser.save();
       gift = {
         type: 'gems',
+        uuid: receivingUser._id,
         gems: {
           amount: 16,
-          uuid: receivingUser._id,
         },
       };
 
@@ -125,7 +125,6 @@ describe('Stripe Payments', () => {
         coupon,
       }, stripe);
 
-      gift.member = receivingUser;
       expect(stripeChargeStub).to.be.calledOnce;
       expect(stripeChargeStub).to.be.calledWith({
         amount: '400',

--- a/website/common/locales/en/groups.json
+++ b/website/common/locales/en/groups.json
@@ -298,5 +298,6 @@
   "managerMarker": " - Manager",
   "joinedGuild": "Joined a Guild",
   "joinedGuildText": "Ventured into the social side of Habitica by joining a Guild!",
-  "badAmountOfGemsToPurchase": "Amount must be at least 1."
+  "badAmountOfGemsToPurchase": "Amount must be at least 1.",
+  "groupPolicyCannotGetGems": "The policy of one group you're part of prevents its members from obtaining gems."
 }

--- a/website/common/script/ops/purchase.js
+++ b/website/common/script/ops/purchase.js
@@ -30,6 +30,11 @@ module.exports = function purchase (user, req = {}, analytics) {
     let convCap = planGemLimits.convCap;
     convCap += user.purchased.plan.consecutive.gemCapExtra;
 
+    // Some groups limit their members ability to obtain gems
+    // The check is async so it's done on the server (in server/controllers/api-v3/user#purchase)
+    // only and not on the client,
+    // resulting in a purchase that will seem successful until the request hit the server.
+
     if (!user.purchased || !user.purchased.plan || !user.purchased.plan.customerId) {
       throw new NotAuthorized(i18n.t('mustSubscribeToPurchaseGems', req.language));
     }

--- a/website/server/controllers/api-v3/user.js
+++ b/website/server/controllers/api-v3/user.js
@@ -19,6 +19,7 @@ import {
   sendTxn as txnEmail,
 } from '../../libs/email';
 import nconf from 'nconf';
+import get from 'lodash/get';
 
 const TECH_ASSISTANCE_EMAIL = nconf.get('EMAILS:TECH_ASSISTANCE_EMAIL');
 
@@ -1227,7 +1228,18 @@ api.purchase = {
   url: '/user/purchase/:type/:key',
   async handler (req, res) {
     let user = res.locals.user;
-    let purchaseRes = req.params.type === 'spells' ? common.ops.buySpecialSpell(user, req) : common.ops.purchase(user, req, res.analytics);
+    const type = get(req.params, 'type');
+    const key = get(req.params, 'key');
+
+    // Some groups limit their members ability to obtain gems
+    // The check is async so it's done on the server only and not on the client,
+    // resulting in a purchase that will seem successful until the request hit the server.
+    if (type === 'gems' && key === 'gem') {
+      const canGetGems = await user.canGetGems();
+      if (!canGetGems) throw new NotAuthorized(res.t('groupPolicyCannotGetGems'));
+    }
+
+    let purchaseRes = type === 'spells' ? common.ops.buySpecialSpell(user, req) : common.ops.purchase(user, req, res.analytics);
     await user.save();
     res.respond(200, ...purchaseRes);
   },

--- a/website/server/controllers/top-level/payments/paypal.js
+++ b/website/server/controllers/top-level/payments/paypal.js
@@ -27,7 +27,7 @@ api.checkout = {
     let gift = req.query.gift ? JSON.parse(req.query.gift) : undefined;
     req.session.gift = req.query.gift;
 
-    let link = await paypalPayments.checkout({gift});
+    let link = await paypalPayments.checkout({gift, user: res.locals.user});
 
     if (req.query.noRedirect) {
       res.respond(200);

--- a/website/server/libs/amazonPayments.js
+++ b/website/server/libs/amazonPayments.js
@@ -110,7 +110,7 @@ api.checkout = async function checkout (options = {}) {
   }
 
   if (!gift || gift.type === this.constants.GIFT_TYPE_GEMS) {
-    const receiver = gift ? user : gift.member;
+    const receiver = gift ? gift.member : user;
     const receiverCanGetGems = await receiver.canGetGems();
     if (!receiverCanGetGems) throw new NotAuthorized(i18n.t('groupPolicyCannotGetGems', receiver.preferences.language));
   }

--- a/website/server/libs/applePayments.js
+++ b/website/server/libs/applePayments.js
@@ -21,6 +21,9 @@ api.constants = {
 };
 
 api.verifyGemPurchase = async function verifyGemPurchase (user, receipt, headers) {
+  const userCanGetGems = await user.canGetGems();
+  if (!userCanGetGems) throw new NotAuthorized(shared.i18n.t('groupPolicyCannotGetGems', user.preferences.language));
+
   await iap.setup();
   let appleRes = await iap.validate(iap.APPLE, receipt);
   let isValidated = iap.isValidated(appleRes);

--- a/website/server/libs/googlePayments.js
+++ b/website/server/libs/googlePayments.js
@@ -20,6 +20,9 @@ api.constants = {
 };
 
 api.verifyGemPurchase = async function verifyGemPurchase (user, receipt, signature, headers) {
+  const userCanGetGems = await user.canGetGems();
+  if (!userCanGetGems) throw new NotAuthorized(shared.i18n.t('groupPolicyCannotGetGems', user.preferences.language));
+
   await iap.setup();
 
   let testObj = {

--- a/website/server/libs/paypalPayments.js
+++ b/website/server/libs/paypalPayments.js
@@ -70,11 +70,15 @@ api.paypalBillingAgreementCancel = Bluebird.promisify(paypal.billingAgreement.ca
 api.ipnVerifyAsync = Bluebird.promisify(ipn.verify, {context: ipn});
 
 api.checkout = async function checkout (options = {}) {
-  let {gift} = options;
+  let {gift, user} = options;
 
   let amount = 5.00;
   let description = 'Habitica Gems';
+
   if (gift) {
+    const member = await User.findById(gift.uuid).exec();
+    gift.member = member;
+
     if (gift.type === 'gems') {
       if (gift.gems.amount <= 0) {
         throw new BadRequest(i18n.t('badAmountOfGemsToPurchase'));
@@ -86,6 +90,14 @@ api.checkout = async function checkout (options = {}) {
       description = 'mo. Habitica Subscription (Gift)';
     }
   }
+
+
+  if (!gift || gift.type === 'gems') {
+    const receiver = gift ? user : gift.member;
+    const receiverCanGetGems = await receiver.canGetGems();
+    if (!receiverCanGetGems) throw new NotAuthorized(shared.i18n.t('groupPolicyCannotGetGems', receiver.preferences.language));
+  }
+
 
   let createPayment = {
     intent: 'sale',

--- a/website/server/libs/paypalPayments.js
+++ b/website/server/libs/paypalPayments.js
@@ -93,7 +93,7 @@ api.checkout = async function checkout (options = {}) {
 
 
   if (!gift || gift.type === 'gems') {
-    const receiver = gift ? user : gift.member;
+    const receiver = gift ? gift.member : user;
     const receiverCanGetGems = await receiver.canGetGems();
     if (!receiverCanGetGems) throw new NotAuthorized(shared.i18n.t('groupPolicyCannotGetGems', receiver.preferences.language));
   }

--- a/website/server/libs/stripePayments.js
+++ b/website/server/libs/stripePayments.js
@@ -120,7 +120,7 @@ api.checkout = async function checkout (options, stripeInc) {
     }
 
     if (!gift || gift.type === 'gems') {
-      const receiver = gift ? user : gift.member;
+      const receiver = gift ? gift.member : user;
       const receiverCanGetGems = await receiver.canGetGems();
       if (!receiverCanGetGems) throw new NotAuthorized(shared.i18n.t('groupPolicyCannotGetGems', receiver.preferences.language));
     }

--- a/website/server/libs/stripePayments.js
+++ b/website/server/libs/stripePayments.js
@@ -76,6 +76,11 @@ api.checkout = async function checkout (options, stripeInc) {
 
   if (!token) throw new BadRequest('Missing req.body.id');
 
+  if (gift) {
+    const member = await User.findById(gift.uuid).exec();
+    gift.member = member;
+  }
+
   if (sub) {
     if (sub.discount) {
       if (!coupon) throw new BadRequest(shared.i18n.t('couponCodeRequired'));
@@ -114,6 +119,12 @@ api.checkout = async function checkout (options, stripeInc) {
       }
     }
 
+    if (!gift || gift.type === 'gems') {
+      const receiver = gift ? user : gift.member;
+      const receiverCanGetGems = await receiver.canGetGems();
+      if (!receiverCanGetGems) throw new NotAuthorized(shared.i18n.t('groupPolicyCannotGetGems', receiver.preferences.language));
+    }
+
     response = await stripeApi.charges.create({
       amount,
       currency: 'usd',
@@ -141,8 +152,6 @@ api.checkout = async function checkout (options, stripeInc) {
     };
 
     if (gift) {
-      let member = await User.findById(gift.uuid).exec();
-      gift.member = member;
       if (gift.type === 'subscription') method = 'createSubscription';
       data.paymentMethod = 'Gift';
     }

--- a/website/server/models/challenge.js
+++ b/website/server/models/challenge.js
@@ -283,7 +283,15 @@ schema.methods.closeChal = async function closeChal (broken = {}) {
   // Award prize to winner and notify
   if (winner) {
     winner.achievements.challenges.push(challenge.name);
-    winner.balance += challenge.prize / 4;
+
+    // If the winner cannot get gems (because of a group policy)
+    // reimburse the leader
+    const winnerCanGetGems = await winner.canGetGems();
+    if (!winnerCanGetGems) {
+      await User.update({_id: challenge.leader}, {$inc: {balance: challenge.prize / 4}}).exec();
+    } else {
+      winner.balance += challenge.prize / 4;
+    }
 
     winner.addNotification('WON_CHALLENGE');
 

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -126,7 +126,7 @@ export let schema = new Schema({
 });
 
 schema.plugin(baseModel, {
-  noSet: ['_id', 'balance', 'quest', 'memberCount', 'chat', 'challengeCount', 'tasksOrder', 'purchased', 'managers', 'blockMembersFromGettingGems'],
+  noSet: ['_id', 'balance', 'quest', 'memberCount', 'chat', 'challengeCount', 'tasksOrder', 'purchased', 'managers'],
   private: ['purchased.plan'],
   toJSONTransform (plainObj, originalDoc) {
     if (plainObj.purchased) plainObj.purchased.active = originalDoc.isSubscribed();

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -76,6 +76,8 @@ export let schema = new Schema({
   leaderOnly: { // restrict group actions to leader (members can't do them)
     challenges: {type: Boolean, default: false, required: true},
     // invites: {type: Boolean, default: false, required: true},
+    // Some group plans prevent members from getting gems
+    getGems: {type: Boolean, default: false},
   },
   memberCount: {type: Number, default: 1},
   challengeCount: {type: Number, default: 0},
@@ -124,7 +126,7 @@ export let schema = new Schema({
 });
 
 schema.plugin(baseModel, {
-  noSet: ['_id', 'balance', 'quest', 'memberCount', 'chat', 'challengeCount', 'tasksOrder', 'purchased', 'managers'],
+  noSet: ['_id', 'balance', 'quest', 'memberCount', 'chat', 'challengeCount', 'tasksOrder', 'purchased', 'managers', 'blockMembersFromGettingGems'],
   private: ['purchased.plan'],
   toJSONTransform (plainObj, originalDoc) {
     if (plainObj.purchased) plainObj.purchased.active = originalDoc.isSubscribed();

--- a/website/server/models/user/methods.js
+++ b/website/server/models/user/methods.js
@@ -287,11 +287,13 @@ schema.methods.canGetGems = async function canObtainGems () {
   const userGroups = user.getGroups();
 
   const groups = await Group
-    .find({_id: {$in: userGroups}})
-    .select('leaderOnly leader')
+    .find({
+      _id: {$in: userGroups},
+    })
+    .select('leaderOnly leader purchased')
     .exec();
 
   return groups.every(g => {
-    return g.leader === user._id || g.leaderOnly.getGems !== true;
+    return !g.isSubscribed() || g.leader === user._id || g.leaderOnly.getGems !== true;
   });
 };

--- a/website/server/models/user/methods.js
+++ b/website/server/models/user/methods.js
@@ -4,6 +4,7 @@ import Bluebird from 'bluebird';
 import {
   chatDefaults,
   TAVERN_ID,
+  model as Group,
 } from '../group';
 import { defaults, map, flatten, flow, compact, uniq, partialRight } from 'lodash';
 import { model as UserNotification } from '../userNotification';
@@ -190,7 +191,7 @@ schema.methods.cancelSubscription = async function cancelSubscription (options =
   return await payments.cancelSubscription(options);
 };
 
-schema.methods.daysUserHasMissed = function  daysUserHasMissed (now, req = {}) {
+schema.methods.daysUserHasMissed = function daysUserHasMissed (now, req = {}) {
   // If the user's timezone has changed (due to travel or daylight savings),
   // cron can be triggered twice in one day, so we check for that and use
   // both timezones to work out if cron should run.
@@ -270,4 +271,29 @@ schema.methods.daysUserHasMissed = function  daysUserHasMissed (now, req = {}) {
   }
 
   return {daysMissed, timezoneOffsetFromUserPrefs};
+};
+
+// Determine if the user can get gems: some groups restrict their members ability to obtain them.
+// User is allowed to buy gems if no group has `leaderOnly.getGems` === true or if
+// its the group leader
+schema.methods.canGetGems = function canObtainGems () {
+  const user = this;
+  const plan = user.purchased.plan;
+
+
+  if (!user.isSubscribed() || plan.customerId !== payments.constants.GROUP_PLAN_CUSTOMER_ID) {
+    return true;
+  }
+
+  const userGroups = user.getGroups();
+
+  return Group
+    .find({_id: {$in: userGroups}})
+    .select('leaderOnly leader')
+    .exec()
+    .then(groups => {
+      return groups.every(g => {
+        return g.leader === user._id || g.leaderOnly.getGems !== true;
+      });
+    });
 };


### PR DESCRIPTION
This PR adds the ability for groups with group plans to prevent their members from obtaining gems in Habitica.

The UI is missing for the setting, groups that need this feature will contact the admins who will then add a field in the database to enabled it.

In particular this becomes blocked for members of such groups:
- Buying gems
- Being gifted gems
- Converting gold to gems: due to the way this is implemented users will briefly see the conversion as successful but it'll be reverted as soon as the request hit the server, because the verification process is made on the server so the client doesn't know if the user can buy gems.
- Winning a challenge prize: in this case the winner creator is refunded

Leaders are excluded.

Tests are coming.