### PR TITLE
Fixed Lunar Battle quest scrolls showing wrong unlock conditions (Issue #10294 )

### DIFF
--- a/website/client/components/shops/quests/index.vue
+++ b/website/client/components/shops/quests/index.vue
@@ -139,7 +139,7 @@
                     h4.popover-content-title(v-else) {{ item.text }}
                     .popover-content-text(v-if='item.locked && item.key === "lostMasterclasser1"') {{ `${$t('questUnlockLostMasterclasser')}` }}
                     .popover-content-text(v-if='item.locked && item.unlockCondition && item.unlockCondition.incentiveThreshold') {{ `${$t('loginIncentiveQuest', {count: item.unlockCondition.incentiveThreshold})}` }}
-                    .popover-content-text(v-if='item.locked && item.previous') {{ `${$t('unlockByQuesting', {title: item.previous})}` }}
+                    .popover-content-text(v-if='item.locked && item.previous && isBuyingDependentOnPrevious(item)') {{ `${$t('unlockByQuesting', {title: item.previous})}` }}
                     .popover-content-text(v-if='item.lvl > user.stats.lvl') {{ `${$t('mustLvlQuest', {level: item.lvl})}` }}
                     questInfo(v-if='!item.locked', :quest="item")
 
@@ -485,6 +485,11 @@ export default {
         this.selectedItemToBuy = item;
 
         this.$root.$emit('bv::show::modal', 'buy-quest-modal');
+      },
+      isBuyingDependentOnPrevious (item) {
+        let questsNotDependentToPrevious = ['moon2', 'moon3'];
+        if (item.key in questsNotDependentToPrevious) return false;
+        return true;
       },
     },
   };


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10295

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Even though the Lunar Battle quest scrolls unlocked according to check-in count, in Shop/Quests, locked Lunar Battle Part 2 & 3 shows a message which implies the scroll will be unlocked when the user finishes the previous quest. This message is removed.
In order to achieve this, a new method is added to website/client/components/shops/quests/index.vue file which checks whether the key of quest scroll item is in a specified list of keys. In the future, other quest keys can be added to the list as well if their unlock condition is not dependent on the completion of previous quests.
Before: 

![](https://user-images.githubusercontent.com/1495809/39402445-c5d09c2c-4ba2-11e8-8bbd-0bd94f51f4e2.png)

After:
![screen shot 2018-05-03 at 16 51 25](https://user-images.githubusercontent.com/20525079/39580893-ebecc0d6-4ef2-11e8-8d42-fcbb2daed8d4.png)

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 1b2e5d14-e918-44aa-b669-7c309781fdba
