### PR TITLE
Added popover stats to costume equipment on profile stats - fixes #9280

### DIFF
--- a/website/client/components/userMenu/profile.vue
+++ b/website/client/components/userMenu/profile.vue
@@ -131,7 +131,7 @@ div
               )
                 div(:class="`shop_${equippedItems[key]}`")
               b-popover(
-                v-if="label !== 'skip' && equippedItems[key] && equippedItems[key].indexOf(\"base_0\") === -1",
+                v-if="label !== 'skip' && equippedItems[key] && equippedItems[key].indexOf('base_0') === -1",
                 :target="key",
                 triggers="hover",
                 :placement="'bottom'",
@@ -150,7 +150,7 @@ div
             .col-12.col-md-4.item-wrapper(v-for="(label, key) in equipTypes")
               // Append a "C" to the key name since HTML IDs have to be unique.
               .box(
-                :id="key + \"C\"",
+                :id="key + 'C'",
                 v-if="label !== 'skip'",
                 :class='{white: costumeItems[key] && costumeItems[key].indexOf("base_0") === -1}'
               )
@@ -161,8 +161,8 @@ div
               )
                 div(:class="'icon_background_' + user.preferences.background")
               b-popover(
-                v-if="label !== 'skip' && costumeItems[key] && costumeItems[key].indexOf(\"base_0\") === -1",
-                :target="key + \"C\"",
+                v-if="label !== 'skip' && costumeItems[key] && costumeItems[key].indexOf('base_0') === -1",
+                :target="key + 'C'",
                 triggers="hover",
                 :placement="'bottom'",
                 :preventOverflow="false",

--- a/website/client/components/userMenu/profile.vue
+++ b/website/client/components/userMenu/profile.vue
@@ -146,42 +146,35 @@ div
         .col-12.col-md-6
           h2.text-center {{$t('costume')}}
           .well
-            .col-12.col-md-4.item-wrapper
-              .box(:class='{white: costumeItems.eyewear && costumeItems.eyewear.indexOf("base_0") === -1}')
-                div(:class="`shop_${costumeItems.eyewear}`")
-              h3 {{$t('eyewear')}}
-            .col-12.col-md-4.item-wrapper
-              .box(:class='{white: costumeItems.head && costumeItems.head.indexOf("base_0") === -1}')
-                div(:class="`shop_${costumeItems.head}`")
-              h3 {{$t('headgearCapitalized')}}
-            .col-12.col-md-4.item-wrapper
-              .box(:class='{white: costumeItems.headAccessory && costumeItems.headAccessory.indexOf("base_0") === -1}')
-                div(:class="`shop_${costumeItems.headAccessory}`")
-              h3 {{$t('headAccess')}}
-            .col-12.col-md-4.item-wrapper
-              .box(:class='{white: costumeItems.back && costumeItems.back.indexOf("base_0") === -1}')
-                div(:class="`shop_${costumeItems.back}`")
-              h3 {{$t('backAccess')}}
-            .col-12.col-md-4.item-wrapper
-              .box(:class='{white: costumeItems.armor && costumeItems.armor.indexOf("base_0") === -1}')
-                div(:class="`shop_${costumeItems.armor}`")
-              h3 {{$t('armorCapitalized')}}
-            .col-12.col-md-4.item-wrapper
-              .box(:class='{white: costumeItems.body && costumeItems.body.indexOf("base_0") === -1}')
-                div(:class="`shop_${costumeItems.body}`")
-              h3 {{$t('bodyAccess')}}
-            .col-12.col-md-4.item-wrapper
-              .box(:class='{white: costumeItems.weapon && costumeItems.weapon.indexOf("base_0") === -1}')
-                div(:class="`shop_${costumeItems.weapon}`")
-              h3 {{$t('mainHand')}}
-            .col-12.col-md-4.item-wrapper
-              .box(:class='{white: user.preferences.background}', style="overflow:hidden")
+            // Use similar for loop for costume items, except show background if label is 'skip'.
+            .col-12.col-md-4.item-wrapper(v-for="(label, key) in equipTypes")
+              // Append a "C" to the key name since HTML IDs have to be unique.
+              .box(
+                :id="key + \"C\"",
+                v-if="label !== 'skip'",
+                :class='{white: costumeItems[key] && costumeItems[key].indexOf("base_0") === -1}'
+              )
+                div(:class="`shop_${costumeItems[key]}`")
+              // Show background on 8th tile rather than a piece of equipment.
+              .box(v-if="label === 'skip'",
+              	:class='{white: user.preferences.background}', style="overflow:hidden"
+              )
                 div(:class="'icon_background_' + user.preferences.background")
-              h3 {{$t('background')}}
-            .col-12.col-md-4.item-wrapper
-              .box(:class='{white: costumeItems.shield && costumeItems.shield.indexOf("base_0") === -1}')
-                div(:class="`shop_${costumeItems.shield}`")
-              h3 {{$t('offHand')}}
+              b-popover(
+                v-if="label !== 'skip' && costumeItems[key] && costumeItems[key].indexOf(\"base_0\") === -1",
+                :target="key + \"C\"",
+                triggers="hover",
+                :placement="'left'",
+                :preventOverflow="false",
+              )
+                h4.gearTitle {{ getGearTitle(costumeItems[key]) }}
+                attributesGrid.attributesGrid(
+                  :item="content.gear.flat[costumeItems[key]]",
+                )
+              
+              h3(v-if="label !== 'skip'") {{ label }}
+              h3(v-else) {{ $t('background') }}
+              
       .row.pet-mount-row
         .col-12.col-md-6
           h2.text-center(v-once) {{ $t('pets') }}

--- a/website/client/components/userMenu/profile.vue
+++ b/website/client/components/userMenu/profile.vue
@@ -157,7 +157,7 @@ div
                 div(:class="`shop_${costumeItems[key]}`")
               // Show background on 8th tile rather than a piece of equipment.
               .box(v-if="label === 'skip'",
-              	:class='{white: user.preferences.background}', style="overflow:hidden"
+                :class='{white: user.preferences.background}', style="overflow:hidden"
               )
                 div(:class="'icon_background_' + user.preferences.background")
               b-popover(

--- a/website/client/components/userMenu/profile.vue
+++ b/website/client/components/userMenu/profile.vue
@@ -134,7 +134,7 @@ div
                 v-if="label !== 'skip' && equippedItems[key] && equippedItems[key].indexOf(\"base_0\") === -1",
                 :target="key",
                 triggers="hover",
-                :placement="'right'",
+                :placement="'bottom'",
                 :preventOverflow="false",
               )
                 h4.gearTitle {{ getGearTitle(equippedItems[key]) }}
@@ -164,7 +164,7 @@ div
                 v-if="label !== 'skip' && costumeItems[key] && costumeItems[key].indexOf(\"base_0\") === -1",
                 :target="key + \"C\"",
                 triggers="hover",
-                :placement="'left'",
+                :placement="'bottom'",
                 :preventOverflow="false",
               )
                 h4.gearTitle {{ getGearTitle(costumeItems[key]) }}


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #9280 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

The costume equipment icons will now show their name and stats as a popover box when viewing someone else's or your own profile.  This uses the same for loop code used for the equipped items, and these popups will be to the left of the displaying box when the mouse hovers over them.

The develop branch of my local installation, for some odd reason, cannot properly test the api-v3 integration component of the full npm test suite; going to rely on Travis CI output for this pr.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: ad05a642-0783-4463-8a9c-cee1d815ac3d
