### PR TITLE
raise coverage for user api calls

### DIFF
--- a/test/api/v3/integration/user/GET-user_inAppRewards.test.js
+++ b/test/api/v3/integration/user/GET-user_inAppRewards.test.js
@@ -1,0 +1,24 @@
+import {
+  generateUser,
+  translate as t,
+} from '../../../../helpers/api-integration/v3';
+
+describe('GET /user/in-app-rewards', () => {
+  let user;
+
+  before(async () => {
+    user = await generateUser();
+  });
+
+  it('returns the reward items available for purchase', async () => {
+    let buyList = await user.get('/user/in-app-rewards');
+
+    expect(_.find(buyList, item => {
+      return item.text === t('armorWarrior1Text');
+    })).to.exist;
+
+    expect(_.find(buyList, item => {
+      return item.text === t('armorWarrior2Text');
+    })).to.not.exist;
+  });
+});

--- a/test/api/v3/integration/user/GET-user_toggle-pinned-item.test.js
+++ b/test/api/v3/integration/user/GET-user_toggle-pinned-item.test.js
@@ -2,8 +2,6 @@ import {
   generateUser,
   translate as t,
 } from '../../../../helpers/api-integration/v3';
-import i18n from "../../../../../website/common/script/i18n";
-import {BadRequest} from "../../../../../website/common/script/libs/errors";
 
 describe('GET /user/toggle-pinned-item', () => {
   let user;

--- a/test/api/v3/integration/user/GET-user_toggle-pinned-item.test.js
+++ b/test/api/v3/integration/user/GET-user_toggle-pinned-item.test.js
@@ -1,0 +1,29 @@
+import {
+  generateUser,
+  translate as t,
+} from '../../../../helpers/api-integration/v3';
+import i18n from "../../../../../website/common/script/i18n";
+import {BadRequest} from "../../../../../website/common/script/libs/errors";
+
+describe('GET /user/toggle-pinned-item', () => {
+  let user;
+
+  before(async () => {
+    user = await generateUser();
+  });
+
+  it('cannot unpin potion', async () => {
+    await expect(user.get('/user/toggle-pinned-item/potion/potion'))
+      .to.eventually.be.rejected.and.eql({
+        code: 400,
+        error: 'BadRequest',
+        message: t('cannotUnpinArmoirPotion'),
+      });
+  });
+
+  it('can pin shield_rogue_5', async () => {
+    let result = await user.get('/user/toggle-pinned-item/marketGear/gear.flat.shield_rogue_5');
+
+    expect(result.pinnedItems.length).to.be.eql(user.pinnedItems.length + 1);
+  });
+});

--- a/test/api/v3/integration/user/POST-user_class_cast_spellId.test.js
+++ b/test/api/v3/integration/user/POST-user_class_cast_spellId.test.js
@@ -258,11 +258,31 @@ describe('POST /user/class/cast/:spellId', () => {
     expect(user.achievements.birthday).to.equal(1);
   });
 
+  it('passes correct target to spell when targetType === \'task\'', async () => {
+    await user.update({'stats.class': 'wizard', 'stats.lvl': 11});
+
+    let task = await user.post('/tasks/user', {
+      text: 'test habit',
+      type: 'habit',
+    });
+
+    let result = await user.post(`/user/class/cast/fireball?targetId=${task._id}`);
+
+    expect(result.task._id).to.equal(task._id);
+  });
+
+  it('passes correct target to spell when targetType === \'self\'', async () => {
+    await user.update({'stats.class': 'wizard', 'stats.lvl': 14, 'stats.mp': 50});
+
+    let result = await user.post('/user/class/cast/frost');
+
+    expect(result.user.stats.mp).to.equal(10);
+  });
+
+
   // TODO find a way to have sinon working in integration tests
   // it doesn't work when tests are running separately from server
-  it('passes correct target to spell when targetType === \'task\'');
   it('passes correct target to spell when targetType === \'tasks\'');
-  it('passes correct target to spell when targetType === \'self\'');
   it('passes correct target to spell when targetType === \'party\'');
   it('passes correct target to spell when targetType === \'user\'');
   it('passes correct target to spell when targetType === \'party\' and user is not in a party');

--- a/test/api/v3/integration/user/PUT-user.test.js
+++ b/test/api/v3/integration/user/PUT-user.test.js
@@ -27,6 +27,33 @@ describe('PUT /user', () => {
       expect(user.stats.hp).to.eql(14);
     });
 
+    it('tags must be an array', async () => {
+      await expect(user.put('/user', {
+        tags: {
+          tag: true,
+        },
+      })).to.eventually.be.rejected.and.eql({
+        code: 400,
+        error: 'BadRequest',
+        message: 'mustBeArray',
+      });
+    });
+
+    it('update tags', async () => {
+      let userTags = user.tags;
+
+      await user.put('/user', {
+        tags: [...user.tags, {
+          name: 'new tag',
+        }],
+      });
+
+      await user.sync();
+
+      expect(user.tags.length).to.be.eql(userTags.length + 1);
+    });
+
+
     it('profile.name cannot be an empty string or null', async () => {
       await expect(user.put('/user', {
         'profile.name': ' ', // string should be trimmed


### PR DESCRIPTION
- GET /user/in-app-rewards
- GET /user/toggle-pinned-item
- POST /user/class/cast/:spellId
   - passes correct target to spell when targetType === \'task\'
   - passes correct target to spell when targetType === \'self\'
- PUT /user
   - tags must be an array
   - update tags




