### PR TITLE
add stats.class to userStyles chat cache #10015

### DIFF
--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -506,14 +506,17 @@ function setUserStyles (newMessage, user) {
     userStyles.preferences.costume = userCopy.preferences.costume;
   }
 
-  userStyles.stats = {};
-  if (userCopy.stats && userCopy.stats.buffs) {
-    userStyles.stats.buffs = {
-      seafoam: userCopy.stats.buffs.seafoam,
-      shinySeed: userCopy.stats.buffs.shinySeed,
-      spookySparkles: userCopy.stats.buffs.spookySparkles,
-      snowball: userCopy.stats.buffs.snowball,
-    };
+  if (userCopy.stats) {
+    userStyles.stats = {};
+    userStyles.stats.class = userCopy.stats.class;
+    if (userCopy.stats.buffs) {
+      userStyles.stats.buffs = {
+        seafoam: userCopy.stats.buffs.seafoam,
+        shinySeed: userCopy.stats.buffs.shinySeed,
+        spookySparkles: userCopy.stats.buffs.spookySparkles,
+        snowball: userCopy.stats.buffs.snowball,
+      };
+    }
   }
 
   newMessage.userStyles = userStyles;


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes https://github.com/HabitRPG/habitica/issues/10015

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
The Flower avatar needs to know the user's class type to render correctly.  This PR adds code to setup the `userStyles.stats.class` variable.

---
Setting user's shinySeed: 
```
db.users.update({ _id: 'b0e24c96-3011-4b92-8ef3-a596748f3db9' }, {$set: { 'stats.buffs.shinySeed': true }})
```

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 4b555b65-318a-42da-b112-bfe090e2d902
