### PR TITLE
Fixed when user unclaims a task assigned to them

### DIFF
--- a/test/api/v3/integration/tasks/groups/POST-tasks_task_id_unassign.test.js
+++ b/test/api/v3/integration/tasks/groups/POST-tasks_task_id_unassign.test.js
@@ -6,7 +6,7 @@ import {
 import { v4 as generateUUID } from 'uuid';
 import { find } from 'lodash';
 
-describe.only('POST /tasks/:taskId/unassign/:memberId', () => {
+describe('POST /tasks/:taskId/unassign/:memberId', () => {
   let user, guild, member, member2, task;
 
   function findAssignedTask (memberTask) {

--- a/test/api/v3/integration/tasks/groups/POST-tasks_task_id_unassign.test.js
+++ b/test/api/v3/integration/tasks/groups/POST-tasks_task_id_unassign.test.js
@@ -6,7 +6,7 @@ import {
 import { v4 as generateUUID } from 'uuid';
 import { find } from 'lodash';
 
-describe('POST /tasks/:taskId/unassign/:memberId', () => {
+describe.only('POST /tasks/:taskId/unassign/:memberId', () => {
   let user, guild, member, member2, task;
 
   function findAssignedTask (memberTask) {
@@ -75,15 +75,6 @@ describe('POST /tasks/:taskId/unassign/:memberId', () => {
       });
   });
 
-  it('returns error when non leader tries to create a task', async () => {
-    await expect(member.post(`/tasks/${task._id}/unassign/${member._id}`))
-      .to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
-        message: t('onlyGroupLeaderCanEditTasks'),
-      });
-  });
-
   it('unassigns a user from a task', async () => {
     await user.post(`/tasks/${task._id}/unassign/${member._id}`);
 
@@ -139,5 +130,16 @@ describe('POST /tasks/:taskId/unassign/:memberId', () => {
 
     expect(groupTask[0].group.assignedUsers).to.not.contain(member._id);
     expect(syncedTask).to.not.exist;
+  });
+
+  // @TODO: Which do we want? The user to unassign themselves or not. This test was in
+  // here, but then we had a request to allow to unaissgn.
+  xit('returns error when non leader tries to unassign their a task', async () => {
+    await expect(member.post(`/tasks/${task._id}/unassign/${member._id}`))
+      .to.eventually.be.rejected.and.eql({
+        code: 401,
+        error: 'NotAuthorized',
+        message: t('onlyGroupLeaderCanEditTasks'),
+      });
   });
 });

--- a/test/api/v3/integration/tasks/groups/POST-tasks_task_id_unassign.test.js
+++ b/test/api/v3/integration/tasks/groups/POST-tasks_task_id_unassign.test.js
@@ -129,4 +129,15 @@ describe('POST /tasks/:taskId/unassign/:memberId', () => {
     expect(groupTask[0].group.assignedUsers).to.not.contain(member._id);
     expect(syncedTask).to.not.exist;
   });
+
+  it('allows a user to unassign themselves', async () => {
+    await member.post(`/tasks/${task._id}/unassign/${member._id}`);
+
+    let groupTask = await user.get(`/tasks/group/${guild._id}`);
+    let memberTasks = await member.get('/tasks/user');
+    let syncedTask = find(memberTasks, findAssignedTask);
+
+    expect(groupTask[0].group.assignedUsers).to.not.contain(member._id);
+    expect(syncedTask).to.not.exist;
+  });
 });

--- a/website/server/controllers/api-v3/tasks/groups.js
+++ b/website/server/controllers/api-v3/tasks/groups.js
@@ -243,7 +243,7 @@ api.unassignTask = {
     let group = await Group.getGroup({user, groupId: task.group.id, fields});
     if (!group) throw new NotFound(res.t('groupNotFound'));
 
-    if (canNotEditTasks(group, user)) throw new NotAuthorized(res.t('onlyGroupLeaderCanEditTasks'));
+    if (canNotEditTasks(group, user, assignedUserId)) throw new NotAuthorized(res.t('onlyGroupLeaderCanEditTasks'));
 
     await group.unlinkTask(task, assignedUser);
 


### PR DESCRIPTION
Fixes #9428

After fixing the 500 error, a new 401 error was found, so this continues that fix. 