### PR TITLE
only store necessary data for social login

### DIFF
--- a/website/server/controllers/api-v3/auth.js
+++ b/website/server/controllers/api-v3/auth.js
@@ -329,6 +329,7 @@ api.loginSocial = {
         auth: {
           [network]: {
             id: profile.id,
+            email: profile.email,
           },
         },
         profile: {

--- a/website/server/controllers/api-v3/auth.js
+++ b/website/server/controllers/api-v3/auth.js
@@ -327,7 +327,12 @@ api.loginSocial = {
     } else { // Create new user
       user = {
         auth: {
-          [network]: profile,
+          [network]: {
+            id: profile.id,
+          },
+        },
+        profile: {
+          name: profile.displayName || profile.name || profile.username,
         },
         preferences: {
           language: req.language,

--- a/website/server/models/user/hooks.js
+++ b/website/server/models/user/hooks.js
@@ -171,29 +171,11 @@ function _setUpNewUser (user) {
   return _populateDefaultTasks(user, taskTypes);
 }
 
-function _getFacebookName (fb) {
-  if (!fb) {
-    return;
-  }
-  let possibleName = fb.displayName || fb.name || fb.username;
-
-  if (possibleName) {
-    return possibleName;
-  }
-
-  if (fb.first_name && fb.last_name) {
-    return `${fb.first_name} ${fb.last_name}`;
-  }
-}
-
 function _setProfileName (user) {
-  let google = user.auth.google;
-
   let localUsername = user.auth.local && user.auth.local.username;
-  let googleUsername = google && google.displayName;
   let anonymous = 'profile name not found';
 
-  return localUsername || _getFacebookName(user.auth.facebook) || googleUsername || anonymous;
+  return localUsername || anonymous;
 }
 
 schema.pre('validate', function preValidateUser (next) {


### PR DESCRIPTION
Previously we stored some data about facebook and google users that is not entirely necessary. This pull request reduces that to the minimum of the login ID and the displayName (which is saved directly as the profile name, since that was the only use for that).