### PR TITLE
Remove three dots menu from copy-as-to-do modal (Fixes #9980)

### DIFF
--- a/website/client/components/chat/copyAsTodoModal.vue
+++ b/website/client/components/chat/copyAsTodoModal.vue
@@ -5,7 +5,7 @@
     .form-group
       textarea.form-control(rows='5', v-model='task.notes' focus-element='true')
     hr
-    task(v-if='task._id', :isUser="isUser", :task="task")
+    task(v-if='task._id', :isUser="isUser", :isCopyAsTodo="isCopyAsTodo", :task="task")
     .modal-footer
       button.btn.btn-secondary(@click='close()') {{ $t('close') }}
       button.btn.btn-primary(@click='saveTodo()') {{ $t('submit') }}
@@ -33,6 +33,7 @@ export default {
   data () {
     return {
       isUser: true,
+      isCopyAsTodo: true,
       task: {},
     };
   },

--- a/website/client/components/chat/copyAsTodoModal.vue
+++ b/website/client/components/chat/copyAsTodoModal.vue
@@ -1,11 +1,11 @@
 <template lang="pug">
   b-modal#copyAsTodo(:title="$t('copyMessageAsToDo')", :hide-footer="true", size='md')
     .form-group
-      input.form-control(type='text', v-model='task.text')
+      input.form-control(type='text', v-model='task.text', readonly)
     .form-group
-      textarea.form-control(rows='5', v-model='task.notes' focus-element='true')
+      textarea.form-control(rows='5', v-model='task.notes' focus-element='true', readonly)
     hr
-    task(v-if='task._id', :isUser="isUser", :isCopyAsTodo="isCopyAsTodo", :task="task")
+    task(v-if='task._id', :isUser="isUser", :preventEdit="preventEdit", :preventCheck="preventCheck", :task="task")
     .modal-footer
       button.btn.btn-secondary(@click='close()') {{ $t('close') }}
       button.btn.btn-primary(@click='saveTodo()') {{ $t('submit') }}
@@ -33,7 +33,8 @@ export default {
   data () {
     return {
       isUser: true,
-      isCopyAsTodo: true,
+      preventEdit: true,
+      preventCheck: true,
       task: {},
     };
   },

--- a/website/client/components/tasks/task.vue
+++ b/website/client/components/tasks/task.vue
@@ -8,7 +8,7 @@
         .task-control.habit-control(:class="controlClass.up.inner", @click="(isUser && task.up) ? score('up') : null")
           .svg-icon.positive(v-html="icons.positive")
       // Dailies and todos left side control
-      .left-control.d-flex.justify-content-center(v-if="task.type === 'daily' || task.type === 'todo'", :class="controlClass.bg")
+      .left-control.d-flex.justify-content-center(v-if="(task.type === 'daily' || task.type === 'todo') && !task.preventCheck", :class="controlClass.bg")
         .task-control.daily-todo-control(:class="controlClass.inner", @click="isUser ? score(task.completed ? 'down' : 'up') : null")
           .svg-icon.check(v-html="icons.check", :class="{'display-check-icon': task.completed, [controlClass.checkbox]: true}")
       // Task title, description and icons
@@ -17,7 +17,7 @@
           .d-flex.justify-content-between
             h3.task-title(:class="{ 'has-notes': task.notes }", v-markdown="task.text")
             menu-dropdown.task-dropdown(
-              v-if="isUser && !isRunningYesterdailies && !isCopyAsTodo",
+              v-if="isUser && !isRunningYesterdailies && !preventEdit",
               :right="task.type === 'reward'",
               ref="taskDropdown"
             )
@@ -524,7 +524,7 @@ export default {
   directives: {
     markdown: markdownDirective,
   },
-  props: ['task', 'isUser', 'group', 'dueDate', 'isCopyAsTodo'], // @TODO: maybe we should store the group on state?
+  props: ['task', 'isUser', 'group', 'dueDate', 'preventCheck', 'preventEdit'], // @TODO: maybe we should store the group on state?
   data () {
     return {
       icons: Object.freeze({

--- a/website/client/components/tasks/task.vue
+++ b/website/client/components/tasks/task.vue
@@ -17,7 +17,7 @@
           .d-flex.justify-content-between
             h3.task-title(:class="{ 'has-notes': task.notes }", v-markdown="task.text")
             menu-dropdown.task-dropdown(
-              v-if="isUser && !isRunningYesterdailies",
+              v-if="isUser && !isRunningYesterdailies && !isCopyAsTodo",
               :right="task.type === 'reward'",
               ref="taskDropdown"
             )
@@ -524,7 +524,7 @@ export default {
   directives: {
     markdown: markdownDirective,
   },
-  props: ['task', 'isUser', 'group', 'dueDate'], // @TODO: maybe we should store the group on state?
+  props: ['task', 'isUser', 'group', 'dueDate', 'isCopyAsTodo'], // @TODO: maybe we should store the group on state?
   data () {
     return {
       icons: Object.freeze({


### PR DESCRIPTION
Fixes #9980

### Changes
[//]: # Remove the three dots menu from the copy-as-to-do modals.

----
UUID: 
3aa5f32e-eadc-47fb-96ee-64b1022c7d43