### PR TITLE
Fix locked class-specific gear after death fixes #10025

### DIFF
--- a/test/common/libs/shops.js
+++ b/test/common/libs/shops.js
@@ -59,6 +59,78 @@ describe('shops', () => {
       expect(specialCategory.items.find((item) => item.key === 'weapon_special_critical'));
       expect(specialCategory.items.find((item) => item.key === 'weapon_armoire_basicCrossbow'));// eslint-disable-line camelcase
     });
+
+    it('does not show gear when it is all owned', () => {
+      let userWithItems = generateUser({
+        stats: {
+          class: 'wizard',
+        },
+        items: {
+          gear: {
+            owned: {
+              weapon_wizard_0: true, // eslint-disable-line camelcase
+              weapon_wizard_1: true, // eslint-disable-line camelcase
+              weapon_wizard_2: true, // eslint-disable-line camelcase
+              weapon_wizard_3: true, // eslint-disable-line camelcase
+              weapon_wizard_4: true, // eslint-disable-line camelcase
+              weapon_wizard_5: true, // eslint-disable-line camelcase
+              weapon_wizard_6: true, // eslint-disable-line camelcase
+              armor_wizard_1: true, // eslint-disable-line camelcase
+              armor_wizard_2: true, // eslint-disable-line camelcase
+              armor_wizard_3: true, // eslint-disable-line camelcase
+              armor_wizard_4: true, // eslint-disable-line camelcase
+              armor_wizard_5: true, // eslint-disable-line camelcase
+              head_wizard_1: true, // eslint-disable-line camelcase
+              head_wizard_2: true, // eslint-disable-line camelcase
+              head_wizard_3: true, // eslint-disable-line camelcase
+              head_wizard_4: true, // eslint-disable-line camelcase
+              head_wizard_5: true, // eslint-disable-line camelcase
+            },
+          },
+        },
+      });
+
+
+      let shopWizardItems = shared.shops.getMarketGearCategories(userWithItems).find(x => x.identifier === 'wizard').items.filter(x => x.klass === 'wizard' && (x.owned === false || x.owned === undefined));
+      expect(shopWizardItems.length).to.eql(0);
+    });
+
+    it('shows available gear not yet purchased and previously owned', () => {
+      let userWithItems = generateUser({
+        stats: {
+          class: 'wizard',
+        },
+        items: {
+          gear: {
+            owned: {
+              weapon_wizard_0: true, // eslint-disable-line camelcase
+              weapon_wizard_1: true, // eslint-disable-line camelcase
+              weapon_wizard_2: true, // eslint-disable-line camelcase
+              weapon_wizard_3: true, // eslint-disable-line camelcase
+              weapon_wizard_4: true, // eslint-disable-line camelcase
+              armor_wizard_1: true, // eslint-disable-line camelcase
+              armor_wizard_2: true, // eslint-disable-line camelcase
+              armor_wizard_3: false, // eslint-disable-line camelcase
+              armor_wizard_4: false, // eslint-disable-line camelcase
+              head_wizard_1: true, // eslint-disable-line camelcase
+              head_wizard_2: false, // eslint-disable-line camelcase
+              head_wizard_3: true, // eslint-disable-line camelcase
+              head_wizard_4: false, // eslint-disable-line camelcase
+              head_wizard_5: true, // eslint-disable-line camelcase
+            },
+          },
+        },
+      });
+
+
+      let shopWizardItems = shared.shops.getMarketGearCategories(userWithItems).find(x => x.identifier === 'wizard').items.filter(x => x.klass === 'wizard' && (x.owned === false || x.owned === undefined));
+      expect(shopWizardItems.find(item => item.key === 'weapon_wizard_5').locked).to.eql(false);
+      expect(shopWizardItems.find(item => item.key === 'weapon_wizard_6').locked).to.eql(true);
+      expect(shopWizardItems.find(item => item.key === 'armor_wizard_3').locked).to.eql(false);
+      expect(shopWizardItems.find(item => item.key === 'armor_wizard_4').locked).to.eql(true);
+      expect(shopWizardItems.find(item => item.key === 'head_wizard_2').locked).to.eql(false);
+      expect(shopWizardItems.find(item => item.key === 'head_wizard_4').locked).to.eql(true);
+    });
   });
 
   describe('questShop', () => {

--- a/website/common/script/libs/shops.js
+++ b/website/common/script/libs/shops.js
@@ -136,7 +136,7 @@ shops.checkMarketGearLocked = function checkMarketGearLocked (user, items) {
     let itemOwned = user.items.gear.owned[gear.key];
 
     if (itemOwned === false) {
-      gear.locked = false;
+      gear.locked = true;
     }
 
     gear.owned = itemOwned;

--- a/website/common/script/libs/shops.js
+++ b/website/common/script/libs/shops.js
@@ -112,9 +112,7 @@ shops.checkMarketGearLocked = function checkMarketGearLocked (user, items) {
       gear.locked = true;
     }
 
-    let itemOwned = user.items.gear.owned[gear.key];
-
-    if (!itemOwned && !gear.locked  && !availableGear.includes(gear.path)) {
+    if (!gear.locked  && !availableGear.includes(gear.path)) {
       gear.locked = true;
     }
 
@@ -132,6 +130,13 @@ shops.checkMarketGearLocked = function checkMarketGearLocked (user, items) {
 
     if (gear.canOwn) {
       gear.locked = !gear.canOwn(user);
+    }
+
+
+    let itemOwned = user.items.gear.owned[gear.key];
+
+    if (itemOwned === false && !availableGear.includes(gear.path)) {
+      gear.locked = true;
     }
 
     gear.owned = itemOwned;

--- a/website/common/script/libs/shops.js
+++ b/website/common/script/libs/shops.js
@@ -112,7 +112,9 @@ shops.checkMarketGearLocked = function checkMarketGearLocked (user, items) {
       gear.locked = true;
     }
 
-    if (!gear.locked  && !availableGear.includes(gear.path)) {
+    let itemOwned = user.items.gear.owned[gear.key];
+
+    if (!itemOwned && !gear.locked  && !availableGear.includes(gear.path)) {
       gear.locked = true;
     }
 
@@ -130,13 +132,6 @@ shops.checkMarketGearLocked = function checkMarketGearLocked (user, items) {
 
     if (gear.canOwn) {
       gear.locked = !gear.canOwn(user);
-    }
-
-
-    let itemOwned = user.items.gear.owned[gear.key];
-
-    if (itemOwned === false) {
-      gear.locked = true;
     }
 
     gear.owned = itemOwned;


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10025
When death has caused you to lose two or more equipment pieces that belong to your class and you try to buy back a more expensive one first, the website seems to let you buy it but the purchase fails with no notification.
### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Fixed incorrect boolean value. If the item.canOwn is false the item should be locked. New behavior is high tier gear is locked if death causes you to lose the higher and lower tier of that gear. No tests added because there aren't any item tests for the market (can add the test if desired).
Sorry for the delay on this fix

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: f57bd235-ec21-4357-b5c9-a0536294b285
