### PR TITLE
Fix Dockerfile's to Run App (Fixes https://github.com/HabitRPG/habitica/issues/8909 & 8910)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN npm install -g gulp grunt-cli bower mocha
 RUN mkdir -p /usr/src/habitrpg
 WORKDIR /usr/src/habitrpg
 RUN git clone https://github.com/HabitRPG/habitica.git /usr/src/habitrpg
+RUN cp config.json.example config.json
 RUN npm install
 RUN bower install --allow-root
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,3 +1,3 @@
 web:
   volumes:
-    - '.:/habitrpg'
+    - '.:/usr/src/habitrpg'


### PR DESCRIPTION
Fixes #8909 https://github.com/HabitRPG/habitica/issues/8909
Fixes #8910 https://github.com/HabitRPG/habitica/issues/8910

### Changes
For 8909, I added the command RUN cp config.json.example config.json so that the Docker container will have a config.json file when it tries to run the app. Previously, it would only check out the source code into the container and not copy the file, so the app would crash without intervention.

For 8910, I changed the volume in docker-compose.dev.yml to mount the local source drive to the location the Docker container runs the application from. Previously, it mounted the directory to a different location, so the user would have to enter the container and run the app manually rather than call `docker-compose up -d`.

----
UUID: 26d0ea00-bad1-4ec2-8531-918d522e6e47