### PR TITLE
Added body param for remove message

### DIFF
--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -904,7 +904,7 @@ api.removeGroupMember = {
       throw new NotFound(res.t('groupMemberNotFound'));
     }
 
-    let message = req.query.message;
+    let message = req.query.message || req.body.message;console.log(message)
     _sendMessageToRemoved(group, member, message, isInGroup);
 
     await Bluebird.all([

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -904,7 +904,7 @@ api.removeGroupMember = {
       throw new NotFound(res.t('groupMemberNotFound'));
     }
 
-    let message = req.query.message || req.body.message;console.log(message)
+    let message = req.query.message || req.body.message;
     _sendMessageToRemoved(group, member, message, isInGroup);
 
     await Bluebird.all([


### PR DESCRIPTION
Fixes #8442

This adds support for items like markdown by passing via the body param allowing for the client message to be encoded correctly. 