### PR TITLE
remove non-working task Difficulty tooltip icon

### DIFF
--- a/website/client/components/tasks/taskModal.vue
+++ b/website/client/components/tasks/taskModal.vue
@@ -42,7 +42,7 @@
         template(v-if="task.type !== 'reward'")
           label(v-once)
             span.float-left {{ $t('difficulty') }}
-            .svg-icon.info-icon(v-html="icons.information")
+            // @TODO .svg-icon.info-icon(v-html="icons.information")
           .d-flex.justify-content-center
             .option-item(:class="optionClass(task.priority === 0.1)", @click="task.priority = 0.1")
               .option-item-box


### PR DESCRIPTION
Ideally this should be merged before go-live.

Removes the tooltip icon for task difficulty until we have time to insert on-hover text for the tip. See this comment in the testing doc: https://docs.google.com/document/d/1_mRMC6pZBZC5LfuC8G9qPgvd_9MmRxRQvQhLcTVdS7I/edit?disco=AAAABT3lnsQ

![image](https://user-images.githubusercontent.com/1495809/30965196-d1be2eb2-a497-11e7-9ca8-54979884c9fe.png)
