### PR TITLE
fix: you are already in group message - fixes #10119

### DIFF
--- a/test/api/v3/integration/groups/POST-groups_groupId_join.test.js
+++ b/test/api/v3/integration/groups/POST-groups_groupId_join.test.js
@@ -44,12 +44,12 @@ describe('POST /group/:groupId/join', () => {
       expect(res.leader.profile.name).to.eql(user.profile.name);
     });
 
-    it('returns an error is user was already a member', async () => {
+    it('returns an error if user was already a member', async () => {
       await joiningUser.post(`/groups/${publicGuild._id}/join`);
       await expect(joiningUser.post(`/groups/${publicGuild._id}/join`)).to.eventually.be.rejected.and.eql({
         code: 401,
         error: 'NotAuthorized',
-        message: t('userAlreadyInGroup'),
+        message: t('youAreAlreadyInGroup'),
       });
     });
 

--- a/website/common/locales/en/groups.json
+++ b/website/common/locales/en/groups.json
@@ -223,6 +223,7 @@
   "inviteMustNotBeEmpty": "Invite must not be empty.",
   "partyMustbePrivate": "Parties must be private",
   "userAlreadyInGroup": "UserID: <%= userId %>, User \"<%= username %>\" already in that group.",
+  "youAreAlreadyInGroup": "You are already a member of this Guild",
   "cannotInviteSelfToGroup": "You cannot invite yourself to a group.",
   "userAlreadyInvitedToGroup": "UserID: <%= userId %>, User \"<%= username %>\" already invited to that group.",
   "userAlreadyPendingInvitation": "UserID: <%= userId %>, User \"<%= username %>\" already pending invitation.",

--- a/website/common/locales/en/groups.json
+++ b/website/common/locales/en/groups.json
@@ -223,7 +223,7 @@
   "inviteMustNotBeEmpty": "Invite must not be empty.",
   "partyMustbePrivate": "Parties must be private",
   "userAlreadyInGroup": "UserID: <%= userId %>, User \"<%= username %>\" already in that group.",
-  "youAreAlreadyInGroup": "You are already a member of this Guild",
+  "youAreAlreadyInGroup": "You are already a member of this group.",
   "cannotInviteSelfToGroup": "You cannot invite yourself to a group.",
   "userAlreadyInvitedToGroup": "UserID: <%= userId %>, User \"<%= username %>\" already invited to that group.",
   "userAlreadyPendingInvitation": "UserID: <%= userId %>, User \"<%= username %>\" already pending invitation.",

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -555,7 +555,7 @@ api.joinGroup = {
 
     if (isUserInvited && group.type === 'guild') {
       if (user.guilds.indexOf(group._id) !== -1) { // if user is already a member (party is checked previously)
-        throw new NotAuthorized(res.t('userAlreadyInGroup'));
+        throw new NotAuthorized(res.t('youAreAlreadyInGroup'));
       }
       user.guilds.push(group._id); // Add group to user's guilds
       if (!user.achievements.joinedGuild) {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # 10119
Fixes https://github.com/HabitRPG/habitica/issues/10119

### Changes
[//]: # display `youAreAlreadyInGroup` message when user attempts to join an already-joined group.



[//]: # b1cf5a63-61c5-46e5-807d-656415fde46b

----
UUID: 
