### PR TITLE
Hide the Block button in the user's own profile screen

### DIFF
--- a/website/client/components/userMenu/profile.vue
+++ b/website/client/components/userMenu/profile.vue
@@ -5,7 +5,7 @@ div
       .profile-actions
         button.btn.btn-secondary(@click='sendMessage()')
           .svg-icon.message-icon(v-html="icons.message")
-        button.btn.btn-secondary(v-if='userLoggedIn.inbox.blocks.indexOf(user._id) === -1', :tooltip="$t('unblock')",
+        button.btn.btn-secondary(v-if='user._id !== this.userLoggedIn._id && userLoggedIn.inbox.blocks.indexOf(user._id) === -1', :tooltip="$t('unblock')",
           @click="blockUser()", tooltip-placement='right')
           span.glyphicon.glyphicon-plus
           | {{$t('block')}}


### PR DESCRIPTION
Hide the Block button in the user's own profile screen. This prevents a user from accidentally blocking themself from sending PMs.
User's own profile:
![image](https://user-images.githubusercontent.com/1495809/31013268-a305e1de-a558-11e7-892c-d6d5205764bd.png)
Another user's profile:
![image](https://user-images.githubusercontent.com/1495809/31013285-b91042f8-a558-11e7-8c84-c670f6b716b2.png)

