### PR TITLE
Open correct group modal from header

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -1,3 +1,0 @@
-`/website/client` contains the source files for the new client side that is being developed as part of the Habitica.com redesign. Static assets for the new client can be found in `website/static`.
-
-The old client side files can be found in `/website/client-old`, they are still used on Habitica.com while the redesign is in progress.

--- a/website/client/components/groups/group.vue
+++ b/website/client/components/groups/group.vue
@@ -1,7 +1,6 @@
 <template lang="pug">
 .row(v-if="group._id")
   group-form-modal(v-if='isParty')
-  invite-modal(:group='this.group')
   start-quest-modal(:group='this.group')
   quest-details-modal(:group='this.group')
   group-gems-modal
@@ -260,7 +259,6 @@ import membersModal from './membersModal';
 import startQuestModal from './startQuestModal';
 import questDetailsModal from './questDetailsModal';
 import groupFormModal from './groupFormModal';
-import inviteModal from './inviteModal';
 import groupChallenges from '../challenges/groupChallenges';
 import groupGemsModal from 'client/components/groups/groupGemsModal';
 import questSidebarSection from 'client/components/groups/questSidebarSection';
@@ -288,7 +286,6 @@ export default {
     membersModal,
     startQuestModal,
     groupFormModal,
-    inviteModal,
     groupChallenges,
     questDetailsModal,
     groupGemsModal,

--- a/website/client/components/groups/group.vue
+++ b/website/client/components/groups/group.vue
@@ -437,7 +437,7 @@ export default {
       this.$root.$emit('bv::show::modal', 'guild-form');
     },
     showInviteModal () {
-      this.$root.$emit('bv::show::modal', 'invite-modal');
+      this.$root.$emit('inviteModal::inviteToGroup', this.group); // This event listener is initiated in ../header/index.vue
     },
     async fetchGuild () {
       if (this.searchId === 'party' && !this.user.party._id) {

--- a/website/client/components/header/index.vue
+++ b/website/client/components/header/index.vue
@@ -10,11 +10,11 @@ div
       :is-header="true",
     )
     .view-party.d-flex.align-items-center(
-      v-if="user.party && user.party._id && partyMembers && partyMembers.length > 1",
+      v-if="hasParty",
     )
-      button.btn.btn-primary.view-party-button(@click='openPartyModal()') {{ $t('viewParty') }}
+      button.btn.btn-primary.view-party-button(@click='showPartyMembers()') {{ $t('viewParty') }}
     .party-members.d-flex(
-      v-if="partyMembers && partyMembers.length > 1",
+      v-if="hasParty",
       v-resize="1500",
       @resized="setPartyMembersWidth($event)"
     )
@@ -34,7 +34,7 @@ div
         h3 {{ $t('battleWithFriends') }}
         span.small-text(v-html="$t('inviteFriendsParty')")
         br
-        button.btn.btn-primary(@click='openPartyModal()') {{ user.party._id ? $t('inviteFriends') : $t('startAParty') }}
+        button.btn.btn-primary(@click='createOrInviteParty()') {{ user.party._id ? $t('inviteFriends') : $t('startAParty') }}
   a.useMobileApp(v-if="isAndroidMobile()", v-once, href="https://play.google.com/store/apps/details?id=com.habitrpg.android.habitica") {{ $t('useMobileApps') }}
   a.useMobileApp(v-if="isIOSMobile()", v-once, href="https://itunes.apple.com/us/app/habitica-gamified-task-manager/id994882113?mt=8") {{ $t('useMobileApps') }}
 </template>
@@ -140,6 +140,9 @@ export default {
       if (this.$store.state.hideHeader) return false;
       return true;
     },
+    hasParty () {
+      return this.user.party && this.user.party._id && this.partyMembers && this.partyMembers.length > 1;
+    },
     membersToShow () {
       return Math.floor(this.currentWidth / 140) + 1;
     },
@@ -164,20 +167,19 @@ export default {
         this.expandedMember = memberId;
       }
     },
-    openPartyModal () {
+    createOrInviteParty () {
       if (this.user.party._id) {
-        if (this.partyMembers.length > 1) {
-          // Set the party details for the members-modal component
-          this.$store.state.memberModalOptions.groupId = this.user.party._id;
-          this.$store.state.memberModalOptions.viewingMembers = this.partyMembers;
-          this.$store.state.memberModalOptions.group = this.user.party;
-          this.$root.$emit('bv::show::modal', 'members-modal');
-        } else {
-          this.$root.$emit('bv::show::modal', 'invite-modal');
-        }
+        this.$root.$emit('bv::show::modal', 'invite-modal');
       } else {
         this.$root.$emit('bv::show::modal', 'create-party-modal');
       }
+    },
+    showPartyMembers () {
+      // Set the party details for the members-modal component
+      this.$store.state.memberModalOptions.groupId = this.user.party._id;
+      this.$store.state.memberModalOptions.viewingMembers = this.partyMembers;
+      this.$store.state.memberModalOptions.group = this.user.party;
+      this.$root.$emit('bv::show::modal', 'members-modal');
     },
     setPartyMembersWidth ($event) {
       if (this.currentWidth !== $event.width) {

--- a/website/client/components/header/index.vue
+++ b/website/client/components/header/index.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 div
-  invite-modal(:group='user.party')
+  invite-modal(:group='inviteModalGroup')
   create-party-modal
   #app-header.row(:class="{'hide-header': $route.name === 'groupPlan'}")
     members-modal(:hide-badge="true")
@@ -129,6 +129,7 @@ export default {
     return {
       expandedMember: null,
       currentWidth: 0,
+      inviteModalGroup: undefined,
     };
   },
   computed: {
@@ -169,7 +170,7 @@ export default {
     },
     createOrInviteParty () {
       if (this.user.party._id) {
-        this.$root.$emit('bv::show::modal', 'invite-modal');
+        this.$root.$emit('inviteModal::inviteToGroup', this.user.party);
       } else {
         this.$root.$emit('bv::show::modal', 'create-party-modal');
       }
@@ -191,6 +192,11 @@ export default {
     if (this.user.party && this.user.party._id) {
       this.$store.state.memberModalOptions.groupId = this.user.party._id;
       this.getPartyMembers();
+
+      this.$root.$on('inviteModal::inviteToGroup', (group) => {
+        this.inviteModalGroup = group;
+        this.$root.$emit('bv::show::modal', 'invite-modal');
+      });
     }
   },
 };

--- a/website/client/components/header/index.vue
+++ b/website/client/components/header/index.vue
@@ -30,7 +30,7 @@ div
         :class-badge-position="'hidden'",
       )
     .no-party.d-flex.justify-content-center.text-center(v-else)
-      .align-self-center(v-once)
+      .align-self-center
         h3 {{ $t('battleWithFriends') }}
         span.small-text(v-html="$t('inviteFriendsParty')")
         br

--- a/website/client/components/header/index.vue
+++ b/website/client/components/header/index.vue
@@ -1,5 +1,6 @@
 <template lang="pug">
 div
+  invite-modal(:group='user.party')
   create-party-modal
   #app-header.row(:class="{'hide-header': $route.name === 'groupPlan'}")
     members-modal(:hide-badge="true")
@@ -33,7 +34,7 @@ div
         h3 {{ $t('battleWithFriends') }}
         span.small-text(v-html="$t('inviteFriendsParty')")
         br
-        button.btn.btn-primary(@click='openPartyModal()') {{ partyMembers && partyMembers.length > 1 ? $t('startAParty') : $t('inviteFriends') }}
+        button.btn.btn-primary(@click='openPartyModal()') {{ user.party._id ? $t('inviteFriends') : $t('startAParty') }}
   a.useMobileApp(v-if="isAndroidMobile()", v-once, href="https://play.google.com/store/apps/details?id=com.habitrpg.android.habitica") {{ $t('useMobileApps') }}
   a.useMobileApp(v-if="isIOSMobile()", v-once, href="https://itunes.apple.com/us/app/habitica-gamified-task-manager/id994882113?mt=8") {{ $t('useMobileApps') }}
 </template>
@@ -110,6 +111,7 @@ import orderBy from 'lodash/orderBy';
 import { mapGetters, mapActions } from 'client/libs/store';
 import MemberDetails from '../memberDetails';
 import createPartyModal from '../groups/createPartyModal';
+import inviteModal from '../groups/inviteModal';
 import membersModal from '../groups/membersModal';
 import ResizeDirective from 'client/directives/resize.directive';
 
@@ -120,6 +122,7 @@ export default {
   components: {
     MemberDetails,
     createPartyModal,
+    inviteModal,
     membersModal,
   },
   data () {
@@ -163,14 +166,18 @@ export default {
     },
     openPartyModal () {
       if (this.user.party._id) {
-        // Set the party details for the members-modal component
-        this.$store.state.memberModalOptions.groupId = this.user.party._id;
-        this.$store.state.memberModalOptions.viewingMembers = this.partyMembers;
-        this.$store.state.memberModalOptions.group = this.user.party;
-        this.$root.$emit('bv::show::modal', 'members-modal');
-        return;
+        if (this.partyMembers.length > 1) {
+          // Set the party details for the members-modal component
+          this.$store.state.memberModalOptions.groupId = this.user.party._id;
+          this.$store.state.memberModalOptions.viewingMembers = this.partyMembers;
+          this.$store.state.memberModalOptions.group = this.user.party;
+          this.$root.$emit('bv::show::modal', 'members-modal');
+        } else {
+          this.$root.$emit('bv::show::modal', 'invite-modal');
+        }
+      } else {
+        this.$root.$emit('bv::show::modal', 'create-party-modal');
       }
-      this.$root.$emit('bv::show::modal', 'create-party-modal');
     },
     setPartyMembersWidth ($event) {
       if (this.currentWidth !== $event.width) {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10238

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Clicking one of the various party buttons in the header now does a check on the status of your party before serving the user a modal. 
- If the user had no party at all, the 'create a party' modal is shown. 
- If the user is in a party on his/her own, the 'invite friends' modal is shown.
- If the user has party members, the party overview modal is shown. 

On a totally unrelated note I also ran into an outdated README.md in the server folder which only contained information relevant to the site overhaul. As the overhaul is finished, the file did not seem to serve any purpose other than to confuse new users, so I removed it. 



[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 6d7d6651-604d-4e7c-adff-a040770a6768
