### PR TITLE
Show not participating and owned challenges on MyChallenges page.

### DIFF
--- a/website/client/components/challenges/findChallenges.vue
+++ b/website/client/components/challenges/findChallenges.vue
@@ -108,6 +108,10 @@ export default {
       if (!this.filters.ownership || this.filters.ownership.length === 0) {
         this.filters.ownership = ['owned', 'not_owned'];
       }
+      // If roles is not defined, show all tasks
+      if (!this.filters.roles || this.filters.roles.length === 0) {
+        this.filters.roles = ['participating', 'not_participating'];
+      }
 
       // @TODO: Move this to the server
       return this.challenges.filter((challenge) => {

--- a/website/client/components/challenges/findChallenges.vue
+++ b/website/client/components/challenges/findChallenges.vue
@@ -103,6 +103,12 @@ export default {
       let search = this.search;
       let filters = this.filters;
       let user = this.$store.state.user.data;
+
+      // If ownership is not defined, show all tasks
+      if (!this.filters.ownership || this.filters.ownership.length === 0) {
+        this.filters.ownership = ['owned', 'not_owned'];
+      }
+
       // @TODO: Move this to the server
       return this.challenges.filter((challenge) => {
         return this.filterChallenge(challenge, filters, search, user);

--- a/website/client/components/challenges/myChallenges.vue
+++ b/website/client/components/challenges/myChallenges.vue
@@ -130,6 +130,10 @@ export default {
       if (!this.filters.ownership || this.filters.ownership.length === 0) {
         this.filters.ownership = ['owned', 'not_owned'];
       }
+      // If roles is not defined, show all tasks
+      if (!this.filters.roles || this.filters.roles.length === 0) {
+        this.filters.roles = ['participating', 'not_participating'];
+      }
 
       // @TODO: Move this to the server
       return this.challenges.filter((challenge) => {

--- a/website/client/components/challenges/myChallenges.vue
+++ b/website/client/components/challenges/myChallenges.vue
@@ -112,7 +112,7 @@ export default {
       ],
       search: '',
       filters: {
-        roles: ['participating'], // This is required for my challenges
+        ownership: [],
       },
     };
   },
@@ -126,8 +126,10 @@ export default {
       let filters = this.filters;
       let user = this.$store.state.user.data;
 
-      // Always filter by member on this page:
-      filters.roles = ['participating'];
+      // If ownership is not defined, show all tasks
+      if (!this.filters.ownership || this.filters.ownership.length === 0) {
+        this.filters.ownership = ['owned', 'not_owned'];
+      }
 
       // @TODO: Move this to the server
       return this.challenges.filter((challenge) => {

--- a/website/client/components/challenges/sidebar.vue
+++ b/website/client/components/challenges/sidebar.vue
@@ -15,6 +15,16 @@
           input.custom-control-input(type="checkbox", :value='group.key' v-model="categoryFilters")
           span.custom-control-indicator
           span.custom-control-description(v-once) {{ $t(group.label) }}
+    .form-group(v-if='$route.name !== "findChallenges"')
+      h3 Membership
+      .form-check(
+        v-for="group in roleOptions",
+        :key="group.key",
+      )
+        label.custom-control.custom-checkbox
+          input.custom-control-input(type="checkbox", :value='group.key' v-model="roleFilters")
+          span.custom-control-indicator
+          span.custom-control-description(v-once) {{ $t(group.label) }}
     .form-group
       h3 Ownership
       .form-check(

--- a/website/client/components/challenges/sidebar.vue
+++ b/website/client/components/challenges/sidebar.vue
@@ -15,16 +15,6 @@
           input.custom-control-input(type="checkbox", :value='group.key' v-model="categoryFilters")
           span.custom-control-indicator
           span.custom-control-description(v-once) {{ $t(group.label) }}
-    .form-group(v-if='$route.name !== "findChallenges"')
-      h3 Membership
-      .form-check(
-        v-for="group in roleOptions",
-        :key="group.key",
-      )
-        label.custom-control.custom-checkbox
-          input.custom-control-input(type="checkbox", :value='group.key' v-model="roleFilters")
-          span.custom-control-indicator
-          span.custom-control-description(v-once) {{ $t(group.label) }}
     .form-group
       h3 Ownership
       .form-check(

--- a/website/client/mixins/challengeUtilities.js
+++ b/website/client/mixins/challengeUtilities.js
@@ -11,7 +11,8 @@ export default {
     filterChallenge (challenge, filters, search, user) {
       let passedSearch = true;
       let hasCategories = true;
-      let isMember = true;
+      let participating = false;
+      let notParticipating = false;
       let owned = false;
       let notOwned = false;
 
@@ -27,11 +28,11 @@ export default {
 
       let filteringRole = filters.roles && filters.roles.length > 0;
       if (filteringRole && filters.roles.indexOf('participating') !== -1) {
-        isMember = this.isMemberOfChallenge(user, challenge);
+        participating = this.isMemberOfChallenge(user, challenge);
       }
 
       if (filteringRole && filters.roles.indexOf('not_participating') !== -1) {
-        isMember = !this.isMemberOfChallenge(user, challenge);
+        notParticipating = !this.isMemberOfChallenge(user, challenge);
       }
 
       if (filters.ownership && filters.ownership.indexOf('not_owned') !== -1) {
@@ -42,7 +43,7 @@ export default {
         owned = this.isLeaderOfChallenge(user, challenge);
       }
 
-      return passedSearch && hasCategories && isMember && (owned || notOwned);
+      return passedSearch && hasCategories && (participating || notParticipating) && (owned || notOwned);
     },
   },
 };

--- a/website/client/mixins/challengeUtilities.js
+++ b/website/client/mixins/challengeUtilities.js
@@ -12,8 +12,8 @@ export default {
       let passedSearch = true;
       let hasCategories = true;
       let isMember = true;
-      let isLeader = true;
-      let ownerShip = true;
+      let owned = false;
+      let notOwned = false;
 
       if (search) {
         passedSearch = challenge.name.toLowerCase().indexOf(search.toLowerCase()) >= 0;
@@ -35,14 +35,14 @@ export default {
       }
 
       if (filters.ownership && filters.ownership.indexOf('not_owned') !== -1) {
-        ownerShip = !this.isLeaderOfChallenge(user, challenge);
+        notOwned = !this.isLeaderOfChallenge(user, challenge);
       }
 
       if (filters.ownership && filters.ownership.indexOf('owned') !== -1) {
-        ownerShip = this.isLeaderOfChallenge(user, challenge);
+        owned = this.isLeaderOfChallenge(user, challenge);
       }
 
-      return passedSearch && hasCategories && isMember && isLeader && ownerShip;
+      return passedSearch && hasCategories && isMember && (owned || notOwned);
     },
   },
 };


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
#9286

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

* Remove Participating/Not Participating filter. I believe if a user is viewing their challenges, they of course want to see only participating challenges (and owned and not participating challenges). If they are on the discover page, they will want to see only challenges they aren't already participating in.
* Separate the ownership variable in the `challengeUtility` into two variables `owned` and `notOwned`. Necessary for filtering `owned` challenges. Before you couldn't see both Not Owned and Owned challenges because the `ownerShip` variable would be flipped twice, only displaying `owned` challenges. 
* MyChallenges page now displays owned and not participating and participating challenges by default. 
* Removed some unused variables from the `filterChallenges` function. 

NOTE: I referenced issue #9286, but It'd be nice to get a second look into the displaying private challenges issue. I set up a private guild and created some challenges with my test user and had another test user create a few challenges as well. Both challenges showed up fine, so something to look out for!


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: b16e0c46-c20b-4aea-9f1f-6e9dd80ad61b
