### PR TITLE
prevent lint indent warning on multi-line reduce function

### DIFF
--- a/website/common/script/fns/randomDrop.js
+++ b/website/common/script/fns/randomDrop.js
@@ -41,9 +41,9 @@ module.exports = function randomDrop (user, options, req = {}, analytics) {
     (1 + (user.contributor.level / 40 || 0)) *          // Contrib levels: +2.5% per level
     (1 + (user.achievements.rebirths / 20 || 0)) *      // Rebirths: +5% per achievement
     (1 + (user.achievements.streak / 200 || 0)) *       // Streak achievements: +0.5% per achievement
-    (user._tmp.crit || 1) * (1 + 0.5 * (reduce(task.checklist, (m, i) => {
-      return m + (i.completed ? 1 : 0); // +50% per checklist item complete. TODO: make this into X individual drop chances instead
-    }, 0) || 0));
+    (user._tmp.crit || 1) * (1 + 0.5 * (reduce(task.checklist, (m, i) => { // +50% per checklist item complete. TODO: make this into X individual drop chances instead
+      return m + (i.completed ? 1 : 0); // eslint-disable-line indent
+    }, 0) || 0)); // eslint-disable-line indent
   chance = diminishingReturns(chance, 0.75);
 
   if (predictableRandom() < chance) {


### PR DESCRIPTION
`npm run client:dev` is producing the eslint indent warnings below. This PR prevents the warnings.

I'm not sure if this is how you'd prefer it to be fixed, so feel free to close this if you want to fix it another way.

```
WARNING in ./website/common/script/fns/randomDrop.js

  ✘  http://eslint.org/docs/rules/indent  Expected indentation of 4 spaces but found 6  
  website/common/script/fns/randomDrop.js:45:1
        return m + (i.completed ? 1 : 0); // +50% per checklist item complete. TODO: make this into X individual drop chances instead
   ^

  ✘  http://eslint.org/docs/rules/indent  Expected indentation of 2 spaces but found 4  
  website/common/script/fns/randomDrop.js:46:1
      }, 0) || 0));
   ^

✘ 2 problems (2 errors, 0 warnings)

Errors:
  2  http://eslint.org/docs/rules/indent
```