### PR TITLE
'cloning' flag bleeding between challenge modals. Fixes issue related to #10419

### DIFF
--- a/website/client/components/challenges/challengeDetail.vue
+++ b/website/client/components/challenges/challengeDetail.vue
@@ -365,9 +365,9 @@ export default {
       this.$root.$emit('bv::show::modal', 'close-challenge-modal');
     },
     edit () {
-      // @TODO: set working challenge
-      this.$store.state.challengeOptions.workingChallenge = Object.assign({}, this.$store.state.challengeOptions.workingChallenge, this.challenge);
-      this.$root.$emit('bv::show::modal', 'challenge-modal');
+      this.$root.$emit('habitica:update-challenge', {
+        challenge: this.challenge,
+      });
     },
     // @TODO: view members
     updatedChallenge (eventData) {

--- a/website/client/components/challenges/challengeModal.vue
+++ b/website/client/components/challenges/challengeModal.vue
@@ -241,6 +241,12 @@ export default {
       this.$store.state.challengeOptions.workingChallenge = Object.assign({}, this.$store.state.challengeOptions.workingChallenge, data.challenge);
       this.$root.$emit('bv::show::modal', 'challenge-modal');
     });
+    this.$root.$on('habitica:update-challenge', (data) => {
+      if (!data.challenge) return;
+      this.cloning = false;
+      this.$store.state.challengeOptions.workingChallenge = Object.assign({}, this.$store.state.challengeOptions.workingChallenge, data.challenge);
+      this.$root.$emit('bv::show::modal', 'challenge-modal');
+    });
   },
   beforeDestroy () {
     this.$root.$off('habitica:clone-challenge');


### PR DESCRIPTION
Added a 'habitica:update-challenge' emitter and listener to mirror the 'clone-challenge' call. This properly sets the 'cloning' flag and makes things more consistent (as the update-challenge now behaves in the same way as the clone-challenge was designed).

This fixes the bug related to #10419 described in the #10419 thread. This is regarding the 'cloning' flag either not being reset or bleeding over into later modals, thereby making all subsequent 'Edit Challenge' modals to show up as 'Clone Challenge' modals if the first 'Clone Challenge' modal is cancelled.

Wasn't sure how to add tests, but it all checks out manually and is a small fix.

----
UUID: c4b8cf42-8b92-4b57-943b-5a2f074ffbac
