### PR TITLE
Stop loading user.inbox from some routes

### DIFF
--- a/website/server/controllers/api-v3/hall.js
+++ b/website/server/controllers/api-v3/hall.js
@@ -60,7 +60,9 @@ let api = {};
 api.getPatrons = {
   method: 'GET',
   url: '/hall/patrons',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     req.checkQuery('page', res.t('pageMustBeNumber')).optional().isNumeric();
 
@@ -120,7 +122,9 @@ api.getPatrons = {
 api.getHeroes = {
   method: 'GET',
   url: '/hall/heroes',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let heroes = await User
       .find({

--- a/website/server/controllers/api-v3/notifications.js
+++ b/website/server/controllers/api-v3/notifications.js
@@ -23,7 +23,9 @@ let api = {};
 api.readNotification = {
   method: 'POST',
   url: '/notifications/:notificationId/read',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
 
@@ -65,7 +67,9 @@ api.readNotification = {
 api.readNotifications = {
   method: 'POST',
   url: '/notifications/read',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
 
@@ -113,7 +117,9 @@ api.readNotifications = {
 api.seeNotification = {
   method: 'POST',
   url: '/notifications/:notificationId/see',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
 
@@ -162,7 +168,9 @@ api.seeNotification = {
 api.seeNotifications = {
   method: 'POST',
   url: '/notifications/see',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
 

--- a/website/server/controllers/api-v3/pushNotifications.js
+++ b/website/server/controllers/api-v3/pushNotifications.js
@@ -21,7 +21,9 @@ let api = {};
 api.addPushDevice = {
   method: 'POST',
   url: '/user/push-devices',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
 
@@ -64,7 +66,9 @@ api.addPushDevice = {
 api.removePushDevice = {
   method: 'DELETE',
   url: '/user/push-devices/:regId',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
 

--- a/website/server/controllers/api-v3/shops.js
+++ b/website/server/controllers/api-v3/shops.js
@@ -15,7 +15,9 @@ let api = {};
 api.getMarketItems = {
   method: 'GET',
   url: '/shops/market',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
 
@@ -36,7 +38,9 @@ api.getMarketItems = {
 api.getMarketGear = {
   method: 'GET',
   url: '/shops/market-gear',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
 
@@ -60,7 +64,9 @@ api.getMarketGear = {
 api.getQuestShopItems = {
   method: 'GET',
   url: '/shops/quests',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
 
@@ -82,7 +88,9 @@ api.getQuestShopItems = {
 api.getTimeTravelerShopItems = {
   method: 'GET',
   url: '/shops/time-travelers',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
 
@@ -104,7 +112,9 @@ api.getTimeTravelerShopItems = {
 api.getSeasonalShopItems = {
   method: 'GET',
   url: '/shops/seasonal',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
 
@@ -126,7 +136,9 @@ api.getSeasonalShopItems = {
 api.getBackgroundShopItems = {
   method: 'GET',
   url: '/shops/backgrounds',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
 

--- a/website/server/controllers/api-v3/tags.js
+++ b/website/server/controllers/api-v3/tags.js
@@ -38,7 +38,9 @@ let api = {};
 api.createTag = {
   method: 'POST',
   url: '/tags',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
 
@@ -64,7 +66,9 @@ api.createTag = {
 api.getTags = {
   method: 'GET',
   url: '/tags',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
     res.respond(200, user.tags);
@@ -89,7 +93,9 @@ api.getTags = {
 api.getTag = {
   method: 'GET',
   url: '/tags/:tagId',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
 
@@ -126,7 +132,9 @@ api.getTag = {
 api.updateTag = {
   method: 'PUT',
   url: '/tags/:tagId',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
 
@@ -168,7 +176,9 @@ api.updateTag = {
 api.reorderTags = {
   method: 'POST',
   url: '/reorder-tags',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
 
@@ -207,7 +217,9 @@ api.reorderTags = {
 api.deleteTag = {
   method: 'DELETE',
   url: '/tags/:tagId',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
 

--- a/website/server/controllers/api-v3/webhook.js
+++ b/website/server/controllers/api-v3/webhook.js
@@ -73,7 +73,9 @@ let api = {};
  */
 api.addWebhook = {
   method: 'POST',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   url: '/user/webhook',
   async handler (req, res) {
     let user = res.locals.user;
@@ -133,7 +135,9 @@ api.addWebhook = {
  */
 api.updateWebhook = {
   method: 'PUT',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   url: '/user/webhook/:id',
   async handler (req, res) {
     let user = res.locals.user;
@@ -184,7 +188,9 @@ api.updateWebhook = {
 */
 api.deleteWebhook = {
   method: 'DELETE',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   url: '/user/webhook/:id',
   async handler (req, res) {
     let user = res.locals.user;


### PR DESCRIPTION
Starting with some routes from which it should be fine to not load the user's inbox from the database. 

The inbox can be big and not loading it should help with performances. Will do the same with other fields like `user.items` 
 
- [x] website/server/controllers/api-v3/hall.js
- [x] website/server/controllers/api-v3/notifications.js
- [x] website/server/controllers/api-v3/pushNotifications.js
- [x] website/server/controllers/api-v3/shops.js
- [x] website/server/controllers/api-v3/tags.js
- [x] website/server/controllers/api-v3/webhook.js

Remaining files to analyze

- [ ] /top-level/auth.js
- [ ] /top-level/dataexport.js
- [ ] /top-level/email.js
- [ ] /top-level/pages.js
- [ ] /top-level/qrcodes.js
- [ ] /top-level/payments/amazon
- [ ] /top-level/payments/iap
- [ ] /top-level/payments/stripe
- [ ] /top-level/payments/paypal

- [ ] /api-v3/tasks/groups.js

- [ ] /api-v3/user/spells
- [ ] /api-v3/user/stats.js

- [ ] /api-v3/auth.js
- [ ] /api-v3/challenges.js
- [ ] /api-v3/chat.js
- [ ] /api-v3/content.js
- [ ] /api-v3/coupon.js
- [ ] /api-v3/cron.js
- [ ] /api-v3/debug.js
- [ ] /api-v3/groups.js
- [ ] /api-v3/hall.js
- [ ] /api-v3/i18n.js
- [ ] /api-v3/iap.js
- [ ] /api-v3/members.js
- [ ] /api-v3/modelsPaths.js
- [ ] /api-v3/news.js
- [ ] /api-v3/notifications.js
- [ ] /api-v3/pushNotifications.js
- [ ] /api-v3/quests.js
- [ ] /api-v3/shops.js
- [ ] /api-v3/status.js
- [ ] /api-v3/user.js
- [ ] /api-v3/tags.js
- [ ] /api-v3/tasks.js
- [ ] /api-v3/webhook.js
- [ ] /api-v3/world.js

Other fields to remove
- [ ] items
- [ ] analyze user model to find other big and unused fields
- [ ] do the same for tasks's history or wait until they're moved outside the model? cc @TheHollidayInn

- [ ] Add notice on top of controller about inbox not being available? 