### PR TITLE
fixes #10116  (this.quickAddText is null when adding a To-Do)

### DIFF
--- a/website/client/components/tasks/column.vue
+++ b/website/client/components/tasks/column.vue
@@ -551,7 +551,7 @@ export default {
         return task;
       });
 
-      this.quickAddText = null;
+      this.quickAddText = '';
       this.quickAddRows = 1;
       this.createTask(tasks);
     },


### PR DESCRIPTION
Once you entered a todo and click again inside the input area, you get `TypeError: this.quickAddText is null`

Fixes #10116