### PR TITLE
Bail if group not passed to canEdit

### DIFF
--- a/website/client-old/js/controllers/groupsCtrl.js
+++ b/website/client-old/js/controllers/groupsCtrl.js
@@ -36,6 +36,7 @@ habitrpg.controller("GroupsCtrl", ['$scope', '$rootScope', 'Shared', 'Groups', '
     };
 
     $scope.isAbleToEditGroup = function (group) {
+      if (!group) return false;
       if (group.leader._id === User.user._id) return true;
       if (User.user.contributor.admin && group.type === "guild") return true;
       return false;


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #8862 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

For some reason, `isAbleToEditGroup` was being called without any actual group being passed to the function, so the JS console would get a bunch of `TypeError`s complaining that we were attempting to check properties on a nonexistent object. This PR has the function do an early `return` if the parameter is falsey.

Not super important as it's a functionally invisible issue on a frontend currently being overhauled, but console errors are a nuisance, so it might be worth our merging in to clean up.

[//]: # (Put User ID in here - found in Settings -> API)