### PR TITLE
Remove Like action from inbox chat messages

### DIFF
--- a/website/client/components/chat/chatCard.vue
+++ b/website/client/components/chat/chatCard.vue
@@ -14,7 +14,7 @@ div
       p.time {{msg.timestamp | timeAgo}}
       .text(v-markdown='msg.text')
       hr
-      .action(@click='like()', v-if='msg.likes', :class='{active: msg.likes[user._id]}')
+      .action(@click='like()', v-if='!inbox && msg.likes', :class='{active: msg.likes[user._id]}')
         .svg-icon(v-html="icons.like")
         span(v-if='!msg.likes[user._id]') {{ $t('like') }}
         span(v-if='msg.likes[user._id]') {{ $t('liked') }}
@@ -235,7 +235,7 @@ export default {
         message.likes[this.user._id] = !message.likes[this.user._id];
       }
 
-      this.$emit('messaged-liked', message);
+      this.$emit('message-liked', message);
     },
     copyAsTodo (message) {
       this.$root.$emit('habitica::copy-as-todo', message);


### PR DESCRIPTION
Fixes #10132

### Changes
Removes Like action from inbox chat messages. There is no API endpoint for this action and seems rather useless for private messages anyway,

![screen shot 2018-03-25 at 15 16 56](https://user-images.githubusercontent.com/65468/37879027-99876b9c-303f-11e8-8f7a-1755a3afd1ba.png)

----
UUID: ffee6b77-0bf8-422a-a65c-c20de17f2b32
