### PR TITLE
new client - various fixes: Earnable Quests removed, equipment type names and sort order changed

### DIFF
--- a/website/client/components/inventory/equipment/index.vue
+++ b/website/client/components/inventory/equipment/index.vue
@@ -183,12 +183,12 @@ export default {
       costume: false,
       groupBy: 'type', // or 'class'
       gearTypesToStrings: Object.freeze({ // TODO use content.itemList?
-        headAccessory: i18n.t('headAccessoryCapitalized'),
-        head: i18n.t('headgearCapitalized'),
-        eyewear: i18n.t('eyewear'),
         weapon: i18n.t('weaponCapitalized'),
         shield: i18n.t('offhandCapitalized'),
+        head: i18n.t('headgearCapitalized'),
         armor: i18n.t('armorCapitalized'),
+        headAccessory: i18n.t('headAccessoryCapitalized'),
+        eyewear: i18n.t('eyewear'),
         body: i18n.t('body'),
         back: i18n.t('back'),
       }),

--- a/website/client/components/shops/quests/index.vue
+++ b/website/client/components/shops/quests/index.vue
@@ -122,7 +122,7 @@
                 )
 
         div.grouped-parent(v-else-if="category.identifier === 'unlockable' || category.identifier === 'gold'")
-          div.group(v-for="(items, key) in getGrouped(questItems(category, selectedSortItemsBy, searchTextThrottled, hideLocked, hidePinned))")
+          div.group(v-for="(items, key) in getGrouped(questItems(category, selectedSortItemsBy, searchTextThrottled, hideLocked, hidePinned))", v-if="key !== 'questGroupEarnable'")
             h3 {{ $t(key) }}
             div.items
               shopItem(

--- a/website/common/locales/en/gear.json
+++ b/website/common/locales/en/gear.json
@@ -6,7 +6,7 @@
   "classBonus": "(This item matches your class, so it gets an additional 1.5 stat multiplier.)",
 
   "weapon": "weapon",
-  "weaponCapitalized" : "Weapon",
+  "weaponCapitalized" : "Main-Hand Item",
 
   "weaponBase0Text": "No Weapon",
   "weaponBase0Notes": "No Weapon.",
@@ -665,9 +665,9 @@
   "armorArmoireYellowPartyDressNotes": "You're perceptive, strong, smart, and so fashionable! Increases Perception, Strength, and Intelligence by <%= attrs %> each. Enchanted Armoire: Yellow Hairbow Set (Item 2 of 2).",
 
   "headgear": "helm",
-  "headgearCapitalized": "Helm",
+  "headgearCapitalized": "Headgear",
 
-  "headBase0Text": "No Helm",
+  "headBase0Text": "No Headgear",
   "headBase0Notes": "No headgear.",
 
   "headWarrior1Text": "Leather Helm",
@@ -1038,7 +1038,7 @@
   "headArmoireAntiProcrastinationHelmNotes": "This mighty steel helm will help you win the fight to be healthy, happy, and productive! Increases Perception by <%= per %>. Enchanted Armoire: Anti-Procrastination Set (Item 1 of 3).",
 
   "offhand": "shield-hand item",
-  "offhandCapitalized": "Shield-Hand Item",
+  "offhandCapitalized": "Off-Hand Item",
 
   "shieldBase0Text": "No Shield-Hand Equipment",
   "shieldBase0Notes": "No shield or shield-hand item.",


### PR DESCRIPTION
Various fixes for the new client (other commits will be added).

- Removes Earnable Quests from Quests Shop because there's currently no easy/neat way to explain how you can buy them. NB We don't have approval from Lemoness/designers for this approach but it's a tier 1 issue.
![image](https://user-images.githubusercontent.com/1495809/29546344-3688f27e-8737-11e7-84c1-82a2894144a4.png)
- Changes name of some equipment types and changes sort order:
![img](http://i.imgur.com/64D5jEk.png)

Regarding the renaming of the equipment types:
The `...Capitalized` strings all have lower-case versions (e.g., "weapon" and "weaponCapitalized"). I suspect we should change or get rid of the uncapitalized version but I'm not sure what other effects that might have (e.g., haven't searched for exactly where it's used; don't know what it would do to the mobile apps). I suggest looking into that after launch. If the old, uncapitalized strings are noticed elsewhere during our site testing, we should probably change them to the Capitalized version then, or if lowercase is essential, create new strings (e.g., "weaponUncapitalized" - that will be much easier to search for than just "weapon" for future code changes when we want to know where it's used).

