### PR TITLE
Remove spaces from filter categories

### DIFF
--- a/website/client/components/challenges/sidebar.vue
+++ b/website/client/components/challenges/sidebar.vue
@@ -83,19 +83,19 @@ export default {
         },
         {
           label: 'mental_health',
-          key: 'mental_health ',
+          key: 'mental_health',
         },
         {
           label: 'getting_organized',
-          key: 'getting_organized ',
+          key: 'getting_organized',
         },
         {
           label: 'self_improvement',
-          key: 'self_improvement ',
+          key: 'self_improvement',
         },
         {
           label: 'spirituality',
-          key: 'spirituality ',
+          key: 'spirituality',
         },
         {
           label: 'time_management',


### PR DESCRIPTION
Found a bug while working on a different issue. [Take a look at this line](https://github.com/HabitRPG/habitica/blob/0c713ab368630781bb399f3bf07be4f8d09b88c1/website/client/components/challenges/sidebar.vue#L97). The `spirituality` key has a space at the end. So does, `mental_health`, `getting_organized`, and `self_improvement`. This makes the challenge filter not pick up on the mentioned categories. I tested each category and removing the space made them appear on the My Challenges page when the filter was applied. 

---
UUID: ugly_cat (b16e0c46-c20b-4aea-9f1f-6e9dd80ad61b)


