### PR TITLE
Hide stats points allocation on locked or disabled class system (#9826)

### DIFF
--- a/website/client/components/userMenu/profile.vue
+++ b/website/client/components/userMenu/profile.vue
@@ -255,7 +255,7 @@ div
                 li
                   strong {{$t('buffs')}}:
                   | {{user.stats.buffs[stat]}}
-      #allocation(v-if='user._id === userLoggedIn._id')
+      #allocation(v-if='user._id === userLoggedIn._id && user.flags.classSelected && !user.preferences.disableClasses')
         .row.title-row
           .col-12.col-md-6
             h3(v-if='userLevel100Plus', v-once, v-html="$t('noMoreAllocate')")


### PR DESCRIPTION
Fixes #9826.

### Changes

The stats points allocation section is now hidden from the Avatar/User Modal if the user hasn't selected a class, or has classes disabled (i.e. user flag 'classSelected' is false, 'disableClasses' is true under preferences).

Screenshots:

![screen shot 2018-01-21 at 8 05 22 pm](https://user-images.githubusercontent.com/17578440/35201279-fe1bc4e2-fee7-11e7-872b-33b0ee9e98fc.png)

Above (before changes), for a user who has not selected a class.

![screen shot 2018-01-21 at 8 00 52 pm](https://user-images.githubusercontent.com/17578440/35201280-fe2bba28-fee7-11e7-89af-d8af1f9dec1d.png)

And after changes.

:)

----
UUID: 35086b7e-ac9c-4c40-9737-2c5bdcd17325
