### PR TITLE
Show toast when special pet is fed, don't throw error

### DIFF
--- a/website/common/script/ops/feed.js
+++ b/website/common/script/ops/feed.js
@@ -47,12 +47,15 @@ module.exports = function feed (user, req = {}) {
     throw new NotFound(i18n.t('messageFoodNotFound', req.language));
   }
 
-  if (pet.type === 'special') {
-    throw new NotAuthorized(i18n.t('messageCannotFeedPet', req.language));
-  }
-
   if (user.items.mounts[pet.key]) {
     throw new NotAuthorized(i18n.t('messageAlreadyMount', req.language));
+  }
+
+  if (pet.type === 'special') {
+    return [
+      userPets[pet.key],
+      i18n.t('messageCannotFeedPet', req.language),
+    ];
   }
 
   let message;


### PR DESCRIPTION
Fixes #10217

### Changes
Instead of issuing an exception when feeding pets of type `special` we just return back the _Can’t feed this pet_ message to be shown as a notification.

![screen shot 2018-04-02 at 17 37 18](https://user-images.githubusercontent.com/65468/38217638-16cccdf0-369d-11e8-90f6-84ba55791406.png)

----
UUID: ffee6b77-0bf8-422a-a65c-c20de17f2b32
