### PR TITLE
text fix: Report a Bug guild not GitHub

### DIFF
--- a/website/views/static/contact.jade
+++ b/website/views/static/contact.jade
@@ -19,7 +19,7 @@ block content
         br
         =env.t('reportBug')
         | &colon;&nbsp;
-        a(target='_blank', href='https://github.com/HabitRPG/habitica/issues?q=is%3Aopen') GitHub
+        a(target='_blank', href='https://habitica.com/#/options/groups/guilds/a29da26b-37de-4a71-b0c6-48e72a900dac') Report a Bug guild
         br
         =env.t('reportCommunityIssues')
         | &colon;&nbsp;


### PR DESCRIPTION
Changes the Contact Us page to specify the Report a Bug guild instead of GitHub. (NB: The Bug guild won't be useful if you can't log in to the site, but the list on the contact us page already has an entry for account problems.)


I suggest leaving this unmerged for a few days in case I find other small fixes.