### PR TITLE
API - Get challenges for a group does not allow `party` or `habitrpg`

### DIFF
--- a/test/api/v3/integration/challenges/GET-challenges_group_groupid.test.js
+++ b/test/api/v3/integration/challenges/GET-challenges_group_groupid.test.js
@@ -6,7 +6,7 @@ import {
 } from '../../../../helpers/api-v3-integration.helper';
 import { TAVERN_ID } from '../../../../../website/common/script/constants';
 
-describe.only('GET challenges/groups/:groupId', () => {
+describe('GET challenges/groups/:groupId', () => {
   context('Public Guild', () => {
     let publicGuild, user, nonMember, challenge, challenge2;
 

--- a/test/api/v3/integration/challenges/GET-challenges_group_groupid.test.js
+++ b/test/api/v3/integration/challenges/GET-challenges_group_groupid.test.js
@@ -5,7 +5,7 @@ import {
   translate as t,
 } from '../../../../helpers/api-v3-integration.helper';
 
-describe('GET challenges/groups/:groupId', () => {
+describe.only('GET challenges/groups/:groupId', () => {
   context('Public Guild', () => {
     let publicGuild, user, nonMember, challenge, challenge2;
 
@@ -179,6 +179,55 @@ describe('GET challenges/groups/:groupId', () => {
 
       foundChallengeIndex = _.findIndex(challenges, { _id: newChallenge._id });
       expect(foundChallengeIndex).to.eql(1);
+    });
+  });
+
+  context('Party', () => {
+    let party, user, nonMember, challenge, challenge2;
+
+    before(async () => {
+      let { group, groupLeader } = await createAndPopulateGroup({
+        groupDetails: {
+          name: 'TestParty',
+          type: 'party',
+        },
+      });
+
+      party = group;
+      user = groupLeader;
+
+      nonMember = await generateUser();
+
+      challenge = await generateChallenge(user, group);
+      challenge2 = await generateChallenge(user, group);
+    });
+
+    it('should prevent non-member from seeing challenges', async () => {
+      await expect(nonMember.get(`/challenges/groups/${party._id}`))
+        .to.eventually.be.rejected.and.eql({
+          code: 404,
+          error: 'NotFound',
+          message: t('groupNotFound'),
+        });
+    });
+
+    it('should return group challenges for member with populated leader', async () => {
+      let challenges = await user.get(`/challenges/groups/${party._id}`);
+
+      let foundChallenge1 = _.find(challenges, { _id: challenge._id });
+      expect(foundChallenge1).to.exist;
+      expect(foundChallenge1.leader).to.eql({
+        _id: party.leader._id,
+        id: party.leader._id,
+        profile: {name: user.profile.name},
+      });
+      let foundChallenge2 = _.find(challenges, { _id: challenge2._id });
+      expect(foundChallenge2).to.exist;
+      expect(foundChallenge2.leader).to.eql({
+        _id: party.leader._id,
+        id: party.leader._id,
+        profile: {name: user.profile.name},
+      });
     });
   });
 });

--- a/test/api/v3/integration/challenges/GET-challenges_group_groupid.test.js
+++ b/test/api/v3/integration/challenges/GET-challenges_group_groupid.test.js
@@ -232,7 +232,7 @@ describe('GET challenges/groups/:groupId', () => {
     });
 
     it('should return group challenges for member using ID "party"', async () => {
-      let challenges = await user.get(`/challenges/groups/party`);
+      let challenges = await user.get('/challenges/groups/party');
 
       let foundChallenge1 = _.find(challenges, { _id: challenge._id });
       expect(foundChallenge1).to.exist;
@@ -283,7 +283,7 @@ describe('GET challenges/groups/:groupId', () => {
     });
 
     it('should return tavern challenges using ID "habitrpg', async () => {
-      let challenges = await user.get(`/challenges/groups/habitrpg`);
+      let challenges = await user.get('/challenges/groups/habitrpg');
 
       let foundChallenge1 = _.find(challenges, { _id: challenge._id });
       expect(foundChallenge1).to.exist;

--- a/test/api/v3/integration/challenges/GET-challenges_group_groupid.test.js
+++ b/test/api/v3/integration/challenges/GET-challenges_group_groupid.test.js
@@ -4,6 +4,7 @@ import {
   createAndPopulateGroup,
   translate as t,
 } from '../../../../helpers/api-v3-integration.helper';
+import { TAVERN_ID } from '../../../../../website/common/script/constants';
 
 describe.only('GET challenges/groups/:groupId', () => {
   context('Public Guild', () => {
@@ -226,6 +227,76 @@ describe.only('GET challenges/groups/:groupId', () => {
       expect(foundChallenge2.leader).to.eql({
         _id: party.leader._id,
         id: party.leader._id,
+        profile: {name: user.profile.name},
+      });
+    });
+
+    it('should return group challenges for member using ID "party"', async () => {
+      let challenges = await user.get(`/challenges/groups/party`);
+
+      let foundChallenge1 = _.find(challenges, { _id: challenge._id });
+      expect(foundChallenge1).to.exist;
+      expect(foundChallenge1.leader).to.eql({
+        _id: party.leader._id,
+        id: party.leader._id,
+        profile: {name: user.profile.name},
+      });
+      let foundChallenge2 = _.find(challenges, { _id: challenge2._id });
+      expect(foundChallenge2).to.exist;
+      expect(foundChallenge2.leader).to.eql({
+        _id: party.leader._id,
+        id: party.leader._id,
+        profile: {name: user.profile.name},
+      });
+    });
+  });
+
+  context('Tavern', () => {
+    let tavern, user, challenge, challenge2;
+
+    before(async () => {
+      user = await generateUser();
+      await user.update({balance: 0.5});
+      tavern = await user.get(`/groups/${TAVERN_ID}`);
+
+      challenge = await generateChallenge(user, tavern, {prize: 1});
+      challenge2 = await generateChallenge(user, tavern, {prize: 1});
+    });
+
+    it('should return tavern challenges with populated leader', async () => {
+      let challenges = await user.get(`/challenges/groups/${TAVERN_ID}`);
+
+      let foundChallenge1 = _.find(challenges, { _id: challenge._id });
+      expect(foundChallenge1).to.exist;
+      expect(foundChallenge1.leader).to.eql({
+        _id: user._id,
+        id: user._id,
+        profile: {name: user.profile.name},
+      });
+      let foundChallenge2 = _.find(challenges, { _id: challenge2._id });
+      expect(foundChallenge2).to.exist;
+      expect(foundChallenge2.leader).to.eql({
+        _id: user._id,
+        id: user._id,
+        profile: {name: user.profile.name},
+      });
+    });
+
+    it('should return tavern challenges using ID "habitrpg', async () => {
+      let challenges = await user.get(`/challenges/groups/habitrpg`);
+
+      let foundChallenge1 = _.find(challenges, { _id: challenge._id });
+      expect(foundChallenge1).to.exist;
+      expect(foundChallenge1.leader).to.eql({
+        _id: user._id,
+        id: user._id,
+        profile: {name: user.profile.name},
+      });
+      let foundChallenge2 = _.find(challenges, { _id: challenge2._id });
+      expect(foundChallenge2).to.exist;
+      expect(foundChallenge2.leader).to.eql({
+        _id: user._id,
+        id: user._id,
         profile: {name: user.profile.name},
       });
     });

--- a/website/server/controllers/api-v3/challenges.js
+++ b/website/server/controllers/api-v3/challenges.js
@@ -432,6 +432,9 @@ api.getGroupChallenges = {
     let validationErrors = req.validationErrors();
     if (validationErrors) throw validationErrors;
 
+    if (groupId === 'party') groupId = user.party._id;
+    if (groupId === 'habitrpg') groupId = TAVERN_ID;
+
     let group = await Group.getGroup({user, groupId});
     if (!group) throw new NotFound(res.t('groupNotFound'));
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes https://github.com/HabitRPG/habitica/issues/8849

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
* Added tests for getting group challenges by party ID, Tavern ID, IDs 'party' and 'habitrpg'
* Added functionality to find challenges by 'party' or 'habitrpg' alias in '/challenges/groups/:groupId'


[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: d97516e4-81d0-4f60-bf03-95f7330925ab
