### PR TITLE
Validate that everyX values in dailies are integers bounded by 0 and 9999 fixes #8782

### DIFF
--- a/migrations/tasks/tasks-set-everyX.js
+++ b/migrations/tasks/tasks-set-everyX.js
@@ -56,7 +56,7 @@ function updateTasks (tasks) {
 
   return Promise.all(taskPromises)
   .then(function () {
-    processtasks(lasttask._id);
+    processTasks(lasttask._id);
   });
 }
 

--- a/migrations/tasks/tasks-set-everyX.js
+++ b/migrations/tasks/tasks-set-everyX.js
@@ -1,0 +1,88 @@
+var migrationName = 'tasks-set-everyX';
+var authorName = ''; // in case script author needs to know when their ...
+var authorUuid = ''; //... own data is done
+
+/*
+ * Iterates over all tasks and sets invalid everyX values (less than 0 or more than 9999 or not an int) field to 0
+ */
+
+var monk = require('monk');
+var connectionString = 'mongodb://localhost:27017/habitrpg?auto_reconnect=true'; // FOR TEST DATABASE
+var dbTasks = monk(connectionString).get('tasks', { castIds: false });
+
+function processTasks(lastId) {
+  // specify a query to limit the affected tasks (empty for all tasks):
+  var query = {
+    type: "daily",
+    everyX: {
+      $not: {
+        $gte: 0,
+        $lte: 9999,
+        $type: "int",
+      }
+    },
+  };
+
+  if (lastId) {
+    query._id = {
+      $gt: lastId
+    }
+  }
+
+  dbTasks.find(query, {
+    sort: {_id: 1},
+    limit: 250,
+    fields: [],
+  })
+  .then(updateTasks)
+  .catch(function (err) {
+    console.log(err);
+    return exiting(1, 'ERROR! ' + err);
+  });
+}
+
+var progressCount = 1000;
+var count = 0;
+
+function updateTasks (tasks) {
+  if (!tasks || tasks.length === 0) {
+    console.warn('All appropriate tasks found and modified.');
+    displayData();
+    return;
+  }
+
+  var taskPromises = tasks.map(updatetask);
+  var lasttask = tasks[tasks.length - 1];
+
+  return Promise.all(taskPromises)
+  .then(function () {
+    processtasks(lasttask._id);
+  });
+}
+
+function updatetask (task) {
+  count++;
+  var set = {'everyX': 0};
+
+  dbTasks.update({_id: task._id}, {$set:set});
+
+  if (count % progressCount == 0) console.warn(count + ' ' + task._id);
+  if (task._id == authorUuid) console.warn(authorName + ' processed');
+}
+
+function displayData() {
+  console.warn('\n' + count + ' tasks processed\n');
+  return exiting(0);
+}
+
+function exiting(code, msg) {
+  code = code || 0; // 0 = success
+  if (code && !msg) { msg = 'ERROR!'; }
+  if (msg) {
+    if (code) { console.error(msg); }
+    else      { console.log(  msg); }
+  }
+  process.exit(code);
+}
+
+module.exports = processTasks;

--- a/test/api/v3/integration/tasks/POST-tasks_user.test.js
+++ b/test/api/v3/integration/tasks/POST-tasks_user.test.js
@@ -628,6 +628,43 @@ describe('POST /tasks/user', () => {
       });
     });
 
+    it('returns an error if everyX is a non int', async () => {
+      await expect(user.post('/tasks/user', {
+        text: 'test daily',
+        type: 'daily',
+        everyX: 2.5,
+      })).to.eventually.be.rejected.and.eql({
+        code: 400,
+        error: 'BadRequest',
+        message: 'daily validation failed',
+      });
+    });
+
+    it('returns an error if everyX is negative', async () => {
+      await expect(user.post('/tasks/user', {
+        text: 'test daily',
+        type: 'daily',
+        everyX: -1,
+      })).to.eventually.be.rejected.and.eql({
+        code: 400,
+        error: 'BadRequest',
+        message: 'daily validation failed',
+      });
+    });
+
+    it('returns an error if everyX is above 9999', async () => {
+      await expect(user.post('/tasks/user', {
+        text: 'test daily',
+        type: 'daily',
+        everyX: 10000,
+      })).to.eventually.be.rejected.and.eql({
+        code: 400,
+        error: 'BadRequest',
+        message: 'daily validation failed',
+      });
+    });
+
+
     it('can create checklists', async () => {
       let task = await user.post('/tasks/user', {
         text: 'test daily',

--- a/test/common/ops/addTask.js
+++ b/test/common/ops/addTask.js
@@ -38,7 +38,7 @@ describe('shared.ops.addTask', () => {
     expect(habit.counterDown).to.equal(0);
   });
 
-  it('adds an habtit when type is invalid', () => {
+  it('adds a habit when type is invalid', () => {
     let habit = addTask(user, {
       body: {
         type: 'invalid',

--- a/website/client/components/tasks/taskModal.vue
+++ b/website/client/components/tasks/taskModal.vue
@@ -98,7 +98,7 @@
                 | {{ $t(frequency) }}
           .form-group
             label(v-once) {{ $t('repeatEvery') }}
-            input(type="number", v-model="task.everyX", min="0", required, :disabled='challengeAccessRequired')
+            input(type="number", v-model="task.everyX", min="0", max="9999", required, :disabled='challengeAccessRequired')
             | {{ repeatSuffix }}
             br
           template(v-if="task.frequency === 'weekly'")

--- a/website/server/models/task.js
+++ b/website/server/models/task.js
@@ -239,7 +239,14 @@ export let habit = Task.discriminator('habit', HabitSchema);
 
 export let DailySchema = new Schema(_.defaults({
   frequency: {type: String, default: 'weekly', enum: ['daily', 'weekly', 'monthly', 'yearly']},
-  everyX: {type: Number, default: 1}, // e.g. once every X weeks
+  everyX: {
+    type: Number,
+    default: 1,
+    validate: [
+      (val) => val % 1 === 0 && val >= 0 && val <= 9999,
+      'Valid everyX values are integers from 0 to 9999',
+    ],
+  },
   startDate: {
     type: Date,
     default () {


### PR DESCRIPTION
[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
https://github.com/HabitRPG/habitica/issues/8782

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Added validation to daily schema, prevents non integer values from being used for everyX.

Note: also added bounding to everyX values, now all values must be 0 to 9999 (inclusive). This was not requested in the issue, but looking at cron.js:99 all dailies with values above 9999 or below 1 are treated as 0, thus the bounding makes sense in this case. In addition added the client side check in editing a task to make sure values are bounded by 9999 as well.

**(Manual) Test cases:**
```
"banana" 
834758923475890234752038945723409857234980572394805728930475390284671827385
-8347589234758902347520389457234098572349805723948057289304753902846718273
10000 
-1
2.5
2.333333
```
all return 400 response code with the following
```
"errors": [{
            "message": "Valid everyX values are integers from 0 to 9999",
            "path": "everyX",
            "value": <SENT-VALUE>
} ]

```
These test cases
```
0
1
2
9998
9999
```
all return 200 response code


@alys would like to remind any admins that before this PR is merged to remove existing non-int values. Not sure how to link to a git comment but it's in the comments on the issue.
"Don't worry about existing non-int values in the database - admins will remove those before your PR is merged. If you could remind us of that in your PR, we'd be grateful. :)"

----
UUID: f57bd235-ec21-4357-b5c9-a0536294b285
