### PR TITLE
Change focused state of introjs button

### DIFF
--- a/website/client/components/notifications.vue
+++ b/website/client/components/notifications.vue
@@ -56,7 +56,7 @@ div
     }
   }
 
-  .introjs-button:hover, .introjs-button:active {
+  .introjs-button:hover, .introjs-button:active, .introjs-button:focus {
     background-image: none;
     background-color: #4f2a93 !important;
     color: #fff;


### PR DESCRIPTION
Fixes #9577

### Changes
Changed the introduction modal button to have intended styling (purple color with white text) when page is loaded by grouping it with the hover and active states.
The bug was caused by the button sometimes being in focus when the page loaded, and the default introjs styling being applied. 

----
UUID: cc212fcc-5f96-403b-a785-17ba66c7b11a
