### PR TITLE
Make modal overlay transparent, not solid purple (partial fix for #10184)

### DIFF
--- a/website/client/app.vue
+++ b/website/client/app.vue
@@ -111,7 +111,6 @@ div
   }
 
   .modal-backdrop.show {
-    opacity: 1 !important;
     background-color: $purple-100 !important;
   }
 


### PR DESCRIPTION
Partial fix for https://github.com/HabitRPG/habitica/issues/10184#issuecomment-376696129

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

#10184 found that the modal overlay had become solid purple, not transparent as it had been before. This PR would change the overlay from this:

![screen shot 2018-03-27 at 22 51 02](https://user-images.githubusercontent.com/728084/38006032-5d13a508-3211-11e8-8ae8-db962a7026a8.png)

To this:

![screen shot 2018-03-27 at 22 42 00](https://user-images.githubusercontent.com/728084/38005981-2e34058e-3211-11e8-82da-2df7d90ba73d.png)

Not yet sure how to fix the modal centering issue referenced in #10184, but hopefully this is a start.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID:  cc3e8b88-f3e8-4428-91b3-ec4c9f814703
