### PR TITLE
Various fixes:  mods can delete any message; no Report / CopyAsTodo button in inbox; etc

### DIFF
--- a/website/client/components/appFooter.vue
+++ b/website/client/components/appFooter.vue
@@ -55,7 +55,7 @@
               li
                 a(href='/apidoc', target='_blank') {{ $t('APIv3') }}
               li
-                a(href='http://data.habitrpg.com/?uuid=', target='_blank') {{ $t('dataDisplayTool') }}
+                a(href='https://oldgods.net/habitrpg/habitrpg_user_data_display.html', target='_blank') {{ $t('dataDisplayTool') }}
               li
                 a(href='http://habitica.wikia.com/wiki/Guidance_for_Blacksmiths', target='_blank') {{ $t('guidanceForBlacksmiths') }}
               li

--- a/website/client/components/chat/chatMessages.vue
+++ b/website/client/components/chat/chatMessages.vue
@@ -36,9 +36,10 @@
               .svg-icon(v-html="icons.like")
               span(v-if='!msg.likes[user._id]') {{ $t('like') }}
               span(v-if='msg.likes[user._id]') {{ $t('liked') }}
-            span.action( @click='copyAsTodo(msg)')
+            span.action(v-if='!inbox', @click='copyAsTodo(msg)')
               .svg-icon(v-html="icons.copy")
               | {{$t('copyAsTodo')}}
+              // @TODO make copyAsTodo work in the inbox
             span.action(v-if='user.contributor.admin || (msg.uuid !== user._id && user.flags.communityGuidelinesAccepted)', @click='report(msg)')
               .svg-icon(v-html="icons.report")
               | {{$t('report')}}
@@ -70,9 +71,10 @@
               .svg-icon(v-html="icons.like")
               span(v-if='!msg.likes[user._id]') {{ $t('like') }}
               span(v-if='msg.likes[user._id]') {{ $t('liked') }}
-            span.action( @click='copyAsTodo(msg)')
+            span.action(v-if='!inbox', @click='copyAsTodo(msg)')
               .svg-icon(v-html="icons.copy")
               | {{$t('copyAsTodo')}}
+              // @TODO make copyAsTodo work in the inbox
             span.action(v-if='user.flags.communityGuidelinesAccepted', @click='report(msg)')
               .svg-icon(v-html="icons.report")
               | {{$t('report')}}

--- a/website/client/components/chat/chatMessages.vue
+++ b/website/client/components/chat/chatMessages.vue
@@ -40,9 +40,10 @@
               .svg-icon(v-html="icons.copy")
               | {{$t('copyAsTodo')}}
               // @TODO make copyAsTodo work in the inbox
-            span.action(v-if='user.contributor.admin || (msg.uuid !== user._id && user.flags.communityGuidelinesAccepted)', @click='report(msg)')
+            span.action(v-if='!inbox && user.flags.communityGuidelinesAccepted', @click='report(msg)')
               .svg-icon(v-html="icons.report")
               | {{$t('report')}}
+              // @TODO make flagging/reporting work in the inbox. NOTE: it must work even if the communityGuidelines are not accepted and it MUST work for messages that you have SENT as well as received. -- Alys
             span.action(v-if='msg.uuid === user._id || inbox || user.contributor.admin', @click='remove(msg, index)')
               .svg-icon(v-html="icons.delete")
               | {{$t('delete')}}
@@ -76,8 +77,10 @@
               | {{$t('copyAsTodo')}}
               // @TODO make copyAsTodo work in the inbox
             span.action(v-if='user.flags.communityGuidelinesAccepted', @click='report(msg)')
+            span.action(v-if='!inbox && user.flags.communityGuidelinesAccepted', @click='report(msg)')
               .svg-icon(v-html="icons.report")
               | {{$t('report')}}
+              // @TODO make flagging/reporting work in the inbox. NOTE: it must work even if the communityGuidelines are not accepted and it MUST work for messages that you have SENT as well as received. -- Alys
             span.action(v-if='msg.uuid === user._id', @click='remove(msg, index)')
               .svg-icon(v-html="icons.delete")
               | {{$t('delete')}}

--- a/website/client/components/chat/chatMessages.vue
+++ b/website/client/components/chat/chatMessages.vue
@@ -43,7 +43,7 @@
             span.action(v-if='user.contributor.admin || (msg.uuid !== user._id && user.flags.communityGuidelinesAccepted)', @click='report(msg)')
               .svg-icon(v-html="icons.report")
               | {{$t('report')}}
-            span.action(v-if='msg.uuid === user._id || inbox', @click='remove(msg, index)')
+            span.action(v-if='msg.uuid === user._id || inbox || user.contributor.admin', @click='remove(msg, index)')
               .svg-icon(v-html="icons.delete")
               | {{$t('delete')}}
             span.action.float-right.liked(v-if='likeCount(msg) > 0')


### PR DESCRIPTION
These fixes should go live as soon as practical but not before the new site is released - they're not that urgent.

The code should be reviewed before merging! It should be tested briefly in staging before deploying; I'm happy to do that if I'm around when it's merged. I've tested in local of course but we want to be extra cautious with these features. 

Changes:
- allow mods/staff to delete any chat message in Tavern/guilds/party
- prevent the Copy As To-Do button appearing in the inbox because it isn't working
- prevent the Flag/Report button appearing in the inbox because it isn't working
- fix link to Data Display Tool in footer (remove unused `uuid=` part of the URL: replace data.habitrpg.com domain name wiith a direct link since that domain is outdated; see also https://github.com/HabitRPG/habitica/pull/9085)
