### PR TITLE
improve code and tests for banned words and slurs

### DIFF
--- a/test/api/v3/integration/chat/POST-chat.test.js
+++ b/test/api/v3/integration/chat/POST-chat.test.js
@@ -39,6 +39,7 @@ describe('POST /chat', () => {
       members: 2,
     });
     user = groupLeader;
+    await user.update({'contributor.level': SPAM_MIN_EXEMPT_CONTRIB_LEVEL}); // prevent tests accidentally throwing messageGroupChatSpam
     groupWithChat = group;
     member = members[0];
     additionalMember = members[1];

--- a/test/api/v3/integration/chat/POST-chat.test.js
+++ b/test/api/v3/integration/chat/POST-chat.test.js
@@ -27,8 +27,7 @@ describe('POST /chat', () => {
   let testBannedWordMessage1 = 'TESTPLACEHOLDERSWEARWORDHERE1';
   let testSlurMessage = 'message with TESTPLACEHOLDERSLURWORDHERE';
   let testSlurMessage1 = 'TESTPLACEHOLDERSLURWORDHERE1';
-  let bannedWordErrorMessage = t('bannedWordUsed').replace('.', ` (${testBannedWordMessage}).`);
-  let slurErrorMessage = t('bannedSlurUsed');
+  let bannedWordErrorMessage = t('bannedWordUsed', {swearWordsUsed: testBannedWordMessage});
 
   before(async () => {
     let { group, groupLeader, members } = await createAndPopulateGroup({
@@ -141,12 +140,11 @@ describe('POST /chat', () => {
     it('errors when word is typed in mixed case', async () => {
       let substrLength = Math.floor(testBannedWordMessage.length / 2);
       let chatMessage = testBannedWordMessage.substring(0, substrLength).toLowerCase() + testBannedWordMessage.substring(substrLength).toUpperCase();
-      let bannedWordErrorMessage = t('bannedWordUsed').replace('.', ` (${chatMessage}).`);
       await expect(user.post('/groups/habitrpg/chat', { message: chatMessage }))
         .to.eventually.be.rejected.and.eql({
           code: 400,
           error: 'BadRequest',
-          message: bannedWordErrorMessage,
+          message: t('bannedWordUsed', {swearWordsUsed: chatMessage}),
         });
     });
 
@@ -341,7 +339,7 @@ describe('POST /chat', () => {
         .to.eventually.be.rejected.and.eql({
           code: 400,
           error: 'BadRequest',
-          message: slurErrorMessage,
+          message: t('bannedSlurUsed'),
         });
     });
   });

--- a/test/api/v3/integration/chat/POST-chat.test.js
+++ b/test/api/v3/integration/chat/POST-chat.test.js
@@ -11,7 +11,7 @@ import {
   TAVERN_ID,
 } from '../../../../../website/server/models/group';
 import { v4 as generateUUID } from 'uuid';
-import { getMatchesByWordArray, removePunctuationFromString } from '../../../../../website/server/libs/stringUtils';
+import { getMatchesByWordArray } from '../../../../../website/server/libs/stringUtils';
 import bannedWords from '../../../../../website/server/libs/bannedWords';
 import guildsAllowingBannedWords from '../../../../../website/server/libs/guildsAllowingBannedWords';
 import * as email from '../../../../../website/server/libs/email';
@@ -26,7 +26,7 @@ describe('POST /chat', () => {
   let testBannedWordMessage = 'TESTPLACEHOLDERSWEARWORDHERE';
   let testSlurMessage = 'message with TESTPLACEHOLDERSLURWORDHERE';
   let bannedWordErrorMessage = t('bannedWordUsed').split('.');
-  bannedWordErrorMessage[0] += ` (${removePunctuationFromString(testBannedWordMessage.toLowerCase())})`;
+  bannedWordErrorMessage[0] += ` (${testBannedWordMessage.toLowerCase()})`;
   bannedWordErrorMessage = bannedWordErrorMessage.join('.');
 
   before(async () => {

--- a/test/api/v3/integration/chat/POST-chat.test.js
+++ b/test/api/v3/integration/chat/POST-chat.test.js
@@ -26,9 +26,7 @@ describe('POST /chat', () => {
   let testBannedWordMessage = 'TESTPLACEHOLDERSWEARWORDHERE';
   let testSlurMessage = 'message with TESTPLACEHOLDERSLURWORDHERE';
   let testSlurMessage1 = 'TESTPLACEHOLDERSLURWORDHERE1';
-  let bannedWordErrorMessage = t('bannedWordUsed').split('.');
-  bannedWordErrorMessage[0] += ` (${testBannedWordMessage.toLowerCase()})`;
-  bannedWordErrorMessage = bannedWordErrorMessage.join('.');
+  let bannedWordErrorMessage = t('bannedWordUsed').replace('.', ` (${testBannedWordMessage}).`);
   let slurErrorMessage = t('bannedSlurUsed');
 
   before(async () => {
@@ -142,6 +140,7 @@ describe('POST /chat', () => {
     it('errors when word is typed in mixed case', async () => {
       let substrLength = Math.floor(testBannedWordMessage.length / 2);
       let chatMessage = testBannedWordMessage.substring(0, substrLength).toLowerCase() + testBannedWordMessage.substring(substrLength).toUpperCase();
+      let bannedWordErrorMessage = t('bannedWordUsed').replace('.', ` (${chatMessage}).`);
       await expect(user.post('/groups/habitrpg/chat', { message: chatMessage }))
         .to.eventually.be.rejected.and.eql({
           code: 400,

--- a/test/api/v3/integration/chat/POST-chat.test.js
+++ b/test/api/v3/integration/chat/POST-chat.test.js
@@ -24,6 +24,7 @@ describe('POST /chat', () => {
   let user, groupWithChat, member, additionalMember;
   let testMessage = 'Test Message';
   let testBannedWordMessage = 'TESTPLACEHOLDERSWEARWORDHERE';
+  let testBannedWordMessage1 = 'TESTPLACEHOLDERSWEARWORDHERE1';
   let testSlurMessage = 'message with TESTPLACEHOLDERSLURWORDHERE';
   let testSlurMessage1 = 'TESTPLACEHOLDERSLURWORDHERE1';
   let bannedWordErrorMessage = t('bannedWordUsed').replace('.', ` (${testBannedWordMessage}).`);
@@ -149,9 +150,8 @@ describe('POST /chat', () => {
         });
     });
 
-    it('checks error message has the banned words used', async () => {
-      let randIndex = Math.floor(Math.random() * (bannedWords.length + 1));
-      let testBannedWords = bannedWords.slice(randIndex, randIndex + 2).map((w) => w.replace(/\\/g, ''));
+    it('checks error message has all the banned words used, regardless of case', async () => {
+      let testBannedWords = [testBannedWordMessage.toUpperCase(), testBannedWordMessage1.toLowerCase()];
       let chatMessage = `Mixing ${testBannedWords[0]} and ${testBannedWords[1]} is bad for you.`;
       await expect(user.post('/groups/habitrpg/chat', { message: chatMessage}))
         .to.eventually.be.rejected

--- a/website/common/locales/en/groups.json
+++ b/website/common/locales/en/groups.json
@@ -34,7 +34,7 @@
   "communityGuidelines": "Community Guidelines",
   "communityGuidelinesRead1": "Please read our",
   "communityGuidelinesRead2": "before chatting.",
-  "bannedWordUsed": "Oops! Looks like this post contains a swearword, religious oath, or reference to an addictive substance or adult topic. Habitica has users from all backgrounds, so we keep our chat very clean. Feel free to edit your message so you can post it!",
+  "bannedWordUsed": "Oops! Looks like this post contains a swearword, religious oath, or reference to an addictive substance or adult topic (<%= swearWordsUsed %>). Habitica has users from all backgrounds, so we keep our chat very clean. Feel free to edit your message so you can post it!",
   "bannedSlurUsed": "Your post contained inappropriate language, and your chat privileges have been revoked.",
   "party": "Party",
   "createAParty": "Create A Party",

--- a/website/server/controllers/api-v3/chat.js
+++ b/website/server/controllers/api-v3/chat.js
@@ -160,10 +160,7 @@ api.postChat = {
     if (group.privacy !== 'private' && !guildsAllowingBannedWords[group._id]) {
       let matchedBadWords = getBannedWordsFromText(req.body.message);
       if (matchedBadWords.length > 0) {
-        // @TODO replace this split mechanism with something that works properly in translations
-        let message = res.t('bannedWordUsed').split('.');
-        message[0] += ` (${matchedBadWords.join(', ')})`;
-        throw new BadRequest(message.join('.'));
+        throw new BadRequest(res.t('bannedWordUsed', {swearWordsUsed: matchedBadWords.join(', ')}));
       }
     }
 

--- a/website/server/libs/stringUtils.js
+++ b/website/server/libs/stringUtils.js
@@ -5,10 +5,10 @@ export function removePunctuationFromString (str) {
 
 export function getMatchesByWordArray (str, wordsToMatch) {
   let matchedWords = [];
-  let wordRegexs = wordsToMatch.map((word) => new RegExp(`\\b([^a-z]+)?${word.toLowerCase()}([^a-z]+)?\\b`));
+  let wordRegexs = wordsToMatch.map((word) => new RegExp(`\\b([^a-z]+)?${word}([^a-z]+)?\\b`, 'i'));
   for (let i = 0; i < wordRegexs.length; i += 1) {
     let regEx = wordRegexs[i];
-    let match = str.toLowerCase().match(regEx);
+    let match = str.match(regEx);
     if (match !== null && match[0] !== null) {
       let trimmedMatch = removePunctuationFromString(match[0]).trim();
       matchedWords.push(trimmedMatch);


### PR DESCRIPTION
This PR makes several improvements to the code and tests for preventing swear words and slurs being used.

Details are given in the commit messages but in brief:

- Remove the `removePunctuationFromString` function from the test code because it's not necessary
- Give contributor tiers to the user account created for testing swearwords so that the `messageGroupChatSpam` error won't be thrown misleadingly if the swear tests fail
- Add tests for mixed-case swearing
- Make the swear word error message show the banned words to the user in the same case that the user posted them in (e.g., if you post "hECk" then the error message will tell you that "hECk" is banned - previously it would have said "heck").
- Stop using real swear words in one of the tests (because if the test failed, the real swear words would appear in the output).
- Put a variable in the `bannedWordUsed` locales string instead of using split and join code to insert the user's swear words in the error message they see (improves translatability).