### PR TITLE
Modals reappear after being closed #9986

### DIFF
--- a/website/client/app.vue
+++ b/website/client/app.vue
@@ -321,12 +321,12 @@ export default {
     }
 
     // Manage modals
-    this.$root.$on('bv::show::modal', (modalId, data = {}) => {
-      if (data.fromRoot) return;
+    this.$root.$on('bv::show::modal', ({modalId, fromRoot = false, alreadyTracked = false}) => {
+      if (fromRoot) return;
 
       // Track opening of gems modal unless it's been already tracked
       // For example the gems button in the menu already tracks the event by itself
-      if (modalId === 'buy-gems' && data.alreadyTracked !== true) {
+      if (modalId === 'buy-gems' && alreadyTracked !== true) {
         Analytics.track({
           hitType: 'event',
           eventCategory: 'button',
@@ -343,21 +343,21 @@ export default {
       this.$store.state.modalStack.push(modalId);
 
       // Hide the previous top modal
-      if (modalOnTop) this.$root.$emit('bv::hide::modal', modalOnTop, {fromRoot: true});
+      if (modalOnTop) this.$root.$emit('bv::hide::modal', {
+        modalId: modalOnTop,
+        fromRoot: true,
+      });
     });
 
     // @TODO: This part is hacky and could be solved with two options:
     // 1 - Find a way to pass fromRoot to hidden
     // 2 - Enforce that all modals use the hide::modal event
     this.$root.$on('bv::modal::hidden', (bvEvent) => {
-      const modalId = bvEvent.target.id;
+      const {fromRoot} = bvEvent;
 
       let modalStackLength = this.$store.state.modalStack.length;
-      let modalSecondToTop = this.$store.state.modalStack[modalStackLength - 2];
-      // Don't remove modal if hid was called from main app
-      // @TODO: I'd reather use this, but I don't know how to pass data to hidden event
-      // if (data && data.fromRoot) return;
-      if (modalId === modalSecondToTop) return;
+      // Don't remove modal if hide was called from main app
+      if (fromRoot) return;
 
       // Remove modal from stack
       this.$store.state.modalStack.pop();
@@ -365,7 +365,7 @@ export default {
       // Recalculate and show the last modal if there is one
       modalStackLength = this.$store.state.modalStack.length;
       let modalOnTop = this.$store.state.modalStack[modalStackLength - 1];
-      if (modalOnTop) this.$root.$emit('bv::show::modal', modalOnTop, {fromRoot: true});
+      if (modalOnTop) this.$root.$emit('bv::show::modal', {modalId: modalOnTop, fromRoot: true, alreadyTracked: true});
     });
   },
   beforeDestroy () {
@@ -409,9 +409,8 @@ export default {
         // remove the dialog from our modal-stack,
         // the default hidden event is delayed
         this.$root.$emit('bv::modal::hidden', {
-          target: {
-            id: 'buy-modal',
-          },
+          modalId: 'buy-modal',
+          fromRoot: false,
         });
 
         this.$root.$emit('bv::show::modal', 'select-member-modal');


### PR DESCRIPTION
Fixes #9986 

### Changes

Prevent most of the modals reappearing after dismissing unrelated modals.

UUID: a120835b-5382-44eb-b6d7-5c597d329c0e