### PR TITLE
If message uuid is set as system append as user 'system message' for Copy as To-Do #9985

### DIFF
--- a/website/client/components/chat/copyAsTodoModal.vue
+++ b/website/client/components/chat/copyAsTodoModal.vue
@@ -38,7 +38,7 @@ export default {
   },
   mounted () {
     this.$root.$on('habitica::copy-as-todo', message => {
-      const notes = `${message.user} wrote in [${this.groupName}](${baseUrl}/groups/guild/${this.groupId})`;
+      const notes = `${message.user || 'system message'}${message.user ? ' wrote' : ''} in [${this.groupName}](${baseUrl}/groups/guild/${this.groupId})`;
       const newTask = {
         text: message.text,
         type: 'todo',


### PR DESCRIPTION
Fixes #9985 

### Changes
When using "Copy As Todo" from a chat Card if the user uuid set in the message is system, add "system message" as the user name for the todo text.

UUID: a120835b-5382-44eb-b6d7-5c597d329c0e
