### PR TITLE
Update the API to prevent the user from leaving a group if they are the only member and have a quest active.

### DIFF
--- a/test/api/v3/integration/groups/POST-groups_groupId_join.test.js
+++ b/test/api/v3/integration/groups/POST-groups_groupId_join.test.js
@@ -262,6 +262,30 @@ describe('POST /group/:groupId/join', () => {
         await expect(checkExistence('groups', oldParty._id)).to.eventually.equal(false);
       });
 
+      it('does not allow user to leave a party if a quest was active and they were the only member', async () => {
+        let userToInvite = await generateUser();
+        let oldParty = await userToInvite.post('/groups', { // add user to a party
+          name: 'Another Test Party',
+          type: 'party',
+        });
+
+        await userToInvite.update({
+          [`items.quests.${PET_QUEST}`]: 1,
+        });
+        await userToInvite.post(`/groups/${oldParty._id}/quests/invite/${PET_QUEST}`);
+
+        await expect(checkExistence('groups', oldParty._id)).to.eventually.equal(true);
+        await user.post(`/groups/${party._id}/invite`, {
+          uuids: [userToInvite._id],
+        });
+
+        await expect(userToInvite.post(`/groups/${party._id}/join`)).to.eventually.be.rejected.and.eql({
+          code: 401,
+          error: 'NotAuthorized',
+          message: t('messageCannotLeaveWhileQuesting'),
+        });
+      });
+
       it('invites joining member to active quest', async () => {
         await user.update({
           [`items.quests.${PET_QUEST}`]: 1,

--- a/website/client/store/actions/guilds.js
+++ b/website/client/store/actions/guilds.js
@@ -55,7 +55,13 @@ export async function join (store, payload) {
   const user = store.state.user.data;
   const invitations = user.invitations;
 
-  let response = await axios.post(`/api/v3/groups/${groupId}/join`);
+  let response;
+  try {
+    response = await axios.post(`/api/v3/groups/${groupId}/join`);
+  } catch (err) {
+    alert(err.response.data.message);
+    return;
+  }
 
   if (type === 'guild') {
     const invitationI = invitations.guilds.findIndex(i => i.id === groupId);

--- a/website/common/locales/en/messages.json
+++ b/website/common/locales/en/messages.json
@@ -60,6 +60,7 @@
   "messageGroupChatAdminClearFlagCount": "Only an admin can clear the flag count!",
   "messageCannotFlagSystemMessages": "You cannot flag a system message. If you need to report a violation of the Community Guidelines related to this message, please email a screenshot and explanation to Lemoness at <%= communityManagerEmail %>.",
   "messageGroupChatSpam": "Whoops, looks like you're posting too many messages! Please wait a minute and try again. The Tavern chat only holds 200 messages at a time, so Habitica encourages posting longer, more thoughtful messages and consolidating replies. Can't wait to hear what you have to say. :)",
+  "messageCannotLeaveWhileQuesting": "You cannot accept this party invitation while you are in a quest. If you'd like to join this party, you must first abort your quest, which you can do from your party screen. You will be given back the quest scroll.",
 
   "messageUserOperationProtected": "path `<%= operation %>` was not saved, as it's a protected path.",
   "messageUserOperationNotFound": "<%= operation %> operation not found",

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -493,7 +493,6 @@ api.updateGroup = {
  * @apiUse groupIdRequired
  * @apiUse GroupNotFound
  * @apiUse messageGroupRequiresInvite
- * @apiUse messageCannotLeaveWhileQuesting
  */
 api.joinGroup = {
   method: 'POST',

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -493,6 +493,7 @@ api.updateGroup = {
  * @apiUse groupIdRequired
  * @apiUse GroupNotFound
  * @apiUse messageGroupRequiresInvite
+ * @apiUse messageCannotLeaveWhileQuesting
  */
 api.joinGroup = {
   method: 'POST',
@@ -519,6 +520,18 @@ api.joinGroup = {
       if (inviterParty) {
         inviter = inviterParty.inviter;
 
+        // If user was in a different party (when partying solo you can be invited to a new party)
+        // make them leave that party before doing anything
+        if (user.party._id) {
+          let userPreviousParty = await Group.getGroup({user, groupId: user.party._id});
+
+          if (userPreviousParty.memberCount === 1 && user.party.quest.key) {
+            throw new NotAuthorized(res.t('messageCannotLeaveWhileQuesting'));
+          }
+
+          if (userPreviousParty) await userPreviousParty.leave(user);
+        }
+
         // Clear all invitations of new user
         user.invitations.parties = [];
         user.invitations.party = {};
@@ -529,13 +542,6 @@ api.joinGroup = {
           user.party.quest.key = group.quest.key;
           group.quest.members[user._id] = null;
           group.markModified('quest.members');
-        }
-
-        // If user was in a different party (when partying solo you can be invited to a new party)
-        // make them leave that party before doing anything
-        if (user.party._id) {
-          let userPreviousParty = await Group.getGroup({user, groupId: user.party._id});
-          if (userPreviousParty) await userPreviousParty.leave(user);
         }
 
         user.party._id = group._id; // Set group as user's party


### PR DESCRIPTION
This change updates the api to return a NotAuthorized error with the message 

>"You cannot accept this party invitation while you are in a quest. If you'd like to join this party, you must first abort your quest, which you can do from your party screen. You will be given back the quest scroll." 

As provided by Alys in #10068 when the user tries to join a different party if they are alone in a party and are currently on a quest.

The client will catch this error and display a javascript alert to the client telling them the above.

fixes #10068 
