### PR TITLE
Fix npm version on Dockerfile to 5.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:boron
 
 # Upgrade NPM to v5 (Yarn is needed because of this bug https://github.com/npm/npm/issues/16807)
 # The used solution is suggested here https://github.com/npm/npm/issues/16807#issuecomment-313591975
-RUN yarn global add npm@5
+RUN yarn global add npm@5.6.0
 # Install global packages
 RUN npm install -g gulp-cli mocha
 


### PR DESCRIPTION
npm@5.7.1 is having some issue during extraction of large projects (see https://github.com/npm/npm/issues/19989). So while this is not fixed, new contributors were not able to start a new local project, because the containers were updating npm to the newest version. In order to fix this issue I fixed the version to 5.6.0, which is more stable and it works on Habitica project.
