### PR TITLE
adding name attribute to radio inputs

### DIFF
--- a/website/client/components/tasks/taskModal.vue
+++ b/website/client/components/tasks/taskModal.vue
@@ -129,10 +129,10 @@
             label.d-block(v-once) {{ $t('repeatOn') }}
             .form-radio
               .custom-control.custom-radio.custom-control-inline
-                input.custom-control-input(type='radio', v-model="repeatsOn", value="dayOfMonth", id="repeat-dayOfMonth")
+                input.custom-control-input(type='radio', v-model="repeatsOn", value="dayOfMonth", id="repeat-dayOfMonth" name="repeatsOn")
                 label.custom-control-label(for="repeat-dayOfMonth") {{ $t('dayOfMonth') }}
               .custom-control.custom-radio.custom-control-inline
-                input.custom-control-input(type='radio', v-model="repeatsOn", value="dayOfWeek", id="repeat-dayOfWeek")
+                input.custom-control-input(type='radio', v-model="repeatsOn", value="dayOfWeek", id="repeat-dayOfWeek" name="repeatsOn")
                 label.custom-control-label(for="repeat-dayOfWeek") {{ $t('dayOfWeek') }}
 
         .tags-select.option(v-if="isUserTask")


### PR DESCRIPTION
Fixes #10234

### Changes
Adds a shared `name` attribute to the two "repeats on" radio buttons so the browser treats them as a set vs. two unrelated radios. This disallows selecting more than one at a time.

----
UUID: 8f4a567a-038c-4c48-9941-fea2dc1d2845