### PR TITLE
fix link to Data Display Tool

### DIFF
--- a/website/client/components/settings/api.vue
+++ b/website/client/components/settings/api.vue
@@ -23,7 +23,7 @@
           br
           | {{ $t('chromeChatExtensionDesc') }}
         li
-          a(target='_blank' :href='`http://data.habitrpg.com?uuid= + user._id`') {{ $t('dataTool') }}
+          a(target='_blank' :href='`https://oldgods.net/habitica/habitrpg_user_data_display.html?uuid=` + user._id') {{ $t('dataTool') }}
           br
           | {{ $t('dataToolDesc') }}
         li(v-html="$t('otherExtensions')")


### PR DESCRIPTION
This fixes the insertion of the user.id into the DDT link, which had been broken.

I've already replaced the data.habitrpg.com domain name wiith a direct link since that domain is outdated anyway. We can put back a habitica domain later if desired.