### PR TITLE
Fix malformed error message in groups

### DIFF
--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -555,7 +555,7 @@ api.joinGroup = {
 
     if (isUserInvited && group.type === 'guild') {
       if (user.guilds.indexOf(group._id) !== -1) { // if user is already a member (party is checked previously)
-        throw new NotAuthorized(res.t('userAlreadyInGroup'));
+        throw new NotAuthorized(res.t('userAlreadyInGroup', {userId: user._id, username: user.profile.name}));
       }
       user.guilds.push(group._id); // Add group to user's guilds
       if (!user.achievements.joinedGuild) {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes part of an issue reported in the Bug Guild:

>I joined a guild, the "Join" button didn't disappear so I clicked it again and I had error Error processing the string "userAlreadyInGroup". Please see Help > Report a Bug.

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

**Previously**, in one scenario where the `userAlreadyInGroup` string was used to construct an error message, the user ID and username were not passed to the translate function, so variables in the string token could not be filled.
**Now**, the user ID and user profile name are passed along, in similar fashion to other places this string is used.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)