### PR TITLE
Only start Stackimpact in prod

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -112,5 +112,6 @@
       "CLOUDKARAFKA_USERNAME": "",
       "CLOUDKARAFKA_PASSWORD": "",
       "CLOUDKARAFKA_TOPIC_PREFIX": ""
-    }
+    },
+    "STACK_IMPACT_KEY": "aaaabbbbccccddddeeeeffffgggg111100002222"
 }

--- a/website/server/index.js
+++ b/website/server/index.js
@@ -20,17 +20,19 @@ setupNconf();
 const nconf = require('nconf');
 const stackimpact = require('stackimpact');
 
-stackimpact.start({
-  agentKey: nconf.get('STACK_IMPACT_KEY'),
-  appName: 'Habitica',
-});
-
 const cluster = require('cluster');
 const logger = require('./libs/logger');
 
 const IS_PROD = nconf.get('IS_PROD');
 const IS_DEV = nconf.get('IS_DEV');
 const CORES = Number(nconf.get('WEB_CONCURRENCY')) || 0;
+
+if (IS_PROD) {
+  stackimpact.start({
+    agentKey: nconf.get('STACK_IMPACT_KEY'),
+    appName: 'Habitica',
+  });
+}
 
 // Setup the cluster module
 if (CORES !== 0 && cluster.isMaster && (IS_DEV || IS_PROD)) {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes an issue preventing the server from starting correctly in non-production environments.

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Adds Stackimpact configuration to config.json.example.
Adds a check that only runs Stackimpact logging if the server is running in production mode.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)
