### PR TITLE
Redesign: Display weekdays in correct order

### DIFF
--- a/website/client/components/tasks/taskModal.vue
+++ b/website/client/components/tasks/taskModal.vue
@@ -76,8 +76,9 @@ form(
         label(v-once) {{ $t('repeatEvery') }}
         input.form-control(type="number", v-model="task.everyX", min="0", required)
         | {{ repeatSuffix }}
+        br
         template(v-if="task.frequency === 'weekly'")
-          .form-check(
+          .form-check-inline.weekday-check(
             v-for="(day, dayNumber) in ['su','m','t','w','th','f','s']",
             :key="dayNumber",
           )
@@ -310,6 +311,11 @@ form(
       .cancel-task-btn {
         color: $blue-10;
       }
+    }
+
+    .weekday-check {
+      margin-left: 0px;
+      width: 57px;
     }
   }
 </style>

--- a/website/client/components/tasks/taskModal.vue
+++ b/website/client/components/tasks/taskModal.vue
@@ -78,7 +78,7 @@ form(
         | {{ repeatSuffix }}
         template(v-if="task.frequency === 'weekly'")
           .form-check(
-            v-for="(day, dayNumber) in dayMapping",
+            v-for="(day, dayNumber) in ['su','m','t','w','th','f','s']",
             :key="dayNumber",
           )
             label.custom-control.custom-checkbox


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes this issue reported by Lemoness in the client redesign:

> All the days of the week are displayed out of order! It’s just a labeling issue, though.

Also addresses this comment from TC:

> These should also be displayed inline and not block.

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

**Previously**, we iterated over the `DAY_MAPPING` object from `constants`, expecting it to be in sorted key order. However, this is not reliable (see the warning in [Vue's documentation for iterating over objects](https://vuejs.org/v2/guide/list.html#Object-v-for)); we ended up with a nonsense sequence of weekdays.

**Now**, we use an inline array with the necessary values in correct index order. We could abstract this to its own constant if needed, though I used this approach due to it being hardcoded on the Angular client (https://github.com/HabitRPG/habitica/blob/develop/website/views/shared/tasks/edit/dailies/repeat_options.jade#L21-L27).

**Previously**, the list of weekdays in the Daily task edit modal used Bootstrap `form-check`, which used block display.

**Now**, this list uses a `form-check-inline` with a bit of custom SCSS to get it to fit nicely on one row.

[//]: # (Put User ID in here - found in Settings -> API)
