### PR TITLE
Restrict Challenge Summary String in API

### DIFF
--- a/website/server/controllers/api-v3/challenges.js
+++ b/website/server/controllers/api-v3/challenges.js
@@ -223,6 +223,8 @@ api.createChallenge = {
 
     if (!req.body.summary) {
       req.body.summary = req.body.name;
+    } else {
+      req.body.summary = req.body.summary.substring(0, Challenge.MAX_SUMMARY_SIZE_FOR_CHALLENGES);
     }
     req.body.leader = user._id;
     req.body.official = user.contributor.admin && req.body.official ? true : false;


### PR DESCRIPTION
Uses substring to cleave off the end of a challenge summary if it's over the constant defining the size limit for the summary.

[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
https://github.com/HabitRPG/habitica/issues/9244

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Just *hopefully* adds a string length limit for the summary to a challenge on the API level, which shouldn't happen anyway because the website restricts the length.

[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: 4a58daa4-52de-49ff-b768-38bfbc84a563

