### PR TITLE
quest leader can start/end quest; admins can edit challenges/guilds; reverse chat works; remove static/videos link; etc

### DIFF
--- a/website/client/components/challenges/challengeDetail.vue
+++ b/website/client/components/challenges/challengeDetail.vue
@@ -35,7 +35,7 @@
         b-dropdown.create-dropdown(text="Select a Participant")
           b-dropdown-item(v-for="member in members", :key="member._id", @click="openMemberProgressModal(member._id)")
             | {{ member.profile.name }}
-        span(v-if='isLeader')
+        span(v-if='isLeader || isAdmin')
           b-dropdown.create-dropdown(:text="$t('addTaskToChallenge')", :variant="'success'")
             b-dropdown-item(v-for="type in columns", :key="type", @click="createTask(type)")
               | {{$t(type)}}
@@ -64,13 +64,13 @@
         button.btn.btn-success(v-once, @click='joinChallenge()') {{$t('joinChallenge')}}
       div(v-if='isMember')
         button.btn.btn-danger(v-once, @click='leaveChallenge()') {{$t('leaveChallenge')}}
-      div(v-if='isLeader')
+      div(v-if='isLeader || isAdmin')
         button.btn.btn-secondary(v-once, @click='edit()') {{$t('editChallenge')}}
-      div(v-if='isLeader')
+      div(v-if='isLeader || isAdmin')
         button.btn.btn-danger(v-once, @click='closeChallenge()') {{$t('endChallenge')}}
       div(v-if='isLeader || isAdmin')
         button.btn.btn-secondary(v-once, @click='exportChallengeCsv()') {{$t('exportChallengeCsv')}}
-      div(v-if='isLeader')
+      div(v-if='isLeader || isAdmin')
         button.btn.btn-secondary(v-once, @click='cloneChallenge()') {{$t('clone')}}
     .description-section
       h2 {{$t('challengeSummary')}}

--- a/website/client/components/challenges/challengeModal.vue
+++ b/website/client/components/challenges/challengeModal.vue
@@ -17,7 +17,7 @@
       .form-group
         label
           strong(v-once) {{$t('challengeDescription')}} *
-        a.float-right {{ $t('markdownFormattingHelp') }}
+        a.float-right(v-markdown='$t("markdownFormattingHelp")')
         textarea.description-textarea.form-control(:placeholder="$t('challengeDescriptionPlaceholder')", v-model="workingChallenge.description")
       .form-group(v-if='creating')
         label
@@ -136,6 +136,8 @@ import bDropdown from 'bootstrap-vue/lib/components/dropdown';
 import bDropdownItem from 'bootstrap-vue/lib/components/dropdown-item';
 import bFormInput from 'bootstrap-vue/lib/components/form-input';
 
+import markdownDirective from 'client/directives/markdown';
+
 import { TAVERN_ID, MIN_SHORTNAME_SIZE_FOR_CHALLENGES, MAX_SUMMARY_SIZE_FOR_CHALLENGES } from '../../../common/script/constants';
 import { mapState } from 'client/libs/store';
 
