### PR TITLE
Don't allow Saddles to be sold (fixes #9596)

### DIFF
--- a/website/client/components/shops/market/sellModal.vue
+++ b/website/client/components/shops/market/sellModal.vue
@@ -7,9 +7,16 @@
     div.close
       span.svg-icon.inline.icon-10(aria-hidden="true", v-html="icons.close", @click="hideDialog()")
 
-    div.content(v-if="item != null")
+    div.content(v-if="item")
 
-      div.inner-content
+      div.inner-content(v-if="item.sellWarningNote")
+        slot(name="item", :item="item")
+
+        h4.title {{ text ? text : item.text() }}
+        div.text {{ item.sellWarningNote() }}
+        br
+
+      div.inner-content(v-else)
         slot(name="item", :item="item")
 
         h4.title {{ text ? text : item.text() }}

--- a/website/common/locales/en/content.json
+++ b/website/common/locales/en/content.json
@@ -286,6 +286,7 @@
 
   "foodSaddleText": "Saddle",
   "foodSaddleNotes": "Instantly raises one of your pets into a mount.",
+  "foodSaddleSellWarningNote": "Hey! This is a pretty useful item! Are you familiar with how to use a Saddle with your Pets?",
 
   "foodNotes": "Feed this to a pet and it may grow into a sturdy steed."
 }

--- a/website/common/script/content/index.js
+++ b/website/common/script/content/index.js
@@ -353,6 +353,7 @@ api.food = {
     canBuy () {
       return true;
     },
+    sellWarningNote: t('foodSaddleSellWarningNote'),
     text: t('foodSaddleText'),
     value: 5,
     notes: t('foodSaddleNotes'),


### PR DESCRIPTION
[x]: Fixes https://github.com/HabitRPG/habitica/issues/9596

### Changes
[x]: Disallow selling of Saddle with conditional rendering with `sellWarningNote` property on Saddle object.

----
UUID: dd16c270-1d6d-44bd-b4f9-737342e79be6