### PR TITLE
Allow users to Batch Buy Quests

### DIFF
--- a/website/client/store/actions/shops.js
+++ b/website/client/store/actions/shops.js
@@ -33,7 +33,7 @@ export function buyQuestItem (store, params) {
 
   return {
     result: opResult,
-    httpCall: axios.post(`/api/v3/user/buy/${params.key}`, {type: 'quest'}),
+    httpCall: axios.post(`/api/v3/user/buy/${params.key}`, {type: 'quest', quantity}),
   };
 }
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes https://github.com/HabitRPG/habitica/issues/9507

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

You can buy multiple quests from the buy modal, but the quantity is never passed to the server. So the client thinks that you are buying the number you said you did and deducts gold for everything, but the server only buys one regardless of how many wanted to buy. This can lead to syncing problems down the road.

Unfortunately, I never was able to create the sync problems that were described in the issue: where you would be permanently deducted gold for quests that you didn't receive, but hopefully if we don't cause the discrepancy in the first place, we won't give it a chance to readjust back to the server values incorrectly.

Since the server and the client use the same code for adjusting the user values, all we needed was that quantity variable to be defined on the server and everything else just fell into place.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: f5d12242-5b66-471d-bfc2-6c3358861d9c
