### PR TITLE
Don't include seasonal class gear in classless category

### DIFF
--- a/website/common/script/libs/shops.js
+++ b/website/common/script/libs/shops.js
@@ -189,8 +189,8 @@ shops.getMarketGearCategories = function getMarketGear (user, language) {
 
   let specialNonClassGear = filter(content.gear.flat, (gear) => {
     return !user.items.gear.owned[gear.key] &&
-      content.classes.indexOf(gear.klass) < 0 &&
-      content.classes.indexOf(gear.specialClass) < 0 &&
+      content.classes.indexOf(gear.klass) === -1 &&
+      content.classes.indexOf(gear.specialClass) === -1 &&
       (gear.canOwn && gear.canOwn(user));
   });
 

--- a/website/common/script/libs/shops.js
+++ b/website/common/script/libs/shops.js
@@ -187,16 +187,14 @@ shops.getMarketGearCategories = function getMarketGear (user, language) {
     text: i18n.t('none', language),
   };
 
-  let falseGear = filter(content.gear.flat, (gear) => {
-    let prevOwnedFalseGear = user.items.gear.owned[gear.key] === false && gear.klass !== user.stats.class;
-    let specialNonClassGear = !user.items.gear.owned[gear.key] &&
-                              content.classes.indexOf(gear.klass) < 0 &&
-                              content.classes.indexOf(gear.specialClass) < 0 &&
-                              (gear.canOwn && gear.canOwn(user));
-    return  prevOwnedFalseGear || specialNonClassGear;
+  let specialNonClassGear = filter(content.gear.flat, (gear) => {
+    return !user.items.gear.owned[gear.key] &&
+      content.classes.indexOf(gear.klass) < 0 &&
+      content.classes.indexOf(gear.specialClass) < 0 &&
+      (gear.canOwn && gear.canOwn(user));
   });
 
-  nonClassCategory.items = map(falseGear, (e) => {
+  nonClassCategory.items = map(specialNonClassGear, (e) => {
     return getItemInfo(user, 'marketGear', e);
   });
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #9971 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Removes some logic from the Market library that was adding broken seasonal equipment to the "None" category in the Market. Not only was this needless and confusing, but it posed problems for upcoming functionality planned for Habitica's mobile apps.

Prompts the question of why this logic was in there in the first place, since it looks so deliberate... o.O

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)