### PR TITLE
Mount raising modal header stuck naming fixed

### DIFF
--- a/website/client/components/inventory/stable/mountRaisedModal.vue
+++ b/website/client/components/inventory/stable/mountRaisedModal.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 b-modal#mount-raised-modal(:hide-header="true")
   div.content(v-if="mount != null")
-    div.dialog-header.title(v-once) {{ $t('raisedPet', {pet: mount.text()}) }}
+    div.dialog-header.title {{ $t('raisedPet', {pet: mount.text()}) }}
     div.inner-content
       div.pet-background
         .mount(:class="`Mount_Icon_${mount.key}`")


### PR DESCRIPTION
Fixes #10306
Header of mount raising modal gets stuck naming first mount of session

---

Habitica UUID:
7aa1622e-18f9-4af6-86b3-8c5a017039fd
