### PR TITLE
Fix drawer text overlapping at smaller screen resolutions

### DIFF
--- a/website/client/components/ui/drawerHeaderTabs.vue
+++ b/website/client/components/ui/drawerHeaderTabs.vue
@@ -35,7 +35,6 @@
 
   .help-item {
     grid-column-start: 3;
-    justify-self: end;
     position: relative;
     right: -11px;
     text-align: right;

--- a/website/client/components/ui/drawerHeaderTabs.vue
+++ b/website/client/components/ui/drawerHeaderTabs.vue
@@ -14,15 +14,15 @@
 
 <style lang="scss" scoped>
   .drawer-tab-text {
-    overflow-x: hidden;
     display: block;
+    overflow-x: hidden;
     text-overflow: ellipsis;
   }
 
   .drawer-tab {
-    white-space: nowrap;
-    overflow-x: hidden;
     flex: inherit;
+    overflow-x: hidden;
+    white-space: nowrap;
   }
 
   .drawer-tab-container {

--- a/website/client/components/ui/drawerHeaderTabs.vue
+++ b/website/client/components/ui/drawerHeaderTabs.vue
@@ -1,14 +1,14 @@
 <template lang="pug">
-div.header-tabs
-  .drawer-tab-container
-    .drawer-tab(v-for="(tab, index) in tabs")
+nav.header-tabs
+  ul.drawer-tab-container
+    li.drawer-tab(v-for="(tab, index) in tabs")
       a.drawer-tab-text(
         @click="changeTab(index)",
         :class="{'drawer-tab-text-active': selectedTabPosition === index}",
         :title="tab.label"
       ) {{ tab.label }}
 
-  span.right-item
+  aside.help-item
     slot(name="right-item")
 </template>
 
@@ -28,9 +28,10 @@ div.header-tabs
   .drawer-tab-container {
     max-width: 50%;
     margin: 0 auto;
+    padding: 0;
   }
 
-  .right-item {
+  .help-item {
     position: absolute;
     right: -11px;
     top: -2px;

--- a/website/client/components/ui/drawerHeaderTabs.vue
+++ b/website/client/components/ui/drawerHeaderTabs.vue
@@ -44,7 +44,14 @@
   .header-tabs {
     display: grid;
     grid-template-columns: 1fr auto 1fr;
-    position: relative;
+  }
+
+  // MS Edge
+  @supports (-ms-ime-align: auto) {
+    .help-item {
+      align-self: center;
+      top: 1px;
+    }
   }
 </style>
 

--- a/website/client/components/ui/drawerHeaderTabs.vue
+++ b/website/client/components/ui/drawerHeaderTabs.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-nav.header-tabs
+.header-tabs
   ul.drawer-tab-container
     li.drawer-tab(v-for="(tab, index) in tabs")
       a.drawer-tab-text(
@@ -26,20 +26,26 @@ nav.header-tabs
   }
 
   .drawer-tab-container {
-    max-width: 50%;
-    margin: 0 auto;
+    grid-column-start: 2;
+    grid-column-end: 3;
+    justify-self: center;
+    margin: 0;
     padding: 0;
   }
 
   .help-item {
-    position: absolute;
+    grid-column-start: 3;
+    justify-self: end;
+    position: relative;
     right: -11px;
+    text-align: right;
     top: -2px;
   }
 
   .header-tabs {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
     position: relative;
-    display: flex;
   }
 </style>
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10264 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Use CSS Grid to layout the tabs container, and the help item. At smaller screen resolutions the help text wraps and no longer overlaps the tabs:

#### Screenshots
![eat_shrink](https://user-images.githubusercontent.com/52329/40015848-88b73a92-57ac-11e8-8296-2a985acb8e56.gif)

Also updated the HTML to be more semantic:
- The tabs are rendered as a list
- The help item is rendered in an `<aside>`

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: c5085c21-2d4a-4707-a178-0d547329095a
