### PR TITLE
describe Login Name limitations on Registration form and Add Local Auth form

### DIFF
--- a/website/client/components/settings/site.vue
+++ b/website/client/components/settings/site.vue
@@ -118,6 +118,7 @@
           hr
           div(v-if='!user.auth.local.username')
             p {{ $t('addLocalAuth') }}
+            p {{ $t('usernameLimitations') }}
             .form(name='localAuth', novalidate)
               //-.alert.alert-danger(ng-messages='changeUsername.$error && changeUsername.submitted') {{ $t('fillAll') }}
               .form-group

--- a/website/client/components/static/home.vue
+++ b/website/client/components/static/home.vue
@@ -23,6 +23,7 @@
             .strike
               span {{$t('or')}}
             .form(@keyup.enter="register()")
+              p.form-text {{$t('usernameLimitations')}}
               input.form-control(type='text', placeholder='Login Name', v-model='username', :class='{"input-valid": username.length > 3}')
               input.form-control(type='email', placeholder='Email', v-model='email', :class='{"input-invalid": emailInvalid, "input-valid": emailValid}')
               input.form-control(type='password', placeholder='Password', v-model='password', :class='{"input-valid": password.length > 3}')

--- a/website/common/locales/en/front.json
+++ b/website/common/locales/en/front.json
@@ -296,7 +296,7 @@
   "signUpWithSocial": "Sign up with <%= social %>",
   "loginWithSocial": "Log in with <%= social %>",
   "confirmPassword": "Confirm Password",
-  "usernameLimitations": "Login Name must be 1 to 36 characters long, containing only letters a to z, or numbers 0 to 9, or hyphens, or underscores.",
+  "usernameLimitations": "Login Name must be 1 to 20 characters long, containing only letters a to z, or numbers 0 to 9, or hyphens, or underscores.",
   "usernamePlaceholder": "e.g., HabitRabbit",
   "emailPlaceholder": "e.g., rabbit@example.com",
   "passwordPlaceholder": "e.g., ******************",

--- a/website/common/locales/en/front.json
+++ b/website/common/locales/en/front.json
@@ -296,6 +296,7 @@
   "signUpWithSocial": "Sign up with <%= social %>",
   "loginWithSocial": "Log in with <%= social %>",
   "confirmPassword": "Confirm Password",
+  "usernameLimitations": "Login Name must be 1 to 20 characters long, containing only letters a to z or numbers 0 to 9.",
   "usernamePlaceholder": "e.g., HabitRabbit",
   "emailPlaceholder": "e.g., rabbit@example.com",
   "passwordPlaceholder": "e.g., ******************",

--- a/website/common/locales/en/front.json
+++ b/website/common/locales/en/front.json
@@ -296,7 +296,7 @@
   "signUpWithSocial": "Sign up with <%= social %>",
   "loginWithSocial": "Log in with <%= social %>",
   "confirmPassword": "Confirm Password",
-  "usernameLimitations": "Login Name must be 1 to 20 characters long, containing only letters a to z or numbers 0 to 9.",
+  "usernameLimitations": "Login Name must be 1 to 36 characters long, containing only letters a to z, or numbers 0 to 9, or hyphens, or underscores.",
   "usernamePlaceholder": "e.g., HabitRabbit",
   "emailPlaceholder": "e.g., rabbit@example.com",
   "passwordPlaceholder": "e.g., ******************",


### PR DESCRIPTION
This modifies two forms to add a description of what characters and length are permitted for the Login Name:
- the registration form (creating a new account)
- the "Add local authentication" form when adding a Login Name (and password, email) to an existing account that uses social media login.

Here's what the registration form looks like:
![2-zoomed-in](https://user-images.githubusercontent.com/1495809/35471361-884c629a-03a5-11e8-8d11-4c926a2539d2.png)
This link shows the full page:
[full registration page with login name limitations text](https://user-images.githubusercontent.com/1495809/35471362-887e2438-03a5-11e8-9ac4-6e27fd325cfc.png)

Here's what the "add local auth" form looks like:
![4-zoomed](https://user-images.githubusercontent.com/1495809/35471359-87e4a164-03a5-11e8-8af6-ae59c2c5f94f.png)
This link shows the full page:
[full settings page with login name limitations text](https://user-images.githubusercontent.com/1495809/35471360-88175898-03a5-11e8-9d40-fb4f3a9fdf45.png)
Ignore the fact that both of the social auth buttons are purple (usually one would be greyed-out). That's just a side-effect of how I tested this visual change and won't occur in the production site.