### PR TITLE
Fixing items sort by number in the market.

### DIFF
--- a/website/client/components/shops/market/index.vue
+++ b/website/client/components/shops/market/index.vue
@@ -702,8 +702,10 @@ export default {
             break;
           }
           case 'sortByNumber': {
-            result = _sortBy(result, i => {
-              return this.userItems[i.purchaseType][i.key] || 0;
+            result = _sortBy(result, item => {
+              if (item.showCount === false) return 0;
+
+              return this.userItems[item.purchaseType][item.key] || 0;
             });
             break;
           }


### PR DESCRIPTION
Item sorting by number in the market was broken because the categoryType for cards (`greetingCards`) didn't match the key structure of the users inventory in the database (where greetingCards fall under `user.items.special`. Greeting cards were already tagged with the showCount = false flag that indicates sorting by number can be ignored for these items as the counts aren't shown so I've simply utilized that flag to bypass the lookup count for those items.

fixes #10093 