### PR TITLE
[Input Needed] Filter out owned items from User Rewards

### DIFF
--- a/website/client/components/tasks/column.vue
+++ b/website/client/components/tasks/column.vue
@@ -52,6 +52,7 @@
       .reward-items
         shopItem(
           v-for="reward in inAppRewards",
+          v-if="!reward.owned",
           :item="reward",
           :key="reward.key",
           :highlightBorder="reward.isSuggested",


### PR DESCRIPTION
Adding an if statment to user rewards to filter out any already owned rewards from the Rewards section of the page when an item is purchased.

[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10049
### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
I've added an additional condition to the loop of items displayed in the rewards section to filter out any items that are already owned.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 2a4d30ee-4833-420e-be7c-ad6a6e261c5f