### PR TITLE
Fix errors when no task type selected during the tour

### DIFF
--- a/website/server/libs/taskManager.js
+++ b/website/server/libs/taskManager.js
@@ -77,6 +77,9 @@ export async function createTasks (req, res, options = {}) {
 
   let toSave = Array.isArray(req.body) ? req.body : [req.body];
 
+  // Return if no tasks are passed, avoids errors with mongo $push being empty
+  if (toSave.length === 0) return [];
+
   let taskOrderToAdd = {};
 
   toSave = toSave.map(taskData => {


### PR DESCRIPTION
If an user, during the initial tour, selected no type of class they would receive an Error because calling `createTasks` with no task caused an empty `$push` op to be sent to mongo, which in turn resulted in this error:

```
2018-03-23T15:58:56.210Z - error: MongoError: '$push' is empty. You must specify a field like so: {$push: {<field>: ...}}
    at Function.MongoError.create (/Users/matteo/dev/habitrpg/habitica/node_modules/mongodb-core/lib/error.js:45:10)
    at toError (/Users/matteo/dev/habitrpg/habitica/node_modules/mongodb/lib/utils.js:149:22)
    at /Users/matteo/dev/habitrpg/habitica/node_modules/mongodb/lib/collection.js:1035:39
    at /Users/matteo/dev/habitrpg/habitica/node_modules/mongodb-core/lib/connection/pool.js:541:18
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
    at process._tickDomainCallback (internal/process/next_tick.js:218:9)
{ method: 'POST',
  originalUrl: '/api/v3/tasks/user',
...
```