### PR TITLE
new and old client: change text for skills, avatar transformation buffs, and antidotes

### DIFF
--- a/website/common/locales/en/spells.json
+++ b/website/common/locales/en/spells.json
@@ -1,75 +1,75 @@
 {
   "spellWizardFireballText": "Burst of Flames",
-  "spellWizardFireballNotes": "Flames burst from your hands. You gain XP, and you deal extra damage to Bosses! Click on a task to cast. (Based on: INT)",
+  "spellWizardFireballNotes": "You summon XP and deal fiery damage to Bosses! (Based on: INT)",
 
   "spellWizardMPHealText": "Ethereal Surge",
-  "spellWizardMPHealNotes": "You sacrifice mana to help your friends. The rest of your party gains MP! (Based on: INT)",
+  "spellWizardMPHealNotes": "You sacrifice mana so the rest of your Party gains MP! (Based on: INT)",
 
   "spellWizardEarthText": "Earthquake",
-  "spellWizardEarthNotes": "Your mental power shakes the earth. Your whole party gains a buff to Intelligence! (Based on: Unbuffed INT)",
+  "spellWizardEarthNotes": "Your mental power shakes the earth and buffs your Party's Intelligence! (Based on: Unbuffed INT)",
 
   "spellWizardFrostText": "Chilling Frost",
-  "spellWizardFrostNotes": "Ice covers your tasks. None of your streaks will reset to zero tomorrow! (One cast affects all streaks.)",
+  "spellWizardFrostNotes": "With one cast, ice freezes all your streaks so they won't reset to zero tomorrow! ",
   "spellWizardFrostAlreadyCast": " You have already cast this today. Your streaks are frozen, and there's no need to cast this again.",
 
 
   "spellWarriorSmashText": "Brutal Smash",
-  "spellWarriorSmashNotes": "You hit a task with all of your might. It gets more blue/less red, and you deal extra damage to Bosses! Click on a task to cast. (Based on: STR)",
+  "spellWarriorSmashNotes": "You make a task more blue/less red to deal extra damage to Bosses! (Based on: STR)",
 
   "spellWarriorDefensiveStanceText": "Defensive Stance",
-  "spellWarriorDefensiveStanceNotes": "You prepare yourself for the onslaught of your tasks. You gain a buff to Constitution! (Based on: Unbuffed CON)",
+  "spellWarriorDefensiveStanceNotes": "You crouch low and gain a buff to Constitution! (Based on: Unbuffed CON)",
 
   "spellWarriorValorousPresenceText": "Valorous Presence",
-  "spellWarriorValorousPresenceNotes": "Your presence emboldens your party. Your whole party gains a buff to Strength! (Based on: Unbuffed STR)",
+  "spellWarriorValorousPresenceNotes": "Your boldness buffs your whole Party's Strength! (Based on: Unbuffed STR)",
 
   "spellWarriorIntimidateText": "Intimidating Gaze",
-  "spellWarriorIntimidateNotes": "Your gaze strikes fear into your enemies. Your whole party gains a buff to Constitution! (Based on: Unbuffed CON)",
+  "spellWarriorIntimidateNotes": "Your fierce stare buffs your whole Party's Constitution! (Based on: Unbuffed CON)",
 
   "spellRoguePickPocketText": "Pickpocket",
-  "spellRoguePickPocketNotes": "You rob a nearby task. You gain gold! Click on a task to cast. (Based on: PER)",
+  "spellRoguePickPocketNotes": "You rob a nearby task and gain gold! (Based on: PER)",
 
   "spellRogueBackStabText": "Backstab",
-  "spellRogueBackStabNotes": "You betray a foolish task. You gain gold and XP! Click on a task to cast. (Based on: STR)",
+  "spellRogueBackStabNotes": "You betray a foolish task and gain gold and XP! (Based on: STR)",
 
   "spellRogueToolsOfTradeText": "Tools of the Trade",
-  "spellRogueToolsOfTradeNotes": "You share your talents with friends. Your whole party gains a buff to Perception! (Based on: Unbuffed PER)",
+  "spellRogueToolsOfTradeNotes": "Your tricky talents buff your whole Party's Perception! (Based on: Unbuffed PER)",
 
   "spellRogueStealthText": "Stealth",
-  "spellRogueStealthNotes": "You are too sneaky to spot. Some of your undone Dailies will not cause damage tonight, and their streaks/color will not change. (Cast multiple times to affect more Dailies. Based on: PER)",
+  "spellRogueStealthNotes": "With each cast, a few of your undone Dailies won't cause damage tonight. Their streaks and colors won't change. (Based on: PER)",
   "spellRogueStealthDaliesAvoided": "<%= originalText %> Number of dailies avoided: <%= number %>.",
   "spellRogueStealthMaxedOut": " You have already avoided all your dailies; there's no need to cast this again.",
 
   "spellHealerHealText": "Healing Light",
-  "spellHealerHealNotes": "Light covers your body, healing your wounds. You regain health! (Based on: CON and INT)",
+  "spellHealerHealNotes": "Shining light restores your health! (Based on: CON and INT)",
 
   "spellHealerBrightnessText": "Searing Brightness",
-  "spellHealerBrightnessNotes": "A burst of light dazzles your tasks. They become more blue and less red! (Based on: INT)",
+  "spellHealerBrightnessNotes": "A burst of light makes your tasks more blue/less red! (Based on: INT)",
 
   "spellHealerProtectAuraText": "Protective Aura",
-  "spellHealerProtectAuraNotes": "You shield your party from damage. Your whole party gains a buff to Constitution! (Based on: Unbuffed CON)",
+  "spellHealerProtectAuraNotes": "You shield your Party by buffing their Constitution! (Based on: Unbuffed CON)",
 
   "spellHealerHealAllText": "Blessing",
-  "spellHealerHealAllNotes": "A soothing aura surrounds you. Your whole party regains health! (Based on: CON and INT)",
+  "spellHealerHealAllNotes": "Your soothing spell restores your whole Party?s health! (Based on: CON and INT)",
 
   "spellSpecialSnowballAuraText": "Snowball",
-  "spellSpecialSnowballAuraNotes": "Throw a snowball at a party member! What could possibly go wrong? Lasts until member's new day.",
+  "spellSpecialSnowballAuraNotes": "Turn a friend into a frosty snowman!",
   "spellSpecialSaltText": "Salt",
-  "spellSpecialSaltNotes": "Someone has snowballed you. Ha ha, very funny. Now get this snow off me!",
+  "spellSpecialSaltNotes": "Reverse the spell that made you a snowman.",
 
   "spellSpecialSpookySparklesText": "Spooky Sparkles",
-  "spellSpecialSpookySparklesNotes": "Turn a friend into a floating blanket with eyes!",
+  "spellSpecialSpookySparklesNotes": "Turn your friend into a transparent pal!",
   "spellSpecialOpaquePotionText": "Opaque Potion",
-  "spellSpecialOpaquePotionNotes": "Cancel the effects of Spooky Sparkles.",
+  "spellSpecialOpaquePotionNotes": "Reverse the spell that made you transparent.",
 
   "spellSpecialShinySeedText": "Shiny Seed",
   "spellSpecialShinySeedNotes": "Turn a friend into a joyous flower!",
   "spellSpecialPetalFreePotionText": "Petal-Free Potion",
-  "spellSpecialPetalFreePotionNotes": "Cancel the effects of a Shiny Seed.",
+  "spellSpecialPetalFreePotionNotes": "Reverse the spell that made you a flower.",
 
   "spellSpecialSeafoamText": "Seafoam",
   "spellSpecialSeafoamNotes": "Turn a friend into a sea creature!",
   "spellSpecialSandText": "Sand",
-  "spellSpecialSandNotes": "Cancel the effects of Seafoam.",
+  "spellSpecialSandNotes": "Reverse the spell that made you a sea star.",
 
   "spellNotFound": "Skill \"<%= spellId %>\" not found.",
   "partyNotFound": "Party not found",

--- a/website/common/locales/en/spells.json
+++ b/website/common/locales/en/spells.json
@@ -35,7 +35,7 @@
   "spellRogueToolsOfTradeNotes": "Your tricky talents buff your whole Party's Perception! (Based on: Unbuffed PER)",
 
   "spellRogueStealthText": "Stealth",
-  "spellRogueStealthNotes": "With each cast, a few of your undone Dailies won't cause damage tonight. Their streaks and colors won't change. (Based on: PER)",
+  "spellRogueStealthNotes": "With each cast, a few of your undone Dailies won't cause damage tonight. Their streaks and colors won't change.",
   "spellRogueStealthDaliesAvoided": "<%= originalText %> Number of dailies avoided: <%= number %>.",
   "spellRogueStealthMaxedOut": " You have already avoided all your dailies; there's no need to cast this again.",
 
@@ -49,7 +49,7 @@
   "spellHealerProtectAuraNotes": "You shield your Party by buffing their Constitution! (Based on: Unbuffed CON)",
 
   "spellHealerHealAllText": "Blessing",
-  "spellHealerHealAllNotes": "Your soothing spell restores your whole Party?s health! (Based on: CON and INT)",
+  "spellHealerHealAllNotes": "Your soothing spell restores your whole Party's health! (Based on: CON and INT)",
 
   "spellSpecialSnowballAuraText": "Snowball",
   "spellSpecialSnowballAuraNotes": "Turn a friend into a frosty snowman!",


### PR DESCRIPTION
For both  the new and old websites, change the text for skills, avatar transformation buffs, and buff antidotes, as requested by Lemoness.