### PR TITLE
Unobscure scroll bar in questDetail component (quest details participant list)

### DIFF
--- a/website/client/components/groups/questDetailsModal.vue
+++ b/website/client/components/groups/questDetailsModal.vue
@@ -52,11 +52,10 @@
     height: 460px;
     width: 320px;
     top: 2.5em;
-    left: -22em;
+    left: -22.8em;
     z-index: -1;
     padding: 2em;
-    overflow: scroll;
-
+    overflow-y: auto;
     h3 {
       color: $white;
     }


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #9537

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

- Adjust `left-panel` positioning in the `questDetailModal` component so the scroll-bar is not obscured.
- Change `overflow` of the left-panel to `overflow-y`. I added an extra long username to the left-panel and it wrapped to the next line, so I assume `overflow-x` isn't necessary. 


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: b16e0c46-c20b-4aea-9f1f-6e9dd80ad61b
