### PR TITLE
Fix for sending chat with ctrl enter for windows chrome/firefox. Fixes https://github.com/HabitRPG/habitica/issues/9380

### DIFF
--- a/website/client/components/groups/group.vue
+++ b/website/client/components/groups/group.vue
@@ -30,7 +30,7 @@
         h3(v-once) {{ $t('chat') }}
 
         .row.new-message-row
-          textarea(:placeholder="!isParty ? $t('chatPlaceholder') : $t('partyChatPlaceholder')", v-model='newMessage', @keydown='updateCarretPosition')
+          textarea(:placeholder="!isParty ? $t('chatPlaceholder') : $t('partyChatPlaceholder')", v-model='newMessage', @keydown='updateCarretPosition', @keyup.ctrl.enter='sendMessage()')
           autocomplete(:text='newMessage', v-on:select="selectedAutocomplete", :coords='coords', :chat='group.chat')
 
         .row
@@ -38,7 +38,7 @@
             button.btn.btn-secondary.float-left.fetch(v-once, @click='fetchRecentMessages()') {{ $t('fetchRecentMessages') }}
             button.btn.btn-secondary.float-left(v-once, @click='reverseChat()') {{ $t('reverseChat') }}
           .col-6
-            button.btn.btn-secondary.send-chat.float-right(v-once, @click='sendMessage()', @keyup.ctrl.enter='sendMessage()') {{ $t('send') }}
+            button.btn.btn-secondary.send-chat.float-right(v-once, @click='sendMessage()') {{ $t('send') }}
 
         .row.community-guidelines(v-if='!communityGuidelinesAccepted')
           div.col-8(v-once, v-html="$t('communityGuidelinesIntro')")

--- a/website/client/components/groups/group.vue
+++ b/website/client/components/groups/group.vue
@@ -712,11 +712,7 @@ export default {
       this._updateCarretPosition(eventUpdate);
     }, 250),
     _updateCarretPosition (eventUpdate) {
-      if (eventUpdate.metaKey && eventUpdate.keyCode === 13) {
-        this.sendMessage();
-        return;
-      }
-
+      
       let text = eventUpdate.target;
       this.getCoord(eventUpdate, text);
     },

--- a/website/client/components/groups/group.vue
+++ b/website/client/components/groups/group.vue
@@ -712,7 +712,6 @@ export default {
       this._updateCarretPosition(eventUpdate);
     }, 250),
     _updateCarretPosition (eventUpdate) {
-      
       let text = eventUpdate.target;
       this.getCoord(eventUpdate, text);
     },

--- a/website/client/components/groups/group.vue
+++ b/website/client/components/groups/group.vue
@@ -38,7 +38,7 @@
             button.btn.btn-secondary.float-left.fetch(v-once, @click='fetchRecentMessages()') {{ $t('fetchRecentMessages') }}
             button.btn.btn-secondary.float-left(v-once, @click='reverseChat()') {{ $t('reverseChat') }}
           .col-6
-            button.btn.btn-secondary.send-chat.float-right(v-once, @click='sendMessage()') {{ $t('send') }}
+            button.btn.btn-secondary.send-chat.float-right(v-once, @click='sendMessage()', @keyup.ctrl.enter='sendMessage()') {{ $t('send') }}
 
         .row.community-guidelines(v-if='!communityGuidelinesAccepted')
           div.col-8(v-once, v-html="$t('communityGuidelinesIntro')")

--- a/website/client/components/groups/tavern.vue
+++ b/website/client/components/groups/tavern.vue
@@ -532,7 +532,6 @@ export default {
       this._updateCarretPosition(eventUpdate);
     }, 250),
     _updateCarretPosition (eventUpdate) {
-      
       let text = eventUpdate.target;
       this.getCoord(eventUpdate, text);
     },

--- a/website/client/components/groups/tavern.vue
+++ b/website/client/components/groups/tavern.vue
@@ -532,11 +532,7 @@ export default {
       this._updateCarretPosition(eventUpdate);
     }, 250),
     _updateCarretPosition (eventUpdate) {
-      if (eventUpdate.metaKey && eventUpdate.keyCode === 13) {
-        this.sendMessage();
-        return;
-      }
-
+      
       let text = eventUpdate.target;
       this.getCoord(eventUpdate, text);
     },

--- a/website/client/components/groups/tavern.vue
+++ b/website/client/components/groups/tavern.vue
@@ -10,7 +10,7 @@
         h3(v-once) {{ $t('tavernChat') }}
 
         .row
-          textarea(:placeholder="$t('tavernCommunityGuidelinesPlaceholder')", v-model='newMessage', :class='{"user-entry": newMessage}', @keydown='updateCarretPosition')
+          textarea(:placeholder="$t('tavernCommunityGuidelinesPlaceholder')", v-model='newMessage', :class='{"user-entry": newMessage}', @keydown='updateCarretPosition', @keyup.ctrl.enter='sendMessage()')
           autocomplete(:text='newMessage', v-on:select="selectedAutocomplete", :coords='coords', :chat='group.chat')
 
         .row


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes https://github.com/HabitRPG/habitica/issues/9380

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Added a keyup event in the tavern and group vue files, tacked it onto the textarea.
Event listens for ctrl.enter and sends the sendMessage, same as with the send button click


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 9c4776eb-7330-465b-85cc-e4ccef6c1ad1
