### PR TITLE
Staging fixes

### DIFF
--- a/website/client/components/groups/groupFormModal.vue
+++ b/website/client/components/groups/groupFormModal.vue
@@ -77,8 +77,8 @@
             v-if='group.key !== "habitica_official" || user.contributor.admin'
           )
             .custom-control.custom-checkbox
-              input.custom-control-input(:id="group.key", type="checkbox", :value="group.key", v-model="workingGroup.categories")
-              label.custom-control-label(v-once, :for="group.key") {{ $t(group.label) }}
+              input.custom-control-input(:id="`category-${group.key}`", type="checkbox", :value="group.key", v-model="workingGroup.categories")
+              label.custom-control-label(v-once, :for="`category-${group.key}`") {{ $t(group.label) }}
           button.btn.btn-primary(@click.prevent="toggleCategorySelect") {{$t('close')}}
         // @TODO: need categories only for PUBLIC GUILDS, not for tavern, private guilds, or party
 

--- a/website/client/components/ui/drawerSlider.vue
+++ b/website/client/components/ui/drawerSlider.vue
@@ -4,13 +4,13 @@
   )
     div.slider-button-area.left-button(
       v-if="scrollButtonsVisible",
-      @mousedown.left="shiftLeft"
+      @mousedown.left="shiftRight"
     )
       a.slider-button
         .svg-icon(v-html="icons.previous")
     div.slider-button-area.right-button(
       v-if="scrollButtonsVisible",
-      @mousedown.left="shiftRight"
+      @mousedown.left="shiftLeft"
     )
       a.slider-button
         .svg-icon(v-html="icons.next")
@@ -127,7 +127,7 @@
         let itemsPerPage = this.itemsPerPage();
         let firstSlice = items.slice(pointer, pointer + itemsPerPage);
 
-        if (firstSlice.length === itemsPerPage) {
+        if (firstSlice.length === itemsPerPage || items.length < itemsPerPage ) {
           return firstSlice;
         } else {
           let getRemainderItems = itemsPerPage - firstSlice.length;


### PR DESCRIPTION
#9802 

>  When creating a Guild in staging, you can't select categories. When you try to tick the checkboxes in the Guild edit modal's category list, they don't become ticked, but if you look carefully at the My Guilds page behind the edit modal, you can see that the filter checkboxes are being ticked as you try to select categories for the new Guild. This means that it's impossible to create a guild since the categories are mandatory.

>  Staging > Stable > Quick Inventory > Special : my Saddles are showing up twice. This is an urgent one.

>  Market carousel is backward: clicking the right button rotates the list rightward instead of showing you the next item rightward in the list.
