### PR TITLE
Given back header the priority over snackbar with z-index value and a padding to avoid collision.

### DIFF
--- a/website/client/components/snackbars/notifications.vue
+++ b/website/client/components/snackbars/notifications.vue
@@ -8,7 +8,7 @@
   .notifications {
     position: fixed;
     right: 10px;
-    top: 10px;
+    top: 65px;
     width: 350px;
     z-index: 99999;
   }

--- a/website/client/components/snackbars/notifications.vue
+++ b/website/client/components/snackbars/notifications.vue
@@ -10,7 +10,7 @@
     right: 10px;
     top: 65px;
     width: 350px;
-    z-index: 99999;
+    z-index: 999;
   }
 </style>
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes https://github.com/HabitRPG/habitica/issues/9678

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Adjusted the top padding of the snackbar notification to be higher
than the main header so the two doesn't overlap.
The header is set at 56px and the old snackbar was set at 10px, now it's set to 65px.
This gives the two elements some space and avoids the overlap.

At the same time the z-index value for snackbar is changed from 99999 (random number?) to 999 (1 less than the header and its drop down menu)

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 5e7df578-43e2-43aa-ac2e-8ed10d8f2fd5
![snackbar vs header test](https://user-images.githubusercontent.com/34314140/33690200-d95e6f8e-dae2-11e7-9ad5-bddea239ccc7.PNG)
