### PR TITLE
User status model: fix attributes box size being too small on Japanese

### DIFF
--- a/website/client/components/userMenu/profile.vue
+++ b/website/client/components/userMenu/profile.vue
@@ -525,7 +525,7 @@ div
     }
 
     .box {
-      width: 141px;
+      width: 148px;
       height: 84px;
       padding: .5em;
       margin: 0 auto;


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #9979

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Increased the width of the box a little so the text "points" (ポイント) fits in its space.
The difference of the box is almost imperceptible when in English.

Also tested seeing the same modal in all available languages, I can guarantee the text "points" in Japanese is the biggest one.

#### - Before
![screenshot1](https://i.imgur.com/lckmIG5.jpg)
![screenshot2](https://user-images.githubusercontent.com/1495809/36068087-85ca404a-0f18-11e8-9355-0da4a00788e0.png)

#### - Now
![screenshot3](https://i.imgur.com/hYia3UG.jpg)
![screenshot4](https://i.imgur.com/1sAiy9l.jpg)

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 203f208a-e0f0-4442-bf16-d4f19e553e8a
