### PR TITLE
Redesign: Sabe fixes 8/29

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "vue-router": "^2.0.0-rc.5",
     "vue-style-loader": "^3.0.0",
     "vue-template-compiler": "^2.1.10",
-    "vuejs-datepicker": "^0.9.4",
+    "vuejs-datepicker": "habitrpg/vuejs-datepicker#v0.9.12",
     "webpack": "^2.2.1",
     "webpack-merge": "^4.0.0",
     "winston": "^2.1.0",

--- a/website/client/components/tasks/taskModal.vue
+++ b/website/client/components/tasks/taskModal.vue
@@ -69,10 +69,24 @@
               .option-item-label(v-once) {{ $t('hard') }}
         .option(v-if="task.type === 'todo'")
           label(v-once) {{ $t('dueDate') }}
-          datepicker(v-model="task.date")
+          datepicker(
+            v-model="task.date",
+            :clearButton='true',
+            clearButtonIcon='category-select',
+            :clearButtonText='$t("clear")',
+            :todayButton='true',
+            todayButtonIcon='category-select',
+            :todayButtonText='$t("today")',
+          )
         .option(v-if="task.type === 'daily'")
           label(v-once) {{ $t('startDate') }}
-          datepicker(v-model="task.startDate")
+          datepicker(
+            v-model="task.startDate",
+            :clearButton='false',
+            :todayButton='true',
+            todayButtonIcon='category-select',
+            :todayButtonText='$t("today")',
+          )
         .option(v-if="task.type === 'daily'")
           .form-group
             label(v-once) {{ $t('repeats') }}


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes this comment in the issues doc:

>SL: In Due dates, we’re missing the “today” button that lets you set the due date as today, as well as the button that lets you delete a due date. [tier 1]

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

**Previously**, we did not include a Clear button or a Today button in our date picker component.
**Now**,  we use a modified version of the vuejs-datepicker module that includes these features.

[//]: # (Put User ID in here - found in Settings -> API)
