### PR TITLE
Fixes stealth to have an upper limit.

### DIFF
--- a/website/client-old/js/controllers/tasksCtrl.js
+++ b/website/client-old/js/controllers/tasksCtrl.js
@@ -1,4 +1,4 @@
-"use strict";
+﻿"use strict";
 
 habitrpg.controller("TasksCtrl", ['$scope', '$rootScope', '$location', 'User','Notification', '$http', 'ApiUrl', '$timeout', 'Content', 'Shared', 'Guide', 'Tasks', 'Analytics', '$modal',
   function($scope, $rootScope, $location, User, Notification, $http, ApiUrl, $timeout, Content, Shared, Guide, Tasks, Analytics, $modal) {
@@ -344,8 +344,8 @@ habitrpg.controller("TasksCtrl", ['$scope', '$rootScope', '$location', 'User','N
 
     $scope.spellDisabled = function (skill) {
       if (skill === 'frost' && $scope.user.stats.buffs.streaks) {
-        return true;
-      } else if (skill === 'stealth' && $scope.user.stats.buffs.stealth >= $scope.user.dailys.length) {
+            return true;
+        } else if (skill === 'stealth' && ($scope.user.stats.buffs.stealth >= $scope.user.dailys.length /*0*/ && false|| /*1*/true && $scope.user.stats.buffs.stealth >= $scope.user.dailys.length / 2)) {
         return true;
       }
 
@@ -360,11 +360,26 @@ habitrpg.controller("TasksCtrl", ['$scope', '$rootScope', '$location', 'User','N
       } else if (skill.key === 'stealth' && $scope.spellDisabled(skill.key)) {
         notes = window.env.t('spellRogueStealthMaxedOut');
       } else if (skill.key === 'stealth') {
-        notes = window.env.t('spellRogueStealthDaliesAvoided', { originalText: notes, number: $scope.user.stats.buffs.stealth });
+          if (true)
+              notes = window.env.t('spellRogueStealthDaliesAvoided', { originalText: notes, number: $scope.user.stats.buffs.stealth });
+          else
+              notes = window.env.t('spellRogueStealthDaliesAvoided', { originalText: notes, number: diminishingReturns(user._statsComputed.per * $scope.user.stats.buffs.stealth * 3, countDues() /2, 55)});
       }
 
       return notes;
     };
+    function countDues() {
+        var dues = 0;
+        tasksByType.dailys.forEach((task) => {
+            if (task.isDue)
+                dues++;
+        });
+
+    }
+    function diminishingReturns(bonus, max, halfway) {
+        if (!halfway) halfway = max / 2;
+        return max * (bonus / (bonus + halfway));
+    }
 
     /*
      * Task Details

--- a/website/common/script/content/spells.js
+++ b/website/common/script/content/spells.js
@@ -1,4 +1,4 @@
-import t from './translation';
+﻿import t from './translation';
 import each from 'lodash/each';
 import { NotAuthorized } from '../libs/errors';
 /*
@@ -192,9 +192,21 @@ spells.rogue = {
     lvl: 14,
     target: 'self',
     notes: t('spellRogueStealthNotes'),
-    cast (user) {
-      if (!user.stats.buffs.stealth) user.stats.buffs.stealth = 0;
-      user.stats.buffs.stealth += Math.ceil(diminishingReturns(user._statsComputed.per, user.tasksOrder.dailys.length * 0.64, 55));
+    cast(user) {
+      var type = 1;
+      switch (type) {
+        case 0: //current
+          if (!user.stats.buffs.stealth) user.stats.buffs.stealth = 0;
+          user.stats.buffs.stealth += Math.ceil(diminishingReturns(user._statsComputed.per, user.tasksOrder.dailys.length * 0.64, 55));
+          break;
+        case 1: //TNychka's response
+          if (!user.stats.buffs.stealth) user.stats.buffs.stealth = 0;    
+          user.stats.buffs.stealth += Math.ceil(diminishingReturns(user._statsComputed.per, (user.tasksOrder.dailys.length * 0.5) - user.stats.buffs.stealth, 55));
+        case 2: //my idea- stealth calculates on cron, for the most accurate usage of the number of due dailies
+          if (!user.stats.buffs.stealth) user.stats.buffs.stealth = 0;
+          user.stats.buffs.stealth++;
+          
+      }
     },
   },
 };

--- a/website/server/libs/cron.js
+++ b/website/server/libs/cron.js
@@ -1,4 +1,4 @@
-import moment from 'moment';
+﻿import moment from 'moment';
 import Bluebird from 'bluebird';
 import { model as User } from '../models/user';
 import common from '../../common/';
@@ -258,6 +258,22 @@ export function cron (options = {}) {
   let atLeastOneDailyDue = false; // were any dailies due?
   if (!user.party.quest.progress.down) user.party.quest.progress.down = 0;
 
+  
+  let tasksToEvade;
+  if (true)//cases 0,1- I added it here just so the different versions would be more readable
+      tasksToEvade = user.stats.buffs.stealth;
+  else
+      tasksToEvade = 0;
+  if (false && user.stats.buffs.stealth) { //my idea (case 2)- casts *per = bonus. probably pretty bad, but only code that is placed here can really be limited to a % of the dues
+      var bonus = user._statsComputed.per * (user.stats.buffs.stealth * 3);
+      var dues = 0;
+      tasksByType.dailys.forEach((task) => {
+          if (task.isDue)
+              dues++;
+      });
+      tasksToEvade = Math.ceil(dues / 2 * ((bonus) / (bonus + 55)));
+  }
+
   tasksByType.dailys.forEach((task) => {
     let completed = task.completed;
     // Deduct points for missed Daily tasks
@@ -284,8 +300,8 @@ export function cron (options = {}) {
         if (shouldDo(thatDay.toDate(), task, user.preferences)) {
           atLeastOneDailyDue = true;
           scheduleMisses++;
-          if (user.stats.buffs.stealth) {
-            user.stats.buffs.stealth--;
+          if (tasksToEvade) { //changed to a local var just to make the different versions less tangled
+            tasksToEvade--;
             EvadeTask++;
           }
           if (multiDaysCountAsOneDay) break;


### PR DESCRIPTION
Fixes #5279. I didn't close it so it could be used to discuss it- will change the title if it shuold be.

First of all I'm sorry it took me until not to send a PR, I was in a seminar so I couldn't submit it.

I made 3 versions of it, which is how I refer to it in the code:
0- The current option.
1- TNychka's idea in the comment to #5279.
2- My idea, which uses isDue. I used the number of casts as a perception buff, but it could be used in a similiar way to 1. I think using isDue is a bad idea, because it would be very confusing to players that they get less defense the more dailies they tick. (Also I don't know how the "number of avoided dailies" on mouseHover would be phrased. note- I couldn't get it to show the current number anyway as I didn't understand how to access the daily list).

Here is a desmos graph I made for the different options:
https://www.desmos.com/calculator/txwic7jqaa
s=the number of casts.
h=halfway.
p=perception.
m=the number of dailies.
d=the number of due dailies.

I couldn't get f1 to be a function of s, so just switch the active one when you change s.

From what it seems, the tasks aren't explicitely sorted by difficulty. What are they sorted by then? If not difficulty, isn't it exploitable? (ie the best option is quancky and not what was intended, like deleting tasks and recreating them in order of difficulty, or rearranging them by difficulty).