### PR TITLE
task types: add new error messages for invalid task types

### DIFF
--- a/website/common/locales/en/tasks.json
+++ b/website/common/locales/en/tasks.json
@@ -149,6 +149,8 @@
   "taskAliasAlreadyUsed": "Task alias already used on another task.",
   "taskNotFound": "Task not found.",
   "invalidTaskType": "Task type must be one of \"habit\", \"daily\", \"todo\", \"reward\".",
+  "invalidTasksType": "Task type must be one of \"habits\", \"dailys\", \"todos\", \"rewards\".",
+  "invalidTasksTypeExtra": "Task type must be one of \"habits\", \"dailys\", \"todos\", \"rewards\", \"completedTodos\".",
   "cantDeleteChallengeTasks": "A task belonging to a challenge can't be deleted.",
   "checklistOnlyDailyTodo": "Checklists are supported only on Dailies and To-Dos",
   "checklistItemNotFound": "No checklist item was found with given id.",

--- a/website/server/controllers/api-v3/tasks.js
+++ b/website/server/controllers/api-v3/tasks.js
@@ -287,7 +287,7 @@ api.getUserTasks = {
   async handler (req, res) {
     let types = Tasks.tasksTypes.map(type => `${type}s`);
     types.push('completedTodos', '_allCompletedTodos'); // _allCompletedTodos is currently in BETA and is likely to be removed in future
-    req.checkQuery('type', res.t('invalidTaskType')).optional().isIn(types);
+    req.checkQuery('type', res.t('invalidTasksTypeExtra')).optional().isIn(types);
 
     let validationErrors = req.validationErrors();
     if (validationErrors) throw validationErrors;
@@ -325,7 +325,7 @@ api.getChallengeTasks = {
   async handler (req, res) {
     req.checkParams('challengeId', res.t('challengeIdRequired')).notEmpty().isUUID();
     let types = Tasks.tasksTypes.map(type => `${type}s`);
-    req.checkQuery('type', res.t('invalidTaskType')).optional().isIn(types);
+    req.checkQuery('type', res.t('invalidTasksType')).optional().isIn(types);
 
     let validationErrors = req.validationErrors();
     if (validationErrors) throw validationErrors;

--- a/website/server/controllers/api-v3/tasks/groups.js
+++ b/website/server/controllers/api-v3/tasks/groups.js
@@ -86,7 +86,7 @@ api.getGroupTasks = {
   middlewares: [authWithHeaders()],
   async handler (req, res) {
     req.checkParams('groupId', res.t('groupIdRequired')).notEmpty().isUUID();
-    req.checkQuery('type', res.t('invalidTaskType')).optional().isIn(types);
+    req.checkQuery('type', res.t('invalidTasksType')).optional().isIn(types);
 
     let validationErrors = req.validationErrors();
     if (validationErrors) throw validationErrors;


### PR DESCRIPTION
* `/task/user` `GET` endpoint takes plurals of task types as allowed parameters, plus  another custom `completedTodos` type
* `/tasks/group/:groupId` and `/tasks/challenge/:challengeId` `GET` endpoints task plurals of task types as allowed parameters

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Updating the message with the current accepted task types for the relevant API calls

----
UUID: 677a7368-89f8-48e7-98f6-77795efd3937

-------

Fixes #10027