### PR TITLE
various fixes: group leader's name at top of edit drop-down; Members List; etc

### DIFF
--- a/website/client/components/chat/chatMessages.vue
+++ b/website/client/components/chat/chatMessages.vue
@@ -36,10 +36,11 @@
               .svg-icon(v-html="icons.like")
               span(v-if='!msg.likes[user._id]') {{ $t('like') }}
               span(v-if='msg.likes[user._id]') {{ $t('liked') }}
-            span.action(v-if='!inbox', @click='copyAsTodo(msg)')
-              .svg-icon(v-html="icons.copy")
-              | {{$t('copyAsTodo')}}
-              // @TODO make copyAsTodo work in the inbox
+            // @TODO make copyAsTodo work in Tavern, guilds, party (inbox can be done later)
+              span.action(v-if='!inbox', @click='copyAsTodo(msg)')
+                .svg-icon(v-html="icons.copy")
+                | {{$t('copyAsTodo')}}
+                // @TODO make copyAsTodo work in the inbox
             span.action(v-if='!inbox && user.flags.communityGuidelinesAccepted', @click='report(msg)')
               .svg-icon(v-html="icons.report")
               | {{$t('report')}}
@@ -72,10 +73,11 @@
               .svg-icon(v-html="icons.like")
               span(v-if='!msg.likes[user._id]') {{ $t('like') }}
               span(v-if='msg.likes[user._id]') {{ $t('liked') }}
-            span.action(v-if='!inbox', @click='copyAsTodo(msg)')
-              .svg-icon(v-html="icons.copy")
-              | {{$t('copyAsTodo')}}
-              // @TODO make copyAsTodo work in the inbox
+            // @TODO make copyAsTodo work in Tavern, guilds, party (inbox can be done later)
+              span.action(v-if='!inbox', @click='copyAsTodo(msg)')
+                .svg-icon(v-html="icons.copy")
+                | {{$t('copyAsTodo')}}
+                // @TODO make copyAsTodo work in the inbox
             span.action(v-if='user.flags.communityGuidelinesAccepted', @click='report(msg)')
             span.action(v-if='!inbox && user.flags.communityGuidelinesAccepted', @click='report(msg)')
               .svg-icon(v-html="icons.report")

--- a/website/client/components/groups/group.vue
+++ b/website/client/components/groups/group.vue
@@ -18,7 +18,7 @@
               .svg-icon.shield(v-html="icons.silverGuildBadgeIcon", v-if='group.memberCount > 100 && group.memberCount < 999')
               .svg-icon.shield(v-html="icons.bronzeGuildBadgeIcon", v-if='group.memberCount < 100')
               span.number {{ group.memberCount | abbrNum }}
-              div(v-once) {{ $t('members') }}
+              div(v-once) {{ $t('memberList') }}
           .col-4(v-if='!isParty')
             .item-with-icon
               .svg-icon.gem(v-html="icons.gem")

--- a/website/client/components/groups/groupFormModal.vue
+++ b/website/client/components/groups/groupFormModal.vue
@@ -9,7 +9,7 @@
         label
           strong(v-once) {{$t('guildOrPartyLeader')}} *
         select.form-control(v-model="workingGroup.newLeader")
-          option(v-for='member in members', :value="member._id") {{ member.profile.name }}
+          option(v-for='potentialLeader in potentialLeaders', :value="potentialLeader._id") {{ potentialLeader.name }}
 
       .form-group(v-if='!this.workingGroup.id')
         label
