### PR TITLE
Reset Habit click counters when sleeping

### DIFF
--- a/test/api/v3/unit/libs/cron.test.js
+++ b/test/api/v3/unit/libs/cron.test.js
@@ -566,6 +566,17 @@ describe('cron', () => {
         expect(tasksByType.habits[0].counterDown).to.equal(0);
       });
 
+      it('should reset habit counters even if user is resting in the Inn', () => {
+        user.preferences.sleep = true;
+        tasksByType.habits[0].counterUp = 1;
+        tasksByType.habits[0].counterDown = 1;
+
+        cron({user, tasksByType, daysMissed, analytics});
+
+        expect(tasksByType.habits[0].counterUp).to.equal(0);
+        expect(tasksByType.habits[0].counterDown).to.equal(0);
+      });
+
       it('should reset a weekly habit counter each Monday', () => {
         tasksByType.habits[0].frequency = 'weekly';
         tasksByType.habits[0].counterUp = 1;


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #8578 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Abstracts the process of resetting Habit click counters to its own function in the `cron` library, and calls it within the normal cron flow as well as in the `performSleepTasks` function. This allows Habit counters to reset even if the user is resting in the Inn.

Adds a unit test to cover this case.

[//]: # (Put User ID in here - found in Settings -> API)