### PR TITLE
Change reward popunder

### DIFF
--- a/website/client/components/tasks/column.vue
+++ b/website/client/components/tasks/column.vue
@@ -24,7 +24,7 @@
       @focus="quickAddFocused = true", @blur="quickAddFocused = false",
     )
     transition(name="quick-add-tip-slide")
-      .quick-add-tip.small-text(v-show="quickAddFocused", v-html="$t('addMultipleTip')")
+      .quick-add-tip.small-text(v-show="quickAddFocused", v-html="$t('addMultipleTip', {taskType: $t(typeLabel)})")
     clear-completed-todos(v-if="activeFilter.label === 'complete2' && isUser === true")
     .column-background(
       v-if="isUser === true",
@@ -370,7 +370,7 @@ export default {
       let rewards = inAppRewards(this.user);
 
       // Add season rewards if user is affected
-      // @TODO: Add buff coniditional
+      // @TODO: Add buff conditional
       const seasonalSkills = {
         snowball: 'salt',
         spookySparkles: 'opaquePotion',

--- a/website/common/locales/en/tasks.json
+++ b/website/common/locales/en/tasks.json
@@ -210,7 +210,6 @@
   "yesterDailiesDescription": "If this setting is applied, Habitica will ask you if you meant to leave the Daily undone before calculating and applying damage to your avatar. This can protect you against unintentional damage.",
   "repeatDayError": "Please ensure that you have at least one day of the week selected.",
   "searchTasks": "Search titles and descriptions...",
-  "repeatDayError": "Please ensure that you have at least one day of the week selected.",
   "sessionOutdated": "Your session is outdated. Please refresh or sync.",
   "errorTemporaryItem": "This item is temporary and cannot be pinned."
 }

--- a/website/common/locales/en/tasks.json
+++ b/website/common/locales/en/tasks.json
@@ -5,7 +5,7 @@
   "sureDeleteCompletedTodos": "Are you sure you want to delete your completed To-Dos?",
   "lotOfToDos": "Your most recent 30 completed To-Dos are shown here. You can see older completed To-Dos from Data > Data Display Tool or Data > Export Data > User Data.",
   "deleteToDosExplanation": "If you click the button below, all of your completed To-Dos and archived To-Dos will be permanently deleted, except for To-Dos from active challenges and Group Plans. Export them first if you want to keep a record of them.",
-  "addMultipleTip": "<strong>Tip:</strong> To add multiple Tasks, separate each one using a line break (Shift + Enter) and then press \"Enter.\"",
+  "addMultipleTip": "<strong>Tip:</strong> To add multiple <%= taskType %>, separate each one using a line break (Shift + Enter) and then press \"Enter.\"",
   "addsingle": "Add Single",
   "addATask": "Add a <%= type %>",
   "editATask": "Edit a <%= type %>",


### PR DESCRIPTION
### Changes
As discussed in the blacksmith guild, this makes the popunder for "add multiple X" reflect the column type. Previously it was always "Tasks" which looked confusing in the Rewards column.

----
UUID: 8f4a567a-038c-4c48-9941-fea2dc1d2845

cc: @Alys 