### PR TITLE
Update Vagrantfile.example to forward port 8080

### DIFF
--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -16,5 +16,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.hostname = "habitrpg"
   config.vm.network "forwarded_port", guest: 3000, host: 3000, auto_correct: true
   config.vm.usable_port_range = (3000..3050)
+  config.vm.network "forwarded_port", guest: 8080, host: 8080, auto_correct: true
+  config.vm.usable_port_range = (8080..8130)
   config.vm.provision :shell, :path => "vagrant_scripts/vagrant.sh"
 end


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes are based on discussion from [#9043](https://github.com/HabitRPG/habitica/issues/9043)

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Updated the Vagrant.example file to forward port 8080 so developers can access that port
when trying to test the client side code on the default port

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID:  b20e27a5-e552-4247-9e91-65442a04f6d4
