### PR TITLE
adjust word order in moderator Slack flagged post message

### DIFF
--- a/test/api/v3/unit/libs/slack.js
+++ b/test/api/v3/unit/libs/slack.js
@@ -47,7 +47,7 @@ describe('slack', () => {
 
       expect(IncomingWebhook.prototype.send).to.be.calledOnce;
       expect(IncomingWebhook.prototype.send).to.be.calledWith({
-        text: 'flagger (flagger-id) flagged a message (language: flagger-lang)',
+        text: 'flagger (flagger-id; language: flagger-lang) flagged a message',
         attachments: [{
           fallback: 'Flag Message',
           color: 'danger',

--- a/website/server/libs/slack.js
+++ b/website/server/libs/slack.js
@@ -32,7 +32,7 @@ function sendFlagNotification ({
   let titleLink;
   let authorName;
   let title = `Flag in ${group.name}`;
-  let text = `${flagger.profile.name} (${flagger.id}) flagged a message (language: ${flagger.preferences.language})`;
+  let text = `${flagger.profile.name} (${flagger.id}; language: ${flagger.preferences.language}) flagged a message`;
 
   if (userComment) {
     text += ` and commented: ${userComment}`;


### PR DESCRIPTION
Makes a minor adjustment to word order in the mod slack flagged post message so it reads a bit more naturally.

This can be merged as soon as tests pass.