### PR TITLE
Set warrior as default for the choose class pop-up

### DIFF
--- a/website/client/components/achievements/chooseClass.vue
+++ b/website/client/components/achievements/chooseClass.vue
@@ -144,7 +144,7 @@ export default {
         healer: healerIcon,
         wizard: wizardIcon,
       }),
-      selectedClass: '',
+      selectedClass: 'warrior',
     };
   },
   directives: {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #9279

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Set warrior as default selection in the 'choose your class' pop-up. This should prevent confusion if people don't immediately understand the class previews are buttons. 

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 6d7d6651-604d-4e7c-adff-a040770a6768

