### PR TITLE
Add variable placeholder.

### DIFF
--- a/website/client/components/challenges/challengeModal.vue
+++ b/website/client/components/challenges/challengeModal.vue
@@ -12,7 +12,7 @@
       .form-group
         label
           strong(v-once) {{$t('challengeSummary')}} *
-        div.summary-count {{charactersRemaining}} {{ $t('charactersRemaining') }}
+        div.summary-count {{ $t('charactersRemaining', {characters: charactersRemaining}) }}
         textarea.summary-textarea.form-control(:placeholder="$t('challengeSummaryPlaceholder')", v-model="workingChallenge.summary")
       .form-group
         label

--- a/website/client/components/groups/groupFormModal.vue
+++ b/website/client/components/groups/groupFormModal.vue
@@ -56,7 +56,7 @@
       .form-group(v-if='!isParty')
         label
           strong(v-once) {{$t('guildSummary')}} *
-        div.summary-count {{charactersRemaining}} {{ $t('charactersRemaining') }}
+        div.summary-count {{ $t('charactersRemaining', {characters: charactersRemaining}) }}
         textarea.form-control.summary-textarea(:placeholder="isParty ? $t('partyDescriptionPlaceholder') : $t('guildSummaryPlaceholder')", v-model="workingGroup.summary")
         // @TODO: need summary only for PUBLIC GUILDS, not for tavern, private guilds, or party
 

--- a/website/common/locales/en/groups.json
+++ b/website/common/locales/en/groups.json
@@ -353,7 +353,7 @@
   "privacySettings": "Privacy Settings",
   "onlyLeaderCreatesChallenges": "Only the Leader can create Challenges",
   "privateGuild": "Private Guild",
-  "charactersRemaining": "characters remaining",
+  "charactersRemaining": "<%= characters %> characters remaining",
   "guildSummary": "Summary",
   "guildSummaryPlaceholder": "Write a short description advertising your Guild to other Habiticans. What is the main purpose of your Guild and why should people join it? Try to include useful keywords in the summary so that Habiticans can easily find it when they search!",
   "groupDescription": "Description",


### PR DESCRIPTION
Fixes #9451

### Changes
Changes the character translation string `charactersRemaining`  in
groups.json to include a variable placeholder `<%= characters %>`

Changed how that string is used in `groupFormModal.vue` and `challengeModal.vue` to account for the variable placeholder.

----
UUID: cc212fcc-5f96-403b-a785-17ba66c7b11a
