### PR TITLE
WIP workaround to stop the random behavior mentioned in issue #9393 (Close Challenge Popup / modal appears erroneously)

### DIFF
--- a/website/client/app.vue
+++ b/website/client/app.vue
@@ -280,7 +280,7 @@ export default {
 
       // Get last modal on stack and hide
       let modalStackLength = this.$store.state.modalStack.length;
-      let modalOnTop = this.$store.state.modalStack[modalStackLength - 1];
+      let modalOnTop = this.$store.state.modalStack[modalStackLength];
 
       // Add new modal to the stack
       this.$store.state.modalStack.push(modalId);
@@ -296,8 +296,8 @@ export default {
       const modalId = bvEvent.target.id;
 
       let modalStackLength = this.$store.state.modalStack.length;
-      let modalOnTop = this.$store.state.modalStack[modalStackLength - 1];
-      let modalSecondToTop = this.$store.state.modalStack[modalStackLength - 2];
+      let modalOnTop = this.$store.state.modalStack[modalStackLength];
+      let modalSecondToTop = this.$store.state.modalStack[modalStackLength - 1];
       // Don't remove modal if hid was called from main app
       // @TODO: I'd reather use this, but I don't know how to pass data to hidden event
       // if (data && data.fromRoot) return;
@@ -308,7 +308,7 @@ export default {
 
       // Recalculate and show the last modal if there is one
       modalStackLength = this.$store.state.modalStack.length;
-      modalOnTop = this.$store.state.modalStack[modalStackLength - 1];
+      modalOnTop = this.$store.state.modalStack[modalStackLength];
       if (modalOnTop) this.$root.$emit('bv::show::modal', modalOnTop, {fromRoot: true});
     });
   },

--- a/website/client/components/challenges/challengeDetail.vue
+++ b/website/client/components/challenges/challengeDetail.vue
@@ -329,7 +329,7 @@ export default {
       this.workingTask = this.editingTask;
       // Necessary otherwise the first time the modal is not rendered
       Vue.nextTick(() => {
-        this.$root.$emit('bv::show::modal', 'task-modal');
+        this.$root.$emit('bv::show::modal', 'task-modal', 'bv::hide::modal');
       });
     },
     createTask (type) {
@@ -338,7 +338,7 @@ export default {
       this.workingTask = this.creatingTask;
       // Necessary otherwise the first time the modal is not rendered
       Vue.nextTick(() => {
-        this.$root.$emit('bv::show::modal', 'task-modal');
+        this.$root.$emit('bv::show::modal', 'task-modal', 'bv::hide::modal');
       });
     },
     cancelTaskModal () {
@@ -365,7 +365,7 @@ export default {
       this.$store.state.memberModalOptions.groupId = 'challenge'; // @TODO: change these terrible settings
       this.$store.state.memberModalOptions.group = this.group;
       this.$store.state.memberModalOptions.viewingMembers = this.members;
-      this.$root.$emit('bv::show::modal', 'members-modal');
+      this.$root.$emit('bv::show::modal', 'members-modal', 'bv::hide::modal');
     },
     async joinChallenge () {
       this.user.challenges.push(this.searchId);
@@ -373,16 +373,16 @@ export default {
       await this.$store.dispatch('tasks:fetchUserTasks', {forceLoad: true});
     },
     async leaveChallenge () {
-      this.$root.$emit('bv::show::modal', 'leave-challenge-modal');
+      this.$root.$emit('bv::show::modal', 'leave-challenge-modal', 'bv::hide::modal');
     },
     closeChallenge () {
-      this.$root.$emit('bv::show::modal', 'close-challenge-modal');
+      this.$root.$emit('bv::show::modal', 'close-challenge-modal', 'bv::hide::modal');
     },
     edit () {
       // @TODO: set working challenge
       this.cloning = false;
       this.$store.state.challengeOptions.workingChallenge = Object.assign({}, this.$store.state.challengeOptions.workingChallenge, this.challenge);
-      this.$root.$emit('bv::show::modal', 'challenge-modal');
+      this.$root.$emit('bv::show::modal', 'challenge-modal', 'bv::hide::modal');
     },
     // @TODO: view members
     updatedChallenge (eventData) {
@@ -390,7 +390,7 @@ export default {
     },
     openMemberProgressModal (memberId) {
       this.progressMemberId = memberId;
-      this.$root.$emit('bv::show::modal', 'challenge-member-modal');
+      this.$root.$emit('bv::show::modal', 'challenge-member-modal', 'bv::hide::modal');
     },
     async exportChallengeCsv () {
       // let response = await this.$store.dispatch('challenges:exportChallengeCsv', {
@@ -402,7 +402,7 @@ export default {
       this.cloning = true;
       this.$store.state.challengeOptions.tasksToClone = this.tasksByType;
       this.$store.state.challengeOptions.workingChallenge = Object.assign({}, this.$store.state.challengeOptions.workingChallenge, this.challenge);
-      this.$root.$emit('bv::show::modal', 'challenge-modal');
+      this.$root.$emit('bv::show::modal', 'challenge-modal', 'bv::hide::modal');
     },
   },
 };


### PR DESCRIPTION
Fixes https://github.com/HabitRPG/habitica/issues/9393

**### Changes**
This will stop the random behavior of the challenge modals. Apparently the problem is caused not only when deleting a challenge, but also when creating one. 

In addition to details given in issue #9393, to reproduce the error when creating a challenge: 
1- Create a new challenge
2- Once created and redirected to the new challenge, click on **Edit Challenge** button but don't change anything
3- Exit the modal by clicking outside the modal dialog
4- Click on **End Challenge** button and exit the same way

Now you'll notice the **Editing Challenge** modal pop up after exiting the **End Challenge** one. This behavior will persist now every time **End Challenge** is clicked until the page is refreshed. 

Notice this behavior will change if **Clone** button is clicked instead of **Edit Challenge** in _step 2_. The only difference now is the modal's title changes from **Editing Challenge** to **Create Challenge**.

Also notice if **Add Task** button is clicked instead of **End Challenge** in _step 4_, the **Editing Challenge** modal will pop up after exiting the **Add Task** modal.

See [Returning focus to the triggering element](https://bootstrap-vue.js.org/docs/components/modal/) for more details on this behavior. In this case, it seems that whatever is being passed as a third argument in each `$emit` statement, the behavior stops.

Thanks.

----
UUID: 4998c3fd-1c32-4ad2-bd2d-cc09823d83c2
