### PR TITLE
Wrap attribute cell value text

### DIFF
--- a/website/client/components/inventory/equipment/attributesGrid.vue
+++ b/website/client/components/inventory/equipment/attributesGrid.vue
@@ -75,6 +75,7 @@
       font-weight: bold;
       line-height: 1.33;
       text-align: right;
+      white-space: nowrap;
 
       &.green {
         color: $green-10;


### PR DESCRIPTION
### Changes
When they become floating point or have more than 3 charcters they wrap to the next line. This CSS change prevents that.

Before:
![screen shot 2018-03-20 at 22 23 06](https://user-images.githubusercontent.com/65468/37692224-b0e2f97e-2c8d-11e8-9f5f-1ab4d6932900.png)

After:
![screen shot 2018-03-20 at 22 23 25](https://user-images.githubusercontent.com/65468/37692228-b4ef0378-2c8d-11e8-9925-77e935f3fbde.png)

----
UUID: ffee6b77-0bf8-422a-a65c-c20de17f2b32
