### PR TITLE
Moved notifications to be read after yesterdailies

### DIFF
--- a/test/client-old/spec/controllers/notificationCtrlSpec.js
+++ b/test/client-old/spec/controllers/notificationCtrlSpec.js
@@ -6,6 +6,7 @@ describe('Notification Controller', function() {
   beforeEach(function() {
     user = specHelper.newUser();
     user._id = "unique-user-id";
+    user.needsCron = false;
 
     var userSync = sinon.stub().returns({
       then: function then (f) { f(); }

--- a/website/client-old/js/controllers/notificationCtrl.js
+++ b/website/client-old/js/controllers/notificationCtrl.js
@@ -315,7 +315,7 @@ habitrpg.controller('NotificationCtrl',
     // are now stored in user.notifications.
     $rootScope.$watchCollection('userNotifications', function (after) {
       if (!User.user._wrapped) return;
-      if (!User.user.needsCron) return;
+      if (User.user.needsCron) return;
       handleUserNotifications(after);
     });
 

--- a/website/client-old/js/controllers/notificationCtrl.js
+++ b/website/client-old/js/controllers/notificationCtrl.js
@@ -315,6 +315,7 @@ habitrpg.controller('NotificationCtrl',
     // are now stored in user.notifications.
     $rootScope.$watchCollection('userNotifications', function (after) {
       if (!User.user._wrapped) return;
+      if (!User.user.needsCron) return;
       handleUserNotifications(after);
     });
 

--- a/website/client-old/js/controllers/notificationCtrl.js
+++ b/website/client-old/js/controllers/notificationCtrl.js
@@ -39,6 +39,7 @@ habitrpg.controller('NotificationCtrl',
       if (yesterDailies.length === 0) {
         User.runCron().then(function () {
           isRunningYesterdailies = false;
+          handleUserNotifications(User.user);
         });
         return;
       };
@@ -73,6 +74,7 @@ habitrpg.controller('NotificationCtrl',
             User.runCron()
               .then(function () {
                 isRunningYesterdailies = false;
+                handleUserNotifications(User.user);
               });
           };
         }],
@@ -316,10 +318,10 @@ habitrpg.controller('NotificationCtrl',
       handleUserNotifications(after);
     });
 
-    var handleUserNotificationsOnFirstSync = _.once(function () {
-      handleUserNotifications($rootScope.userNotifications);
-    });
-    $rootScope.$on('userUpdated', handleUserNotificationsOnFirstSync);
+    // var handleUserNotificationsOnFirstSync = _.once(function () {
+    //   handleUserNotifications($rootScope.userNotifications);
+    // });
+    // $rootScope.$on('userUpdated', handleUserNotificationsOnFirstSync);
 
     // TODO what about this?
     $rootScope.$watch('user.achievements', function(){


### PR DESCRIPTION
I have been recreating the VersionError issue on our server by sending parallel requests that update documents (User, Task and Group) arrays. Currently, the biggest affect we are seeing is from Cron because RYA now sends the cron as a request. This PR post a quick fix for that, however, there are some options to handle the on the server side.

To recreate the Cron version error. A user must have a notification, specifically a cron notification in their array. Then, the two parallel requests `notification` and `cron` will change the `user.notification` array in parallel and cause an issue. The following will recreate the issue:

```
    user = await generateUser({
      lastCron: moment().subtract(1, 'days').toDate(),
    });
    await user.post(`/cron`);
    await user.sync();
    await user.update({
      lastCron: moment().subtract(1, 'days').toDate(),
    });

    let notificationId4 = user.notifications[3].id;// The CRON notification that gets alerted in two urls
    user.post(`/cron`);
    user.post(`/notifications/read`, {
      notificationIds: [notificationId4],
    });
```

I have fixed this by preventing the notifications from being read until after the user crons. 
