### PR TITLE
Fixes equipment sorting by name in inventory

### DIFF
--- a/website/client/components/inventory/equipment/index.vue
+++ b/website/client/components/inventory/equipment/index.vue
@@ -243,7 +243,7 @@ export default {
       });
     },
     sortItems (items, sortBy) {
-      return _reverse(_sortBy(items, sortGearTypeMap[sortBy]));
+      return sortBy === 'sortByName' ? _sortBy(items, sortGearTypeMap[sortBy]) : _reverse(_sortBy(items, sortGearTypeMap[sortBy]));
     },
     drawerToggled (newState) {
       this.$store.state.equipmentDrawerOpen = newState;


### PR DESCRIPTION
Fixes #9682 

### Changes

- modifies `sortItems` method so that it returns an array of items in ascending order when `sortByName` is passed as an argument. Otherwise, return an array sorted in reverse order.

----
UUID: 62a29b30-6dcf-47e7-92f5-87e2cf2a510f
