### PR TITLE
Fixes 2017/10/09

### DIFF
--- a/website/client/components/inventory/equipment/attributesPopover.vue
+++ b/website/client/components/inventory/equipment/attributesPopover.vue
@@ -1,10 +1,16 @@
 <template lang="pug">
 div
-  h4.popover-content-title {{ itemText }}
-  .popover-content-text {{ itemNotes }}
-  .popover-content-attr(v-for="attr in ATTRIBUTES", :key="attr")
-    span.popover-content-attr-key {{ `${$t(attr)}: ` }}
-    span.popover-content-attr-val {{ `+${item[attr]}` }}
+  div(v-if='item.locked')
+    h4.popover-content-title Locked Item
+    .popover-content-text(v-if='item.specialClass') {{ `${$t('classLockedItem')}` }}
+    .popover-content-text(v-else) {{ `${$t('tierLockedItem')}` }}
+    p
+  div(v-else)
+    h4.popover-content-title {{ itemText }}
+    .popover-content-text {{ itemNotes }}
+    .popover-content-attr(v-for="attr in ATTRIBUTES", :key="attr")
+      span.popover-content-attr-key {{ `${$t(attr)}: ` }}
+      span.popover-content-attr-val {{ `+${item[attr]}` }}
 </template>
 
 <script>

--- a/website/client/components/shops/quests/questDialogDrops.vue
+++ b/website/client/components/shops/quests/questDialogDrops.vue
@@ -7,8 +7,12 @@
     div.reward-item(v-if="item.drop.gp != 0")
       span.svg-icon.inline.icon(v-html="icons.gold")
       span.reward-text {{ $t('amountGold', { amount: item.drop.gp }) }}
-    h3.text-center(v-if='item.drop.items') {{$t('questOwnerRewards')}}
-    div.reward-item(v-for="drop in item.drop.items")
+    div.reward-item(v-for='drop in getDropsList(item.drop.items, false)')
+      span.icon
+        div(:class="getDropIcon(drop)")
+      span.reward-text {{ getDropName(drop) }}
+    h3.text-center(v-if='getDropsList(item.drop.items, true).length > 0') {{$t('questOwnerRewards')}}
+    div.reward-item(v-for='drop in getDropsList(item.drop.items, true)')
       span.icon
         div(:class="getDropIcon(drop)")
       span.reward-text {{ getDropName(drop) }}
@@ -60,7 +64,6 @@
 </style>
 
 <script>
-
   import svgGold from 'assets/svg/gold.svg';
   import svgExperience from 'assets/svg/experience.svg';
 
@@ -95,6 +98,15 @@
       },
       getDropName (drop) {
         return drop.text();
+      },
+      getDropsList (drops, ownerOnly) {
+        return drops.filter(function dropsList (drop) {
+          if (ownerOnly) {
+            return drop.onlyOwner;
+          } else {
+            return !drop.onlyOwner;
+          }
+        });
       },
     },
     props: {

--- a/website/common/locales/en/gear.json
+++ b/website/common/locales/en/gear.json
@@ -10,6 +10,8 @@
   "gearNotOwned": "You do not own this item.",
   "noGearItemsOfType": "You don't own any of these.",
   "noGearItemsOfClass": "You already have all your class equipment! More will be released during the Grand Galas, near the solstices and equinoxes.",
+  "classLockedItem": "This item is only available to a specific class. Change your class under the User icon > Settings > Character Build!",
+  "tierLockedItem": "This item is only available once you've purchased the previous items in sequence. Keep working your way up!",
 
   "sortByType": "Type",
   "sortByPrice": "Price",


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes these issues from the redesign bugs doc:

> Quest rewards are displayed wrongly - the pet eggs are listed as being only for the quest owner. Probably a fast fix. Distressing: “I just pulled up the PET Quest for the sheep that we started before the big change and now is stuck in limbo.... BUT it says that ONLY the OWNER of the quest is going to get the eggs .... PLEASE tell me that this is a bug.” {Note: “Quest Owner’s Rewards” is only supposed to be used when there’s something that only the quest owner gets, namely a scroll for the next quest, and it should always be UNDER the normal “Quest Rewards” that everyone gets.}

> Instead of a popup for locked items in the Seasonal Shop and Market that belong to other classes, there should be a note on hover that says “You need to be a [CLASS] to purchase this item!”

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

**Previously**, quest information popups wrongly assumed that any items awarded went only to the quest owner, and only Gold and Experience went to the whole party.
**Now**, we correctly display party item rewards under the general "Quest Rewards" heading, reserving only the relatively uncommon case of sequential quest scrolls for the "Quest Owner" heading. The Quest Owner heading will be hidden in most cases.

**Previously**, Seasonal Shop equipment and sequential class gear had a tiny lock icon showing they could not be purchased, but there was no explanation as to why they weren't buyable.
**Now**, for locked gear, hover text explains why the user can't currently buy it.

[//]: # (Put User ID in here - found in Settings -> API)