### PR TITLE
Fixed party modal shown incorrectly after viewing challenge participants. Fixes https://github.com/HabitRPG/habitica/issues/9294

### DIFF
--- a/website/client/components/appHeader.vue
+++ b/website/client/components/appHeader.vue
@@ -157,6 +157,7 @@ export default {
     openPartyModal () {
       if (this.user.party._id) {
         this.$store.state.memberModalOptions.groupId = this.user.party._id;
+        this.$store.state.memberModalOptions.viewingMembers = this.partyMembers;
         // @TODO: do we need to fetch party?
         // this.$store.state.memberModalOptions.group = this.$store.state.party;
         this.$root.$emit('show::modal', 'members-modal');


### PR DESCRIPTION
Fixes https://github.com/HabitRPG/habitica/issues/9294
Issue #9294: Can't view Party modal after viewing Challenge participants

### Changes
Fix: In the function called for opening the party modal the party members "this.partMembers" is assigned to "this.$store.state.memberModalOptions.viewingMembers", which is used to show the list of members.
Bug: Whenever the challenge participants were seen this variable was changed, and therefore the party modal showed the wrong list of members, because variable was never changed to previous state.

----
UUID: 059375fe-7075-4b24-9154-d8236f4c4e76
