### PR TITLE
Set a max-width for Markdown images [Fixes #9171]

### DIFF
--- a/website/client/assets/scss/markdown.scss
+++ b/website/client/assets/scss/markdown.scss
@@ -28,4 +28,8 @@
       text-decoration: underline;
     }
   }
+
+  img {
+    max-width: 100%;
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/HabitRPG/habitica/issues/9171

### Changes

Prevents images from overflowing horizontally in tavern chat, guild sidebars, tasks, and anywhere else using Markdown

#### Before

Images take up whatever width they want; no nice spacing if they are too big and overflow

![image](https://user-images.githubusercontent.com/6765732/31734671-0edb0582-b405-11e7-8290-553acf529aa5.png)

#### After

Images that are too wide are automatically resized to fit the width of the parent container. Nice spacing! Smaller images will not be resized larger.

![image](https://user-images.githubusercontent.com/6765732/31734703-34e08194-b405-11e7-9720-b3c92897ff20.png)


----
UUID: d411186f-fcf2-4226-b4dc-55983626def6
