### PR TITLE
HOTFIX: purchase marketGear

### DIFF
--- a/test/client/unit/specs/store/actions/shops.js
+++ b/test/client/unit/specs/store/actions/shops.js
@@ -1,0 +1,55 @@
+import axios from 'axios';
+import generateStore from 'client/store';
+
+import content from 'common/script/content';
+import getItemInfo from 'common/script/libs/getItemInfo';
+
+import getOfficialPinnedItems from 'common/script/libs/getOfficialPinnedItems';
+
+describe('shops actions', () => {
+  let store;
+
+  beforeEach(() => {
+    store = generateStore();
+  });
+
+  describe('genericPurchase', () => {
+    it('buy gear', async () => {
+      let user = {
+        id: 1,
+        stats: {
+          class: 'rogue',
+        },
+        items: {
+          gear: {
+            owned: {},
+            equipped: {},
+          },
+        },
+        pinnedItems: [],
+        preferences: {
+          autoEquip: true,
+        },
+      };
+
+      store.state.user.data = user;
+
+      // select a gear item
+      let gearItem = content.gear.flat.armor_rogue_1;
+
+      let item = getItemInfo(user, 'marketGear', gearItem, getOfficialPinnedItems(user));
+
+      sandbox.stub(axios, 'post').withArgs('/api/v3/user/buy/armor_rogue_1').returns(Promise.resolve({data: {data: {}}}));
+
+      await store.dispatch('shops:genericPurchase', {
+        pinType: item.pinType,
+        type: item.purchaseType,
+        key: item.key,
+        currency: item.currency,
+        quantity: 1,
+      });
+
+      expect(store.state.user.data.item.equipped.armor_rogue_1).to.equal(true);
+    });
+  });
+});

--- a/website/client/store/actions/shops.js
+++ b/website/client/store/actions/shops.js
@@ -11,7 +11,7 @@ import { getDropClass } from 'client/libs/notifications';
 // @TODO: Purchase means gems and buy means gold. That wording is misused below, but we should also change
 // the generic buy functions to something else. Or have a Gold Vendor and Gem Vendor, etc
 
-export function buyItem (store, params) {
+function buyItem (store, params) {
   const quantity = params.quantity || 1;
   const user = store.state.user.data;
 
@@ -151,7 +151,9 @@ export async function genericPurchase (store, params) {
       return store.dispatch('user:rebirth');
     case 'potion':
     case 'marketGear':
-      return buyItem(store, params);
+      // 'marketGear' gets `type`= `gear` which is used for gem-purchasable gear
+      // resetting type to pinType only here
+      return buyItem(store, {...params, type: params.pinType});
     case 'background':
       return unlock(store, {
         query: {


### PR DESCRIPTION
While working on the purchase-refactoring part 2 - I discovered a bug where marketGear wasn't able to be purchased in the website (the API still working as expected)

its just the needed `type` was `gear` instead of `marketGear`

I hope to refactor it so something like this shouldn't happen again.

- `potion` still work after this change


This should be merged before the next deploy.