### PR TITLE
Force menu links to have white color on :hover

### DIFF
--- a/website/client/components/header/menu.vue
+++ b/website/client/components/header/menu.vue
@@ -210,6 +210,7 @@ div
 
       &:hover {
         background: $purple-300;
+        color: $white;
 
         &:last-child {
           border-bottom-right-radius: 5px;


### PR DESCRIPTION
### Changes
Force menu links to have white color on :hover

This is mostly to fix the contact form link under the Help menu inheriting the wrong color on hover due to missing href attribute (that link would have black text on hover before this fix).

----
UUID: ffee6b77-0bf8-422a-a65c-c20de17f2b32
