### PR TITLE
fixes #10423 ("profile name not found" being used for facebook auth accounts)

### DIFF
--- a/website/server/libs/setupPassport.js
+++ b/website/server/libs/setupPassport.js
@@ -19,7 +19,7 @@ passport.deserializeUser((obj, done) => done(null, obj));
 passport.use(new FacebookStrategy({
   clientID: nconf.get('FACEBOOK_KEY'),
   clientSecret: nconf.get('FACEBOOK_SECRET'),
-  profileFields: ['email'],
+  profileFields: ['id', 'email', 'displayName'],
   // callbackURL: nconf.get("BASE_URL") + "/auth/facebook/callback"
 }, (accessToken, refreshToken, profile, done) => done(null, profile)));
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10423
### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)



[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 
