### PR TITLE
add an Earnable Quests group for Basi-List and Dust Bunnnies (new client fix)

### DIFF
--- a/website/common/locales/en/questsContent.json
+++ b/website/common/locales/en/questsContent.json
@@ -68,7 +68,7 @@
   "questSpiderDropSpiderEgg": "Spider (Egg)",
   "questSpiderUnlockText": "Unlocks purchasable Spider eggs in the Market",
 
-  "questGroupVice": "Vice",
+  "questGroupVice": "Vice the Shadow Wyrm",
   "questVice1Text": "Vice, Part 1: Free Yourself of the Dragon's Influence",
   "questVice1Notes": "<p>They say there lies a terrible evil in the caverns of Mt. Habitica. A monster whose presence twists the wills of the strong heroes of the land, turning them towards bad habits and laziness! The beast is a grand dragon of immense power and comprised of the shadows themselves: Vice, the treacherous Shadow Wyrm. Brave Habiteers, stand up and defeat this foul beast once and for all, but only if you believe you can stand against its immense power. </p><h3>Vice Part 1: </h3><p>How can you expect to fight the beast if it already has control over you? Don't fall victim to laziness and vice! Work hard to fight against the dragon's dark influence and dispel his hold on you!</p>",
   "questVice1Boss": "Vice's Shade",
@@ -87,7 +87,7 @@
   "questVice3DropDragonEgg": "Dragon (Egg)",
   "questVice3DropShadeHatchingPotion": "Shade Hatching Potion",
 
-  "questGroupMoonstone": "Recidivate",
+  "questGroupMoonstone": "Recidivate Rising",
   "questMoonstone1Text": "Recidivate, Part 1: The Moonstone Chain",
   "questMoonstone1Notes": "A terrible affliction has struck Habiticans. Bad Habits thought long-dead are rising back up with a vengeance. Dishes lie unwashed, textbooks linger unread, and procrastination runs rampant!<br><br>You track some of your own returning Bad Habits to the Swamps of Stagnation and discover the culprit: the ghostly Necromancer, Recidivate. You rush in, weapons swinging, but they slide through her specter uselessly.<br><br>\"Don’t bother,\" she hisses with a dry rasp. \"Without a chain of moonstones, nothing can harm me – and master jeweler @aurakami scattered all the moonstones across Habitica long ago!\" Panting, you retreat... but you know what you must do.",
   "questMoonstone1CollectMoonstone": "Moonstones",

--- a/website/common/locales/en/questsContent.json
+++ b/website/common/locales/en/questsContent.json
@@ -124,6 +124,7 @@
   "questGoldenknight3DropGoldenPotion": "Golden Hatching Potion",
   "questGoldenknight3DropWeapon": "Mustaine's Milestone Mashing Morning Star (Shield-hand Weapon)",
 
+  "questGroupEarnable": "Earnable Quests",
   "questBasilistText": "The Basi-List",
   "questBasilistNotes": "There's a commotion in the marketplace--the kind that should make you run away. Being a courageous adventurer, you run towards it instead, and discover a Basi-list, coalescing from a clump of incomplete To-Dos! Nearby Habiticans are paralyzed with fear at the length of the Basi-list, unable to start working. From somewhere in the vicinity, you hear @Arcosine shout: \"Quick! Complete your To-Dos and Dailies to defang the monster, before someone gets a paper cut!\" Strike fast, adventurer, and check something off - but beware! If you leave any Dailies undone, the Basi-list will attack you and your party!",
   "questBasilistCompletion": "The Basi-list has scattered into paper scraps, which shimmer gently in rainbow colors. \"Whew!\" says @Arcosine. \"Good thing you guys were here!\" Feeling more experienced than before, you gather up some fallen gold from among the papers.",

--- a/website/common/script/content/quests.js
+++ b/website/common/script/content/quests.js
@@ -1054,6 +1054,7 @@ let quests = {
   basilist: {
     text: t('questBasilistText'),
     notes: t('questBasilistNotes'),
+    group: 'questGroupEarnable',
     completion: t('questBasilistCompletion'),
     value: 4,
     category: 'unlockable',
@@ -2224,6 +2225,7 @@ let quests = {
   dustbunnies: {
     text: t('questDustBunniesText'),
     notes: t('questDustBunniesNotes'),
+    group: 'questGroupEarnable',
     completion: t('questDustBunniesCompletion'),
     value: 4,
     category: 'unlockable',


### PR DESCRIPTION
This modifies `website/common/script/content/quests.js` to allow Basi-List and Dust Bunnies to be automatically placed in their own group on the Quests Shop page in the new client. I.e., it fixes this bug from our testing doc:

![image](https://user-images.githubusercontent.com/1495809/29349118-6282f9ba-829b-11e7-9ba2-25eb1faef64b.png)

Like so:

![image](https://user-images.githubusercontent.com/1495809/29349523-d750b172-829d-11e7-8c02-7af631dabd6b.png)

It doesn't seem to have any effect on the old client:

![image](https://user-images.githubusercontent.com/1495809/29349130-7369e4c8-829b-11e7-92d7-3ea24da30658.png)


@vIiRuS Will this have a negative effect on either of the mobile apps?