### PR TITLE
prevent a muted user from inviting any player to a guild or party

### DIFF
--- a/test/api/v3/integration/groups/POST-groups_invite.test.js
+++ b/test/api/v3/integration/groups/POST-groups_invite.test.js
@@ -24,6 +24,19 @@ describe('Post /groups/:groupId/invite', () => {
   });
 
   describe('user id invites', () => {
+    it('returns an error when inviter has no chat privileges', async () => {
+      let inviterMuted = await inviter.update({'flags.chatRevoked': true});
+      let userToInvite = await generateUser();
+      await expect(inviterMuted.post(`/groups/${group._id}/invite`, {
+        uuids: [userToInvite._id],
+      }))
+        .to.eventually.be.rejected.and.eql({
+          code: 401,
+          error: 'NotAuthorized',
+          message: t('cannotInviteWhenMuted'),
+        });
+    });
+
     it('returns an error when invited user is not found', async () => {
       let fakeID = generateUUID();
 
@@ -159,6 +172,19 @@ describe('Post /groups/:groupId/invite', () => {
 
   describe('email invites', () => {
     let testInvite = {name: 'test', email: 'test@habitica.com'};
+
+    it('returns an error when inviter has no chat privileges', async () => {
+      let inviterMuted = await inviter.update({'flags.chatRevoked': true});
+      await expect(inviterMuted.post(`/groups/${group._id}/invite`, {
+        emails: [testInvite],
+        inviter: 'inviter name',
+      }))
+        .to.eventually.be.rejected.and.eql({
+          code: 401,
+          error: 'NotAuthorized',
+          message: t('cannotInviteWhenMuted'),
+        });
+    });
 
     it('returns an error when invite is missing an email', async () => {
       await expect(inviter.post(`/groups/${group._id}/invite`, {
@@ -321,6 +347,19 @@ describe('Post /groups/:groupId/invite', () => {
   });
 
   describe('guild invites', () => {
+    it('returns an error when inviter has no chat privileges', async () => {
+      let inviterMuted = await inviter.update({'flags.chatRevoked': true});
+      let userToInvite = await generateUser();
+      await expect(inviterMuted.post(`/groups/${group._id}/invite`, {
+        uuids: [userToInvite._id],
+      }))
+        .to.eventually.be.rejected.and.eql({
+          code: 401,
+          error: 'NotAuthorized',
+          message: t('cannotInviteWhenMuted'),
+        });
+    });
+
     it('returns an error when invited user is already invited to the group', async () => {
       let userToInvite = await generateUser();
       await inviter.post(`/groups/${group._id}/invite`, {
@@ -396,6 +435,19 @@ describe('Post /groups/:groupId/invite', () => {
         name: 'Test Party',
         type: 'party',
       });
+    });
+
+    it('returns an error when inviter has no chat privileges', async () => {
+      let inviterMuted = await inviter.update({'flags.chatRevoked': true});
+      let userToInvite = await generateUser();
+      await expect(inviterMuted.post(`/groups/${party._id}/invite`, {
+        uuids: [userToInvite._id],
+      }))
+        .to.eventually.be.rejected.and.eql({
+          code: 401,
+          error: 'NotAuthorized',
+          message: t('cannotInviteWhenMuted'),
+        });
     });
 
     it('returns an error when invited user has a pending invitation to the party', async () => {

--- a/website/common/locales/en/groups.json
+++ b/website/common/locales/en/groups.json
@@ -256,6 +256,7 @@
   "userCountRequestsApproval": "<%= userCount %> request approval",
   "youAreRequestingApproval": "You are requesting approval",
   "chatPrivilegesRevoked": "Your chat privileges have been revoked.",
+  "cannotInviteWhenMuted": "You cannot invite anyone to a guild or party because your chat privileges have been revoked.",
   "newChatMessagePlainNotification": "New message in <%= groupName %> by <%= authorName %>. Click here to open the chat page!",
   "newChatMessageTitle": "New message in <%= groupName %>",
   "exportInbox": "Export Messages",

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -1138,6 +1138,7 @@ async function _inviteByEmail (invite, group, inviter, req, res) {
  *
  * @apiError (401) {NotAuthorized} UserAlreadyInvited The user has already been invited to the group.
  * @apiError (401) {NotAuthorized} UserAlreadyInGroup The user is already a member of the group.
+ * @apiError (401) {NotAuthorized} CannotInviteWhenMuted You cannot invite anyone to a guild or party because your chat privileges have been revoked.
  *
  * @apiUse GroupNotFound
  * @apiUse UserNotFound
@@ -1149,6 +1150,8 @@ api.inviteToGroup = {
   middlewares: [authWithHeaders()],
   async handler (req, res) {
     let user = res.locals.user;
+
+    if (user.flags.chatRevoked) throw new NotAuthorized(res.t('cannotInviteWhenMuted'));
 
     req.checkParams('groupId', res.t('groupIdRequired')).notEmpty();
 


### PR DESCRIPTION
This PR  prevents a user who has had their chat privileges revoked from inviting any player to a guild or party.

This was requested by @veeeeeee.

This PR does not prevent muted users from chatting with players who are already in their groups. We don't want to prohibit that (e.g., a child who is in a party with their parents can chat there). This PR is designed to prevent cases such as a child trying to get around a chat ban by inviting strangers to a group.