### PR TITLE
Rename constant for restricted email domains

### DIFF
--- a/website/server/models/user/schema.js
+++ b/website/server/models/user/schema.js
@@ -14,7 +14,7 @@ import {
 
 const Schema = mongoose.Schema;
 
-const INVALID_DOMAINS = Object.freeze(['habitica.com', 'habitrpg.com']);
+const RESTRICTED_EMAIL_DOMAINS = Object.freeze(['habitica.com', 'habitrpg.com']);
 
 // User schema definition
 let schema = new Schema({
@@ -41,11 +41,11 @@ let schema = new Schema({
           validator (email) {
             let lowercaseEmail = email.toLowerCase();
 
-            return INVALID_DOMAINS.every((domain) => {
+            return RESTRICTED_EMAIL_DOMAINS.every((domain) => {
               return !lowercaseEmail.endsWith(`@${domain}`);
             });
           },
-          message: shared.i18n.t('invalidEmailDomain', { domains: INVALID_DOMAINS.join(', ')}),
+          message: shared.i18n.t('invalidEmailDomain', { domains: RESTRICTED_EMAIL_DOMAINS.join(', ')}),
         }],
       },
       username: {


### PR DESCRIPTION
### Changes

This was just bugging me. The constant is `INVALID_DOMAINS` but does not give much indication what it is for. You need to actually parse the code to figure it out. I think a simple rename to `RESTRICTED_EMAIL_DOMAINS` makes it a bit clearer.

Feel free to just close this if y'all don't care. Won't get my feelings hurt. 😄 