### PR TITLE
Fixing issue with hair bangs, styles and colors not getting the option.active class upon refresh

### DIFF
--- a/website/client/components/creatorIntro.vue
+++ b/website/client/components/creatorIntro.vue
@@ -159,7 +159,7 @@ b-modal#avatar-modal(title="", :size='editing ? "lg" : "md"', :hide-header='true
         .col-12.customize-options
           .head_0.option(@click='set({"preferences.hair.bangs": 0})',
             :class="[{ active: user.preferences.hair.bangs === 0 }, 'hair_bangs_0_' + user.preferences.hair.color]")
-          .option(v-for='option in ["1", "2", "3", "4"]',
+          .option(v-for='option in [1, 2, 3, 4]',
             :class='{active: user.preferences.hair.bangs === option}')
             .bangs.sprite.customize-option(:class="`hair_bangs_${option}_${user.preferences.hair.color}`", @click='set({"preferences.hair.bangs": option})')
       #facialhair.row(v-if='activeSubPage === "facialhair"')
@@ -227,7 +227,7 @@ b-modal#avatar-modal(title="", :size='editing ? "lg" : "md"', :hide-header='true
       #flowers.row(v-if='activeSubPage === "flower"')
         .col-12.customize-options
           .head_0.option(@click='set({"preferences.hair.flower":0})', :class='{active: user.preferences.hair.flower === 0}')
-          .option(v-for='option in ["1", "2", "3", "4", "5", "6"]',
+          .option(v-for='option in [1, 2, 3, 4, 5, 6]',
             :class='{active: user.preferences.hair.flower === option}')
             .sprite.customize-option(:class="`hair_flower_${option}`", @click='set({"preferences.hair.flower": option})')
       .row(v-if='activeSubPage === "flower"')
@@ -980,12 +980,12 @@ export default {
       rainbowSkinKeys: ['eb052b', 'f69922', 'f5d70f', '0ff591', '2b43f6', 'd7a9f7', '800ed0', 'rainbow'],
       animalSkinKeys: ['bear', 'cactus', 'fox', 'lion', 'panda', 'pig', 'tiger', 'wolf'],
       premiumHairColorKeys: ['rainbow', 'yellow', 'green', 'purple', 'blue', 'TRUred'],
-      baseHair1: ['1', '3'],
-      baseHair2Keys: ['2', '4', '5', '6', '7', '8'],
-      baseHair3Keys: ['9', '10', '11', '12', '13', '14'],
-      baseHair4Keys: ['15', '16', '17', '18', '19', '20'],
-      baseHair5Keys: ['1', '2', '3'],
-      baseHair6Keys: ['1', '2'],
+      baseHair1: [1, 3],
+      baseHair2Keys: [2, 4, 5, 6, 7, 8],
+      baseHair3Keys: [9, 10, 11, 12, 13, 14],
+      baseHair4Keys: [15, 16, 17, 18, 19, 20],
+      baseHair5Keys: [1, 2, 3],
+      baseHair6Keys: [1, 2],
       animalEarsKeys: ['bearEars', 'cactusEars', 'foxEars', 'lionEars', 'pandaEars', 'pigEars', 'tigerEars', 'wolfEars'],
       icons: Object.freeze({
         logoPurple,


### PR DESCRIPTION
[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes https://github.com/HabitRPG/habitica/issues/9756

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Updated creatorIntro.vue so that values for the following objects get stored as numbers instead of strings : 
```
user.preferences.hair.bangs
user.preferences.hair.base
user.preferences.hair.flower
```
These values were getting stored as strings  e.g.: `user.preferences.hair.bangs : "3"` when user first chooses an option/style. However, value is defined as numeric in the schema  e.g.:  `bangs: {type: Number, default: 1}`, in website/server/models/user/schema.js. After page is refreshed, preference value becomes numeric e.g.: `{ user:preferences.hair.bangs : 3 }`. Code that checks which option is selected so that it can apply the right css class was expecting a character so nothing would get selected. 
```
option(v-for='option in ["1", "2", "3", "4"]',
          :class='{active: user.preferences.hair.bangs === option}') 
```

After the change, selection for all three ( hair color, hair style, hair flower ) persist through page refreshes.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 
