### PR TITLE
Remove inbox from more routes

### DIFF
--- a/test/api/v3/unit/middlewares/auth.test.js
+++ b/test/api/v3/unit/middlewares/auth.test.js
@@ -15,7 +15,7 @@ describe('auth middleware', () => {
 
   describe('auth with headers', () => {
     it('allows to specify a list of user field that we do not want to load', (done) => {
-      const authWithHeaders = authWithHeadersFactory(false, {
+      const authWithHeaders = authWithHeadersFactory({
         userFieldsToExclude: ['items', 'flags', 'auth.timestamps'],
       });
 

--- a/website/server/controllers/api-v3/auth.js
+++ b/website/server/controllers/api-v3/auth.js
@@ -93,7 +93,9 @@ function hasBackupAuth (user, networkToRemove) {
  */
 api.registerLocal = {
   method: 'POST',
-  middlewares: [authWithHeaders(true)],
+  middlewares: [authWithHeaders({
+    optional: true,
+  })],
   url: '/user/auth/local/register',
   async handler (req, res) {
     let existingUser = res.locals.user; // If adding local auth to social user
@@ -299,7 +301,9 @@ function _passportProfile (network, accessToken) {
 // Called as a callback by Facebook (or other social providers). Internal route
 api.loginSocial = {
   method: 'POST',
-  middlewares: [authWithHeaders(true)],
+  middlewares: [authWithHeaders({
+    optional: true,
+  })],
   url: '/user/auth/social', // this isn't the most appropriate url but must be the same as v2
   async handler (req, res) {
     let existingUser = res.locals.user;

--- a/website/server/controllers/api-v3/challenges.js
+++ b/website/server/controllers/api-v3/challenges.js
@@ -183,7 +183,9 @@ let api = {};
 api.createChallenge = {
   method: 'POST',
   url: '/challenges',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
 
@@ -232,7 +234,9 @@ api.createChallenge = {
 api.joinChallenge = {
   method: 'POST',
   url: '/challenges/:challengeId/join',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
 
@@ -289,7 +293,9 @@ api.joinChallenge = {
 api.leaveChallenge = {
   method: 'POST',
   url: '/challenges/:challengeId/leave',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
     let keep = req.body.keep === 'remove-all' ? 'remove-all' : 'keep-all';
@@ -338,7 +344,9 @@ api.leaveChallenge = {
 api.getUserChallenges = {
   method: 'GET',
   url: '/challenges/user',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     const CHALLENGES_PER_PAGE = 10;
     const page = req.query.page;
@@ -439,7 +447,9 @@ api.getUserChallenges = {
 api.getGroupChallenges = {
   method: 'GET',
   url: '/challenges/groups/:groupId',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
     let groupId = req.params.groupId;
@@ -497,7 +507,9 @@ api.getGroupChallenges = {
 api.getChallenge = {
   method: 'GET',
   url: '/challenges/:challengeId',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     req.checkParams('challengeId', res.t('challengeIdRequired')).notEmpty().isUUID();
 
@@ -651,7 +663,9 @@ api.exportChallengeCsv = {
 api.updateChallenge = {
   method: 'PUT',
   url: '/challenges/:challengeId',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     req.checkParams('challengeId', res.t('challengeIdRequired')).notEmpty().isUUID();
 
@@ -693,7 +707,9 @@ api.updateChallenge = {
 api.deleteChallenge = {
   method: 'DELETE',
   url: '/challenges/:challengeId',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
 
@@ -738,7 +754,9 @@ api.deleteChallenge = {
 api.selectChallengeWinner = {
   method: 'POST',
   url: '/challenges/:challengeId/selectWinner/:winnerId',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
 
@@ -787,7 +805,9 @@ api.selectChallengeWinner = {
 api.cloneChallenge = {
   method: 'POST',
   url: '/challenges/:challengeId/clone',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
 

--- a/website/server/controllers/api-v3/chat.js
+++ b/website/server/controllers/api-v3/chat.js
@@ -61,7 +61,9 @@ function textContainsBannedSlur (message) {
 api.getChat = {
   method: 'GET',
   url: '/groups/:groupId/chat',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
 
@@ -100,7 +102,9 @@ function getBannedWordsFromText (message) {
 api.postChat = {
   method: 'POST',
   url: '/groups/:groupId/chat',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
     let groupId = req.params.groupId;
@@ -221,7 +225,9 @@ api.postChat = {
 api.likeChat = {
   method: 'POST',
   url: '/groups/:groupId/chat/:chatId/like',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
     let groupId = req.params.groupId;
@@ -278,7 +284,9 @@ api.likeChat = {
 api.flagChat = {
   method: 'POST',
   url: '/groups/:groupId/chat/:chatId/flag',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     const chatReporter = chatReporterFactory('Group', req, res);
     const message = await chatReporter.flag();
@@ -307,7 +315,9 @@ api.flagChat = {
 api.clearChatFlags = {
   method: 'Post',
   url: '/groups/:groupId/chat/:chatId/clearflags',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
     let groupId = req.params.groupId;
@@ -377,7 +387,9 @@ api.clearChatFlags = {
 api.seenChat = {
   method: 'POST',
   url: '/groups/:groupId/chat/seen',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
     let groupId = req.params.groupId;
@@ -443,7 +455,9 @@ api.seenChat = {
 api.deleteChat = {
   method: 'DELETE',
   url: '/groups/:groupId/chat/:chatId',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
     let groupId = req.params.groupId;

--- a/website/server/controllers/api-v3/coupon.js
+++ b/website/server/controllers/api-v3/coupon.js
@@ -67,7 +67,9 @@ api.getCoupons = {
 api.generateCoupons = {
   method: 'POST',
   url: '/coupons/generate/:event',
-  middlewares: [authWithHeaders(), ensureSudo],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  }), ensureSudo],
   async handler (req, res) {
     req.checkParams('event', res.t('eventRequired')).notEmpty();
     req.checkQuery('count', res.t('countRequired')).notEmpty().isNumeric();
@@ -92,7 +94,9 @@ api.generateCoupons = {
 api.enterCouponCode = {
   method: 'POST',
   url: '/coupons/enter/:code',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     let user = res.locals.user;
 
@@ -120,6 +124,7 @@ api.validateCoupon = {
   url: '/coupons/validate/:code',
   middlewares: [authWithHeaders({
     optional: true,
+    userFieldsToExclude: ['inbox'],
   })],
   async handler (req, res) {
     req.checkParams('code', res.t('couponCodeRequired')).notEmpty();

--- a/website/server/controllers/api-v3/coupon.js
+++ b/website/server/controllers/api-v3/coupon.js
@@ -118,7 +118,9 @@ api.enterCouponCode = {
 api.validateCoupon = {
   method: 'POST',
   url: '/coupons/validate/:code',
-  middlewares: [authWithHeaders(true)],
+  middlewares: [authWithHeaders({
+    optional: true,
+  })],
   async handler (req, res) {
     req.checkParams('code', res.t('couponCodeRequired')).notEmpty();
 

--- a/website/server/controllers/api-v3/members.js
+++ b/website/server/controllers/api-v3/members.js
@@ -312,7 +312,9 @@ function _getMembersForItem (type) {
 api.getMembersForGroup = {
   method: 'GET',
   url: '/groups/:groupId/members',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   handler: _getMembersForItem('group-members'),
 };
 
@@ -333,7 +335,9 @@ api.getMembersForGroup = {
 api.getInvitesForGroup = {
   method: 'GET',
   url: '/groups/:groupId/invites',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   handler: _getMembersForItem('group-invites'),
 };
 
@@ -359,7 +363,9 @@ api.getInvitesForGroup = {
 api.getMembersForChallenge = {
   method: 'GET',
   url: '/challenges/:challengeId/members',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   handler: _getMembersForItem('challenge-members'),
 };
 
@@ -379,7 +385,9 @@ api.getMembersForChallenge = {
 api.getChallengeMemberProgress = {
   method: 'GET',
   url: '/challenges/:challengeId/members/:memberId',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   async handler (req, res) {
     req.checkParams('challengeId', res.t('challengeIdRequired')).notEmpty().isUUID();
     req.checkParams('memberId', res.t('memberIdRequired')).notEmpty().isUUID();

--- a/website/server/controllers/api-v3/news.js
+++ b/website/server/controllers/api-v3/news.js
@@ -60,7 +60,9 @@ api.getNews = {
  */
 api.tellMeLaterNews = {
   method: 'POST',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   url: '/news/tell-me-later',
   async handler (req, res) {
     const user = res.locals.user;

--- a/website/server/controllers/api-v3/user/stats.js
+++ b/website/server/controllers/api-v3/user/stats.js
@@ -27,7 +27,9 @@ let api = {};
  */
 api.allocate = {
   method: 'POST',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   url: '/user/allocate',
   async handler (req, res) {
     let user = res.locals.user;
@@ -67,7 +69,9 @@ api.allocate = {
  */
 api.allocateBulk = {
   method: 'POST',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   url: '/user/allocate-bulk',
   async handler (req, res) {
     let user = res.locals.user;
@@ -123,7 +127,9 @@ api.allocateBulk = {
  */
 api.allocateNow = {
   method: 'POST',
-  middlewares: [authWithHeaders()],
+  middlewares: [authWithHeaders({
+    userFieldsToExclude: ['inbox'],
+  })],
   url: '/user/allocate-now',
   async handler (req, res) {
     let user = res.locals.user;

--- a/website/server/middlewares/auth.js
+++ b/website/server/middlewares/auth.js
@@ -38,7 +38,7 @@ export function authWithHeaders (options = {}) {
   return function authWithHeadersHandler (req, res, next) {
     const userId = req.header('x-api-user');
     const apiToken = req.header('x-api-key');
-    const optional = options.optional === true || false;
+    const optional = options.optional || false;
 
     if (!userId || !apiToken) {
       if (optional) return next();

--- a/website/server/middlewares/auth.js
+++ b/website/server/middlewares/auth.js
@@ -34,10 +34,11 @@ function getUserFields (userFieldsToExclude, req) {
 
 // Authenticate a request through the x-api-user and x-api key header
 // If optional is true, don't error on missing authentication
-export function authWithHeaders (optional = false, options = {}) {
+export function authWithHeaders (options = {}) {
   return function authWithHeadersHandler (req, res, next) {
-    let userId = req.header('x-api-user');
-    let apiToken = req.header('x-api-key');
+    const userId = req.header('x-api-user');
+    const apiToken = req.header('x-api-key');
+    const optional = options.optional === true || false;
 
     if (!userId || !apiToken) {
       if (optional) return next();


### PR DESCRIPTION
Continuation of #10259

### Routes to analyze

- [x] /api-v3/user/spells - uses inbox
- [x] /api-v3/user/stats.js
- [x] /api-v3/world.js - no auth
- [x] /api-v3/debug.js - available only in development mode
- [x] /api-v3/challenges.js
- [x] /api-v3/content.js - no auth
- [x] /api-v3/coupon.js
- [x] /api-v3/i18n.js - no auth
- [x] /api-v3/iap.js - no routes
- [x] /api-v3/members.js
- [x] /api-v3/modelsPaths.js - no auth
- [x] /api-v3/news.js
- [x] /api-v3/status.js - no auth
- [x] /api-v3/chat.js
- [x] /api-v3/tasks/groups.js
- [x] /api-v3/auth.js
- [x] /api-v3/cron.js
- [x] /api-v3/groups.js
- [x] /api-v3/quests.js
- [x] /api-v3/user.js
- [x] /api-v3/tasks.js

### Routes that need access to the inbox

### Routes using authWithSession (no option available yet)
- [ ] /top-level/auth.js
- [ ] /top-level/dataexport.js
- [ ] /top-level/email.js
- [ ] /top-level/pages.js
- [ ] /top-level/qrcodes.js
- [ ] /top-level/payments/amazon
- [ ] /top-level/payments/iap
- [ ] /top-level/payments/stripe
- [ ] /top-level/payments/paypal
- [ ] /api-v3/coupon.js - one route using authWithSession
- [ ] /api-v3/challenges.js - one route using authWithSession


### Other things to do
- [ ] remove `items`
- [ ] analyze user model to find other big and unused fields
- [ ] do the same for tasks's history or wait until they're moved outside the model? cc @TheHollidayInn
- [x] Add notice on top of controller about inbox not being available? 