### PR TITLE
Prettify background overview

### DIFF
--- a/website/client/components/creatorIntro.vue
+++ b/website/client/components/creatorIntro.vue
@@ -261,12 +261,9 @@ b-modal#avatar-modal(title="", :size='editing ? "lg" : "md"', :hide-header='true
         .col-2.text-center.sub-menu-item(@click='changeSubPage("2014")', :class='{active: activeSubPage === "2014"}')
           strong(v-once) 2014
       .row.customize-menu(v-for='(sets, key) in backgroundShopSetsByYear')
-        .row(v-for='set in sets', v-if='activeSubPage === key')
+        .row.background-set(v-for='set in sets', v-if='activeSubPage === key')
           .col-8.offset-2.text-center.set-title
             strong {{set.text}}
-            button.buy-set-btn.btn.btn-secondary(v-if='!ownsSet("background", set.items) && set.identifier !== "incentiveBackgrounds"' @click='unlock(setKeys("background", set.items))') Purchase Set
-              .svg-icon.gem(v-html='icons.gem')
-              span 15
           .col-4.text-center.customize-option.background-button(v-for='bg in set.items',
             @click='!user.purchased.background[bg.key] ? backgroundSelected(bg) : unlock("background." + bg.key)',
             :popover-title='bg.text',
@@ -274,16 +271,19 @@ b-modal#avatar-modal(title="", :size='editing ? "lg" : "md"', :hide-header='true
             popover-trigger='mouseenter')
             .background(:class='[`background_${bg.key}`, backgroundLockedStatus(bg.key)]')
             i.glyphicon.glyphicon-lock(v-if='!user.purchased.background[bg.key]')
-            .purchase-single(v-if='!user.purchased.background[bg.key]')
+            .purchase-background.single(v-if='!user.purchased.background[bg.key]')
               .svg-icon.gem(v-html='icons.gem')
-              span 7
+              span.price 7
             span.badge.badge-pill.badge-item.badge-svg(
               :class="{'item-selected-badge': isBackgroundPinned(bg), 'hide': !isBackgroundPinned(bg)}",
               @click.prevent.stop="togglePinned(bg)",
               v-if='!user.purchased.background[bg.key]'
             )
               span.svg-icon.inline.icon-12.color(v-html="icons.pin")
-
+          .purchase-background.set(v-if='!ownsSet("background", set.items) && set.identifier !== "incentiveBackgrounds"' @click='unlock(setKeys("background", set.items))')
+            span.label Purchase Set
+            .svg-icon.gem(v-html='icons.gem')
+            span.price 15
 
   .container.interests-section(v-if='modalPage === 3 && !editing')
     .section.row
@@ -677,22 +677,34 @@ b-modal#avatar-modal(title="", :size='editing ? "lg" : "md"', :hide-header='true
       cursor: pointer;
     }
 
-    .purchase-single {
-      width: 141px;
+    .purchase-background {
       margin: 0 auto;
       background: #fff;
       padding: 0.5em;
-      box-shadow: 0 2px 2px 0 rgba(26, 24, 29, 0.16), 0 1px 4px 0 rgba(26, 24, 29, 0.12);
       border-radius: 0 0 2px 2px;
+      cursor: pointer;
 
       span {
         font-weight: bold;
         font-size: 12px;
-        color: #24cc8f;
       }
 
+      span.price {
+        color: #24cc8f;
+      }
+      
       .gem {
         width: 16px;
+      }
+
+      &.single {
+        width: 141px;
+        box-shadow: 0 2px 2px 0 rgba(26, 24, 29, 0.16), 0 1px 4px 0 rgba(26, 24, 29, 0.12);
+
+      }
+
+      &.set {
+        width: 100%;
       }
     }
 
@@ -702,20 +714,12 @@ b-modal#avatar-modal(title="", :size='editing ? "lg" : "md"', :hide-header='true
       vertical-align: bottom;
     }
 
