### PR TITLE
Don't time out server error snacks

### DIFF
--- a/website/client/app.vue
+++ b/website/client/app.vue
@@ -317,7 +317,7 @@ export default {
           title: 'Habitica',
           text: errorMessage,
           type: 'error',
-          timeout: true,
+          timeout: false,
         });
       }
 

--- a/website/client/components/snackbars/notification.vue
+++ b/website/client/components/snackbars/notification.vue
@@ -130,7 +130,6 @@ export default {
     };
   },
   created () {
-    // @TODO the notifications always close even if timeout is false
     let timeout = this.notification.hasOwnProperty('timeout') ? this.notification.timeout : true;
     if (timeout) {
       let delay = this.notification.delay || 1500;


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10031 and #9249. A cleaner look for login-related error messages as suggested by @Tressley could still be implemented, but this covers the basic issue of server error snacks vanishing faster than the user can read.

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Sets `timeout` to `false` when sending an error message to the notifications store. This means that the user must click to dismiss the snack rather than it disappearing on its own after 1500ms.

Also removes a code comment that claimed the above behavior wasn't working, when in fact it does :P

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)