### PR TITLE
Hiding popunder if challenge data is incomplete

### DIFF
--- a/test/client/README.md
+++ b/test/client/README.md
@@ -1,3 +1,0 @@
-This folder contains the test files for the new client side that is being developed.
-
-The old client side tests can be found in /test/client-old.

--- a/test/common/shouldDo.test.js
+++ b/test/common/shouldDo.test.js
@@ -966,7 +966,7 @@ describe('shouldDo', () => {
         m: false,
       };
 
-      let today = moment('2017-01-27');
+      let today = moment('2017-01-27:00:00.000-00:00');
       let week = today.monthWeek();
       let dayOfWeek = today.day();
       dailyTask.startDate = today.toDate();
@@ -974,7 +974,7 @@ describe('shouldDo', () => {
       dailyTask.repeat[DAY_MAPPING[dayOfWeek]] = true;
       dailyTask.everyX = 1;
       dailyTask.frequency = 'monthly';
-      day = moment('2017-02-24');
+      day = moment('2017-02-24:00:00.000-00:00');
 
       expect(shouldDo(day, dailyTask, options)).to.equal(true);
     });

--- a/test/helpers/start-server.js
+++ b/test/helpers/start-server.js
@@ -12,7 +12,7 @@ if (process.env.LOAD_SERVER === '0') { // when the server is in a different proc
   nconf.set('NODE_DB_URI', nconf.get('TEST_DB_URI'));
   nconf.set('NODE_ENV', 'test');
   nconf.set('IS_TEST', true);
-  // We require src/server and npt src/index because
+  // We require src/server and not src/index because
   // 1. nconf is already setup
   // 2. we don't need clustering
   require('../../website/server/server'); // eslint-disable-line global-require

--- a/website/client/components/tasks/column.vue
+++ b/website/client/components/tasks/column.vue
@@ -590,7 +590,7 @@ export default {
     },
     filterByTagList (taskList, tagList = []) {
       let filteredTaskList = taskList;
-      // fitler requested tasks by tags
+      // filter requested tasks by tags
       if (!isEmpty(tagList)) {
         filteredTaskList = taskList.filter(
           task => tagList.every(tag => task.tags.indexOf(tag) !== -1)

--- a/website/client/components/tasks/task.vue
+++ b/website/client/components/tasks/task.vue
@@ -81,7 +81,7 @@
                 span.m-0(v-if="task.up && task.down") &nbsp;|&nbsp;
                 span.m-0(v-if="task.down") -{{task.counterDown}}
             .d-flex.align-items-center(v-if="task.challenge && task.challenge.id")
-              .svg-icon.challenge(v-html="icons.challenge", v-if='!task.challenge.broken', v-b-tooltip.hover.bottom="`${task.challenge.shortName}`")
+              .svg-icon.challenge(v-html="icons.challenge", v-if='!task.challenge.broken', v-b-tooltip.hover.bottom="shortName")
               .svg-icon.challenge.broken(v-html="icons.brokenChallengeIcon", v-if='task.challenge.broken', @click='handleBrokenTask(task)', v-b-tooltip.hover.bottom="$t('brokenChaLink')")
             .d-flex.align-items-center(v-if="hasTags", :id="`tags-icon-${task._id}`")
               .svg-icon.tags(v-html="icons.tags")
@@ -626,6 +626,11 @@ export default {
     },
     hasTags () {
       return this.task.tags && this.task.tags.length > 0;
+    },
+    shortName () {
+      if (this.task.challenge.broken) return '';
+
+      return this.task.challenge.shortName ? this.task.challenge.shortName.toString() : '';
     },
   },
   methods: {

--- a/website/server/controllers/api-v3/challenges.js
+++ b/website/server/controllers/api-v3/challenges.js
@@ -68,7 +68,7 @@ let api = {};
 
 /**
  * @apiDefine ChallengeSuccessExample
- * @apiSuccessExample {json} Sucessfull response with single challenge
+ * @apiSuccessExample {json} Successful response with single challenge
  {
    "data": {
      "group": {
@@ -112,7 +112,7 @@ let api = {};
 
 /**
  * @apiDefine ChallengeArrayExample
- * @apiSuccessExample {json} Sucessful response with array of challenges
+ * @apiSuccessExample {json} Successful response with array of challenges
  {
    "data": [{
      "group": {

--- a/website/server/libs/taskManager.js
+++ b/website/server/libs/taskManager.js
@@ -125,7 +125,7 @@ export async function createTasks (req, res, options = {}) {
 
   await owner.update(taskOrderUpdateQuery).exec();
 
-  // tasks with aliases need to be validated asyncronously
+  // tasks with aliases need to be validated asynchronously
   await _validateTaskAlias(toSave, res);
 
   toSave = toSave.map(task => task.save({ // If all tasks are valid (this is why it's not in the previous .map()), save everything, withough running validation again


### PR DESCRIPTION
Fixes #10280

### Changes
Tasks on the Challenge pages only have `task.challenge.id` set, whereas tasks on the Tasks pages also have `tasks.challenge.shortName` (used for popup text). By checking if that property is set, we can pass an empty string to the popup so it disables itself if there is no data to display.

I also deleted an inaccurate README file and fixed a few typos in comments

----
UUID: 8f4a567a-038c-4c48-9941-fea2dc1d2845
