### PR TITLE
supply the correct type and path for featured Magic Hatching Potions - fixes #10135

### DIFF
--- a/website/common/script/content/shop-featuredItems.js
+++ b/website/common/script/content/shop-featuredItems.js
@@ -1,3 +1,6 @@
+// Magic Hatching Potions are configured like this:
+// type: 'premiumHatchingPotion',  // note no "s" at the end
+// path: 'premiumHatchingPotions.Rainbow',
 const featuredItems = {
   market: [
     {
@@ -5,12 +8,12 @@ const featuredItems = {
       path: 'armoire',
     },
     {
-      type: 'hatchingPotions',
-      path: 'hatchingPotions.Shimmer',
+      type: 'premiumHatchingPotion',
+      path: 'premiumHatchingPotions.Shimmer',
     },
     {
-      type: 'hatchingPotions',
-      path: 'hatchingPotions.Rainbow',
+      type: 'premiumHatchingPotion',
+      path: 'premiumHatchingPotions.Rainbow',
     },
     {
       type: 'card',


### PR DESCRIPTION
fixes #10135

- Adjusts the `featuredItems` constant to have the correct type and path for the premium hatching potions.
- Adds a comment to make it easy to remember the syntax in future Grand Galas.

With this fix in place, you can pin a potion from the Shop's featured box or its Magic Hatching Potion section and the pinning works identically in either case, and allows the item to remain pinned after it's been bought once.
