### PR TITLE
Fixing edit profile page so blurb can be edited after reload.

### DIFF
--- a/website/client/components/userMenu/profile.vue
+++ b/website/client/components/userMenu/profile.vue
@@ -574,6 +574,7 @@ import each from 'lodash/each';
 import { mapState } from 'client/libs/store';
 import size from 'lodash/size';
 import keys from 'lodash/keys';
+import cloneDeep from 'lodash/cloneDeep';
 import { beastMasterProgress, mountMasterProgress } from '../../../common/script/count';
 import statsComputed from  '../../../common/script/libs/statsComputed';
 import autoAllocate from '../../../common/script/fns/autoAllocate';
@@ -786,10 +787,13 @@ export default {
     save () {
       let values = {};
 
-      each(this.editingProfile, (value, key) => {
+      let edits = cloneDeep(this.editingProfile);
+
+      each(edits, (value, key) => {
         // Using toString because we need to compare two arrays (websites)
         let curVal = this.user.profile[key];
-        if (!curVal || this.editingProfile[key].toString() !== curVal.toString()) {
+
+        if (!curVal || value.toString() !== curVal.toString()) {
           values[`profile.${key}`] = value;
           this.$set(this.user.profile, key, value);
         }


### PR DESCRIPTION
The issue here is that the user on the modal is a computed property. Part of the `computed` logic for the user was to [set the editingUser fields back to the original user fields](https://github.com/HabitRPG/habitica/blob/develop/website/client/components/userMenu/profile.vue#L710-L712). This resulted in the editingUser being reset in the middle of the loop that it was being read from. I fixed this by copying the edits into a local object where adjustments to the user object wouldn't cause the input data to be overwritten.

fixes #10032
