### PR TITLE
Add empty state values for profile photo and description - fixes #9133

### DIFF
--- a/website/client/components/userMenu/profile.vue
+++ b/website/client/components/userMenu/profile.vue
@@ -37,10 +37,12 @@ div
         .col-8
           .about
             h2 {{ $t('about') }}
-            p(v-markdown='user.profile.blurb')
+            p(v-if='user.profile.blurb', v-markdown='user.profile.blurb')
+            p(v-else) {{ $t('noDescription') }}
           .photo
             h2 {{ $t('photo') }}
             img.img-rendering-auto(v-if='user.profile.imageUrl', :src='user.profile.imageUrl')
+            p(v-else) {{ $t('noPhoto') }}
 
         .col-4
           .info
@@ -671,8 +673,7 @@ export default {
       this.achievements = achievementsLib.getAchievementsForProfile(user);
 
       // @TODO For some reason markdown doesn't seem to be handling numbers or maybe undefined?
-      user.profile.blurb = `${user.profile.blurb}`;
-
+      user.profile.blurb = user.profile.blurb ? `${user.profile.blurb}` : '';
       return user;
     },
     incentivesProgress () {

--- a/website/common/locales/en/character.json
+++ b/website/common/locales/en/character.json
@@ -3,6 +3,8 @@
   "profile": "Profile",
   "avatar": "Customize Avatar",
   "editAvatar": "Edit Avatar",
+  "noDescription": "This Habitican hasn't added a description.",
+  "noPhoto": "This Habitican hasn't added a photo.",
   "other": "Other",
   "fullName": "Full Name",
   "displayName": "Display Name",


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes https://github.com/HabitRPG/habitica/issues/9133

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Added empty state descriptions in the user profile for the the fields - 
description & image url.


[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: f011fa04-2a3a-454f-a048-1b41ba66b340
