### PR TITLE
fixes #10173 - Task page search bar only searches task titles, not No…

### DIFF
--- a/test/client/unit/specs/components/tasks/column.js
+++ b/test/client/unit/specs/components/tasks/column.js
@@ -145,17 +145,17 @@ describe('Task Column', () => {
         tasks = [
           {
             text: 'Hello world 1',
-            note: '',
+            notes: '',
             checklist: [],
           },
           {
             text: 'Hello world 2',
-            note: '',
+            notes: '',
             checklist: [],
           },
           {
             text: 'Generic Task Title',
-            note: '',
+            notes: '',
             checklist: [
               { text: 'Check 1' },
               { text: 'Check 2' },
@@ -164,7 +164,7 @@ describe('Task Column', () => {
           },
           {
             text: 'Hello world 3',
-            note: 'Generic Task Note',
+            notes: 'Generic Task Note',
             checklist: [
               { text: 'Checkitem 1' },
               { text: 'Checkitem 2' },

--- a/website/client/components/tasks/column.vue
+++ b/website/client/components/tasks/column.vue
@@ -584,7 +584,7 @@ export default {
             /* eslint-disable no-extra-parens */
             return (
               task.text.toLowerCase().indexOf(searchTextLowerCase) > -1 ||
-              (task.note && task.note.toLowerCase().indexOf(searchTextLowerCase) > -1) ||
+              (task.notes && task.notes.toLowerCase().indexOf(searchTextLowerCase) > -1) ||
               (task.checklist && task.checklist.length > 0 &&
                 task.checklist.some(checkItem => checkItem.text.toLowerCase().indexOf(searchTextLowerCase) > -1))
             );


### PR DESCRIPTION
It seems that the logic stills the same, it searches also for `note`. But for some reason the **task** object has the key `notes` instead (some refactor maybe?).

```
return (
  task.text.toLowerCase().indexOf(searchTextLowerCase) > -1 ||
  (task.note && task.note.toLowerCase().indexOf(searchTextLowerCase) > -1) ||
  (task.checklist && task.checklist.length > 0 &&
  task.checklist.some(checkItem => checkItem.text.toLowerCase().indexOf(searchTextLowerCase) > -1))
);
```

Fixes #10173 

### Changes
Changed `task.note` to `task.notes` on both calls on `/website/client/components/tasks/column.vue` line **587**.
Also changed the unit test on `/test/client/unit/specs/components/tasks/column.js` to expect for a `notes` key on task object instead of `note`.



UUID: 4b91de39-99bd-4323-aed0-8937a016343b
