### PR TITLE
new client: allow on-hover text to work for all achievements

### DIFF
--- a/website/client/components/userMenu/profile.vue
+++ b/website/client/components/userMenu/profile.vue
@@ -94,9 +94,9 @@ div
       .row(v-for='(category, key) in achievements')
         h2.col-12.text-center {{ $t(key+'Achievs') }}
         .col-3.text-center(v-for='(achievement, key) in category.achievements')
-          .box.achievement-container(:id='key', :class='{"achievement-unearned": !achievement.earned}')
+          .box.achievement-container(:id='`achievmt-${key}`', :class='{"achievement-unearned": !achievement.earned}')
             b-popover(
-              :target="'#' + key",
+              :target="'#achievmt-' + key",
               triggers="hover",
               placement="top",
             )


### PR DESCRIPTION
Fixes this item from the testing doc:

**Tester (Chrome OS):   Some achievement hovertexts don't show (streaks, rebirths) [Tier 2a]**

The problem was that the achievements were using their keys as HTML id attributes and some keys were already in use as ids for other elements (`streak` and `rebirth`). This stopped the on-hover effect from triggering.