### PR TITLE
Remove extra 'to' paramater from router link

### DIFF
--- a/website/client/components/header/menu.vue
+++ b/website/client/components/header/menu.vue
@@ -46,7 +46,7 @@ div
           .dropdown-menu
             router-link.dropdown-item(:to="{name: 'myChallenges'}") {{ $t('myChallenges') }}
             router-link.dropdown-item(:to="{name: 'findChallenges'}") {{ $t('findChallenges') }}
-        router-link.nav-item.dropdown(tag="li", to="/help", :class="{'active': $route.path.startsWith('/help')}", :to="{name: 'faq'}")
+        router-link.nav-item.dropdown(tag="li", :class="{'active': $route.path.startsWith('/help')}", :to="{name: 'faq'}")
           a.nav-link(v-once) {{ $t('help') }}
           .dropdown-menu
             router-link.dropdown-item(:to="{name: 'faq'}") {{ $t('faq') }}


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)


### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Removed an extra `to` from the following line (`to="/help"`):

https://github.com/HabitRPG/habitica/blob/c06d5107ac7e45fa1edfa803a2085e37633d6113/website/client/components/header/menu.vue#L49

This line was causing the client tests to fail out because PhantomJS would throw a syntax error. 

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: ID:b16e0c46-c20b-4aea-9f1f-6e9dd80ad61b
