### PR TITLE
allow subscribers to buy their final monthly gem

### DIFF
--- a/website/common/script/ops/buy/buyGem.js
+++ b/website/common/script/ops/buy/buyGem.js
@@ -49,7 +49,7 @@ export class BuyGemOperation extends AbstractGoldItemOperation {
       throw new NotAuthorized(this.i18n('reachedGoldToGemCap', {convCap: this.convCap}));
     }
 
-    if (user.purchased.plan.gemsBought + this.quantity >= this.convCap) {
+    if (user.purchased.plan.gemsBought + this.quantity > this.convCap) {
       throw new NotAuthorized(this.i18n('reachedGoldToGemCapQuantity', {
         convCap: this.convCap,
         quantity: this.quantity,


### PR DESCRIPTION
The recent change to purchase code has prevented subscribers being able to buy the final gem in their monthly allotment. This PR fixes that.

I've made it against release so it can be deployed sooner than staging.

It's possible that the new purchase code needs more tests but I'm not going to add them in this PR because a quick fix is more desirable. It's a commonly reported bug already.