@@ -146,6 +148,9 @@ export default {
     bDropdown,
     bDropdownItem,
     bFormInput,
+  },
+  directives: {
+    markdown: markdownDirective,
   },
   data () {
     let categoryOptions = [

--- a/website/client/components/groups/group.vue
+++ b/website/client/components/groups/group.vue
@@ -56,15 +56,16 @@
           button.btn.btn-success(class='btn-success', v-if='isLeader && !group.purchased.active', @click='upgradeGroup()')
             | {{ $t('upgrade') }}
         .button-container
-          button.btn.btn-primary(b-btn, @click="updateGuild", v-once, v-if='isLeader') {{ $t('edit') }}
+          button.btn.btn-primary(b-btn, @click="updateGuild", v-once, v-if='isLeader || isAdmin') {{ $t('edit') }}
         .button-container
           button.btn.btn-success(class='btn-success', v-if='!isMember', @click='join()') {{ $t('join') }}
         .button-container
           button.btn.btn-primary(v-once, @click='showInviteModal()') {{$t('invite')}}
+          // @TODO: hide the invitation button if there's an active group plan and the player is not the leader
         .button-container
-          // @TODO: V2 button.btn.btn-primary(v-once, v-if='!isLeader') {{$t('messageGuildLeader')}}
+          // @TODO: V2 button.btn.btn-primary(v-once, v-if='!isLeader') {{$t('messageGuildLeader')}} // Suggest making the button visible to the leader too - useful for them to test how the feature works or to send a note to themself. -- Alys
         .button-container
-          // @TODO: V2 button.btn.btn-primary(v-once, v-if='isMember && !isParty') {{$t('donateGems')}}
+          // @TODO: V2 button.btn.btn-primary(v-once, v-if='isMember && !isParty') {{$t('donateGems')}} // Suggest removing the isMember restriction - it's okay if non-members donate to a public guild. Also probably allow it for parties if parties can buy imagery. -- Alys
 
     .section-header(v-if='isParty')
       .row
@@ -561,6 +562,9 @@ export default {
     },
     isLeader () {
       return this.user._id === this.group.leader._id;
+    },
+    isAdmin () {
+      return Boolean(this.user.contributor.admin);
     },
     isMember () {
       return this.isMemberOfGroup(this.user, this.group);

--- a/website/client/components/groups/group.vue
+++ b/website/client/components/groups/group.vue
@@ -716,6 +716,9 @@ export default {
     fetchRecentMessages () {
       this.fetchGuild();
     },
+    reverseChat () {
+      this.group.chat.reverse();
+    },
     updateGuild () {
       this.$store.state.editingGroup = this.group;
       this.$root.$emit('show::modal', 'guild-form');

--- a/website/client/components/groups/group.vue
+++ b/website/client/components/groups/group.vue
@@ -82,7 +82,7 @@
             .svg-icon(v-html="icons.questIcon")
             h4(v-once) {{ $t('youAreNotOnQuest') }}
             p(v-once) {{ $t('questDescription') }}
-            button.btn.btn-secondary(v-once, @click="openStartQuestModal()", v-if='isLeader') {{ $t('startAQuest') }}
+            button.btn.btn-secondary(v-once, @click="openStartQuestModal()") {{ $t('startAQuest') }}
         .row.quest-active-section(v-if='isParty && onPendingQuest && !onActiveQuest')
           .col-2
             .quest(:class='`inventory_quest_scroll_${questData.key}`')

--- a/website/client/components/groups/group.vue
+++ b/website/client/components/groups/group.vue
@@ -130,7 +130,7 @@
                     .col-6
                       span.float-left
                         | Rage {{questData.boss.rage.value}}
-            button.btn.btn-secondary(v-once, @click="questAbort()", v-if='isLeader') {{ $t('abort') }}
+            button.btn.btn-secondary(v-once, @click="questAbort()", v-if='canEditQuest') {{ $t('abort') }}
 
     .section-header(v-if='!isParty')
       .row
@@ -570,8 +570,10 @@ export default {
       return this.isMemberOfGroup(this.user, this.group);
     },
     canEditQuest () {
-      let isQuestLeader = this.group.quest && this.group.quest.leader === this.user._id;
-      return isQuestLeader;
+      if (!this.group.quest) return false;
+      let isQuestLeader = this.group.quest.leader === this.user._id;
+      let isPartyLeader = this.group.leader._id === this.user._id;
+      return isQuestLeader || isPartyLeader;
     },
     isMemberOfPendingQuest () {
       let userid = this.user._id;

--- a/website/client/components/groups/groupFormModal.vue
+++ b/website/client/components/groups/groupFormModal.vue
@@ -63,7 +63,7 @@
       .form-group
         label
           strong(v-once) {{$t('groupDescription')}} *
-        a.float-right {{ $t('markdownFormattingHelp') }}
+        a.float-right(v-markdown='$t("markdownFormattingHelp")')
         textarea.form-control.description-textarea(type="text", textarea, :placeholder="isParty ? $t('partyDescriptionPlaceholder') : $t('guildDescriptionPlaceholder')", v-model="workingGroup.description")
 
       .form-group(v-if='creatingParty && !workingGroup.id')
@@ -177,6 +177,7 @@ import bTooltip from 'bootstrap-vue/lib/components/tooltip';
 
 import { mapState } from 'client/libs/store';
 import toggleSwitch from 'client/components/ui/toggleSwitch';
+import markdownDirective from 'client/directives/markdown';
 import gemIcon from 'assets/svg/gem.svg';
 import informationIcon from 'assets/svg/information.svg';
 
@@ -197,6 +198,9 @@ export default {
     bFormSelect,
     bTooltip,
     toggleSwitch,
+  },
+  directives: {
+    markdown: markdownDirective,
   },
   data () {
     let data = {

--- a/website/client/components/groups/questDetailsModal.vue
+++ b/website/client/components/groups/questDetailsModal.vue
@@ -13,9 +13,10 @@
           .pending.float-right(v-if='member.accepted === null') {{ $t('pending') }}
     div(v-if='questData')
       questDialogContent(:item="questData")
-    div.text-center.actions
+    div.text-center.actions(v-if='canEditQuest')
       div
         button.btn.btn-secondary(v-once, @click="questForceStart()") {{ $t('begin') }}
+        // @TODO don't allow the party leader to start the quest until the leader has accepted or rejected the invitation (users get confused and think "begin" means "join quest")
       div
         .cancel(v-once, @click="questCancel()") {{ $t('cancel') }}
     .side-panel(v-if='questData')
@@ -188,6 +189,12 @@ export default {
           accepted: this.group.quest.members[member._id],
         };
       });
+    },
+    canEditQuest () {
+      if (!this.group.quest) return false;
+      let isQuestLeader = this.group.quest.leader === this.user._id;
+      let isPartyLeader = this.group.leader._id === this.user._id;
+      return isQuestLeader || isPartyLeader;
     },
   },
   methods: {

--- a/website/client/components/static/features.vue
+++ b/website/client/components/static/features.vue
@@ -71,9 +71,6 @@
         p.span
           span {{ $t('marketing4Lead3-2') }}
           a.btn.btn-primary(href='/static/plans',target='_blank') {{ $t('contactUs') }}
-        p.span
-          span {{ $t('marketing4Lead3-3') }}
-          a.btn.btn-primary(href='/static/videos') {{ $t('watchVideos') }}
 </template>
 
 <style lang='scss' scoped>

--- a/website/common/locales/en/challenge.json
+++ b/website/common/locales/en/challenge.json
@@ -116,7 +116,7 @@
   "shortName": "Short Name",
   "shortNamePlaceholder": "What short tag should be used to identify your Challenge?",
   "updateChallenge": "Update Challenge",
-  "haveNoChallenges": "You don't have any Challenges",
+  "haveNoChallenges": "This group has no Challenges",
   "loadMore": "Load More",
   "exportChallengeCsv": "Export Challenge",
   "editingChallenge": "Editing Challenge",

--- a/website/common/locales/en/generic.json
+++ b/website/common/locales/en/generic.json
@@ -125,7 +125,7 @@
   "error": "Error",
   "menu": "Menu",
   "notifications": "Notifications",
-  "noNotifications": "You have no new messages.",
+  "noNotifications": "You have no notifications.",
   "clear": "Clear",
   "endTour": "End Tour",
   "audioTheme": "Audio Theme",

--- a/website/common/locales/en/groups.json
+++ b/website/common/locales/en/groups.json
@@ -391,7 +391,7 @@
   "reverseChat": "Reverse Chat",
   "invites": "Invites",
   "details": "Details",
-  "participantDesc": "Once all members have either accepted or declined, the Quest begins. Only those that clicked 'accept' will be able to participate in the Quest and receive the drops.",
+  "participantDesc": "Once all members have either accepted or declined, the Quest begins. Only those who clicked 'accept' will be able to participate in the Quest and receive the rewards.",
   "groupGems": "Group Gems",
   "groupGemsDesc": "Guild Gems can be spent to make Challenges! In the future, you will be able to add more Guild Gems."
 }

--- a/website/common/locales/en/groups.json
+++ b/website/common/locales/en/groups.json
@@ -358,7 +358,7 @@
   "guildSummaryPlaceholder": "Write a short description advertising your Guild to other Habiticans. What is the main purpose of your Guild and why should people join it? Try to include useful keywords in the summary so that Habiticans can easily find it when they search!",
   "groupDescription": "Description",
   "guildDescriptionPlaceholder": "Use this section to go into more detail about everything that Guild members should know about your Guild. Useful tips, helpful links, and encouraging statements all go here!",
-  "markdownFormattingHelp": "Markdown formatting help",
+  "markdownFormattingHelp": "[Markdown formatting help](http://habitica.wikia.com/wiki/Markdown_Cheat_Sheet)",
   "partyDescriptionPlaceholder": "This is our party's description. It describes what we do in this party. If you want to learn more about what we do in this party, read the description. Party on.",
   "guildGemCostInfo": "A Gem cost promotes high quality Guilds and is transferred into your Guild's bank.",
   "noGuildsTitle": "You aren't a member of any Guilds.",


### PR DESCRIPTION
- enable link to markdown info on group and challenge edit screen
- allow admin (moderators and staff) to edit challenges
- allow admin (moderators and staff) to edit guilds (Also add some unrelated TODO comments.)
- allow any party member (not just leader) to start quest from party page
- allow quest owner to cancel, begin, abort quest (Previously only the party leader could see those buttons. The leader still can. This also hides those buttons from all other party members.)
- enable reverse chat in guilds and party
- remove outdated videos from press kit
- adjust various wordings
