### PR TITLE
Choose class modal use only tooltip for Opt Out text

### DIFF
--- a/website/client/components/achievements/chooseClass.vue
+++ b/website/client/components/achievements/chooseClass.vue
@@ -35,21 +35,17 @@
         .modal-actions.text-center
           button.btn.btn-primary.d-inline-block(v-if='!selectedClass', :disabled='true') {{ $t('select') }}
           button.btn.btn-primary.d-inline-block(v-else, @click='clickSelectClass(selectedClass); close();') {{ $t('selectClass', {heroClass: $t(selectedClass)}) }}
-          #classOptOutBtn.danger(@click='clickDisableClasses(); close();') {{ $t('optOutOfClasses') }}
-          b-popover.d-inline-block(
-            target="classOptOutBtn",
-            triggers="hover",
-            placement="top",
-          )
-            .popover-content-text {{ $t('optOutOfClassesText') }}
+          .opt-out-wrapper
+            span#classOptOutBtn.danger(@click='clickDisableClasses(); close();') {{ $t('optOutOfClasses') }}
+            b-popover.popover-content-text(
+              target="classOptOutBtn",
+              triggers="hover",
+              placement="top",
+            ) {{ $t('optOutOfClassesText') }}
 </template>
 
 <style lang="scss" scoped>
   @import '~client/assets/scss/colors.scss';
-
-  .btn-primary {
-    margin-right: 1em;
-  }
 
   .class-badge {
     $badge-size: 32px;
@@ -77,6 +73,10 @@
     margin: auto 0.33333em;
   }
 
+  #classOptOutBtn {
+    cursor: pointer;
+  }
+
   .danger {
     color: $red-50;
     margin-bottom: 0em;
@@ -90,6 +90,10 @@
 
   .modal-actions {
     margin: 2em auto;
+  }
+
+  .opt-out-wrapper {
+    margin: 1em 0 0.5em 0;
   }
 
   .selection-box {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Habitica_Git#Pull_Request for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes https://github.com/HabitRPG/habitica/issues/9132

* Note that this is one of the two options I provided in the issue. I've done ahead and created both PRs so that @Tressley can easily see the two proposals

Advantage of this option: the UI is cleaner without text below the Opt Out button
Disadvantage: user must hover over the opt out button to see actionable description

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
- Remove the tooltip on hover of the Opt Out button in the choose class modal
- Change opt out to be a span inside a wrapper to prevent it taking up the whole modal width
- Add pointer cursor over the Opt Out text to show that it is clickable
- Center the Select button
- Minor margin adjustment for Opt Out button

## Screenshots:
![chooseclasstooltipnohover](https://user-images.githubusercontent.com/5060851/32090506-9953ea94-baa4-11e7-8fce-49284009ee8c.png)
![chooseclasstooltiphover](https://user-images.githubusercontent.com/5060851/32090508-9c54506c-baa4-11e7-9153-e138024c92ff.png)
![choosclasstooltipclassselected](https://user-images.githubusercontent.com/5060851/32090517-a6c3494a-baa4-11e7-96a3-455478f54aa6.png)
![chooseclasstooltipclassselectedhover](https://user-images.githubusercontent.com/5060851/32090538-bcec4d02-baa4-11e7-90ec-da10afa162ca.png)




[//]: # (Put User ID in here - found in Settings -> API)

----
UUID: 9135bc92-bf74-4c15-82c2-64f1128fe950
