### PR TITLE
WIP Tests for new summary field in challenges and public guilds (partial fix for #9245)

### DIFF
--- a/test/api/v3/integration/challenges/POST-challenges.test.js
+++ b/test/api/v3/integration/challenges/POST-challenges.test.js
@@ -315,7 +315,7 @@ describe('POST /challenges', () => {
       expect(groupLeader.achievements.joinedChallenge).to.be.true;
     });
 
-    it.only('sets challenge summary equal to challenge name if no summary provided', async () => {
+    it('sets challenge summary equal to challenge name if no summary provided', async () => {
       let name = 'Test Challenge'
 
       let challenge = await groupLeader.post('/challenges', {

--- a/test/api/v3/integration/challenges/POST-challenges.test.js
+++ b/test/api/v3/integration/challenges/POST-challenges.test.js
@@ -315,6 +315,20 @@ describe('POST /challenges', () => {
       expect(groupLeader.achievements.joinedChallenge).to.be.true;
     });
 
+    it('successfully sets a summary when summary provided', async () => {
+      let name = 'Test Challenge'
+      let summary = 'Test Summary'
+
+      let challenge = await groupLeader.post('/challenges', {
+        group: group._id,
+        name: name,
+        shortName: 'TC Label',
+        summary: summary,
+      });
+
+      expect(challenge.summary).to.eql(summary);
+    });
+
     it('sets challenge summary equal to challenge name if no summary provided', async () => {
       let name = 'Test Challenge'
 

--- a/test/api/v3/integration/challenges/POST-challenges.test.js
+++ b/test/api/v3/integration/challenges/POST-challenges.test.js
@@ -314,5 +314,19 @@ describe('POST /challenges', () => {
       groupLeader = await groupLeader.sync();
       expect(groupLeader.achievements.joinedChallenge).to.be.true;
     });
+
+    it.only('sets challenge summary equal to challenge name if no summary provided', async () => {
+      let name = 'Test Challenge'
+
+      let challenge = await groupLeader.post('/challenges', {
+        group: group._id,
+        name: name,
+        shortName: 'TC Label',
+        summary: null,
+      });
+
+      expect(challenge.name).to.eql(challenge.summary);
+    });
+
   });
 });

--- a/test/api/v3/integration/groups/POST-groups.test.js
+++ b/test/api/v3/integration/groups/POST-groups.test.js
@@ -87,15 +87,18 @@ describe('POST /group', () => {
     });
 
     context('public guild', () => {
+      let groupName = 'Test Public Guild';
+      let groupType = 'guild';
+      let groupPrivacy = 'public';
+      let summary = 'Test Summary';
+
       it('creates a group', async () => {
-        let groupName = 'Test Public Guild';
-        let groupType = 'guild';
-        let groupPrivacy = 'public';
 
         let publicGuild = await user.post('/groups', {
           name: groupName,
           type: groupType,
           privacy: groupPrivacy,
+          summary: summary,
         });
 
         expect(publicGuild._id).to.exist;
@@ -103,6 +106,7 @@ describe('POST /group', () => {
         expect(publicGuild.type).to.equal(groupType);
         expect(publicGuild.memberCount).to.equal(1);
         expect(publicGuild.privacy).to.equal(groupPrivacy);
+        expect(publicGuild.summary).to.equal(summary);
         expect(publicGuild.leader).to.eql({
           _id: user._id,
           profile: {
@@ -110,18 +114,30 @@ describe('POST /group', () => {
           },
         });
       });
+
+      it('sets the summary equal to the name if no summary provided', async () => {
+        let publicGuild = await user.post('/groups', {
+          name: groupName,
+          type: groupType,
+          privacy: groupPrivacy,
+        });
+
+        expect(publicGuild.summary).to.eql(groupName);
+      });
     });
 
     context('private guild', () => {
       let groupName = 'Test Private Guild';
       let groupType = 'guild';
       let groupPrivacy = 'private';
+      let summary = 'Test Summary';
 
       it('creates a group', async () => {
         let privateGuild = await user.post('/groups', {
           name: groupName,
           type: groupType,
           privacy: groupPrivacy,
+          summary: summary,
         });
 
         expect(privateGuild._id).to.exist;
@@ -129,6 +145,7 @@ describe('POST /group', () => {
         expect(privateGuild.type).to.equal(groupType);
         expect(privateGuild.memberCount).to.equal(1);
         expect(privateGuild.privacy).to.equal(groupPrivacy);
+        expect(privateGuild.summary).to.equal(summary);
         expect(privateGuild.leader).to.eql({
           _id: user._id,
           profile: {
@@ -149,6 +166,16 @@ describe('POST /group', () => {
         let updatedUser = await user.get('/user');
 
         expect(updatedUser.balance).to.eql(user.balance - 1);
+      });
+
+      it('sets the summary equal to the name if no summary provided', async () => {
+        let privateGuild = await user.post('/groups', {
+          name: groupName,
+          type: groupType,
+          privacy: groupPrivacy,
+        });
+
+        expect(privateGuild.summary).to.eql(groupName);
       });
     });
   });

--- a/test/api/v3/integration/groups/POST-groups.test.js
+++ b/test/api/v3/integration/groups/POST-groups.test.js
@@ -115,11 +115,13 @@ describe('POST /group', () => {
         });
       });
 
+      // @TODO I'm pretty sure this test is written correctly, but it is not passing
       it('sets the summary equal to the name if no summary provided', async () => {
         let publicGuild = await user.post('/groups', {
           name: groupName,
           type: groupType,
           privacy: groupPrivacy,
+          summary: null,
         });
 
         expect(publicGuild.summary).to.eql(groupName);
@@ -166,16 +168,6 @@ describe('POST /group', () => {
         let updatedUser = await user.get('/user');
 
         expect(updatedUser.balance).to.eql(user.balance - 1);
-      });
-
-      it('sets the summary equal to the name if no summary provided', async () => {
-        let privateGuild = await user.post('/groups', {
-          name: groupName,
-          type: groupType,
-          privacy: groupPrivacy,
-        });
-
-        expect(privateGuild.summary).to.eql(groupName);
       });
     });
   });


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Partial fix https://github.com/HabitRPG/habitica/issues/9245

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

4 new integration tests:

Tests creation of challenge through the API with NO summary provided - summary should equal challenge.name (necessary to ensure backwards compatibility for existing third-party tools)

Tests creating a challenge with a summary provided - summary should be correct

Tests creating a public guild with a summary provided - summary should be correct

WIP: Tests creating a public guild with NO summary provided - summary should equal guild.name. This is not working. Opening a PR to see if Travis CI returns useful information.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: b2e304a7-2830-4788-95aa-a2cc5230c4da
