### PR TITLE
fix Stable component to correctly count pets

### DIFF
--- a/website/client/components/inventory/stable/index.vue
+++ b/website/client/components/inventory/stable/index.vue
@@ -831,7 +831,8 @@
 
         let countAll = animals.length;
         let countOwned = _filter(animals, (a) => {
-          return a.isOwned();
+          // when counting pets, include those that have been raised into mounts
+          return a.isOwned() || a.mountOwned();
         });
 
         return `${countOwned.length}/${countAll}`;


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #9151

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
update the `countOwnedAnimals()` method in the Stable component (`website/client/components/inventory/stable/index.vue`) to still count pets that have been raised into mounts, but not yet hatched again. This is accomplished by checking if each pet is either currently owned, or the mount version of that pet is currently owned (which implies the pet was previously owned).

Another approach might be to import the `beastMasterProgress()` and `mountMasterProgress()` functions from the Count module (`website/common/script/count.js`), since those accomplish basically the same thing. I don't have a good sense of how the whole app hangs together yet, though, so I don't know if that might have some drawbacks I'm missing.



[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: 7620c72a-bb5a-4798-b3c0-846dacb2b44d
