### PR TITLE
redirects: Fix parsing BASE_URL with port number

### DIFF
--- a/website/server/middlewares/redirects.js
+++ b/website/server/middlewares/redirects.js
@@ -1,11 +1,11 @@
 import nconf from 'nconf';
+import url from 'url';
 
 const IS_PROD = nconf.get('IS_PROD');
 const IGNORE_REDIRECT = nconf.get('IGNORE_REDIRECT') === 'true';
 const BASE_URL = nconf.get('BASE_URL');
 
-let baseUrlSplit = BASE_URL.split('//');
-const BASE_URL_HOST = baseUrlSplit[1];
+const BASE_URL_HOST = url.parse(BASE_URL).hostname;
 
 function isHTTP (req) {
   return ( // eslint-disable-line no-extra-parens


### PR DESCRIPTION
The parsing in the redirects module was simply determining the base host via trimming off everything up to `//`, so a `BASE_URL` like `http://localhost:3000` will result in the host name `localhost:3000`,
which isn't a valid host name.

So the problem here is that `BASE_URL_HOST` is used for determining whether the client should be redirected and it's comparing the host name of the request object with `BASE_URL_HOST`.

For example if we have the aforementioned `BASE_URL`, we get to the following comparison:

```js
req.hostname !== BASE_URL_HOST
```

Which expands to:

```js
"localhost" !== "localhost:3000"
```

So in order to get rid of the port number, we now use `url.parse()` to get the right host name.