### PR TITLE
add website/raw_sprites/** to list of files ignored by nodemon

### DIFF
--- a/.nodemonignore
+++ b/.nodemonignore
@@ -17,3 +17,4 @@ CHANGELOG.md
 newrelic_agent.log
 *.swp
 *.swx
+website/raw_sprites/**


### PR DESCRIPTION
This PR just makes one addition to `.nodemonignore` to fix a common problem in contributors' local installs.

Without this change or without other workarounds like adding `fs.inotify.max_user_watches=524288` to `/etc/sysctl.conf`, it's common for `npm start` to fail with messages like this:
```
[19:27:17] [nodemon] Internal watch failed: watch /home/alys/code/habitica/website/raw_sprites/spritesmith/stable/mounts/icon/Mount_Icon_Hedgehog-CottonCandyBlue.png ENOSPC
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! habitica@4.38.0 start: `gulp nodemon`
npm ERR! Exit status 1
npm ERR! 
```

This change has already been sort of approved by paglias here: https://github.com/HabitRPG/habitica/pull/10098#pullrequestreview-102060294  but MathWhiz removed that line since it wasn't part of the equipment fix.