### PR TITLE
Fix Server Errors Appear As Blank Red Bar

### DIFF
--- a/website/client/app.vue
+++ b/website/client/app.vue
@@ -225,7 +225,7 @@ export default {
 
         this.$store.dispatch('snackbars:add', {
           title: 'Habitica',
-          text: error.response.data.message,
+          text: error.response.data,
           type: 'error',
           timeout: true,
         });

--- a/website/client/app.vue
+++ b/website/client/app.vue
@@ -210,7 +210,7 @@ export default {
       if (error.response.status >= 400) {
         // Check for conditions to reset the user auth
         const invalidUserMessage = [this.$t('invalidCredentials'), 'Missing authentication headers.'];
-        if (invalidUserMessage.indexOf(error.response.data.message) !== -1) {
+        if (invalidUserMessage.indexOf(error.response.data) !== -1) {
           this.$store.dispatch('auth:logout');
         }
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #9213 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Changed the path for the error text that was pointing to null data.
From  `error.response.data.message` to `error.response.data`.



[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 4a5d7afb-d65e-485b-8e46-c9414a43b0bb
