### PR TITLE
Prevent closing death modal by pressing esc or clicking on backdrop

### DIFF
--- a/website/client/components/achievements/death.vue
+++ b/website/client/components/achievements/death.vue
@@ -1,5 +1,11 @@
 <template lang="pug">
-  b-modal#death(:title="$t('lostAllHealth')", size='md', :hide-footer="true")
+  b-modal#death(
+    :title="$t('lostAllHealth')",
+    size='md',
+    :hide-footer="true",
+    no-close-on-esc,
+    no-close-on-backdrop,
+  )
     .row
       .col-12
         .hero-stats


### PR DESCRIPTION
Fixes #10001
