### PR TITLE
Make a challenge's leader profile available via click

### DIFF
--- a/website/client/components/challenges/challengeDetail.vue
+++ b/website/client/components/challenges/challengeDetail.vue
@@ -8,7 +8,7 @@
     .row
       .col-8
         h1(v-markdown='challenge.name')
-        div
+        div(@click="showLeaderProfileModal(challenge.leader)")
           strong(v-once) {{$t('createdBy')}}:
           span(v-if='challenge.leader && challenge.leader.profile') {{challenge.leader.profile.name}}
           // @TODO: make challenge.author a variable inside the createdBy string (helps with RTL languages)
@@ -362,6 +362,12 @@ export default {
       this.$store.state.memberModalOptions.group = this.group;
       this.$store.state.memberModalOptions.viewingMembers = this.members;
       this.$root.$emit('show::modal', 'members-modal');
+    },
+    async showLeaderProfileModal (leader) {
+      let leaderDetails = await this.$store.dispatch('members:fetchMember', { memberId: leader._id });
+      this.$store.state.profileUser = leaderDetails.data.data;
+      this.$store.state.profileOptions.startingPage = 'profile';
+      this.$root.$emit('show::modal', 'profile');
     },
     async joinChallenge () {
       this.user.challenges.push(this.searchId);


### PR DESCRIPTION
Fixes https://github.com/HabitRPG/habitica/issues/9283

### Changes
When viewing a challenge, it was requested that the leader's profile be made available for quick access. This PR makes the challenge leaders name clickable, fetching and showing their profile via modal.

![oct-27-2017 14-51-35](https://user-images.githubusercontent.com/1076168/32126946-59619e3e-bb28-11e7-8431-a7f6dcab13e9.gif)
_The mouse clicks were not captured, but in this gif I click "Spidy" next to "Created By"_

----
UUID: 80036403-41ff-4ac8-b398-247af41c68dc
