### PR TITLE
disabling checking off a subtask if not assigned to a user

### DIFF
--- a/website/client/components/tasks/task.vue
+++ b/website/client/components/tasks/task.vue
@@ -64,7 +64,7 @@
               type="checkbox",
               :checked="item.completed",
               @change="toggleChecklistItem(item)",
-              :disabled="castingSpell",
+              :disabled="castingSpell || !isUser",
               :id="`checklist-${item.id}`"
             )
             label.custom-control-label(v-markdown="item.text", :for="`checklist-${item.id}`")


### PR DESCRIPTION
Fixes #10254

### Changes
Disabling task checkboxes if not assigned to a user

----
UUID: 8f4a567a-038c-4c48-9941-fea2dc1d2845