### PR TITLE
Sort challenges by habitica_official category instead of official flag

### DIFF
--- a/test/api/v3/integration/challenges/GET-challenges_group_groupid.test.js
+++ b/test/api/v3/integration/challenges/GET-challenges_group_groupid.test.js
@@ -151,7 +151,10 @@ describe('GET challenges/groups/:groupId', () => {
       });
 
       officialChallenge = await generateChallenge(user, group, {
-        official: true,
+        categories: [{
+          name: 'habitica_official',
+          slug: 'habitica_official',
+        }],
       });
 
       challenge = await generateChallenge(user, group);

--- a/test/api/v3/integration/challenges/GET-challenges_user.test.js
+++ b/test/api/v3/integration/challenges/GET-challenges_user.test.js
@@ -193,7 +193,10 @@ describe('GET challenges/user', () => {
       });
 
       officialChallenge = await generateChallenge(user, group, {
-        official: true,
+        categories: [{
+          name: 'habitica_official',
+          slug: 'habitica_official',
+        }],
       });
 
       challenge = await generateChallenge(user, group);

--- a/website/server/controllers/api-v3/challenges.js
+++ b/website/server/controllers/api-v3/challenges.js
@@ -356,13 +356,18 @@ api.getUserChallenges = {
     let challenges = await Challenge.find({
       $or: orOptions,
     })
-      .sort('-official -createdAt')
+      .sort('-createdAt')
       // see below why we're not using populate
       // .populate('group', basicGroupFields)
       // .populate('leader', nameFields)
       .exec();
 
     let resChals = challenges.map(challenge => challenge.toJSON());
+
+    resChals = _.orderBy(resChals, [challenge => {
+      return challenge.categories.map(category => category.slug).includes('habitica_official');
+    }], ['desc']);
+
     // Instead of populate we make a find call manually because of https://github.com/Automattic/mongoose/issues/3833
     await Bluebird.all(resChals.map((chal, index) => {
       return Bluebird.all([
@@ -413,11 +418,16 @@ api.getGroupChallenges = {
     if (!group) throw new NotFound(res.t('groupNotFound'));
 
     let challenges = await Challenge.find({group: groupId})
-      .sort('-official -createdAt')
+      .sort('-createdAt')
       // .populate('leader', nameFields) // Only populate the leader as the group is implicit
       .exec();
 
     let resChals = challenges.map(challenge => challenge.toJSON());
+
+    resChals = _.orderBy(resChals, [challenge => {
+      return challenge.categories.map(category => category.slug).includes('habitica_official');
+    }], ['desc']);
+
     // Instead of populate we make a find call manually because of https://github.com/Automattic/mongoose/issues/3833
     await Bluebird.all(resChals.map((chal, index) => {
       return User


### PR DESCRIPTION
Updated get challenges api to return challenges sorted by which challenges include the `habitica_official` category instead of looking at the official flag on the challenges object.

[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #9955

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
I've changed the api for getUserChallenges and getGroupChallenges to sort on the whether or not the challenge contains the category `habitica_official` instead of the `challenge.official` field. This preserves the existing behavior around the secondary sort of creation date because lodash's orderBy preserves existing order when the value being sorted on is the same.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 2a4d30ee-4833-420e-be7c-ad6a6e261c5f
