### PR TITLE
fix: Quest collected items displayed multiple times.

### DIFF
--- a/website/client/components/groups/questSidebarSection.vue
+++ b/website/client/components/groups/questSidebarSection.vue
@@ -41,7 +41,7 @@ div
                 .grey-progress-bar
                   .collect-progress-bar(:style="{width: (group.quest.progress.collect[key] / value.count) * 100 + '%'}")
                 strong {{group.quest.progress.collect[key]}} / {{value.count}}
-                span.float-right {{parseFloat(user.party.quest.progress.collectedItems) || 0}} items found
+            div.text-right {{parseFloat(user.party.quest.progress.collectedItems) || 0}} items found
           .boss-info(v-if='questData.boss')
             .row
               .col-6


### PR DESCRIPTION
Updated the quest `collected items` section to only be displayed once at the bottom of the quest progress section of the sidebar.

### Before

![](https://user-images.githubusercontent.com/1253400/36765250-e4d3fb8c-1bf5-11e8-8d9d-36674256683e.jpg)

### After
![screen shot 2018-03-08 at 8 43 54 am](https://user-images.githubusercontent.com/17734753/37164249-9ed01bce-22ae-11e8-91f0-6b60dbea9864.png)

![screen shot 2018-03-08 at 8 45 16 am](https://user-images.githubusercontent.com/17734753/37164256-a30d11ce-22ae-11e8-8f69-8707d0ce6019.png)


fixes #10065