### PR TITLE
fix drawer-slider carousel function && convert to pointer logic (fixes #9366 AND #9638)

### DIFF
--- a/website/client/components/inventory/stable/index.vue
+++ b/website/client/components/inventory/stable/index.vue
@@ -186,6 +186,7 @@
           slot="drawer-slider",
           :itemWidth=94,
           :itemMargin=24,
+          :itemType="selectedDrawerTab"
         )
           template(slot="item", slot-scope="context")
             foodItem(

--- a/website/client/components/shops/market/index.vue
+++ b/website/client/components/shops/market/index.vue
@@ -194,6 +194,7 @@
           slot="drawer-slider",
           :itemWidth=94,
           :itemMargin=24,
+          :itemType="selectedDrawerTab"
         )
           template(slot="item", slot-scope="ctx")
             item(

--- a/website/client/components/ui/drawerSlider.vue
+++ b/website/client/components/ui/drawerSlider.vue
@@ -130,7 +130,7 @@
         if (firstSlice.length === itemsPerPage) {
           return firstSlice;
         } else {
-          let getRemainderItems = Math.abs(itemsPerPage - firstSlice.length);
+          let getRemainderItems = itemsPerPage - firstSlice.length;
           let secondSlice = items.slice(0, getRemainderItems);
 
           return firstSlice.concat(secondSlice);

--- a/website/client/components/ui/drawerSlider.vue
+++ b/website/client/components/ui/drawerSlider.vue
@@ -4,13 +4,13 @@
   )
     div.slider-button-area.left-button(
       v-if="scrollButtonsVisible",
-      @mousedown.left="lastPage"
+      @mousedown.left="shiftLeft"
     )
       a.slider-button
         .svg-icon(v-html="icons.previous")
     div.slider-button-area.right-button(
       v-if="scrollButtonsVisible",
-      @mousedown.left="nextPage"
+      @mousedown.left="shiftRight"
     )
       a.slider-button
         .svg-icon(v-html="icons.next")
@@ -18,8 +18,11 @@
     // 120 = width of the left/right buttons
     div.sliding-content(v-resize="500", @resized="currentWidth = $event.width - 120")
       .items.items-one-line
-        template(v-for="item in pages[currentPage]")
-          div.vertical-divider(v-if="item.ofNextPage")
+        template(v-for="item in showItems")
+          div.vertical-divider(
+            v-if="shouldAddVerticalLine(item)"
+            v-bind:style="dividerMargins"
+          )
 
           slot(
             name="item",
@@ -80,12 +83,13 @@
   }
 
   .sliding-content .items {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
     padding-top: 10px;
     margin-left: $buttonAreaWidth+ px;
-
-    & > div:last-of-type {
-      margin-right: $buttonAreaWidth + 20px;
-    }
+    margin-right: $buttonAreaWidth+ px;
   }
 
   .vertical-divider {
@@ -102,8 +106,6 @@
   import next from 'assets/svg/next.svg';
   import ResizeDirective from 'client/directives/resize.directive';
 
-  import _chunk from 'lodash/chunk';
-
   export default {
     directives: {
       resize: ResizeDirective,
@@ -115,44 +117,59 @@
           next,
         }),
         currentWidth: 0,
-        currentPage: 0,
+        pointer: 0,
       };
     },
     computed: {
-      pages () {
-        return _chunk(this.items, this.itemsPerPage() - 1).map((content, index, array) => {
-          let resultData = [...content];
+      showItems () {
+        let items = this.items;
+        let pointer = this.pointer;
+        let itemsPerPage = this.itemsPerPage();
+        let firstSlice = items.slice(pointer, pointer + itemsPerPage);
 
-          if (array[index + 1]) {
-            resultData.push({
-              ...array[index + 1][0],
-              ofNextPage: true,
-            });
-          }
+        if (firstSlice.length === itemsPerPage) {
+          return firstSlice;
+        } else if (items.length > itemsPerPage) {
+          let getRemainderItems = Math.abs(itemsPerPage - firstSlice.length);
+          let secondSlice = items.slice(0, getRemainderItems);
 
-          return resultData;
-        });
+          return firstSlice.concat(secondSlice);
+        }
+
+        return items;
+      },
+      dividerMargins () {
+        return {
+          marginLeft: `${-this.itemMargin / 2}px`,
+          marginRight: `${this.itemMargin / 2}px`,
+        };
+      },
+    },
+    watch: {
+      itemType () {
+        this.pointer = 0;
       },
     },
     methods: {
-      lastPage () {
-        if (this.currentPage > 0) {
-          this.currentPage--;
+      shiftLeft () {
+        if (this.pointer < this.items.length - 1) {
+          this.pointer++;
         } else {
-          this.currentPage = this.pages.length - 1;
+          this.pointer = 0;
         }
       },
-
-      nextPage () {
-        if (this.currentPage < this.pages.length - 1) {
-          this.currentPage++;
+      shiftRight () {
+        if (this.pointer > 0) {
+          this.pointer--;
         } else {
-          this.currentPage = 0;
+          this.pointer = this.items.length - 1;
         }
       },
-
       itemsPerPage () {
         return Math.floor(this.currentWidth / (this.itemWidth + this.itemMargin));
+      },
+      shouldAddVerticalLine (item) {
+        return this.items[this.itemsPerPage() - 1] === item && this.pointer !== 5;
       },
     },
     props: {
@@ -162,6 +179,9 @@
       },
       items: {
         type: Array,
+      },
+      itemType: {
+        type: Number,
       },
       itemWidth: {
         type: Number,

--- a/website/client/components/ui/drawerSlider.vue
+++ b/website/client/components/ui/drawerSlider.vue
@@ -129,14 +129,12 @@
 
         if (firstSlice.length === itemsPerPage) {
           return firstSlice;
-        } else if (items.length > itemsPerPage) {
+        } else {
           let getRemainderItems = Math.abs(itemsPerPage - firstSlice.length);
           let secondSlice = items.slice(0, getRemainderItems);
 
           return firstSlice.concat(secondSlice);
         }
-
-        return items;
       },
       dividerMargins () {
         return {


### PR DESCRIPTION
[x]: Fixes https://github.com/HabitRPG/habitica/issues/9366 && https://github.com/HabitRPG/habitica/issues/9638

### Changes
[x]: Delete logic for paging for `drawerSlider.vue` and implement pointer logic. The pointer will act as the index of the array `this.items` and take `this.itemsPerPage()` elements.
[x]: Handle logic to display divider correctly.
[x]: Evenly space out `this.items` for the items being shown.
[x]: Create a new prop in `drawerSlider.vue` called `itemType` and watch for its value to change and reset `this.pointer` to 0 if it changes. This will remedy any false-negatives of not showing a user's items.

----
UUID: dd16c270-1d6d-44bd-b4f9-737342e79be6