### PR TITLE
enable translated pet names in hatching success message

### DIFF
--- a/website/client/components/inventory/items/index.vue
+++ b/website/client/components/inventory/items/index.vue
@@ -351,7 +351,7 @@ export default {
     },
     hatchPet (potion, egg) {
       this.$store.dispatch('common:hatch', {egg: egg.key, hatchingPotion: potion.key});
-      this.text(this.$t('hatchedPet', {egg: egg.key, potion: potion.key}));
+      this.text(this.$t('hatchedPet', {egg: egg.text, potion: potion.text}));
       if (this.user.preferences.suppressModals.hatchPet) return;
       const newPet = createAnimal(egg, potion, 'pet', this.content, this.user.items);
       this.$root.$emit('hatchedPet::open', newPet);

--- a/website/client/components/inventory/stable/index.vue
+++ b/website/client/components/inventory/stable/index.vue
@@ -875,7 +875,7 @@
         this.closeHatchPetDialog();
 
         this.$store.dispatch('common:hatch', {egg: pet.eggKey, hatchingPotion: pet.potionKey});
-        this.text(this.$t('hatchedPet', {egg: pet.eggKey, potion: pet.potionKey}));
+        this.text(this.$t('hatchedPet', {egg: pet.eggName, potion: pet.potionName}));
       },
       onDragStart (ev, food) {
         this.currentDraggingFood = food;


### PR DESCRIPTION
Currently, when you hatch a Pet from your Inventory or Stable while using a language other than English, the "You hatched a new [pet name]" growl message has the pet name in English. This PR fixes that.

Before, Stable:
![image](https://user-images.githubusercontent.com/1495809/38452897-5e75f680-3a90-11e8-938a-05aecbbe3f81.png)

After, Stable:
![image](https://user-images.githubusercontent.com/1495809/38452871-ff5edc7a-3a8f-11e8-9076-215ae3ac3b4c.png)

Before, Inventory:
![image](https://user-images.githubusercontent.com/1495809/38452938-194b6eae-3a91-11e8-90ed-2c28a086f131.png)

After, Inventory:
![image](https://user-images.githubusercontent.com/1495809/38452942-2e1d660c-3a91-11e8-9069-5c541aaea245.png)
