### PR TITLE
Added test to recreate early cron issue

### DIFF
--- a/test/api/v3/unit/models/user.test.js
+++ b/test/api/v3/unit/models/user.test.js
@@ -323,4 +323,29 @@ describe('User Model', () => {
       expect(user.achievements.beastMaster).to.not.equal(true);
     });
   });
+
+  context.only('days missed', () => {
+    let user;
+
+    beforeEach(() => {
+      user = new User();
+    });
+
+    it.only('should not cron early when going back a timezone', () => {
+      const yesterday = moment('2017-12-05T00:00:00.000-05:00'); // 11 pm on 4 Texas
+      const timezoneOffset = yesterday.zone();
+      user.lastCron = yesterday;
+      user.preferences.timezoneOffset = timezoneOffset;
+
+      const today = moment('2017-12-06T00:00:00.000-05:00'); // 11 pm on 4 Texas
+      const req = {};
+      req.header = () => {
+        return timezoneOffset + 60;
+      };
+
+      const {daysMissed} = user.daysUserHasMissed(today, req);
+
+      expect(daysMissed).to.eql(0);
+    });
+  });
 });

--- a/test/api/v3/unit/models/user.test.js
+++ b/test/api/v3/unit/models/user.test.js
@@ -324,20 +324,39 @@ describe('User Model', () => {
     });
   });
 
-  context.only('days missed', () => {
+  context('days missed', () => {
+    // http://forbrains.co.uk/international_tools/earth_timezones
     let user;
 
     beforeEach(() => {
       user = new User();
     });
 
-    it.only('should not cron early when going back a timezone', () => {
-      const yesterday = moment('2017-12-05T00:00:00.000-05:00'); // 11 pm on 4 Texas
-      const timezoneOffset = yesterday.zone();
+    it('should not cron early when going back a timezone', () => {
+      const yesterday = moment('2017-12-05T00:00:00.000-06:00'); // 11 pm on 4 Texas
+      const timezoneOffset = moment().zone('-06:00').zone();
       user.lastCron = yesterday;
       user.preferences.timezoneOffset = timezoneOffset;
 
-      const today = moment('2017-12-06T00:00:00.000-05:00'); // 11 pm on 4 Texas
+      const today = moment('2017-12-06T00:00:00.000-06:00'); // 11 pm on 4 Texas
+      const req = {};
+      req.header = () => {
+        return timezoneOffset + 60;
+      };
+
+      const {daysMissed} = user.daysUserHasMissed(today, req);
+
+      expect(daysMissed).to.eql(0);
+    });
+
+    it('should not cron early when going back a timezone with a custom day start', () => {
+      const yesterday = moment('2017-12-05T02:00:00.000-08:00');
+      const timezoneOffset = moment().zone('-08:00').zone();
+      user.lastCron = yesterday;
+      user.preferences.timezoneOffset = timezoneOffset;
+      user.preferences.dayStart = 2;
+
+      const today = moment('2017-12-06T02:00:00.000-08:00');
       const req = {};
       req.header = () => {
         return timezoneOffset + 60;

--- a/website/common/script/cron.js
+++ b/website/common/script/cron.js
@@ -47,7 +47,6 @@ function sanitizeOptions (o) {
   }
 
   let now = o.now ? moment(o.now).zone(timezoneOffset) : moment().zone(timezoneOffset);
-
   // return a new object, we don't want to add "now" to user object
   return {
     dayStart,

--- a/website/server/models/user/methods.js
+++ b/website/server/models/user/methods.js
@@ -18,7 +18,6 @@ import paypalPayments from '../../libs/paypalPayments';
 
 const daysSince = common.daysSince;
 
-
 schema.methods.isSubscribed = function isSubscribed () {
   let now = new Date();
   let plan = this.purchased.plan;

--- a/website/server/models/user/methods.js
+++ b/website/server/models/user/methods.js
@@ -214,6 +214,12 @@ schema.methods.daysUserHasMissed = function daysUserHasMissed (now, req = {}) {
   let daysMissed = daysSince(this.lastCron, defaults({now}, this.preferences));
 
   if (timezoneOffsetAtLastCron !== timezoneOffsetFromUserPrefs) {
+    // Give the user extra time based on the difference in timezones
+    if (timezoneOffsetAtLastCron < timezoneOffsetFromUserPrefs) {
+      const differenceBetweenTimezonesInMinutes = timezoneOffsetFromUserPrefs - timezoneOffsetAtLastCron;
+      now = moment(now).subtract(differenceBetweenTimezonesInMinutes, 'minutes');
+    }
+
     // Since cron last ran, the user's timezone has changed.
     // How many days have we missed using the old timezone:
     let daysMissedNewZone = daysMissed;


### PR DESCRIPTION
Fixes #9415

This is the beginning of a fix for the above issue. The problem is two things:
1. From a UX perspective, the user thinks the app should not cron with respect to their current timezone even though it has been 24 hours
2. When Daylight Savings time changes, the timezone is perceived as 24 hours, but it shouldn't be. This is correct that 24 hours has passed, but the user loses an hour