### PR TITLE
Fixed learn more in user dropdown.

### DIFF
--- a/website/client/components/header/userDropdown.vue
+++ b/website/client/components/header/userDropdown.vue
@@ -22,9 +22,8 @@ menu-dropdown.item-user(:right="true")
       .dropdown-item.text-center
         h3.purple {{ $t('needMoreGems') }}
         span.small-text {{ $t('needMoreGemsInfo') }}
-      img.float-left.align-self-end(src='~assets/images/gem-rain.png')
-      button.btn.btn-primary.btn-lg.learn-button Learn More
-      img.float-right.align-self-end(src='~assets/images/gold-rain.png')
+      .learn-background.py-2.text-center
+        button.btn.btn-primary.btn-lg.learn-button {{ $t('learnMore') }}
 </template>
 
 <style lang='scss' scoped>
@@ -42,6 +41,11 @@ menu-dropdown.item-user(:right="true")
 
 .user-dropdown {
   width: 14.75em;
+}
+
+.learn-background {
+    background: url('~assets/images/gem-rain.png') bottom left no-repeat,
+                url('~assets/images/gold-rain.png') bottom right no-repeat;
 }
 
 .learn-button {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Fixed styling of gold and gem rain in user dropdown. "Learn More" button is now translated as well.

Before:

<img width="310" alt="broken" src="https://user-images.githubusercontent.com/515860/39470799-fdd29c44-4d3f-11e8-98b7-73494f269591.png">

After:

<img width="312" alt="fixed" src="https://user-images.githubusercontent.com/515860/39470805-0344a83e-4d40-11e8-8ad5-d32c562a7383.png">

Tested in Chrome, Safari and Firefox.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: b3eeebf4-b03e-48dd-9e3c-abb27410d1d4
