### PR TITLE
Hide "Delete Completed" To-Dos button on Challenge or Group Task Board - fixes #9935

### DIFF
--- a/website/client/components/tasks/column.vue
+++ b/website/client/components/tasks/column.vue
@@ -26,7 +26,7 @@
     )
     transition(name="quick-add-tip-slide")
       .quick-add-tip.small-text(v-show="quickAddFocused", v-html="$t('addMultipleTip')")
-    clear-completed-todos(v-if="activeFilters[type].label === 'complete2'")
+    clear-completed-todos(v-if="activeFilters[type].label === 'complete2' && isUser === true")
     .column-background(
       v-if="isUser === true",
       :class="{'initial-description': initialColumnDescription}",
@@ -347,7 +347,7 @@ export default {
     }),
     onUserPage () {
       let onUserPage = Boolean(this.taskList.length) && (!this.taskListOverride || this.taskListOverride.length === 0);
-
+      
       if (!onUserPage) {
         this.activateFilter('daily', this.types.daily.filters[0]);
         this.types.reward.filters = [];

--- a/website/client/components/tasks/column.vue
+++ b/website/client/components/tasks/column.vue
@@ -347,7 +347,7 @@ export default {
     }),
     onUserPage () {
       let onUserPage = Boolean(this.taskList.length) && (!this.taskListOverride || this.taskListOverride.length === 0);
-      
+
       if (!onUserPage) {
         this.activateFilter('daily', this.types.daily.filters[0]);
         this.types.reward.filters = [];


### PR DESCRIPTION
Checks the prop `isUser` in a task column to determine whether the "clear completed to-dos" component is shown (including "Delete Completed" button and info text). It will only display in the User task board and is hidden for the Challenges and Group task board.  

### Before
<img width="496" alt="screen shot 2018-03-11 at 7 39 30 pm" src="https://user-images.githubusercontent.com/5035757/37260082-64bac722-2565-11e8-8b68-89a6bc3fbe3c.png">
Challenges

<img width="687" alt="screen shot 2018-03-11 at 7 39 38 pm" src="https://user-images.githubusercontent.com/5035757/37260084-664a07a6-2565-11e8-8eb2-ef39e6e0e3e8.png">
Group

### After
<img width="522" alt="screen shot 2018-03-11 at 7 39 05 pm" src="https://user-images.githubusercontent.com/5035757/37260092-7b459d28-2565-11e8-95b5-9ac26de11fb1.png">
Challenges

<img width="581" alt="screen shot 2018-03-11 at 7 37 17 pm" src="https://user-images.githubusercontent.com/5035757/37260090-76b87dd4-2565-11e8-80eb-86fa5c22170f.png">
Group


fixes #9935 

UUID: 375b8855-d745-4b9f-abdb-ccfa5043415e