### PR TITLE
client: Fix display of class bonus for other users

### DIFF
--- a/website/client/components/inventory/equipment/attributesGrid.vue
+++ b/website/client/components/inventory/equipment/attributesGrid.vue
@@ -147,11 +147,13 @@
       item: {
         type: Object,
       },
+      user: {
+        type: Object,
+      },
     },
     computed: {
       ...mapState({
         ATTRIBUTES: 'constants.ATTRIBUTES',
-        user: 'user.data',
         flatGear: 'content.gear.flat',
       }),
     },

--- a/website/client/components/inventory/equipment/attributesPopover.vue
+++ b/website/client/components/inventory/equipment/attributesPopover.vue
@@ -8,7 +8,7 @@ div
   div(v-else)
     h4.popover-content-title {{ itemText }}
     .popover-content-text {{ itemNotes }}
-    attributesGrid(:item="item")
+    attributesGrid(:user="user", :item="item")
 </template>
 
 <style scoped>

--- a/website/client/components/inventory/equipment/equipGearModal.vue
+++ b/website/client/components/inventory/equipment/equipGearModal.vue
@@ -28,6 +28,7 @@
           span.className.textCondensed(:class="itemClass") {{ getClassName(itemClass) }}
 
         attributesGrid.attributesGrid(
+          :user="user",
           :item="item",
           v-if="attributesGridVisible"
         )

--- a/website/client/components/shops/buyModal.vue
+++ b/website/client/components/shops/buyModal.vue
@@ -39,7 +39,8 @@
         slot(name="additionalInfo", :item="item")
           equipmentAttributesGrid.attributesGrid(
             v-if="showAttributesGrid",
-            :item="item"
+            :item="item",
+            :user="user"
           )
 
         .purchase-amount(v-if='item.value > 0')

--- a/website/client/components/userMenu/profileStats.vue
+++ b/website/client/components/userMenu/profileStats.vue
@@ -21,6 +21,7 @@
               h4.gearTitle {{ getGearTitle(equippedItems[key]) }}
               attributesGrid.attributesGrid(
                 :item="content.gear.flat[equippedItems[key]]",
+                :user="user"
               )
 
             h3(v-if="label !== 'skip'") {{ label }}
@@ -51,6 +52,7 @@
               h4.gearTitle {{ getGearTitle(costumeItems[key]) }}
               attributesGrid.attributesGrid(
                :item="content.gear.flat[costumeItems[key]]",
+               :user="user"
               )
 
             h3(v-if="label !== 'skip'") {{ label }}


### PR DESCRIPTION
Whenever one is hovering an item from another user, the bonuses of these items are shown for the own user. So for example if you're a mage and view a Royal Magus Robe of another mage, the class bonus is 6.

However if you're a warrior, the class bonus displays as 0 because the attributes grid is always using the stats for the own user even if viewing equipment of a different user.

I've fixed this by moving the user object to the properties in `attributesGrid` and passing the current user from every other Vue file that's using `attributesGrid`.

Not sure whether this is the right approach, as I'm no expert in Vue.js but some testing with the client now shows the correct values.