### PR TITLE
Add responsive margins to pets and mounts.

### DIFF
--- a/website/client/assets/scss/item.scss
+++ b/website/client/assets/scss/item.scss
@@ -22,22 +22,22 @@
 .item.pet-slot {
   // Desktop XL (1440)
   @media only screen and (min-width: 1440px){
-    margin: 0 0.85em;
+    margin-right: 1.71em;
   }
   
   // Desktop L (1280)
   @media only screen and (min-width: 1280px) and (max-width: 1439px) {
-    margin: 0 0.21em;
+    margin-right: 0.43em;
   }
 
   // Desktop M (1024)
   @media only screen and (min-width: 1024px) and (max-width: 1279px) {
-    margin: 0 0.43em;
+    margin-right: 0.86em;
   }
 
   // Tablets and mobile
   @media only screen and (max-width: 1023px) {
-    margin: 0 0.85em;
+    margin-right: 1.71em;
   }
 }
 

--- a/website/client/assets/scss/item.scss
+++ b/website/client/assets/scss/item.scss
@@ -20,7 +20,25 @@
 }
 
 .item.pet-slot {
-  margin: 0 2px;
+  // Desktop XL (1440)
+  @media only screen and (min-width: 1440px){
+    margin: 0 0.85em;
+  }
+  
+  // Desktop L (1280)
+  @media only screen and (min-width: 1280px) and (max-width: 1439px) {
+    margin: 0 0.21em;
+  }
+
+  // Desktop M (1024)
+  @media only screen and (min-width: 1024px) and (max-width: 1279px) {
+    margin: 0 0.43em;
+  }
+
+  // Tablets and mobile
+  @media only screen and (max-width: 1023px) {
+    margin: 0 0.85em;
+  }
 }
 
 .item {


### PR DESCRIPTION
Fixes #9651

### Changes
#### Add responsive margins to Pets and Mounts per @Tressley specifications
I used the requested margins, splitting them between the objects on either side, and converted them to em, which seems based on a 14px default font. However, the design isn't quite matching up: Pets spill over to two rows at 1440px and 1024px resolutions. 1280px resolutions look nice out of the box.

![stable1440](https://user-images.githubusercontent.com/16312666/39464664-4af5c8cc-4ccb-11e8-9945-318b532a6159.png)

Eliminating the left-margins from first items and the right-margins from last items fixes the issues for 1440px resolutions and I tried to figure out where to do that, but the nested classes on the inventory page is making that non-trivial. If someone can point me in the right direction, I'd happily make that modification. I _think_ we need to add a 'first' and 'last' class since simply adding a first-child or first-type doesn't work with the pet-group and item-wrapper classes between the pet-row and pet-slot.

![stable1280](https://user-images.githubusercontent.com/16312666/39464672-542cad48-4ccb-11e8-8a29-22660a134567.png)

Eliminating the left-margins from first items and right-margins from last items does **not** fix the issue for 1024px resolutions. Three items spillover to the second row at that resolution.

![stable1024](https://user-images.githubusercontent.com/16312666/39464799-f2482084-4ccb-11e8-9f50-6f4e382b06aa.png)

Also: I know I'm jumping the gun here since no one officially accepted my offer of help with that issue, and I'll understand if we don't use my code because of it. I have to submit a PR to an Open Source project for a class assignment otherwise I'd wait to hear back from someone before starting. 

![stable768](https://user-images.githubusercontent.com/16312666/39464688-64122bac-4ccb-11e8-89a6-46eb019e2dbe.png)

Thanks! - OldeSword

----
UUID: b91f66db-35ec-4ea4-8148-d03fec89f504
