### PR TITLE
fix pophover position

### DIFF
--- a/fixstyle.css
+++ b/fixstyle.css
@@ -1,0 +1,10 @@
+<style>
+	@media screen and (max-width: 767px){
+		.popover.ng-isolate-scope.bottom.fade.in{
+	            left: 0px !important;
+            }
+		.popover.bottom .arrow{
+			left: 25% !important;
+		}
+    }
+</style>


### PR DESCRIPTION
Fixed [#8760](https://github.com/HabitRPG/habitica/issues/8760)

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
fix the position of pophover of the pending the damage boss

![screenshot_617](https://user-images.githubusercontent.com/30581795/28854884-b967958a-7763-11e7-9750-11967c2b0d2b.png)
![screenshot_615](https://user-images.githubusercontent.com/30581795/28854890-bd4810c6-7763-11e7-83b1-437caefeee08.png)


[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: d693fffd-5951-473b-b18b-300c134eb557