### PR TITLE
Fixed tavern chat button spacing 

### DIFF
--- a/website/client/components/groups/tavern.vue
+++ b/website/client/components/groups/tavern.vue
@@ -15,11 +15,11 @@
           textarea(:placeholder="$t('tavernCommunityGuidelinesPlaceholder')", v-model='newMessage', :class='{"user-entry": newMessage}', @keydown='updateCarretPosition', @keyup.ctrl.enter='sendMessage()')
           autocomplete(:text='newMessage', v-on:select="selectedAutocomplete", :coords='coords', :chat='group.chat')
 
-        .row
-          .col-6
+        .row.chat-actions
+          .col-6.chat-receive-actions
             button.btn.btn-secondary.float-left.fetch(v-once, @click='fetchRecentMessages()') {{ $t('fetchRecentMessages') }}
             button.btn.btn-secondary.float-left(v-once, @click='reverseChat()') {{ $t('reverseChat') }}
-          .col-6
+          .col-6.chat-send-actions
             button.btn.btn-secondary.send-chat.float-right(v-once, @click='sendMessage()') {{ $t('send') }}
 
         community-guidelines
@@ -204,6 +204,26 @@
 <style lang='scss' scoped>
   @import '~client/assets/scss/colors.scss';
   @import '~client/assets/scss/variables.scss';
+
+  .chat-actions {
+    margin-top: 1em;
+
+    .chat-receive-actions {
+      padding-left: 0;
+
+      button {
+        margin-bottom: 1em;
+
+        &:not(:last-child) {
+          margin-right: 1em;
+        }
+      }
+    }
+
+    .chat-send-actions {
+      padding-right: 0;
+    }
+  }
 
   .chat-row {
     position: relative;


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Cosmetic fix.

Before:

<img width="872" alt="before" src="https://user-images.githubusercontent.com/515860/39728900-79b07d04-5259-11e8-9e64-9e8c452665f3.png">

After:

<img width="907" alt="after" src="https://user-images.githubusercontent.com/515860/39728905-7dc9c8fa-5259-11e8-89c0-e3a0418c7240.png">

They have now the same styling (margin, ...) like the group chat buttons.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: b3eeebf4-b03e-48dd-9e3c-abb27410d1d4
