### PR TITLE
Allow Masterclasser achievement when quests completed out of order

### DIFF
--- a/test/api/v3/unit/models/group.test.js
+++ b/test/api/v3/unit/models/group.test.js
@@ -1410,8 +1410,44 @@ describe('Group Model', () => {
           updatedLeader,
           updatedParticipatingMember,
         ] = await Promise.all([
-          User.findById(questLeader._id),
-          User.findById(participatingMember._id),
+          User.findById(questLeader._id).exec(),
+          User.findById(participatingMember._id).exec(),
+        ]);
+
+        expect(updatedLeader.achievements.lostMasterclasser).to.eql(true);
+        expect(updatedParticipatingMember.achievements.lostMasterclasser).to.not.eql(true);
+      });
+
+      it('gives out super awesome Masterclasser achievement when quests done out of order', async () => {
+        quest = questScrolls.lostMasterclasser1;
+        party.quest.key = quest.key;
+
+        questLeader.achievements.quests = {
+          mayhemMistiflying1: 1,
+          mayhemMistiflying2: 1,
+          mayhemMistiflying3: 1,
+          stoikalmCalamity1: 1,
+          stoikalmCalamity2: 1,
+          stoikalmCalamity3: 1,
+          taskwoodsTerror1: 1,
+          taskwoodsTerror2: 1,
+          taskwoodsTerror3: 1,
+          dilatoryDistress1: 1,
+          dilatoryDistress2: 1,
+          dilatoryDistress3: 1,
+          lostMasterclasser2: 1,
+          lostMasterclasser3: 1,
+          lostMasterclasser4: 1,
+        };
+        await questLeader.save();
+        await party.finishQuest(quest);
+
+        let [
+          updatedLeader,
+          updatedParticipatingMember,
+        ] = await Promise.all([
+          User.findById(questLeader._id).exec(),
+          User.findById(participatingMember._id).exec(),
         ]);
 
         expect(updatedLeader.achievements.lostMasterclasser).to.eql(true);

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -769,25 +769,33 @@ schema.methods.finishQuest = async function finishQuest (quest) {
     }
   });
 
-  if (questK === 'lostMasterclasser4') {
+  let masterClasserQuests = [
+    'dilatoryDistress1',
+    'dilatoryDistress2',
+    'dilatoryDistress3',
+    'mayhemMistiflying1',
+    'mayhemMistiflying2',
+    'mayhemMistiflying3',
+    'stoikalmCalamity1',
+    'stoikalmCalamity2',
+    'stoikalmCalamity3',
+    'taskwoodsTerror1',
+    'taskwoodsTerror2',
+    'taskwoodsTerror3',
+    'lostMasterclasser1',
+    'lostMasterclasser2',
+    'lostMasterclasser3',
+    'lostMasterclasser4',
+  ];
+
+  if (masterClasserQuests.includes(questK)) {
     let lostMasterclasserQuery = {
       'achievements.lostMasterclasser': {$ne: true},
-      'achievements.quests.mayhemMistiflying1': {$gt: 0},
-      'achievements.quests.mayhemMistiflying2': {$gt: 0},
-      'achievements.quests.mayhemMistiflying3': {$gt: 0},
-      'achievements.quests.stoikalmCalamity1': {$gt: 0},
-      'achievements.quests.stoikalmCalamity2': {$gt: 0},
-      'achievements.quests.stoikalmCalamity3': {$gt: 0},
-      'achievements.quests.taskwoodsTerror1': {$gt: 0},
-      'achievements.quests.taskwoodsTerror2': {$gt: 0},
-      'achievements.quests.taskwoodsTerror3': {$gt: 0},
-      'achievements.quests.dilatoryDistress1': {$gt: 0},
-      'achievements.quests.dilatoryDistress2': {$gt: 0},
-      'achievements.quests.dilatoryDistress3': {$gt: 0},
-      'achievements.quests.lostMasterclasser1': {$gt: 0},
-      'achievements.quests.lostMasterclasser2': {$gt: 0},
-      'achievements.quests.lostMasterclasser3': {$gt: 0},
     };
+    masterClasserQuests.forEach(questName => {
+      lostMasterclasserQuery[`achievements.quests.${questName}`] = {$gt: 0};
+    });
+
     let lostMasterclasserUpdate = {
       $set: {'achievements.lostMasterclasser': true},
     };

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -710,16 +710,15 @@ function _getUserUpdateForQuestReward (itemToAward, allAwardedItems) {
 
 async function _updateUserWithRetries (userId, updates, numTry = 1, query = {}) {
   query._id = userId;
-  return await User.update(query, updates).exec()
-    .then((raw) => {
-      return raw;
-    }).catch((err) => {
-      if (numTry < MAX_UPDATE_RETRIES) {
-        return _updateUserWithRetries(userId, updates, ++numTry);
-      } else {
-        throw err;
-      }
-    });
+  try {
+    return await User.update(query, updates).exec();
+  } catch (err) {
+    if (numTry < MAX_UPDATE_RETRIES) {
+      return _updateUserWithRetries(userId, updates, ++numTry);
+    } else {
+      throw err;
+    }
+  }
 }
 
 // Participants: Grant rewards & achievements, finish quest.


### PR DESCRIPTION
Fixes #9461

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Updated file `website\server\models\group.js`
- Changed the check that current completed quest is the final in Master Classer series, it now checks that the completed quest is any in the series
- Updated query to include last Master Classer quest

Updated test file `test\api\v3\unit\models\group.test.js`
- Added a new test to check whether Master Classer achievement is given when the final quest to be completed is not the final one in the series
- Updated test for Master Classer achievement (existing test and new test for when completed out of order) to include an `exec()` call after `findById()`

----
UUID: cc212fcc-5f96-403b-a785-17ba66c7b11a
