### PR TITLE
Revert "Move notification snackbars when resting bar is shown (#10177)"

### DIFF
--- a/website/client/app.vue
+++ b/website/client/app.vue
@@ -10,7 +10,7 @@ div
         p {{currentTip}}
   #app(:class='{"casting-spell": castingSpell}')
     amazon-payments-modal
-    snackbars(:class='{"restingInn": showRestingBanner}')
+    snackbars
     router-view(v-if="!isUserLoggedIn || isStaticPage")
     template(v-else)
       template(v-if="isUserLoaded")

--- a/website/client/components/snackbars/notifications.vue
+++ b/website/client/components/snackbars/notifications.vue
@@ -11,10 +11,6 @@
     top: 65px;
     width: 350px;
     z-index: 1041; // 1041 is above modal backgrounds
-
-    &.restingInn {
-      top: 105px;
-    }
   }
 </style>
 


### PR DESCRIPTION
This reverts #10177 because the console was showing errors like this:

[Vue warn]: Error in render: "TypeError: this.user is null"
found in
---> <App> at website/client/app.vue
       <Root>

This was happening in our staging server and also in my local install and so was preventing new code being tested effectively.

I'm going to merge this to staging now so that staff and mods can keep using staging for their regular use of Habitica and so that all contributors can keep basing new code off develop without seeing unrelated errors, but we can investigate what went wrong with #10177 and do a proper fix for it.