-    .buy-set-btn {
-      margin: 0 0 5px 5px;
-      padding: 5px;
-      font-size: 16px;
-
-      .gem {
-        width: 24px;
-      }
-
-      span {
-        font-weight: bold;
-        font-size: 20px;
-        color: #24cc8f;
-      }
+    .background-set {
+        width: 100%;
+        margin: 10px;
+        background-color: #edecee;
+        box-shadow: 0 2px 2px 0 rgba(26, 24, 29, 0.16), 0 1px 4px 0 rgba(26, 24, 29, 0.12);
+        border-radius: 2px;
     }
   }
 
@@ -788,6 +792,10 @@ b-modal#avatar-modal(title="", :size='editing ? "lg" : "md"', :hide-header='true
 
   span.badge.badge-pill.badge-item.badge-svg.hide {
     display: none;
+  }
+
+  .background-button {
+      margin-bottom: 10px;
   }
 
   .background-button:hover {

--- a/website/client/components/creatorIntro.vue
+++ b/website/client/components/creatorIntro.vue
@@ -988,7 +988,7 @@ export default {
   mixins: [guide, notifications],
   components: {
     avatar,
-    toggleSwitch
+    toggleSwitch,
   },
   mounted () {
     if (this.editing) this.modalPage = 2;

--- a/website/client/components/creatorIntro.vue
+++ b/website/client/components/creatorIntro.vue
@@ -264,6 +264,9 @@ b-modal#avatar-modal(title="", :size='editing ? "lg" : "md"', :hide-header='true
         .row(v-for='set in sets', v-if='activeSubPage === key')
           .col-8.offset-2.text-center.set-title
             strong {{set.text}}
+            button.buy-set-btn.btn.btn-secondary(v-if='!ownsSet("background", set.items) && set.identifier !== "incentiveBackgrounds"' @click='unlock(setKeys("background", set.items))') Purchase Set
+              .svg-icon.gem(v-html='icons.gem')
+              span 15
           .col-4.text-center.customize-option.background-button(v-for='bg in set.items',
             @click='!user.purchased.background[bg.key] ? backgroundSelected(bg) : unlock("background." + bg.key)',
             :popover-title='bg.text',
@@ -281,11 +284,6 @@ b-modal#avatar-modal(title="", :size='editing ? "lg" : "md"', :hide-header='true
             )
               span.svg-icon.inline.icon-12.color(v-html="icons.pin")
 
-          .col-12.text-center(v-if='!ownsSet("background", set.items) && set.identifier !== "incentiveBackgrounds"')
-            .gem-amount
-              .svg-icon.gem(v-html='icons.gem')
-              span 15
-            button.btn.btn-secondary(@click='unlock(setKeys("background", set.items))') Purchase Set
 
   .container.interests-section(v-if='modalPage === 3 && !editing')
     .section.row
@@ -699,14 +697,15 @@ b-modal#avatar-modal(title="", :size='editing ? "lg" : "md"', :hide-header='true
     }
 
     .gem {
-      margin-right: .5em;
+      margin: 0 .5em;
       display: inline-block;
       vertical-align: bottom;
     }
 
-    .gem-amount {
-      margin-top: 1em;
-      margin-bottom: 1em;
+    .buy-set-btn {
+      margin: 0 0 5px 5px;
+      padding: 5px;
+      font-size: 16px;
 
       .gem {
         width: 24px;

--- a/website/client/components/creatorIntro.vue
+++ b/website/client/components/creatorIntro.vue
@@ -238,9 +238,8 @@ b-modal#avatar-modal(title="", :size='editing ? "lg" : "md"', :hide-header='true
             popover-placement='right', popover-append-to-body='true',
             ng-click='user.items.gear.owned[item.key] ? equip(item.key) : purchase(item.type,item)')
     #backgrounds.section.container.customize-section(v-if='activeTopPage === "backgrounds"')
-      .title-row
-        input(id='filterBackgroundsCheckbox' type='checkbox' v-model='filterBackgrounds')
-        label(for='filterBackgroundsCheckbox') Hide locked backgrounds
+      .row.title-row
+        toggle-switch.backgroundFilterToggle(:label="'Hide locked backgrounds'", v-model='filterBackgrounds')
       .row.text-center.title-row(v-if='!filterBackgrounds')
         strong {{backgroundShopSets[0].text}}
       .row.title-row(v-if='!filterBackgrounds')
@@ -620,11 +619,11 @@ b-modal#avatar-modal(title="", :size='editing ? "lg" : "md"', :hide-header='true
   #backgrounds {
     .title-row {
       margin-bottom: 1em;
+    }
 
-      label {
-        margin-left: 5px;
-        font-weight: bold;
-      }
+    .backgroundFilterToggle {
+      margin-left: auto;
+      margin-right: auto;
     }
 
     .set-title {
@@ -698,6 +697,7 @@ b-modal#avatar-modal(title="", :size='editing ? "lg" : "md"', :hide-header='true
       background: #fff;
       padding: 0.5em;
       border-radius: 0 0 2px 2px;
+      box-shadow: 0 2px 2px 0 rgba(26, 24, 29, 0.16), 0 1px 4px 0 rgba(26, 24, 29, 0.12);
       cursor: pointer;
 
       span {
@@ -715,12 +715,18 @@ b-modal#avatar-modal(title="", :size='editing ? "lg" : "md"', :hide-header='true
 
       &.single {
         width: 141px;
-        box-shadow: 0 2px 2px 0 rgba(26, 24, 29, 0.16), 0 1px 4px 0 rgba(26, 24, 29, 0.12);
-
       }
 
       &.set {
         width: 100%;
+
+        span {
+          font-size: 14px;
+        }
+      
+        .gem {
+          width: 20px;
+        }
       }
     }
 
@@ -734,7 +740,6 @@ b-modal#avatar-modal(title="", :size='editing ? "lg" : "md"', :hide-header='true
         width: 100%;
         margin: 10px;
         background-color: #edecee;
-        box-shadow: 0 2px 2px 0 rgba(26, 24, 29, 0.16), 0 1px 4px 0 rgba(26, 24, 29, 0.12);
         border-radius: 2px;
     }
   }
@@ -811,7 +816,7 @@ b-modal#avatar-modal(title="", :size='editing ? "lg" : "md"', :hide-header='true
   }
 
   .background-button {
-      margin-bottom: 10px;
+      margin-bottom: 15px;
   }
 
   .background-button:hover {
@@ -835,6 +840,7 @@ import guide from 'client/mixins/guide';
 import notifications from 'client/mixins/notifications';
 import appearance from 'common/script/content/appearance';
 import appearanceSets from 'common/script/content/appearance/sets';
+import toggleSwitch from 'client/components/ui/toggleSwitch';
 
 import logoPurple from 'assets/svg/logo-purple.svg';
 import bodyIcon from 'assets/svg/body.svg';
@@ -982,6 +988,7 @@ export default {
   mixins: [guide, notifications],
   components: {
     avatar,
+    toggleSwitch
   },
   mounted () {
     if (this.editing) this.modalPage = 2;

--- a/website/client/components/inventory/equipment/index.vue
+++ b/website/client/components/inventory/equipment/index.vue
@@ -54,18 +54,12 @@
                 :class="{'drawer-tab-text-active': costume === true}",
               ) {{ $t('costume') }}
 
-            toggle-switch#costumePrefToggleSwitch.float-right(
+            toggle-switch.float-right(
               :label="$t(costume ? 'useCostume' : 'autoEquipBattleGear')",
               :checked="user.preferences[drawerPreference]",
               @change="changeDrawerPreference",
+              :hoverText="$t(drawerPreference+'PopoverText')",
             )
-
-            b-popover(
-              target="costumePrefToggleSwitch"
-              triggers="hover",
-              placement="top"
-            )
-              .popover-content-text {{ $t(drawerPreference+'PopoverText') }}
       .items.items-one-line(slot="drawer-slider")
         item.pointer(
           v-for="(label, group) in gearTypesToStrings",

--- a/website/client/components/inventory/equipment/index.vue
+++ b/website/client/components/inventory/equipment/index.vue
@@ -54,7 +54,7 @@
                 :class="{'drawer-tab-text-active': costume === true}",
               ) {{ $t('costume') }}
 
-            toggle-switch.float-right(
+            toggle-switch.float-right.align-with-tab(
               :label="$t(costume ? 'useCostume' : 'autoEquipBattleGear')",
               :checked="user.preferences[drawerPreference]",
               @change="changeDrawerPreference",
@@ -128,6 +128,14 @@
 .pointer {
   cursor: pointer;
 }
+
+.align-with-tab {
+  margin-top: 3px;
+}
+
+.drawer-tab-text {
+  display: inline-block;
+}
 </style>
 
 <script>
@@ -141,7 +149,6 @@ import _sortBy from 'lodash/sortBy';
 import _reverse from 'lodash/reverse';
 
 import toggleSwitch from 'client/components/ui/toggleSwitch';
-
 import Item from 'client/components/inventory/item';
 import ItemRows from 'client/components/ui/itemRows';
 import EquipmentAttributesPopover from 'client/components/inventory/equipment/attributesPopover';

--- a/website/client/components/inventory/stable/index.vue
+++ b/website/client/components/inventory/stable/index.vue
@@ -48,7 +48,7 @@
 
         div.form-group.clearfix
           h3.float-left Hide Missing
-          toggle-switch.float-right.no-margin(
+          toggle-switch.float-right(
             :checked="hideMissing",
             @change="updateHideMissing"
           )

--- a/website/client/components/inventory/stable/index.vue
+++ b/website/client/components/inventory/stable/index.vue
@@ -49,7 +49,6 @@
         div.form-group.clearfix
           h3.float-left Hide Missing
           toggle-switch.float-right.no-margin(
-            :label="''",
             :checked="hideMissing",
             @change="updateHideMissing"
           )

--- a/website/client/components/shops/market/index.vue
+++ b/website/client/components/shops/market/index.vue
@@ -16,13 +16,11 @@
         div.form-group.clearfix
           h3.float-left(v-once) {{ $t('hideLocked') }}
           toggle-switch.float-right.no-margin(
-            :label="''",
             v-model="hideLocked",
           )
         div.form-group.clearfix
           h3.float-left(v-once) {{ $t('hidePinned') }}
           toggle-switch.float-right.no-margin(
-            :label="''",
             v-model="hidePinned",
           )
     .standard-page

--- a/website/client/components/shops/market/index.vue
+++ b/website/client/components/shops/market/index.vue
@@ -15,12 +15,12 @@
               label.custom-control-label(v-once, :for="`category-${category.identifier}`") {{ category.text }}
         div.form-group.clearfix
           h3.float-left(v-once) {{ $t('hideLocked') }}
-          toggle-switch.float-right.no-margin(
+          toggle-switch.float-right(
             v-model="hideLocked",
           )
         div.form-group.clearfix
           h3.float-left(v-once) {{ $t('hidePinned') }}
-          toggle-switch.float-right.no-margin(
+          toggle-switch.float-right(
             v-model="hidePinned",
           )
     .standard-page

--- a/website/client/components/shops/quests/index.vue
+++ b/website/client/components/shops/quests/index.vue
@@ -18,13 +18,11 @@
         div.form-group.clearfix
           h3.float-left(v-once) {{ $t('hideLocked') }}
           toggle-switch.float-right.no-margin(
-            :label="''",
             v-model="hideLocked",
           )
         div.form-group.clearfix
           h3.float-left(v-once) {{ $t('hidePinned') }}
           toggle-switch.float-right.no-margin(
-            :label="''",
             v-model="hidePinned",
           )
     .standard-page

--- a/website/client/components/shops/quests/index.vue
+++ b/website/client/components/shops/quests/index.vue
@@ -17,12 +17,12 @@
 
         div.form-group.clearfix
           h3.float-left(v-once) {{ $t('hideLocked') }}
-          toggle-switch.float-right.no-margin(
+          toggle-switch.float-right(
             v-model="hideLocked",
           )
         div.form-group.clearfix
           h3.float-left(v-once) {{ $t('hidePinned') }}
-          toggle-switch.float-right.no-margin(
+          toggle-switch.float-right(
             v-model="hidePinned",
           )
     .standard-page

--- a/website/client/components/shops/seasonal/index.vue
+++ b/website/client/components/shops/seasonal/index.vue
@@ -18,7 +18,6 @@
         div.form-group.clearfix
           h3.float-left(v-once) {{ $t('hidePinned') }}
           toggle-switch.float-right.no-margin(
-            :label="''",
             v-model="hidePinned",
           )
     .standard-page

--- a/website/client/components/shops/seasonal/index.vue
+++ b/website/client/components/shops/seasonal/index.vue
@@ -17,7 +17,7 @@
 
         div.form-group.clearfix
           h3.float-left(v-once) {{ $t('hidePinned') }}
-          toggle-switch.float-right.no-margin(
+          toggle-switch.float-right(
             v-model="hidePinned",
           )
     .standard-page

--- a/website/client/components/shops/timeTravelers/index.vue
+++ b/website/client/components/shops/timeTravelers/index.vue
@@ -18,7 +18,6 @@
         div.form-group.clearfix
           h3.float-left(v-once) {{ $t('hidePinned') }}
           toggle-switch.float-right.no-margin(
-            :label="''",
             v-model="hidePinned",
           )
     .standard-page

--- a/website/client/components/shops/timeTravelers/index.vue
+++ b/website/client/components/shops/timeTravelers/index.vue
@@ -17,7 +17,7 @@
 
         div.form-group.clearfix
           h3.float-left(v-once) {{ $t('hidePinned') }}
-          toggle-switch.float-right.no-margin(
+          toggle-switch.float-right(
             v-model="hidePinned",
           )
     .standard-page

--- a/website/client/components/tasks/taskModal.vue
+++ b/website/client/components/tasks/taskModal.vue
@@ -181,7 +181,6 @@
           .form-group
             label(v-once) {{ $t('approvalRequired') }}
             toggle-switch.d-inline-block(
-              label="",
               :checked="requiresApproval",
               @change="updateRequiresApproval"
             )

--- a/website/client/components/ui/toggleSwitch.vue
+++ b/website/client/components/ui/toggleSwitch.vue
@@ -29,7 +29,6 @@
 
   .toggle-switch-description {
     height: 20px;
-    border-bottom: 1px dashed $gray-200;
   }
 
   .toggle-switch-checkbox {

--- a/website/client/components/ui/toggleSwitch.vue
+++ b/website/client/components/ui/toggleSwitch.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 .popover-box
-  .clearfix.toggle-switch-container(:id="containerId")
+  .clearfix(:id="containerId")
     .float-left.toggle-switch-description(v-if="label", :class="hoverText ? 'hasPopOver' : ''") {{ label }}
     .toggle-switch.float-left
       input.toggle-switch-checkbox(
@@ -24,10 +24,6 @@
 
 <style lang="scss" scoped>
   @import '~client/assets/scss/colors.scss';
-
-  .toggle-switch-container {
-    margin-top: 6px;
-  }
 
   .toggle-switch {
     position: relative;

--- a/website/client/components/ui/toggleSwitch.vue
+++ b/website/client/components/ui/toggleSwitch.vue
@@ -1,16 +1,25 @@
 <template lang="pug">
-.clearfix.toggle-switch-container
-  .float-left.toggle-switch-description {{ label }}
-  .toggle-switch.float-left
-    input.toggle-switch-checkbox(
-      type='checkbox', :id="id",
-      @change="handleChange",
-      :checked="isChecked",
-      :value="value",
-    )
-    label.toggle-switch-label(:for="id")
-      span.toggle-switch-inner
-      span.toggle-switch-switch
+.popover-box
+  .clearfix.toggle-switch-container(:id="containerId")
+    .float-left.toggle-switch-description(:class="hoverText ? 'hasPopOver' : ''") {{ label }}
+    .toggle-switch.float-left
+      input.toggle-switch-checkbox(
+        type='checkbox', :id="toggleId",
+        @change="handleChange",
+        :checked="isChecked",
+        :value="value",
+      )
+      label.toggle-switch-label(:for="toggleId")
+        span.toggle-switch-inner
+        span.toggle-switch-switch
+
+  b-popover(
+    v-if="hoverText"
+    :target="containerId"
+    triggers="hover",
+    placement="top"
+  )
+    .popover-content-text {{ hoverText }}
 </template>
 
 <style lang="scss" scoped>
@@ -29,6 +38,10 @@
 
   .toggle-switch-description {
     height: 20px;
+
+    &.hasPopOver {
+      border-bottom: 1px dashed $gray-200;
+    }
   }
 
   .toggle-switch-checkbox {
@@ -101,8 +114,10 @@
 export default {
   data () {
     return {
-      // A value is required for the required for the for and id attributes
-      id: Math.random(),
+      // The toggle requires a unique id to link it to the label
+      toggleId: this.generateId(),
+      // The container requires a unique id to link it to the pop-over
+      containerId: this.generateId(),
     };
   },
   model: {
@@ -121,6 +136,9 @@ export default {
       type: Boolean,
       default: false,
     },
+    hoverText: {
+      type: String,
+    },
   },
   computed: {
     isChecked () {
@@ -131,6 +149,10 @@ export default {
     handleChange ({ target: { checked } }) {
       this.$emit('change', checked);
     },
+    generateId () {
+      return `id-${Math.random().toString(36).substr(2, 16)}`;
+    },
   },
 };
 </script>
+

--- a/website/client/components/ui/toggleSwitch.vue
+++ b/website/client/components/ui/toggleSwitch.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 .popover-box
   .clearfix.toggle-switch-container(:id="containerId")
-    .float-left.toggle-switch-description(:class="hoverText ? 'hasPopOver' : ''") {{ label }}
+    .float-left.toggle-switch-description(v-if="label", :class="hoverText ? 'hasPopOver' : ''") {{ label }}
     .toggle-switch.float-left
       input.toggle-switch-checkbox(
         type='checkbox', :id="toggleId",
@@ -130,7 +130,6 @@ export default {
     },
     label: {
       type: String,
-      required: true,
     },
     checked: {
       type: Boolean,


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10076
### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
- Set the width of background sets to 100% to ensure both purchased and non-purchased sets align vertically.
- A variety of css tweaks to make the backgrounds overview clearer, more concise, and, if I may say so myself, prettier. 
- Bonus feature: a checkbox at the top of the backgrounds overview to filter out the backgrounds the user hasn't unlocked/purchased yet! Having to scroll through a million backgrounds in four different tabs to find the one you know you have is a thing of the past! This has been a thorn in my side ever since I bought my very first background, so I'd love for this to make the review. However, if there's some intrinsic reason no one has ever done this then I can easily revert the last commit and leave you with a prettier overview that is functionally identical to the one we have now. 

#### Prettier!
![image](https://user-images.githubusercontent.com/13566991/36836911-fe87b46a-1d3a-11e8-95e3-13082f8553de.png)
#### Bonus feature: now you see me.
![image](https://user-images.githubusercontent.com/13566991/36850483-3c846a70-1d67-11e8-9fa8-001b6ef12833.png)
#### Bonus feature: now you don't!
![image](https://user-images.githubusercontent.com/13566991/36850514-53714320-1d67-11e8-8662-951cf0fcad1a.png)





[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 6d7d6651-604d-4e7c-adff-a040770a6768
