### PR TITLE
Added confirmation step at begin button for quest

### DIFF
--- a/website/client/components/groups/questDetailsModal.vue
+++ b/website/client/components/groups/questDetailsModal.vue
@@ -201,9 +201,10 @@ export default {
     async questConfirm () {
       let count = 0;
       for (let uuid in this.group.quest.members) {
-        if (this.group.quest.members[uuid]) count += 1;}
+        if (this.group.quest.members[uuid]) count += 1;
+      }
       if (!confirm(this.$t('questConfirm', { questmembers: count, totalmembers: this.group.memberCount}))) return;
-      this.questForceStart ();
+      this.questForceStart();
     },
     async questForceStart () {
       let quest = await this.$store.dispatch('quests:sendAction', {groupId: this.group._id, action: 'quests/force-start'});

--- a/website/client/components/groups/questDetailsModal.vue
+++ b/website/client/components/groups/questDetailsModal.vue
@@ -15,7 +15,7 @@
       questDialogContent(:item="questData")
     div.text-center.actions(v-if='canEditQuest')
       div
-        button.btn.btn-secondary(v-once, @click="questForceStart()") {{ $t('begin') }}
+        button.btn.btn-secondary(v-once, @click="questConfirm()") {{ $t('begin') }}
         // @TODO don't allow the party leader to start the quest until the leader has accepted or rejected the invitation (users get confused and think "begin" means "join quest")
       div
         .cancel(v-once, @click="questCancel()") {{ $t('cancel') }}
@@ -198,6 +198,13 @@ export default {
     },
   },
   methods: {
+    async questConfirm () {
+      let count = 0;
+      for (let uuid in this.group.quest.members) {
+        if (this.group.quest.members[uuid]) count += 1;}
+      if (!confirm(this.$t('questConfirm', { questmembers: count, totalmembers: this.group.memberCount}))) return;
+      this.questForceStart ();
+    },
     async questForceStart () {
       let quest = await this.$store.dispatch('quests:sendAction', {groupId: this.group._id, action: 'quests/force-start'});
       this.group.quest = quest;

--- a/website/common/locales/en/quests.json
+++ b/website/common/locales/en/quests.json
@@ -77,6 +77,7 @@
   "mustLvlQuest": "You must be level <%= level %> to buy this quest!",
   "mustInviteFriend": "To earn this quest, invite a friend to your Party. Invite someone now?",
   "unlockByQuesting": "To unlock this quest, complete <%= title %>.",
+  "questConfirm": "Are you sure? Only <%= questmembers %> of your <%= totalmembers %> party members have joined this quest! Quests start automatically when all players have joined or rejected the invitation.",
   "sureCancel": "Are you sure you want to cancel this quest? All invitation acceptances will be lost. The quest owner will retain possession of the quest scroll.",
   "sureAbort": "Are you sure you want to abort this mission? It will abort it for everyone in your party and all progress will be lost. The quest scroll will be returned to the quest owner.",
   "doubleSureAbort": "Are you double sure? Make sure they won't hate you forever!",


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes https://github.com/HabitRPG/habitica/issues/9083

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
**This adds a confirmation step at the "Begin" button for quests.**

- Added a new method "questConfirm()" in "website/client/components/groups/questDetailsModal.vue"
 (line 201). This method counts number of party members that have accepted the quest and outputs (using "questConfirm" from "website/common/locales/en/quests.json") a confirmation box (as shown in image below). Followed by a method call to the "questForceStart()" method if user confirms the message('OK' button), which force starts the quest.

![habitica quest confirmation](https://user-images.githubusercontent.com/3469070/31597208-dce12bca-b264-11e7-9512-c5a4d9bae91b.jpg)

- Changed method called when "begin" button is clicked from "questForceStart()" to "questConfirm()" in "website/client/components/groups/questDetailsModal.vue" (line 18). This calls the new method added in step 1.

- Added "questConfirm" in "website/common/locales/en/quests.json" (line 80). This stores the message string required by the questConfirm() method in "website/client/components/groups/questDetailsModal.vue".



[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: 8581d7a9-61b4-4f16-a019-4e2f7d5e996e
