### PR TITLE
Pending collection items shown in quest progress (fixes #9944)

### DIFF
--- a/website/client/components/groups/questSidebarSection.vue
+++ b/website/client/components/groups/questSidebarSection.vue
@@ -41,6 +41,7 @@ div
                 .grey-progress-bar
                   .collect-progress-bar(:style="{width: (group.quest.progress.collect[key] / value.count) * 100 + '%'}")
                 strong {{group.quest.progress.collect[key]}} / {{value.count}}
+                span.float-right {{parseFloat(user.party.quest.progress.collectedItems) || 0}} items found
           .boss-info(v-if='questData.boss')
             .row
               .col-6


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: #9944 
Fixes https://github.com/HabitRPG/habitica/issues/9944

### Changes
[//]: # Added collectedItems under progress bar, didn't see any tests needing modification so hopefully this will do the trick.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 9c4776eb-7330-465b-85cc-e4ccef6c1ad1
