### PR TITLE
new client: fix warning: "component lists rendered with v-for should have explicit keys"

### DIFF
--- a/website/client/components/snackbars/notifications.vue
+++ b/website/client/components/snackbars/notifications.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 .notifications
-  notification(v-for='notification in notifications', :notification='notification')
+  notification(v-for='notification in notifications', :notification='notification', :key='notification.id')
 </template>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
My local install has been outputting the warning below for a couple of days. This PR prevents the warning but I don't know if this is the best way to do it so feel free to close if it's not, or tell me how to fix it better.

```
WARNING in ./~/vue-loader/lib/template-compiler?{"id":"data-v-78f7211c"}!./~/vue-loader/lib/template-compiler/preprocessor.js?raw&engine=pug!./~/vue-loader/lib/selector.js?type=template&index=0!./website/client/components/snackbars/notifications.vue
(Emitted value instead of an instance of Error) <notification v-for="notification in notifications">: component lists rendered with v-for should have explicit keys. See https://vuejs.org/guide/list.html#key for more info.
 @ ./website/client/components/snackbars/notifications.vue 9:2-284
 @ ./~/babel-loader/lib!./~/vue-loader/lib/selector.js?type=script&index=0!./website/client/app.vue
 @ ./website/client/app.vue
 @ ./website/client/main.js
 @ multi ./webpack/dev-client ./website/client/main.js
```