### PR TITLE
Move notification snackbars when resting bar is shown

### DIFF
--- a/website/client/app.vue
+++ b/website/client/app.vue
@@ -10,7 +10,7 @@ div
         p {{currentTip}}
   #app(:class='{"casting-spell": castingSpell}')
     amazon-payments-modal
-    snackbars
+    snackbars(:class='{"restingInn": showRestingBanner}')
     router-view(v-if="!isUserLoggedIn || isStaticPage")
     template(v-else)
       template(v-if="isUserLoaded")

--- a/website/client/components/snackbars/notifications.vue
+++ b/website/client/components/snackbars/notifications.vue
@@ -11,6 +11,10 @@
     top: 65px;
     width: 350px;
     z-index: 1041; // 1041 is above modal backgrounds
+
+    &.restingInn {
+      top: 105px;
+    }
   }
 </style>
 


### PR DESCRIPTION
Fixes #10169

### Changes
Moves notification snackbars when resting bar is shown

![screen shot 2018-03-24 at 21 46 06](https://user-images.githubusercontent.com/65468/37870834-3d52e118-2fad-11e8-8130-b530ced69e5b.png)

----
UUID: ffee6b77-0bf8-422a-a65c-c20de17f2b32
