### PR TITLE
Make images responsive on features page

### DIFF
--- a/website/client/components/static/features.vue
+++ b/website/client/components/static/features.vue
@@ -82,6 +82,10 @@
     box-shadow: 0 0 10px 5px #888;
     margin: 0.5em;
     max-width: 500px;
+
+    @media (max-width: 1200px) {
+      max-width: 100%;
+    }
   }
 </style>
 


### PR DESCRIPTION
On screens in [features page](https://habitica.com/static/features) less than 1200 px there is a horizontal scrolling because the pictures can not fit (do not adapt to the screen size).

Before
![image](https://user-images.githubusercontent.com/4408379/35765274-496dc1dc-08d1-11e8-96e6-5ed668407a3e.png)

After
![image](https://user-images.githubusercontent.com/4408379/35765275-4c4ccd76-08d1-11e8-9021-984cdc8e3d44.png)
