### PR TITLE
Add space in profile modal to make it consistent with other text

### DIFF
--- a/website/client/components/userMenu/profile.vue
+++ b/website/client/components/userMenu/profile.vue
@@ -27,7 +27,7 @@ div
           .header
             h1 {{user.profile.name}}
             h4
-              strong {{ $t('userId') }}:
+              strong {{ $t('userId') }}:&nbsp;
               | {{user._id}}
         .col-12.col-md-4
           button.btn.btn-secondary(v-if='user._id === userLoggedIn._id', @click='editing = !editing') {{ $t('edit') }}


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
This adds a space in the profile modal after the "User ID:" text and the actual UUID.

![image](https://user-images.githubusercontent.com/1355540/37075799-694875cc-2188-11e8-9008-39913b28eac0.png)


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 6932e502-552a-4f45-9144-7f62ce1320ce
