### PR TITLE
Marked new stuff complete when clicking later

### DIFF
--- a/website/client/components/achievements/newStuff.vue
+++ b/website/client/components/achievements/newStuff.vue
@@ -50,7 +50,6 @@
     methods: {
       tellMeLater () {
         this.$store.dispatch('user:newStuffLater');
-        this.$store.dispatch('user:set', {'flags.newStuff': false});
         this.$root.$emit('bv::hide::modal', 'new-stuff');
       },
       dismissAlert () {

--- a/website/client/components/achievements/newStuff.vue
+++ b/website/client/components/achievements/newStuff.vue
@@ -50,6 +50,7 @@
     methods: {
       tellMeLater () {
         this.$store.dispatch('user:newStuffLater');
+        this.$store.dispatch('user:set', {'flags.newStuff': false});
         this.$root.$emit('bv::hide::modal', 'new-stuff');
       },
       dismissAlert () {

--- a/website/client/store/actions/user.js
+++ b/website/client/store/actions/user.js
@@ -119,7 +119,8 @@ export function openMysteryItem () {
   return axios.post('/api/v3/user/open-mystery-item');
 }
 
-export function newStuffLater () {
+export function newStuffLater (store) {
+  store.state.user.data.flags.newStuff = false;
   return axios.post('/api/v3/news/tell-me-later');
 }
 


### PR DESCRIPTION
When a user clicks new stuff later, we add a notification to their account. However, we don't mark newstuff completed as false which can cause the bailey to show multiple times. 