### PR TITLE
add contributor info for inbox tier styling

### DIFF
--- a/website/client/components/userMenu/inbox.vue
+++ b/website/client/components/userMenu/inbox.vue
@@ -239,11 +239,13 @@ export default {
           user: message.user,
           uuid: message.uuid,
           id: message.id,
+          contributor: message.contributor,
         };
 
         if (message.sent) {
           newMessage.user = this.user.profile.name;
           newMessage.uuid = this.user._id;
+          newMessage.contributor = this.user.contributor;
         }
 
         if (newMessage.text) conversations[userId].messages.push(newMessage);
@@ -306,6 +308,7 @@ export default {
         timestamp: new Date(),
         user: this.user.profile.name,
         uuid: this.user._id,
+        contributor: this.user.contributor,
       });
 
       this.activeChat = convoFound.messages;


### PR DESCRIPTION
[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #9843 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Tier styling of username within a chat context is done by userLevelStyle() which requires contributor info. Previously, the inbox messages did not contain this info. This PR adds contributor info to inbox messages.

Old, showing no tier color or icon:
<img width="131" alt="screen shot 2018-01-29 at 10 45 28 pm" src="https://user-images.githubusercontent.com/13597875/35552205-dbbbd570-0547-11e8-81a5-1d796b8367a4.png">

New, shows tier color and icon:
<img width="113" alt="screen shot 2018-01-29 at 10 45 40 pm" src="https://user-images.githubusercontent.com/13597875/35552207-dd8bbf5a-0547-11e8-8970-4e34d0512f1e.png">


----
UUID: bea2a16e-fc0b-4b98-87f6-946165c839a6