### PR TITLE
Stop market background from covering featured items sign

### DIFF
--- a/website/client/components/shops/market/index.vue
+++ b/website/client/components/shops/market/index.vue
@@ -294,6 +294,7 @@
       .content {
         display: flex;
         flex-direction: column;
+        z-index: 1; // Always cover background. 
       }
 
       .npc {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10037

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Add a z-index to the market's featured items to keep the background from covering the sign. 



[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 6d7d6651-604d-4e7c-adff-a040770a6768
