### PR TITLE
Redesign: Correct issue with "worst" checkboxes

### DIFF
--- a/website/client/assets/scss/task.scss
+++ b/website/client/assets/scss/task.scss
@@ -35,7 +35,7 @@
 
   &-worst {
     background: $maroon-100;
-    
+
     &-color {
       color: darken($maroon-100, 12%);
     }
@@ -46,7 +46,7 @@
 
     &-control-daily-todo {
       background: $maroon-500;
-      background: $maroon-100;
+      color: $maroon-100;
     }
 
     &-modal-input {
@@ -56,7 +56,7 @@
 
   &-worse {
     background: $red-100;
-    
+
     &-color {
       color: darken($red-100, 12%);
     }
@@ -77,7 +77,7 @@
 
   &-bad {
     background: $orange-100;
-    
+
     &-color {
       color: darken($orange-100, 12%);
     }
@@ -98,7 +98,7 @@
 
   &-neutral {
     background: $yellow-100;
-    
+
     &-color {
       color: darken($yellow-100, 12%);
     }
@@ -119,7 +119,7 @@
 
   &-good {
     background: $green-10;
-    
+
     &-color {
       color: darken($green-10, 12%);
     }
@@ -140,7 +140,7 @@
 
   &-better {
     background: $blue-50;
-    
+
     &-color {
       color: darken($blue-50, 12%);
     }
@@ -161,7 +161,7 @@
 
   &-best {
     background: $teal-50;
-    
+
     &-color {
       color: darken($teal-50, 12%);
     }


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes this issue reported by Lemoness on the new client:
> My darkest red tasks are missing the checkbox!

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Fixes an erroneous `background` line in task CSS that was causing the background and foreground colors for checkboxes on "worst" tasks to be identical.

Also incidentally corrects some whitespace issues in the same file.

[//]: # (Put User ID in here - found in Settings -> API)