### PR TITLE
Redesign: Floor HP/MP/XP values

### DIFF
--- a/website/client/components/memberDetails.vue
+++ b/website/client/components/memberDetails.vue
@@ -17,17 +17,17 @@ div
         .svg-icon(v-html="icons.health")
         .progress
           .progress-bar.bg-health(:style="{width: `${percent(member.stats.hp, MAX_HEALTH)}%`}")
-        span.small-text {{member.stats.hp | round}} / {{MAX_HEALTH}}
+        span.small-text {{member.stats.hp | floor}} / {{MAX_HEALTH}}
       .progress-container.d-flex
         .svg-icon(v-html="icons.experience")
         .progress
           .progress-bar.bg-experience(:style="{width: `${percent(member.stats.exp, toNextLevel)}%`}")
-        span.small-text {{member.stats.exp | round}} / {{toNextLevel}}
+        span.small-text {{member.stats.exp | floor}} / {{toNextLevel}}
       .progress-container.d-flex(v-if="hasClass")
         .svg-icon(v-html="icons.mana")
         .progress
           .progress-bar.bg-mana(:style="{width: `${percent(member.stats.mp, maxMP)}%`}")
-        span.small-text {{member.stats.mp | round}} / {{maxMP}}
+        span.small-text {{member.stats.mp | floor}} / {{maxMP}}
 </template>
 
 <style lang="scss" scoped>
@@ -210,6 +210,11 @@ export default {
         mana: manaIcon,
       }),
     };
+  },
+  filters: {
+    floor (value) {
+      return Math.floor(value);
+    },
   },
   methods: {
     percent,


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes this issue reported by TC regarding the frontend redesign:

> There shouldn’t be decimal points in level bars; they should be rounded down

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

**Previously**, member stat bars used a `round` filter that did not exist.

**Now**, we define and use a `floor` filter to cut off the decimal places from these values in display.

[//]: # (Put User ID in here - found in Settings -> API)