### PR TITLE
Include seasonal gear in Market class lists

### DIFF
--- a/website/common/script/libs/shops.js
+++ b/website/common/script/libs/shops.js
@@ -163,7 +163,7 @@ shops.getMarketGearCategories = function getMarketGear (user, language) {
           class: classType,
         },
       };
-      if (gearItem.specialClass === classType) return gearItem.canOwn(classShift);
+      if (gearItem.specialClass === classType && user.items.gear.owned[gearItem.key] !== false) return gearItem.canOwn(classShift);
     });
 
     category.items = map(result, (e) => {
@@ -193,9 +193,7 @@ shops.getMarketGearCategories = function getMarketGear (user, language) {
   };
 
   let falseGear = filter(content.gear.flat, (gear) => {
-    return user.items.gear.owned[gear.key] === false &&
-      gear.klass !== user.stats.class &&
-      gear.klass !== 'special';
+    return user.items.gear.owned[gear.key] === false && (gear.klass === 'special' && !gear.specialClass || gear.key.indexOf('mystery') !== -1);
   });
 
   nonClassCategory.items = map(falseGear, (e) => {

--- a/website/common/script/libs/shops.js
+++ b/website/common/script/libs/shops.js
@@ -155,7 +155,16 @@ shops.getMarketGearCategories = function getMarketGear (user, language) {
       text: getClassName(classType, language),
     };
 
-    let result = filter(content.gear.flat, ['klass', classType]);
+    let result = filter(content.gear.flat, function findClassGear (gearItem) {
+      if (gearItem.klass === classType) return true;
+      let classShift = {
+        items: user.items,
+        stats: {
+          class: classType,
+        },
+      };
+      if (gearItem.specialClass === classType) return gearItem.canOwn(classShift);
+    });
 
     category.items = map(result, (e) => {
       let newItem = getItemInfo(user, 'marketGear', e, officialPinnedItems);


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

**Previously**, the gear section of the regular Market did not display seasonal class equipment. This proved a bit confusing, as users would expect to see currently buyable, class-specific gear there.
**Now**, Gold-buyable seasonal gear shows up in the Market under the expected class heading.

**Previously**, some special items did not show up in the Market if they were broken due to running out of Health. This affected, for example, "legendary" quest items and Take This challenge gear.
**Now**, these "classless" special items do show up in the Market. This is a partial fix for #9731.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)