### PR TITLE
Bug with notification menu having unneeded scroll bars fixes #9173

### DIFF
--- a/website/client/components/notificationMenu.vue
+++ b/website/client/components/notificationMenu.vue
@@ -108,7 +108,7 @@ div.item-with-icon.item-notifications.dropdown
 
   .user-dropdown {
     max-height: 350px;
-    overflow: scroll;
+    overflow: auto;
   }
 
   /* @TODO: Move to shared css */


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #9173 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Fixes notification menu from scroll to auto. Scroll bars will only appears once notifications surpass the maximum height. 


[//]: # (Put User ID in here - found in Settings -> API)


