### PR TITLE
Redesign: Fixes 09/26

### DIFF
--- a/website/client/components/avatar.vue
+++ b/website/client/components/avatar.vue
@@ -18,8 +18,8 @@
       span(:class="'chair_' + member.preferences.chair")
       span(:class="getGearClass('back')")
       span(:class="skinClass")
-      span.head_0
       span(:class="member.preferences.size + '_shirt_' + member.preferences.shirt")
+      span.head_0
       span(:class="member.preferences.size + '_' + getGearClass('armor')")
       span(:class="getGearClass('back_collar')")
       span(:class="getGearClass('body')")

--- a/website/client/components/challenges/challengeDetail.vue
+++ b/website/client/components/challenges/challengeDetail.vue
@@ -7,7 +7,7 @@
   .col-8.standard-page
     .row
       .col-8
-        h1 {{challenge.name}}
+        h1(v-markdown='challenge.name')
         div
           strong(v-once) {{$t('createdBy')}}:
           span {{challenge.leader.profile.name}}

--- a/website/common/locales/en/front.json
+++ b/website/common/locales/en/front.json
@@ -284,7 +284,7 @@
   "alreadyHaveAccountLogin": "Already have a Habitica account? <strong>Log in.</strong>",
   "dontHaveAccountSignup": "Don’t have a Habitica account? <strong>Sign up.</strong>",
   "motivateYourself": "Motivate yourself to achieve your goals.",
-  "timeToGetThingsDone": "It's time to have fun when you get things done! Join over 2 million Habiticans and improve your life one task at a time.",
+  "timeToGetThingsDone": "It's time to have fun when you get things done! Join over 2.5 million Habiticans and improve your life one task at a time.",
   "singUpForFree": "Sign Up For Free",
   "or": "OR",
   "gamifyYourLife": "Gamify Your Life",


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes these issues on the Vue client reported by @lemoness:

> SL: The avatars in chat and in the header appear to be missing their head outlines, or perhaps it’s on the wrong layer. Compare these two avatars below. [tier 2a]
> on the prod front page it says we have 2.5 million users, but on staging it says "Join over 2 million Habiticans"
> Another good thing to tackle -- making markdown work in Challenge titles

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

**Previously**, the `head_0` layer was accidentally placed one layer too deep.
**Now**, it is correctly situated so it is visible above the shirt.

**Previously**, front page copy referenced 2 million users.
**Now**, it correctly boasts 2.5 million.

**Previously**, Challenge titles did not parse Markdown.
**Now**, they do.

[//]: # (Put User ID in here - found in Settings -> API)