### PR TITLE
Fixes #10423 ("profile name not found" being used for facebook auth accounts)

### DIFF
--- a/website/server/libs/setupPassport.js
+++ b/website/server/libs/setupPassport.js
@@ -19,7 +19,7 @@ passport.deserializeUser((obj, done) => done(null, obj));
 passport.use(new FacebookStrategy({
   clientID: nconf.get('FACEBOOK_KEY'),
   clientSecret: nconf.get('FACEBOOK_SECRET'),
-  profileFields: ['email'],
+  profileFields: ['id', 'email', 'displayName'],
   // callbackURL: nconf.get("BASE_URL") + "/auth/facebook/callback"
 }, (accessToken, refreshToken, profile, done) => done(null, profile)));
 


### PR DESCRIPTION
Fixes #10423 