### PR TITLE
prevent a muted user from creating a public guild (API change)

### DIFF
--- a/test/api/v3/integration/groups/POST-groups.test.js
+++ b/test/api/v3/integration/groups/POST-groups.test.js
@@ -136,6 +136,21 @@ describe('POST /group', () => {
           },
         });
       });
+
+      it('returns an error when a user with no chat privileges attempts to create a public guild', async () => {
+        await user.update({ 'flags.chatRevoked': true });
+
+        await expect(
+          user.post('/groups', {
+            name: 'Test Public Guild',
+            type: 'guild',
+          })
+        ).to.eventually.be.rejected.and.eql({
+          code: 401,
+          error: 'NotAuthorized',
+          message: t('cannotCreatePublicGuildWhenMuted'),
+        });
+      });
     });
 
     context('private guild', () => {
@@ -161,6 +176,17 @@ describe('POST /group', () => {
             name: user.profile.name,
           },
         });
+      });
+
+      it('creates a private guild when the user has no chat privileges', async () => {
+        await user.update({ 'flags.chatRevoked': true });
+        let privateGuild = await user.post('/groups', {
+          name: groupName,
+          type: groupType,
+          privacy: groupPrivacy,
+        });
+
+        expect(privateGuild._id).to.exist;
       });
 
       it('deducts gems from user and adds them to guild bank', async () => {
@@ -199,6 +225,16 @@ describe('POST /group', () => {
           name: user.profile.name,
         },
       });
+    });
+
+    it('creates a party when the user has no chat privileges', async () => {
+      await user.update({ 'flags.chatRevoked': true });
+      let party = await user.post('/groups', {
+        name: partyName,
+        type: partyType,
+      });
+
+      expect(party._id).to.exist;
     });
 
     it('does not require gems to create a party', async () => {

--- a/website/client/components/header/menu.vue
+++ b/website/client/components/header/menu.vue
@@ -62,7 +62,7 @@ div
           span {{ userHourglasses }}
         .item-with-icon
           .top-menu-icon.svg-icon.gem(v-html="icons.gem", @click='showBuyGemsModal("gems")', v-b-tooltip.hover.bottom="$t('gems')")
-          span {{userGems | roundBigNumber}}
+          span {{userGems}}
         .item-with-icon.gold
           .top-menu-icon.svg-icon(v-html="icons.gold", v-b-tooltip.hover.bottom="$t('gold')")
           span {{Math.floor(user.stats.gp * 100) / 100}}

--- a/website/common/locales/en/groups.json
+++ b/website/common/locales/en/groups.json
@@ -256,6 +256,7 @@
   "userCountRequestsApproval": "<%= userCount %> request approval",
   "youAreRequestingApproval": "You are requesting approval",
   "chatPrivilegesRevoked": "Your chat privileges have been revoked.",
+  "cannotCreatePublicGuildWhenMuted": "You cannot create a public guild because your chat privileges have been revoked.",
   "newChatMessagePlainNotification": "New message in <%= groupName %> by <%= authorName %>. Click here to open the chat page!",
   "newChatMessageTitle": "New message in <%= groupName %>",
   "exportInbox": "Export Messages",

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -78,9 +78,10 @@ let api = {};
  *       "privacy": "private"
  *     }
  *
- * @apiError (400) {NotAuthorized} messageInsufficientGems User does not have enough gems (4)
- * @apiError (400) {NotAuthorized} partyMustbePrivate Party must have privacy set to private
- * @apiError (400) {NotAuthorized} messageGroupAlreadyInParty
+ * @apiError (401) {NotAuthorized} messageInsufficientGems User does not have enough gems (4)
+ * @apiError (401) {NotAuthorized} partyMustbePrivate Party must have privacy set to private
+ * @apiError (401) {NotAuthorized} messageGroupAlreadyInParty
+ * @apiError (401) {NotAuthorized} cannotCreatePublicGuildWhenMuted You cannot create a public guild because your chat privileges have been revoked.
  *
  * @apiSuccess (201) {Object} data The created group (See <a href="https://github.com/HabitRPG/habitica/blob/develop/website/server/models/group.js" target="_blank">/website/server/models/group.js</a>)
  *
@@ -115,6 +116,7 @@ api.createGroup = {
     group.leader = user._id;
 
     if (group.type === 'guild') {
+      if (group.privacy === 'public' && user.flags.chatRevoked) throw new NotAuthorized(res.t('cannotCreatePublicGuildWhenMuted'));
       if (user.balance < 1) throw new NotAuthorized(res.t('messageInsufficientGems'));
 
       group.balance = 1;


### PR DESCRIPTION
This PR modifies the API to prevent a public guild being created by a user who has had their chat privileges revoked. E.g., a young child is not allowed to create a public guild because they might put personal details in the description.

This does not prevent creating a party or private guild, both of which are still desirable for muted users so they can do solo quests or host private challenges for themselves. (NB https://github.com/HabitRPG/habitica/pull/10194 will prevent the user from inviting any other players to a private guild or party.)

We should also make UI changes in the website and mobile apps to make it clearer in advance that a muted user cannot create a public guild or invite users to a private guild, but that's less important than this API change to protect the community.

This PR also removes the `roundBigNumber` filter from the user's gem display in the header. This is because my test user happened to have more than 1000 gems and I needed to see the exact gem number to ensure gems weren't removed inappropriately. A similar requirement is likely to exist for other developers in future so I believe making this change permanent is advantageous.
The chance of a real user in production having more than 1000 gems is so small that I don't believe we need to consider it. Even if a user did have that many gems, they'd want to see the exact number to ensure that purchases were happening correctly.