### PR TITLE
Use margin offsets for group plan header

### DIFF
--- a/website/client/components/groups/groupPlan.vue
+++ b/website/client/components/groups/groupPlan.vue
@@ -171,6 +171,8 @@ div
     color: #fff;
     padding: 2em;
     height: 356px;
+    margin-left: -12px;
+    margin-right: -12px;
 
     h1 {
       font-size: 48px;


### PR DESCRIPTION
Fixes #9951 

### Changes
Use margin offsets for group plan header. So there are no whitespaces around the header

I tried to wrap this in a `row` class at first since that’s the _ideal_ way to handle grid offsets being done by `container-fluid` but there’s so much going on in this page that it didn’t end up being a reliable solution (couldn’t get things aligned correctly even with different flex declarations).

![screencapture-localhost-8080-group-plans-2018-03-24-23_05_20](https://user-images.githubusercontent.com/65468/37871255-d942c7aa-2fb7-11e8-95ce-34f0726d3d1a.png)

----
UUID: ffee6b77-0bf8-422a-a65c-c20de17f2b32
