### PR TITLE
fix allocate() function in userMenu/profile.vue component (fixes #9096)

### DIFF
--- a/website/client/components/userMenu/profile.vue
+++ b/website/client/components/userMenu/profile.vue
@@ -795,7 +795,7 @@ export default {
       return display;
     },
     allocate (stat) {
-      allocate(this.user, stat);
+      allocate(this.user, {query: { stat }});
       axios.post(`/api/v3/user/allocate?stat=${stat}`);
     },
     allocateNow () {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #9096 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Fixes the `allocate()` function in `website/client/components/userMenu/profile.vue`. When a user is allocating stat points, this function delegates to the `allocate()` function in `website/common/script/ops/allocate.js` but calls it incorrectly with a String instead of an Object, causing the latter function to default to the (potentially incorrect) Strength stat. As a result, the UI always displays the points being allocated to Strength, as described in the issue.

I didn't see an obvious place to write a new test for this bug, so I didn't write one. Sorry! Happy to add one if someone can show me the right place to do so. For what it's worth, no new test breakage seems to result from this change.

Thanks! Let me know if I can improve this in any way.

\- Trevor


[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: 7620c72a-bb5a-4798-b3c0-846dacb2b44d
