### PR TITLE
Allow user to buy numbered special gear

### DIFF
--- a/test/common/ops/buy/buyGear.js
+++ b/test/common/ops/buy/buyGear.js
@@ -138,5 +138,27 @@ describe('shared.ops.buyGear', () => {
         done();
       }
     });
+
+    it('does not buyGear equipment if user does not own prior item in sequence', (done) => {
+      user.stats.gp = 200;
+
+      try {
+        buyGear(user, {params: {key: 'armor_warrior_2'}});
+      } catch (err) {
+        expect(err).to.be.an.instanceof(NotAuthorized);
+        expect(err.message).to.equal(i18n.t('previousGearNotOwned'));
+        expect(user.items.gear.owned).to.not.have.property('armor_warrior_2');
+        done();
+      }
+    });
+
+    it('does buyGear equipment if item is a numbered special item user qualifies for', () => {
+      user.stats.gp = 200;
+      user.items.gear.owned.head_special_2 = false;
+
+      buyGear(user, {params: {key: 'head_special_2'}});
+
+      expect(user.items.gear.owned).to.have.property('head_special_2', true);
+    });
   });
 });

--- a/website/common/script/ops/buyGear.js
+++ b/website/common/script/ops/buyGear.js
@@ -37,7 +37,7 @@ module.exports = function buyGear (user, req = {}, analytics) {
 
   let itemIndex = Number(item.index);
 
-  if (Number.isInteger(itemIndex) && content.CLASSES.includes(item.klass)) {
+  if (Number.isInteger(itemIndex) && content.classes.includes(item.klass)) {
     let previousLevelGear = key.replace(/[0-9]/, itemIndex - 1);
     let hasPreviousLevelGear = user.items.gear.owned[previousLevelGear];
     let checkIndexToType = itemIndex > (item.type === 'weapon' || item.type === 'shield' && item.klass === 'rogue' ? 0 : 1);

--- a/website/common/script/ops/buyGear.js
+++ b/website/common/script/ops/buyGear.js
@@ -37,10 +37,10 @@ module.exports = function buyGear (user, req = {}, analytics) {
 
   let itemIndex = Number(item.index);
 
-  if (Number.isInteger(itemIndex)) {
+  if (Number.isInteger(itemIndex) && content.CLASSES.includes(item.klass)) {
     let previousLevelGear = key.replace(/[0-9]/, itemIndex - 1);
     let hasPreviousLevelGear = user.items.gear.owned[previousLevelGear];
-    let checkIndexToType = itemIndex > (item.type === 'weapon' ? 0 : 1);
+    let checkIndexToType = itemIndex > (item.type === 'weapon' || item.type === 'shield' && item.klass === 'rogue' ? 0 : 1);
 
     if (checkIndexToType && !hasPreviousLevelGear) {
       throw new NotAuthorized(i18n.t('previousGearNotOwned', req.language));
@@ -51,7 +51,6 @@ module.exports = function buyGear (user, req = {}, analytics) {
     user.items.gear.equipped[item.type] = item.key;
     message = handleTwoHanded(user, item, undefined, req);
   }
-
 
   removePinnedGearAddPossibleNewOnes(user, `gear.flat.${item.key}`, item.key);
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes https://github.com/HabitRPG/habitica/issues/9731#issuecomment-357417784

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

**Previously**, logic to determine if a user was eligible to purchase a piece of equipment mistakenly treated `special` equipment with numeric names (i.e., early-released legendary quest rewards) as sequential, requiring the numbered pieces to be bought in order.
**Now**, this correctly only applies to class gear.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)