### PR TITLE
Fixing the pig flying too high in the stable square bug

### DIFF
--- a/website/client/components/inventory/stable/index.vue
+++ b/website/client/components/inventory/stable/index.vue
@@ -867,7 +867,7 @@
         }
 
         if (pet.mountOwned()) {
-          return `GreyedOut Pet Pet-${pet.key}`;
+          return `GreyedOut Pet Pet-${pet.key} ${pet.eggKey}`;
         }
 
         if (pet.isHatchable()) {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes https://github.com/HabitRPG/habitica/issues/9364

### Changes

Because the flying pig sprite is offset upwards a bit in the sprite sheet (so it can be "flying"), there is some CSS put in `website/client/components/inventory/stable/index.vue` to manually adjust the flying pig:

``` css
  .stable .item .item-content.Pet:not(.FlyingPig) {
    top: -28px;
  }

  .stable .item .item-content.FlyingPig {
    top: 7px;
  }
```

Well, the issue is that when you grey out the pets it doesn't include the type of pet anymore as a class and so the `FlyingPig` class is lost. Thus the flying pig doesn't get its special treatment from this CSS when it is greyed out, and it ends up going upwards to it's natural flying pig state.

So this pull request is just me adding the name of the pet back into the class when it is greyed out as well. This name is stored in `${pet.eggKey}`. Now, it is important to note then that we add the name of the pet class to all of the pets, so there is a potential to change the appearance of the other pets. However, I only found custom CSS to adjust offsets the Flying Pig and the Hydra (which has a large sprite). And we shouldn't have to worry about the Hydra because it never gets greyed out. So I am pretty confident that we will be fine. Feel free to check more thoroughly than I did for offsets in the quest pets or magic potion pets. I didn't see any, but I didn't check them all.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: f5d12242-5b66-471d-bfc2-6c3358861d9c

