### PR TITLE
Fix broken sound effects

### DIFF
--- a/website/client/app.vue
+++ b/website/client/app.vue
@@ -42,9 +42,9 @@ div
           div(:class='{sticky: user.preferences.stickyHeader}')
             router-view
         app-footer
-          audio#sound(autoplay, ref="sound")
-            source#oggSource(type="audio/ogg", :src="sound.oggSource")
-            source#mp3Source(type="audio/mp3", :src="sound.mp3Source")
+        audio#sound(autoplay, ref="sound")
+          source#oggSource(type="audio/ogg", :src="sound.oggSource")
+          source#mp3Source(type="audio/mp3", :src="sound.mp3Source")
 </template>
 
 <style lang='scss' scoped>


### PR DESCRIPTION
Fixes #10172

### Changes
Move audio element outside of footer. Fixes sounds. Not entirely sure why this worked, but perhaps because app component cannot see the sound ref due to previous nesting.

Blame 3d4107db3ed12254b1ec9e742d442fcda2cddca5

----
UUID: ffee6b77-0bf8-422a-a65c-c20de17f2b32
