### PR TITLE
pinned items fixes #10012

### DIFF
--- a/test/common/ops/buy/purchase.js
+++ b/test/common/ops/buy/purchase.js
@@ -10,6 +10,7 @@ import {
   generateUser,
 } from '../../../helpers/common.helper';
 import forEach from 'lodash/forEach';
+import includes from 'lodash/includes';
 import moment from 'moment';
 
 describe('shared.ops.purchase', () => {
@@ -174,6 +175,12 @@ describe('shared.ops.purchase', () => {
       user.stats.gp = goldPoints;
       user.purchased.plan.gemsBought = 0;
       user.purchased.plan.customerId = 'customer-id';
+      user.pinnedItems.push({type: 'eggs', key: 'Wolf'});
+      user.pinnedItems.push({type: 'hatchingPotions', key: 'Base'});
+      user.pinnedItems.push({type: 'food', key: SEASONAL_FOOD});
+      user.pinnedItems.push({type: 'quests', key: 'gryphon'});
+      user.pinnedItems.push({type: 'gear', key: 'headAccessory_special_tigerEars'});
+      user.pinnedItems.push({type: 'bundles', key: 'featheredFriends'});
     });
 
     it('purchases gems', () => {
@@ -202,6 +209,7 @@ describe('shared.ops.purchase', () => {
       purchase(user, {params: {type, key}}, analytics);
 
       expect(user.items[type][key]).to.equal(1);
+      expect(includes(user.pinnedItems, 'Wolf')).to.equal(true);
       expect(analytics.track).to.be.calledOnce;
     });
 
@@ -212,6 +220,7 @@ describe('shared.ops.purchase', () => {
       purchase(user, {params: {type, key}});
 
       expect(user.items[type][key]).to.equal(1);
+      expect(includes(user.pinnedItems, 'Base')).to.equal(true);
     });
 
     it('purchases food', () => {
@@ -221,6 +230,7 @@ describe('shared.ops.purchase', () => {
       purchase(user, {params: {type, key}});
 
       expect(user.items[type][key]).to.equal(1);
+      expect(includes(user.pinnedItems, SEASONAL_FOOD)).to.equal(true);
     });
 
     it('purchases quests', () => {
@@ -230,6 +240,7 @@ describe('shared.ops.purchase', () => {
       purchase(user, {params: {type, key}});
 
       expect(user.items[type][key]).to.equal(1);
+      expect(includes(user.pinnedItems, 'gryphon')).to.equal(true);
     });
 
     it('purchases gear', () => {
@@ -239,6 +250,7 @@ describe('shared.ops.purchase', () => {
       purchase(user, {params: {type, key}});
 
       expect(user.items.gear.owned[key]).to.be.true;
+      expect(includes(user.pinnedItems, 'headAccessory_special_tigerEars')).to.equal(false);
     });
 
     it('purchases quest bundles', () => {
@@ -261,6 +273,7 @@ describe('shared.ops.purchase', () => {
 
       expect(user.balance).to.equal(startingBalance - price);
 
+      expect(includes(user.pinnedItems, 'featheredFriends')).to.equal(true);
       clock.restore();
     });
   });

--- a/test/common/ops/buy/purchase.js
+++ b/test/common/ops/buy/purchase.js
@@ -26,7 +26,7 @@ describe('shared.ops.purchase', () => {
 
   beforeEach(() => {
     sinon.stub(analytics, 'track');
-    sinon.spy(pinnedGearUtils, 'removeItemByPath')
+    sinon.spy(pinnedGearUtils, 'removeItemByPath');
   });
 
   afterEach(() => {

--- a/test/common/ops/buy/purchase.js
+++ b/test/common/ops/buy/purchase.js
@@ -1,4 +1,5 @@
 import purchase from '../../../../website/common/script/ops/buy/purchase';
+import pinnedGearUtils from '../../../../website/common/script/ops/pinnedGearUtils';
 import planGemLimits from '../../../../website/common/script/libs/planGemLimits';
 import {
   BadRequest,
@@ -10,7 +11,6 @@ import {
   generateUser,
 } from '../../../helpers/common.helper';
 import forEach from 'lodash/forEach';
-import includes from 'lodash/includes';
 import moment from 'moment';
 
 describe('shared.ops.purchase', () => {
@@ -26,10 +26,12 @@ describe('shared.ops.purchase', () => {
 
   beforeEach(() => {
     sinon.stub(analytics, 'track');
+    sinon.spy(pinnedGearUtils, 'removeItemByPath')
   });
 
   afterEach(() => {
     analytics.track.restore();
+    pinnedGearUtils.removeItemByPath.restore();
   });
 
   context('failure conditions', () => {
@@ -209,7 +211,7 @@ describe('shared.ops.purchase', () => {
       purchase(user, {params: {type, key}}, analytics);
 
       expect(user.items[type][key]).to.equal(1);
-      expect(includes(user.pinnedItems, 'Wolf')).to.equal(true);
+      expect(pinnedGearUtils.removeItemByPath.notCalled).to.equal(true);
       expect(analytics.track).to.be.calledOnce;
     });
 
@@ -220,7 +222,7 @@ describe('shared.ops.purchase', () => {
       purchase(user, {params: {type, key}});
 
       expect(user.items[type][key]).to.equal(1);
-      expect(includes(user.pinnedItems, 'Base')).to.equal(true);
+      expect(pinnedGearUtils.removeItemByPath.notCalled).to.equal(true);
     });
 
     it('purchases food', () => {
@@ -230,7 +232,7 @@ describe('shared.ops.purchase', () => {
       purchase(user, {params: {type, key}});
 
       expect(user.items[type][key]).to.equal(1);
-      expect(includes(user.pinnedItems, SEASONAL_FOOD)).to.equal(true);
+      expect(pinnedGearUtils.removeItemByPath.notCalled).to.equal(true);
     });
 
     it('purchases quests', () => {
@@ -240,7 +242,7 @@ describe('shared.ops.purchase', () => {
       purchase(user, {params: {type, key}});
 
       expect(user.items[type][key]).to.equal(1);
-      expect(includes(user.pinnedItems, 'gryphon')).to.equal(true);
+      expect(pinnedGearUtils.removeItemByPath.notCalled).to.equal(true);
     });
 
     it('purchases gear', () => {
@@ -250,7 +252,7 @@ describe('shared.ops.purchase', () => {
       purchase(user, {params: {type, key}});
 
       expect(user.items.gear.owned[key]).to.be.true;
-      expect(includes(user.pinnedItems, 'headAccessory_special_tigerEars')).to.equal(false);
+      expect(pinnedGearUtils.removeItemByPath.calledOnce).to.equal(true);
     });
 
     it('purchases quest bundles', () => {
@@ -273,7 +275,7 @@ describe('shared.ops.purchase', () => {
 
       expect(user.balance).to.equal(startingBalance - price);
 
-      expect(includes(user.pinnedItems, 'featheredFriends')).to.equal(true);
+      expect(pinnedGearUtils.removeItemByPath.notCalled).to.equal(true);
       clock.restore();
     });
   });

--- a/website/common/script/ops/buy/purchase.js
+++ b/website/common/script/ops/buy/purchase.js
@@ -144,8 +144,11 @@ module.exports = function purchase (user, req = {}, analytics) {
     throw new NotAuthorized(i18n.t('notEnoughGems', req.language));
   }
 
-  let itemInfo = getItemInfo(user, type, item);
-  removeItemByPath(user, itemInfo.path);
+  let singlePurchaseTypes = ['gear'];
+  if (singlePurchaseTypes.indexOf(type) !== -1) {
+    let itemInfo = getItemInfo(user, type, item);
+    removeItemByPath(user, itemInfo.path);
+  }
 
   for (let i = 0; i < quantity; i += 1) {
     purchaseItem(user, item, price, type, key);

--- a/website/common/script/ops/buy/purchase.js
+++ b/website/common/script/ops/buy/purchase.js
@@ -106,6 +106,8 @@ function purchaseItem (user, item, price, type, key) {
   }
 }
 
+const acceptedTypes = ['eggs', 'hatchingPotions', 'food', 'quests', 'gear', 'bundles'];
+const singlePurchaseTypes = ['gear'];
 module.exports = function purchase (user, req = {}, analytics) {
   let type = get(req.params, 'type');
   let key = get(req.params, 'key');
@@ -129,8 +131,7 @@ module.exports = function purchase (user, req = {}, analytics) {
     return gemResponse;
   }
 
-  let acceptedTypes = ['eggs', 'hatchingPotions', 'food', 'quests', 'gear', 'bundles'];
-  if (acceptedTypes.indexOf(type) === -1) {
+  if (!acceptedTypes.includes(type)) {
     throw new NotFound(i18n.t('notAccteptedType', req.language));
   }
 
@@ -144,8 +145,7 @@ module.exports = function purchase (user, req = {}, analytics) {
     throw new NotAuthorized(i18n.t('notEnoughGems', req.language));
   }
 
-  let singlePurchaseTypes = ['gear'];
-  if (singlePurchaseTypes.indexOf(type) !== -1) {
+  if (singlePurchaseTypes.includes(type)) {
     let itemInfo = getItemInfo(user, type, item);
     removeItemByPath(user, itemInfo.path);
   }


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10012
When you pin any of the following items to your Rewards column and then buy it from that column, it unpins itself as soon as the purchase has been made:
The correct behavior is that it should remain pinned until the user chooses to unpin it.

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Added a check on the type of item in buy to ensure that only gear items are removed.
**Assumes that ALL quests, eggs, potions, bundles, food, quests should remain pinned after purchase.**


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: f57bd235-ec21-4357-b5c9-a0536294b285
