### PR TITLE
Choose class modal remove tooltip

### DIFF
--- a/website/client/components/achievements/chooseClass.vue
+++ b/website/client/components/achievements/chooseClass.vue
@@ -67,10 +67,6 @@
     cursor: pointer;
   }
 
-  .opt-out-wrapper {
-    margin: 1em 0 0.5em 0;
-  }
-
   .class-name {
     font-size: 24px;
     font-weight: bold;
@@ -90,6 +86,10 @@
 
   .modal-actions {
     margin: 2em auto;
+  }
+
+  .opt-out-wrapper {
+    margin: 1em 0 0.5em 0;
   }
 
   .selection-box {

--- a/website/client/components/achievements/chooseClass.vue
+++ b/website/client/components/achievements/chooseClass.vue
@@ -35,21 +35,13 @@
         .modal-actions.text-center
           button.btn.btn-primary.d-inline-block(v-if='!selectedClass', :disabled='true') {{ $t('select') }}
           button.btn.btn-primary.d-inline-block(v-else, @click='clickSelectClass(selectedClass); close();') {{ $t('selectClass', {heroClass: $t(selectedClass)}) }}
-          #classOptOutBtn.danger(@click='clickDisableClasses(); close();') {{ $t('optOutOfClasses') }}
-          b-popover.d-inline-block(
-            target="classOptOutBtn",
-            triggers="hover",
-            placement="top",
-          )
-            .popover-content-text {{ $t('optOutOfClassesText') }}
+          .opt-out-wrapper
+            span#classOptOutBtn.danger(@click='clickDisableClasses(); close();') {{ $t('optOutOfClasses') }}
+          span.opt-out-description {{ $t('optOutOfClassesText') }}
 </template>
 
 <style lang="scss" scoped>
   @import '~client/assets/scss/colors.scss';
-
-  .btn-primary {
-    margin-right: 1em;
-  }
 
   .class-badge {
     $badge-size: 32px;
@@ -69,6 +61,14 @@
   .class-explanation {
     font-size: 16px;
     margin: 1.5em auto;
+  }
+
+  #classOptOutBtn {
+    cursor: pointer;
+  }
+
+  .opt-out-wrapper {
+    margin: 1em 0 0.5em 0;
   }
 
   .class-name {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes https://github.com/HabitRPG/habitica/issues/9132

* Note that this is one of the two options I provided in the issue. I've done ahead and created both PRs so that @Tressley can easily see the two proposals

Advantage of this option: it is clear right away what the action of the Opt Out button without having to hover over it
Disadvantage: UI looks a little cluttered

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
- Remove the tooltip on hover of the Opt Out button in the choose class modal
- Change opt out to be a span inside a wrapper to prevent it taking up the whole modal width
- Add pointer cursor over the Opt Out text to show that it is clickable
- Center the Select button
- Minor margin adjustment for Opt Out button

## Screenshots:
![choosclassremovetooltipclassselected](https://user-images.githubusercontent.com/5060851/32090326-b605c5fa-baa3-11e7-86ab-aee822e6c1a8.png)
![chooseclassremovetooltip](https://user-images.githubusercontent.com/5060851/32090327-b61e57fa-baa3-11e7-9f5c-c7908218d5a3.png)


[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: 9135bc92-bf74-4c15-82c2-64f1128fe950
