### PR TITLE
sep 25 fixes

### DIFF
--- a/website/client/components/inventory/equipment/attributesPopover.vue
+++ b/website/client/components/inventory/equipment/attributesPopover.vue
@@ -2,7 +2,7 @@
 div
   h4.popover-content-title {{ itemText }}
   .popover-content-text {{ itemNotes }}
-  .popover-content-attr(v-for="attr in ATTRIBUTES", :key="attr", v-once)
+  .popover-content-attr(v-for="attr in ATTRIBUTES", :key="attr")
     span.popover-content-attr-key {{ `${$t(attr)}: ` }}
     span.popover-content-attr-val {{ `+${item[attr]}` }}
 </template>

--- a/website/client/components/inventory/equipment/index.vue
+++ b/website/client/components/inventory/equipment/index.vue
@@ -68,12 +68,13 @@
       .items.items-one-line(slot="drawer-slider")
         item.pointer(
           v-for="(label, group) in gearTypesToStrings",
-          :key="group",
+          :key="flatGear[activeItems[group]] ? flatGear[activeItems[group]].key : group",
           :item="flatGear[activeItems[group]]",
           :itemContentClass="flatGear[activeItems[group]] ? 'shop_' + flatGear[activeItems[group]].key : null",
           :emptyItem="!flatGear[activeItems[group]] || flatGear[activeItems[group]].key.indexOf('_base_0') !== -1",
           :label="label",
           :popoverPosition="'top'",
+          :showPopover="flatGear[activeItems[group]] && Boolean(flatGear[activeItems[group]].text)",
           @click="equipItem(flatGear[activeItems[group]])",
         )
           template(slot="popoverContent", scope="context")

--- a/website/client/components/inventory/items/index.vue
+++ b/website/client/components/inventory/items/index.vue
@@ -201,6 +201,7 @@ import QuestInfo from '../../shops/quests/questInfo.vue';
 import moment from 'moment';
 
 const allowedSpecialItems = ['snowball', 'spookySparkles', 'shinySeed', 'seafoam'];
+
 import notifications from 'client/mixins/notifications';
 import DragDropDirective from 'client/directives/dragdrop.directive';
 import MouseMoveDirective from 'client/directives/mouseposition.directive';
@@ -444,8 +445,9 @@ export default {
 
     mouseMoved ($event) {
       if (this.potionClickMode) {
-        this.$refs.clickPotionInfo.style.left = `${$event.x + 20}px`;
-        this.$refs.clickPotionInfo.style.top = `${$event.y + 20}px`;
+        // dragging potioninfo is 180px wide (90 would be centered)
+        this.$refs.clickPotionInfo.style.left = `${$event.x - 70}px`;
+        this.$refs.clickPotionInfo.style.top = `${$event.y}px`;
       } else {
         lastMouseMoveEvent = $event;
       }

--- a/website/client/components/inventory/stable/index.vue
+++ b/website/client/components/inventory/stable/index.vue
@@ -451,7 +451,7 @@
 
     .popover {
       position: inherit;
-      width: 100px;
+      width: 180px;
     }
 
     .popover-content {
@@ -971,8 +971,8 @@
 
       mouseMoved ($event) {
         if (this.foodClickMode) {
-          this.$refs.clickFoodInfo.style.left = `${$event.x + 20}px`;
-          this.$refs.clickFoodInfo.style.top = `${$event.y + 20}px`;
+          this.$refs.clickFoodInfo.style.left = `${$event.x - 70}px`;
+          this.$refs.clickFoodInfo.style.top = `${$event.y}px`;
         } else {
           lastMouseMoveEvent = $event;
         }

--- a/website/common/script/ops/changeClass.js
+++ b/website/common/script/ops/changeClass.js
@@ -7,7 +7,7 @@ import {
   NotAuthorized,
   BadRequest,
 } from '../libs/errors';
-import { removePinnedGearByClass, addPinnedGearByClass } from './pinnedGearUtils';
+import { removePinnedGearByClass, removePinnedItemsByOwnedGear, addPinnedGearByClass } from './pinnedGearUtils';
 
 function resetClass (user, req = {}) {
   removePinnedGearByClass(user);
@@ -48,6 +48,8 @@ module.exports = function changeClass (user, req = {}, analytics) {
 
     user.items.gear.owned[`weapon_${klass}_0`] = true;
     if (klass === 'rogue')  user.items.gear.owned[`shield_${klass}_0`] = true;
+
+    removePinnedItemsByOwnedGear(user);
 
     if (analytics) {
       analytics.track('change class', {

--- a/website/common/script/ops/pinnedGearUtils.js
+++ b/website/common/script/ops/pinnedGearUtils.js
@@ -105,6 +105,18 @@ function removePinnedGearAddPossibleNewOnes (user, itemPath, newItemKey) {
 }
 
 /**
+ * removes all pinned gear that the user already owns (like class starter gear which has been pinned before)
+ * @param user
+ */
+function removePinnedItemsByOwnedGear (user) {
+  each(user.items.gear.owned, (bool, key) => {
+    if (bool) {
+      removeItemByPath(user, `gear.flat.${key}`);
+    }
+  });
+}
+
+/**
  * @returns {boolean} TRUE added the item / FALSE removed it
  */
 function togglePinnedItem (user, {item, type, path}, req = {}) {
@@ -150,6 +162,7 @@ module.exports = {
   addPinnedGear,
   removePinnedGearByClass,
   removePinnedGearAddPossibleNewOnes,
+  removePinnedItemsByOwnedGear,
   togglePinnedItem,
   removeItemByPath,
   isPinned,


### PR DESCRIPTION
there are multiple popovers that just won't hide, example: 
- the equipment gear drawer, once you unpin an item the popover stays active 
- or if you open the `What does my pet like to eat? 
` popover & hide the drawer in the stable the popover stays active.

there is an update of `bootstrap-vue` but if we upgrade it could break a lot of our code again ...

what do you think - upgrade the package or do you have a better idea / fix for this?

@paglias  @TheHollidayInn 
