### PR TITLE
Fix: Featured Quests label under decoration (fixes #10195)

### DIFF
--- a/website/client/assets/scss/banner.scss
+++ b/website/client/assets/scss/banner.scss
@@ -9,6 +9,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  z-index: 10;
 
   &.with-border {
     border: solid 2px $yellow-10;


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes https://github.com/HabitRPG/habitica/issues/10195

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Gave the `.featured-label` a higher z-index so it shows up above the butterflies. Any z-index will work; I just picked 10 arbitrarily but it looked like z=1 and z=2 worked too.

Before:

<img width="1552" alt="screen shot 2018-03-29 at 12 19 57 am" src="https://user-images.githubusercontent.com/728084/38069983-585e2f48-32e7-11e8-88a0-31c4f8989c64.png">

After (look at the "Featured Quests" banner):

<img width="1552" alt="screen shot 2018-03-29 at 12 20 16 am" src="https://user-images.githubusercontent.com/728084/38069986-5a9fac0a-32e7-11e8-9554-84e2359bd72e.png">


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 
cc3e8b88-f3e8-4428-91b3-ec4c9f814703