### PR TITLE
Add support for `multiDaysCountAsOneDay == false` to evasion

### DIFF
--- a/website/server/libs/cron.js
+++ b/website/server/libs/cron.js
@@ -321,8 +321,8 @@ export function cron (options = {}) {
             user.stats.buffs.stealth--;
             EvadeTask++;
           }
-          if (multiDaysCountAsOneDay) break;
         }
+        if (multiDaysCountAsOneDay) break;
       }
 
       if (scheduleMisses > EvadeTask) {

--- a/website/server/libs/cron.js
+++ b/website/server/libs/cron.js
@@ -301,10 +301,6 @@ export function cron (options = {}) {
     let EvadeTask = 0;
     let scheduleMisses = daysMissed;
 
-    // Only check one day back
-    let dailiesDaysMissed = daysMissed;
-    if (dailiesDaysMissed > 1) dailiesDaysMissed = 1;
-
     if (completed) {
       dailyChecked += 1;
       if (!atLeastOneDailyDue) { // only bother checking until the first thing is found
@@ -315,7 +311,7 @@ export function cron (options = {}) {
       // dailys repeat, so need to calculate how many they've missed according to their own schedule
       scheduleMisses = 0;
 
-      for (let i = 0; i < dailiesDaysMissed; i++) {
+      for (let i = 0; i < daysMissed; i++) {
         let thatDay = moment(now).subtract({days: i + 1});
 
         if (shouldDo(thatDay.toDate(), task, user.preferences)) {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
There is no corresponding issue.  I found this bug while reading the cron code.

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

`if (dailiesDaysMissed > 1) dailiesDaysMissed = 1;` causes the evasion for-loop to only evaluate once even if `multiDaysCountAsOneDay == false`.  This statement isn't necessary because `if (multiDaysCountAsOneDay) break;` will cause the for-loop to evaluate only once if `multiDaysCountAsOneDay == true`.  Removing this statement makes the `dailiesDaysMissed` variable unnecessary.

[//]: # (Put User ID in here - found in Settings -> API)

----
UUID:  5c08b0b0-dfc9-4bdb-b02a-b1d735bab587
