### PR TITLE
groups: Fix Markdown for claimed task messages

### DIFF
--- a/website/common/locales/en/groups.json
+++ b/website/common/locales/en/groups.json
@@ -321,7 +321,7 @@
   "approvalsTitle": "Tasks Awaiting Approval",
   "upgradeTitle": "Upgrade",
   "blankApprovalsDescription": "When your group completes tasks that need your approval, they'll appear here! Adjust approval requirement settings under task editing.",
-  "userIsClamingTask": "`<%= username %> has claimed \"<%= task %>\"`",
+  "userIsClamingTask": "`<%= username %> has claimed:` <%= task %>",
   "approvalRequested": "Approval Requested",
   "refreshApprovals": "Refresh Approvals",
   "refreshGroupTasks": "Refresh Group Tasks",


### PR DESCRIPTION
So far if a task contained Markdown, a system message like this would have been posted to the group chat:

```markdown
foo has claimed "Some [link](http://example.org/)"
```

Also, if the Markdown contained backticked code fragments, the whole text would be displayed in red except the code part.

The reason for this is because the system message is already in Markdown and a backticked task text would result in the following Markdown:

```markdown
`foo has claimed "Foo `bar`"`
```

Here there are two code blocks, one with `foo has claimed "Foo ` and another which only has `"`.

This is fixed by running the task text through the Markdown parser and stripping all HTML tags from it.