@@ -315,6 +315,17 @@ export default {
     },
     isParty () {
       return this.workingGroup.type === 'party';
+    },
+    potentialLeaders () {
+      let leaders = [{ _id: this.user._id, name: this.user.profile.name }];
+      // @TODO consider pushing all recent posters to the top of the list if they are guild members - more likely to be the ones the leader wants to see (and then ignore them in the while below)
+      let i = 0;
+      while (this.members[i]) {
+        let memb = this.members[i];
+        i++;
+        if (memb._id !== this.user._id) leaders.push({_id: memb._id, name: memb.profile.name});
+      }
+      return leaders;
     },
   },
   watch: {

--- a/website/client/components/settings/site.vue
+++ b/website/client/components/settings/site.vue
@@ -169,14 +169,15 @@
             .form-group
               input.form-control(type='password', :placeholder="$t('confirmPass')", v-model='passwordUpdates.confirmPassword')
             button.btn.btn-primary(type='submit', @click='changeUser("password", passwordUpdates)') {{ $t('submit')  }}
+          hr
 
+        div
+          h5 {{ $t('dangerZone') }}
           div
-            h5 {{ $t('dangerZone') }}
-            div
-              button.btn.btn-danger(@click='openResetModal()',
-                popover-trigger='mouseenter', popover-placement='right', v-b-popover.hover.auto="$t('resetAccPop')") {{ $t('resetAccount') }}
-              button.btn.btn-danger(@click='openDeleteModal()',
-                popover-trigger='mouseenter', v-b-popover.hover.auto="$t('deleteAccPop')") {{ $t('deleteAccount') }}
+            button.btn.btn-danger(@click='openResetModal()',
+              popover-trigger='mouseenter', popover-placement='right', v-b-popover.hover.auto="$t('resetAccPop')") {{ $t('resetAccount') }}
+            button.btn.btn-danger(@click='openDeleteModal()',
+              popover-trigger='mouseenter', v-b-popover.hover.auto="$t('deleteAccPop')") {{ $t('deleteAccount') }}
 </template>
 
 <style scoped>

--- a/website/common/locales/en/groups.json
+++ b/website/common/locales/en/groups.json
@@ -80,6 +80,7 @@
   "logoUrl": "Logo URL",
   "assignLeader": "Assign Group Leader",
   "members": "Members",
+  "memberList": "Member List",
   "partyList": "Order for party members in header",
   "banTip": "Boot Member",
   "moreMembers": "more members",

--- a/website/common/locales/en/subscriber.json
+++ b/website/common/locales/en/subscriber.json
@@ -70,7 +70,7 @@
     "subCanceled": "Subscription will become inactive on",
     "buyGemsGoldTitle": "To Buy Gems with Gold",
     "becomeSubscriber": "Become a Subscriber",
-    "subGemPop": "Because you subscribe to Habitica, you can purchase a number of Gems each month using Gold. You can see how many Gems are available to buy at the corner of the Gem icon.",
+    "subGemPop": "Because you subscribe to Habitica, you can purchase a number of Gems each month using Gold.",
     "subGemName": "Subscriber Gems",
     "freeGemsTitle": "Obtain Gems for Free",
     "maxBuyGems": "You have bought all the Gems you can this month. More become available within the first three days of each month. Thanks for subscribing!",

--- a/website/common/locales/en/subscriber.json
+++ b/website/common/locales/en/subscriber.json
@@ -19,7 +19,7 @@
     "exclusiveJackalopePetText": "Get the Royal Purple Jackalope pet, available only to subscribers!",
     "giftSubscription": "Want to gift a subscription to someone?",
     "giftSubscriptionText1": "Open their profile! You can do this by clicking on their avatar in your party header or by clicking on their name in chat.",
-    "giftSubscriptionText2": "Click on the gift icon in the bottom left of their profile.",
+    "giftSubscriptionText2": "Click on the gift icon in the top right of their profile.",
     "giftSubscriptionText3": "Select \"subscription\" and enter your payment information.",
     "giftSubscriptionText4": "Thanks for supporting Habitica!",
     "monthUSD": "USD / Month",


### PR DESCRIPTION
- put current group leader's name at top of Leader change drop-down (NB: leader change is broken for other reasons - leader doesn't change after you've selected a new one and clicked update) 
- change members label on group pages to Member List
- disable Copy As To-Do in Tavern, guilds, party because it's not working
- allow Danger Zone to be seen by players without local authentication
- remove outdated info about seeing number of Gems available to buy
- fix text describing location of subscription/gem gift box
