### PR TITLE
pinning mongodb container to recommended, supported version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - mongo
 
   mongo:
-    image: mongo
+    image: mongo:3.4
     ports:
       - "27017:27017"
     networks:


### PR DESCRIPTION
### Changes
Pinning the mongodb container to version 3.4, as specified in the install instructions, so Docker users don't have to install mongo locally.

----
UUID: 8f4a567a-038c-4c48-9941-fea2dc1d2845