### PR TITLE
Add quantity information to Amplitude analytics data when purchasing items

### DIFF
--- a/website/common/script/ops/purchase.js
+++ b/website/common/script/ops/purchase.js
@@ -156,6 +156,7 @@ module.exports = function purchase (user, req = {}, analytics) {
       itemType: 'Market',
       acquireMethod: 'Gems',
       gemCost: price * 4,
+      quantityPurchased: quantity,
       category: 'behavior',
       headers: req.headers,
     });


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes https://github.com/HabitRPG/habitica/issues/9462

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Adds a `quantityPurchased` key to items purchased with gems, such as eggs, potions, food, quests, etc.

@Alys 

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 
