### PR TITLE
Tavern UI fixes to match recent Guild and Party page changes, fixes #9932

### DIFF
--- a/website/client/components/groups/tavern.vue
+++ b/website/client/components/groups/tavern.vue
@@ -13,11 +13,11 @@
           textarea(:placeholder="$t('tavernCommunityGuidelinesPlaceholder')", v-model='newMessage', :class='{"user-entry": newMessage}', @keydown='updateCarretPosition', @keyup.ctrl.enter='sendMessage()')
           autocomplete(:text='newMessage', v-on:select="selectedAutocomplete", :coords='coords', :chat='group.chat')
 
-        .row
-          .col-6
+        .row.chat-actions
+          .col-6.chat-receive-actions
             button.btn.btn-secondary.float-left.fetch(v-once, @click='fetchRecentMessages()') {{ $t('fetchRecentMessages') }}
             button.btn.btn-secondary.float-left(v-once, @click='reverseChat()') {{ $t('reverseChat') }}
-          .col-6
+          .col-6.chat-send-actions
             button.btn.btn-secondary.send-chat.float-right(v-once, @click='sendMessage()') {{ $t('send') }}
 
         community-guidelines
@@ -334,6 +334,27 @@
   .bailey .title {
     color: $black;
   }
+
+
+  .chat-actions {
+    margin-top: 1em;
+ 
+    .chat-receive-actions {
+      padding-left: 0;
+ 
+      button {
+        margin-bottom: 1em;
+ 
+        &:not(:last-child) {
+          margin-right: 1em;
+        }
+      }
+    }
+
+   .chat-send-actions {
+     padding-right: 0;
+   }
+ }
 
 </style>
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes https://github.com/HabitRPG/habitica/issues/9932

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Fixes the Tavern UI button spacing to match the recent Guild and Party page changes.

Before:
![screenshot from 2018-02-08 10-47-05](https://user-images.githubusercontent.com/14113984/35956747-9a88ca36-0cbd-11e8-9c63-adbb5fb9c64e.png)

After:
![screenshot from 2018-02-08 10-46-48](https://user-images.githubusercontent.com/14113984/35956754-a9e5e284-0cbd-11e8-86f4-b982571b0355.png)





[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 3ee8618b-8f24-43d6-ab22-80e1013d255c
