### PR TITLE
consistent sizes and spacing in action buttons - fixes #9880

### DIFF
--- a/website/client/components/userMenu/profile.vue
+++ b/website/client/components/userMenu/profile.vue
@@ -280,7 +280,8 @@ div
   }
 
   .message-icon svg {
-    height: 16px;
+    height: 11px;
+    margin-top: 1px;
   }
 
   .gift-icon svg {
@@ -307,15 +308,15 @@ div
     }
   }
 
-  .message-icon {
-    width: 16px;
+  .message-icon,
+  .gift-icon {
+    width: 14px;
+    margin: auto;
     color: #686274;
   }
 
   .gift-icon {
-    width: 14px;
-    padding: 0 0 0 1px;
-    color: #686274;
+    width: 12px;
   }
 
   .remove-icon {


### PR DESCRIPTION
Fixes #9880 - action icons (send message, gift gems) in the user modal were unevenly sized. Adjusted the CSS to get everything in line.

### Changes

Before:
![habitica-icons--before](https://user-images.githubusercontent.com/3606708/37730544-60958c1e-2d16-11e8-8c5e-a84f3df1cec5.png)

After:
![habitica-icons--after](https://user-images.githubusercontent.com/3606708/37730560-654f0a3c-2d16-11e8-8fda-15acbec93f2f.png)

----
UUID: 55e3fcfd-52e0-4082-bc6c-d32d5af8b760

(This is my first Habitica PR; let me know if I'm missing anything!)

