### PR TITLE
Adding hand cursor to FAQ headings, and ability to address answers via URL hash

### DIFF
--- a/website/client/components/static/faq.vue
+++ b/website/client/components/static/faq.vue
@@ -3,32 +3,21 @@
     .row
       .col-12.col-md-6.offset-md-3
         h1#faq-heading {{ $t('frequentlyAskedQuestions') }}
-        b-card.faq-question(no-body, v-for='(heading, index) in headings', :key="index")
+        .faq-question(v-for='(heading, index) in headings', :key="index")
           h2(role="tab", v-b-toggle="heading", @click="handleClick($event)", variant="info") {{ $t(`faqQuestion${index}`) }}
           b-collapse(:id="heading", :visible="isVisible(heading)", accordion="faq", role="tabpanel")
-            b-card-body(v-markdown="$t('webFaqAnswer' + index, replacements)")
+            div.card-body(v-markdown="$t('webFaqAnswer' + index, replacements)")
         hr
         p(v-markdown="$t('webFaqStillNeedHelp')")
 </template>
 
 <style lang='scss' scoped>
-  .card {
-    background: transparent;
-    border: 0;
-    border-radius: 0;
-  }
-
   .card-body {
       margin-bottom: 1em;
   }
 
   .faq-question h2 {
     cursor: pointer;
-  }
-
-  .faq-question .card {
-    background: none;
-    border: none;
   }
 
   .faq-question .card-body {

--- a/website/client/components/static/faq.vue
+++ b/website/client/components/static/faq.vue
@@ -6,7 +6,7 @@
         .faq-question(v-for='(heading, index) in headings')
           h2.accordion(:ref='uniqueRef(index)')
             a(href="#", :id='heading', @click.stop.prevent='setActivePage(heading)') {{ $t(`faqQuestion${index}`) }}
-          div(v-if='pageState[heading]', v-markdown="$t('webFaqAnswer' + index, replacements)")
+          div(:class='classObject(heading)', v-markdown="$t('webFaqAnswer' + index, replacements)")
         hr
         p(v-markdown="$t('webFaqStillNeedHelp')")
 </template>
@@ -80,6 +80,9 @@
     methods: {
       setActivePage (page) {
         this.pageState[page] = !this.pageState[page];
+      },
+      classObject (heading) {
+        return { 'd-none': !this.pageState[heading] };
       },
       uniqueRef (index) {
         return this.headings[index];

--- a/website/client/components/static/faq.vue
+++ b/website/client/components/static/faq.vue
@@ -17,6 +17,9 @@
   .faq-question {
     margin-bottom: 1em;
   }
+  .faq-question h2 {
+      cursor: pointer;
+  }
 
   .faq-question .card {
     background: none;

--- a/website/client/components/static/faq.vue
+++ b/website/client/components/static/faq.vue
@@ -5,7 +5,7 @@
         h1 {{ $t('frequentlyAskedQuestions') }}
         .faq-question(v-for='(heading, index) in headings')
           h2.accordion(:ref='uniqueRef(index)')
-            a(href="#", :id='heading', @click.stop.prevent='setActivePage(heading)') {{ $t(`faqQuestion${index}`) }}
+            a(v-bind:href="`#${heading}`", id='heading', @click.stop.prevent='setActivePage(heading)') {{ $t(`faqQuestion${index}`) }}
           div(:class='classObject(heading)', v-markdown="$t('webFaqAnswer' + index, replacements)")
         hr
         p(v-markdown="$t('webFaqStillNeedHelp')")

--- a/website/client/components/static/faq.vue
+++ b/website/client/components/static/faq.vue
@@ -1,12 +1,14 @@
 <template lang="pug">
-  .container-fluid
+  .container-fluid(role="tablist")
     .row
       .col-12.col-md-6.offset-md-3
         h1 {{ $t('frequentlyAskedQuestions') }}
         .faq-question(v-for='(heading, index) in headings')
-          h2.accordion(:ref='uniqueRef(index)')
-            a(v-bind:href="`#${heading}`", id='heading', @click.stop.prevent='setActivePage(heading)') {{ $t(`faqQuestion${index}`) }}
-          div(:class='classObject(heading)', v-markdown="$t('webFaqAnswer' + index, replacements)")
+          b-card(no-body)
+            h2.accordion(role="tab" :ref="heading")
+              a(v-bind:href="`#${heading}`", v-b-toggle="heading", role="tabpanel" variant="info") {{ $t(`faqQuestion${index}`) }}
+            b-collapse(:id='heading', accordion="faq", role="tabpanel", :visible='isVisible(heading)')
+              b-card-body(v-markdown="$t('webFaqAnswer' + index, replacements)")
         hr
         p(v-markdown="$t('webFaqStillNeedHelp')")
 </template>
@@ -14,6 +16,19 @@
 <style lang='scss' scoped>
   .faq-question {
     margin-bottom: 1em;
+  }
+
+  .faq-question .card {
+    background: none;
+    border: none;
+  }
+
+  .faq-question .card-body {
+    padding: 0;
+  }
+
+  .static-wrapper .faq-question h2 {
+    margin: 0;
   }
 
   .faq-question a {
@@ -34,6 +49,7 @@
   const NAVBAR_HEIGHT = 56;
 
   import Vue from 'vue';
+
   import markdownDirective from 'client/directives/markdown';
 
   export default {
@@ -57,14 +73,7 @@
         'world-boss',
       ];
 
-      let pageState = {};
-      for (let index in headings) {
-        let heading = headings[index];
-        pageState[heading] = false;
-      }
-
       return  {
-        pageState,
         headings,
         replacements: {
           techAssistanceEmail: TECH_ASSISTANCE_EMAIL,
@@ -78,25 +87,19 @@
       };
     },
     methods: {
-      setActivePage (page) {
-        this.pageState[page] = !this.pageState[page];
-      },
-      classObject (heading) {
-        return { 'd-none': !this.pageState[heading] };
-      },
-      uniqueRef (index) {
-        return this.headings[index];
+      isVisible (heading) {
+        const hash = window.location.hash.replace('#', '');
+        return hash && this.headings.includes(hash) && hash === heading;
       },
     },
     mounted () {
       const hash = window.location.hash.replace('#', '');
       if (hash && this.headings.includes(hash)) {
-        this.setActivePage(hash);
+        Vue.nextTick(() => {
+          if (!this.$refs[hash] || !this.$refs[hash][0]) return;
+          window.scroll(0, this.$refs[hash][0].getBoundingClientRect().top - NAVBAR_HEIGHT);
+        });
       }
-      Vue.nextTick(() => {
-        if (!this.$refs[hash] || !this.$refs[hash][0]) return;
-        window.scroll(0, this.$refs[hash][0].getBoundingClientRect().top - NAVBAR_HEIGHT);
-      });
     },
   };
 </script>

--- a/website/client/components/static/faq.vue
+++ b/website/client/components/static/faq.vue
@@ -4,7 +4,7 @@
       .col-12.col-md-6.offset-md-3
         h1#faq-heading {{ $t('frequentlyAskedQuestions') }}
         b-card.faq-question(no-body, v-for='(heading, index) in headings', :key="index")
-          b-card-header(header-tag="h2", role="tab", v-b-toggle="heading", @click="handleClick($event)", variant="info") {{ $t(`faqQuestion${index}`) }}
+          h2(role="tab", v-b-toggle="heading", @click="handleClick($event)", variant="info") {{ $t(`faqQuestion${index}`) }}
           b-collapse(:id="heading", :visible="isVisible(heading)", accordion="faq", role="tabpanel")
             b-card-body(v-markdown="$t('webFaqAnswer' + index, replacements)")
         hr

--- a/website/client/components/static/faq.vue
+++ b/website/client/components/static/faq.vue
@@ -4,7 +4,8 @@
       .col-12.col-md-6.offset-md-3
         h1 {{ $t('frequentlyAskedQuestions') }}
         .faq-question(v-for='(heading, index) in headings')
-          h2.accordion(@click='setActivePage(heading)') {{ $t(`faqQuestion${index}`) }}
+          h2.accordion(:ref='uniqueRef(index)')
+            a(v-on:click.stop.prevent="" href="#", :id='heading', @click='setActivePage(heading)') {{ $t(`faqQuestion${index}`) }}
           div(v-if='pageState[heading]', v-markdown="$t('webFaqAnswer' + index, replacements)")
         hr
         p(v-markdown="$t('webFaqStillNeedHelp')")
@@ -13,6 +14,11 @@
 <style lang='scss' scoped>
   .faq-question {
     margin-bottom: 1em;
+  }
+
+  .faq-question a {
+    text-decoration: none;
+    color: #4F2A93;
   }
 
   @media only screen and (max-width: 768px) {
@@ -25,6 +31,9 @@
 <script>
   // @TODO:  env.EMAILS.TECH_ASSISTANCE_EMAIL
   const TECH_ASSISTANCE_EMAIL = 'admin@habitica.com';
+  const NAVBAR_HEIGHT = 56;
+
+  import Vue from 'vue';
   import markdownDirective from 'client/directives/markdown';
 
   export default {
@@ -72,6 +81,19 @@
       setActivePage (page) {
         this.pageState[page] = !this.pageState[page];
       },
+      uniqueRef (index) {
+        return this.headings[index];
+      },
+    },
+    mounted () {
+      const hash = window.location.hash.replace('#', '');
+      if (hash && this.headings.includes(hash)) {
+        this.setActivePage(hash);
+      }
+      Vue.nextTick(() => {
+        if (!this.$refs[hash] || !this.$refs[hash][0]) return;
+        window.scroll(0, this.$refs[hash][0].getBoundingClientRect().top - NAVBAR_HEIGHT);
+      });
     },
   };
 </script>

--- a/website/client/components/static/faq.vue
+++ b/website/client/components/static/faq.vue
@@ -49,9 +49,6 @@
 <script>
   // @TODO:  env.EMAILS.TECH_ASSISTANCE_EMAIL
   const TECH_ASSISTANCE_EMAIL = 'admin@habitica.com';
-  const NAVBAR_HEIGHT = 56;
-
-  import Vue from 'vue';
 
   import markdownDirective from 'client/directives/markdown';
 
@@ -76,12 +73,15 @@
         'world-boss',
       ];
 
+      const hash = window.location.hash.replace('#', '');
+
       return  {
         headings,
         replacements: {
           techAssistanceEmail: TECH_ASSISTANCE_EMAIL,
           wikiTechAssistanceEmail: `mailto:${TECH_ASSISTANCE_EMAIL}`,
         },
+        visible: hash && headings.includes(hash) ? hash : null,
         // @TODO webFaqStillNeedHelp: {
         // linkStart: '[',
         // linkEnd: '](/groups/guild/5481ccf3-5d2d-48a9-a871-70a7380cee5a)',
@@ -91,18 +91,13 @@
     },
     methods: {
       isVisible (heading) {
-        const hash = window.location.hash.replace('#', '');
-        return hash && this.headings.includes(hash) && hash === heading;
+        return this.visible && this.visible === heading;
       },
-    },
-    mounted () {
-      const hash = window.location.hash.replace('#', '');
-      if (hash && this.headings.includes(hash)) {
-        Vue.nextTick(() => {
-          if (!this.$refs[hash] || !this.$refs[hash][0]) return;
-          window.scroll(0, this.$refs[hash][0].getBoundingClientRect().top - NAVBAR_HEIGHT);
-        });
-      }
+      handleClick (e) {
+        if (!e) return;
+        const heading = e.originalTarget.nextElementSibling.id;
+        history.pushState({}, heading, `#${heading}`);
+      },
     },
   };
 </script>

--- a/website/client/components/static/faq.vue
+++ b/website/client/components/static/faq.vue
@@ -89,7 +89,7 @@
       },
       handleClick (e) {
         if (!e) return;
-        const heading = e.originalTarget.nextElementSibling.id;
+        const heading = e.target.nextElementSibling.id;
         history.pushState({}, heading, `#${heading}`);
       },
     },

--- a/website/client/components/static/faq.vue
+++ b/website/client/components/static/faq.vue
@@ -2,13 +2,11 @@
   .container-fluid(role="tablist")
     .row
       .col-12.col-md-6.offset-md-3
-        h1 {{ $t('frequentlyAskedQuestions') }}
-        .faq-question(v-for='(heading, index) in headings')
-          b-card(no-body)
-            h2.accordion(role="tab" :ref="heading")
-              a(v-bind:href="`#${heading}`", v-b-toggle="heading", role="tabpanel" variant="info") {{ $t(`faqQuestion${index}`) }}
-            b-collapse(:id='heading', accordion="faq", role="tabpanel", :visible='isVisible(heading)')
-              b-card-body(v-markdown="$t('webFaqAnswer' + index, replacements)")
+        h1#faq-heading {{ $t('frequentlyAskedQuestions') }}
+        b-card.faq-question(no-body, v-for='(heading, index) in headings', :key="index")
+          b-card-header(header-tag="h2", role="tab", v-b-toggle="heading", @click="handleClick($event)", variant="info") {{ $t(`faqQuestion${index}`) }}
+          b-collapse(:id="heading", :visible="isVisible(heading)", accordion="faq", role="tabpanel")
+            b-card-body(v-markdown="$t('webFaqAnswer' + index, replacements)")
         hr
         p(v-markdown="$t('webFaqStillNeedHelp')")
 </template>

--- a/website/client/components/static/faq.vue
+++ b/website/client/components/static/faq.vue
@@ -12,11 +12,18 @@
 </template>
 
 <style lang='scss' scoped>
-  .faq-question {
-    margin-bottom: 1em;
+  .card {
+    background: transparent;
+    border: 0;
+    border-radius: 0;
   }
+
+  .card-body {
+      margin-bottom: 1em;
+  }
+
   .faq-question h2 {
-      cursor: pointer;
+    cursor: pointer;
   }
 
   .faq-question .card {
@@ -29,7 +36,7 @@
   }
 
   .static-wrapper .faq-question h2 {
-    margin: 0;
+    margin: 0 0 16px 0;
   }
 
   .faq-question a {

--- a/website/client/components/static/faq.vue
+++ b/website/client/components/static/faq.vue
@@ -5,7 +5,7 @@
         h1 {{ $t('frequentlyAskedQuestions') }}
         .faq-question(v-for='(heading, index) in headings')
           h2.accordion(:ref='uniqueRef(index)')
-            a(v-on:click.stop.prevent="" href="#", :id='heading', @click='setActivePage(heading)') {{ $t(`faqQuestion${index}`) }}
+            a(href="#", :id='heading', @click.stop.prevent='setActivePage(heading)') {{ $t(`faqQuestion${index}`) }}
           div(v-if='pageState[heading]', v-markdown="$t('webFaqAnswer' + index, replacements)")
         hr
         p(v-markdown="$t('webFaqStillNeedHelp')")


### PR DESCRIPTION
Fixes #10055

### Changes
Change H2 accordian text to links to make them addressable via URL fragments. Also gives us the hand cursor for free.
Overriding link styling (color & such)
Adding Vue ref to headings
Adding onload handler to check for existing fragment, open that answer, and scroll the answer into view.

----
UUID: 8f4a567a-038c-4c48-9941-fea2dc1d2845
