### PR TITLE
WIP Fix flicker when user mouses over the very leftmost edge of party member avatar

### DIFF
--- a/test/client/unit/specs/components/memberDetails.js
+++ b/test/client/unit/specs/components/memberDetails.js
@@ -1,20 +1,23 @@
 import Vue from 'vue';
 import MemberDetailsComponent from 'client/components/memberDetails.vue';
 
-  describe('Members Details Component', () => {
-    let CTor;
-    let vm;
+describe('Members Details Component', () => {
+  let CTor;
+  let vm;
 
-    beforeEach(() => {
-      CTor = Vue.extend(MembersModalComponent);
-      vm = new CTor().$mount();
-    });
-
-    afterEach(() => {
-      vm.$destroy();
-    });
-
-    it('prevents flickering by setting a 1px margin-right on elements of class member-stats', () => {
-      expect(vm.find('.member-stats').element.style['margin-right']).to.equal('1');
-    });
+  beforeEach(() => {
+    CTor = Vue.extend(MemberDetailsComponent);
+    vm = new CTor().$mount();
   });
+
+  afterEach(() => {
+    vm.$destroy();
+  });
+
+  it('prevents flickering by setting a 1px margin-right on elements of class member-stats', () => {
+    const memberstats = vm.$el.querySelector('.member-stats');
+    const style = window.getComputedStyle(memberstats, null);
+    const marginRightProp = style.getPropertyValue('margin-right');
+    expect(marginRightProp).to.equal('1');
+  });
+});

--- a/test/client/unit/specs/components/memberDetails.js
+++ b/test/client/unit/specs/components/memberDetails.js
@@ -1,0 +1,20 @@
+import Vue from 'vue';
+import MemberDetailsComponent from 'client/components/memberDetails.vue';
+
+  describe('Members Details Component', () => {
+    let CTor;
+    let vm;
+
+    beforeEach(() => {
+      CTor = Vue.extend(MembersModalComponent);
+      vm = new CTor().$mount();
+    });
+
+    afterEach(() => {
+      vm.$destroy();
+    });
+
+    it.only('prevents flickering by setting a 1px margin-right on elements of class member-stats', () => {
+      expect(vm.find('.member-stats').element.style['margin-right']).to.equal('1');
+    });
+  });

--- a/test/client/unit/specs/components/memberDetails.js
+++ b/test/client/unit/specs/components/memberDetails.js
@@ -14,7 +14,7 @@ import MemberDetailsComponent from 'client/components/memberDetails.vue';
       vm.$destroy();
     });
 
-    it.only('prevents flickering by setting a 1px margin-right on elements of class member-stats', () => {
+    it('prevents flickering by setting a 1px margin-right on elements of class member-stats', () => {
       expect(vm.find('.member-stats').element.style['margin-right']).to.equal('1');
     });
   });

--- a/website/client/components/memberDetails.vue
+++ b/website/client/components/memberDetails.vue
@@ -48,6 +48,7 @@
   .member-stats {
     padding-left: 12px;
     padding-right: 24px;
+    margin-right: 1px;
     opacity: 1;
     transition: width 0.15s ease-out;
   }


### PR DESCRIPTION
Fixes #10379 

### Changes
Add one pixel of margin-right to the .member-stats class.

Video Before: https://drive.google.com/file/d/1q7ONERmRuZXTo5VVq6GQ9sv_DHUAQSJj/view
Video After: https://drive.google.com/open?id=1FSM-PFIjGzr1yEvs6OkjQ2vcQaUKd5i6