### PR TITLE
Use consistent elements in footer links (fix add-on/forum link colors)

### DIFF
--- a/website/client/components/appFooter.vue
+++ b/website/client/components/appFooter.vue
@@ -135,23 +135,6 @@
         margin-bottom: 7px;
       }
     }
-
-    &.expanded {
-      padding-left: 6em;
-      padding-right: 6em;
-      padding-top: 3em;
-      background: #e1e0e3;
-      color: #878190;
-      min-height: 408px;
-
-      a {
-        color: #878190;
-      }
-
-      .logo {
-        color: #c3c0c7;
-      }
-    }
   }
 
   h3 {
@@ -231,10 +214,29 @@
   }
 </style>
 
-<style>
+<style lang="scss">
   .facebook svg {
     width: 10px;
     margin: 0 auto;
+  }
+
+  footer {
+    &.expanded {
+      padding-left: 6em;
+      padding-right: 6em;
+      padding-top: 3em;
+      background: #e1e0e3;
+      color: #878190;
+      min-height: 408px;
+
+      a {
+        color: #878190;
+      }
+
+      .logo {
+        color: #c3c0c7;
+      }
+    }
   }
 </style>
 

--- a/website/client/components/appFooter.vue
+++ b/website/client/components/appFooter.vue
@@ -39,10 +39,8 @@
             router-link(to='/groups/guild/a29da26b-37de-4a71-b0c6-48e72a900dac') {{ $t('reportBug') }}
           li
             a(href='https://trello.com/c/odmhIqyW/440-read-first-table-of-contents', target='_blank') {{ $t('requestFeature') }}
-          li
-            a(v-html='$t("communityExtensions")')
-          li
-            a(v-html='$t("communityForum")')
+          li(v-html='$t("communityExtensions")')
+          li(v-html='$t("communityForum")')
           li
             a(href='https://www.facebook.com/Habitica', target='_blank') {{ $t('communityFacebook') }}
           li


### PR DESCRIPTION
### Changes
Use consistent elements in footer links

_Add-on_ and _Forum_ links appear differently due to how they are rendered. This commit is to address that, but is dependant on stripping out element tags from remaining translations, as demonstrated in `locales/en/front.json` This also removes the duplication in translations since both values reference the same URLs.

Before:
![screen shot 2018-03-31 at 16 14 50](https://user-images.githubusercontent.com/65468/38167253-26f1c9ea-3500-11e8-9293-119433c5d05f.png)

After (dependent on translations):
![screen shot 2018-03-31 at 16 24 16](https://user-images.githubusercontent.com/65468/38167255-2d7050de-3500-11e8-99b9-97baf8426731.png)

----
UUID: ffee6b77-0bf8-422a-a65c-c20de17f2b32
