### PR TITLE
tests: Increase timeouts instead of disabling them

### DIFF
--- a/test/api/v3/integration/challenges/GET-challenges_challengeId_members.test.js
+++ b/test/api/v3/integration/challenges/GET-challenges_challengeId_members.test.js
@@ -123,8 +123,8 @@ describe('GET /challenges/:challengeId/members', () => {
     });
   });
 
-  // @TODO times out too many times (when it takes more than 8s)
-  xit('supports using req.query.lastId to get more members', async () => {
+  it('supports using req.query.lastId to get more members', async function () {
+    this.timeout(30000); // @TODO: times out after 8 seconds
     let group = await generateGroup(user, {type: 'party', name: generateUUID()});
     let challenge = await generateChallenge(user, group);
 

--- a/test/api/v3/integration/groups/GET-groups_groupId_members.test.js
+++ b/test/api/v3/integration/groups/GET-groups_groupId_members.test.js
@@ -142,8 +142,8 @@ describe('GET /groups/:groupId/members', () => {
     });
   });
 
-  // @TODO times out too many times (when it takes more than 8s)
-  xit('supports using req.query.lastId to get more members', async () => {
+  it('supports using req.query.lastId to get more members', async function () {
+    this.timeout(30000); // @TODO: times out after 8 seconds
     let leader = await generateUser({balance: 4});
     let group = await generateGroup(leader, {type: 'guild', privacy: 'public', name: generateUUID()});
 


### PR DESCRIPTION
Some tests were disabled in ba799c67f9f31e94bd3cc97975d1b5768b45817c and 10567d81e2efa5256242d396116c1973dfb170fc, because they tend to frequently time out after 8 seconds.

Instead of disabling the tests (which IMHO is bad, because tests are there for a reason), we're now increasing the timeout to 30 seconds just for these tests. It would probably be a good idea to somehow add an ESLint warning, but I haven't found a rule so far that is very suitable for adding a warning that contains a portion of a comment.

So for now I've marked it with an `XXX` and added the `no-warning-comments` ESLint rule to the test suite.

I also needed to change the arrow notation for the test cases to use the function keyword, because otherwise we don't have `this.timeout()` available.

Cc: @paglias