### PR TITLE
Add timestamp to moderator Slack messages (fixes #10441)

### DIFF
--- a/test/api/v3/unit/libs/slack.js
+++ b/test/api/v3/unit/libs/slack.js
@@ -34,6 +34,7 @@ describe('slack', () => {
           user: 'Author',
           uuid: 'author-id',
           text: 'some text',
+          timestamp: ISODate("2018-06-09T23:56:26.367Z"),
         },
       };
     });
@@ -51,11 +52,11 @@ describe('slack', () => {
         attachments: [{
           fallback: 'Flag Message',
           color: 'danger',
-          author_name: 'Author - author@example.com - author-id',
+          author_name: 'Author - author@example.com - author-id\n2018-06-09 23:56 UTC',
           title: 'Flag in Some group - (private guild)',
           title_link: undefined,
           text: 'some text',
-          footer: sandbox.match(/<.*?groupId=group-id&chatId=chat-id\|Flag this message>/),
+          footer: sandbox.match(/.*?groupId=group-id&chatId=chat-id\|Flag this message/),
           mrkdwn_in: [
             'text',
           ],
@@ -99,7 +100,7 @@ describe('slack', () => {
 
       expect(IncomingWebhook.prototype.send).to.be.calledWithMatch({
         attachments: [sandbox.match({
-          author_name: 'System Message',
+          author_name: 'System Message\n2018-06-09 23:56 UTC',
         })],
       });
     });

--- a/test/api/v3/unit/libs/slack.js
+++ b/test/api/v3/unit/libs/slack.js
@@ -5,6 +5,7 @@ import slack from '../../../../../website/server/libs/slack';
 import logger from '../../../../../website/server/libs/logger';
 import { TAVERN_ID } from '../../../../../website/server/models/group';
 import nconf from 'nconf';
+import moment from 'moment';
 
 describe('slack', () => {
   describe('sendFlagNotification', () => {
@@ -34,7 +35,6 @@ describe('slack', () => {
           user: 'Author',
           uuid: 'author-id',
           text: 'some text',
-          timestamp: Date('2018-06-09T23:56:26.367Z'),
         },
       };
     });
@@ -46,17 +46,19 @@ describe('slack', () => {
     it('sends a slack webhook', () => {
       slack.sendFlagNotification(data);
 
+      const timestamp = `${moment(data.message.timestamp).utc().format('YYYY-MM-DD HH:mm')} UTC`;
+
       expect(IncomingWebhook.prototype.send).to.be.calledOnce;
       expect(IncomingWebhook.prototype.send).to.be.calledWith({
         text: 'flagger (flagger-id; language: flagger-lang) flagged a message',
         attachments: [{
           fallback: 'Flag Message',
           color: 'danger',
-          author_name: 'Author - author@example.com - author-id\n2018-06-09 23:56 UTC',
+          author_name: `Author - author@example.com - author-id\n${timestamp}`,
           title: 'Flag in Some group - (private guild)',
           title_link: undefined,
           text: 'some text',
-          footer: sandbox.match(/.*?groupId=group-id&chatId=chat-id\|Flag this message/),
+          footer: sandbox.match(/<.*?groupId=group-id&chatId=chat-id\|Flag this message>/),
           mrkdwn_in: [
             'text',
           ],
@@ -98,9 +100,11 @@ describe('slack', () => {
 
       slack.sendFlagNotification(data);
 
+      const timestamp = `${moment(data.message.timestamp).utc().format('YYYY-MM-DD HH:mm')} UTC`;
+
       expect(IncomingWebhook.prototype.send).to.be.calledWithMatch({
         attachments: [sandbox.match({
-          author_name: 'System Message\n2018-06-09 23:56 UTC',
+          author_name: `System Message\n${timestamp}`,
         })],
       });
     });

--- a/test/api/v3/unit/libs/slack.js
+++ b/test/api/v3/unit/libs/slack.js
@@ -34,7 +34,7 @@ describe('slack', () => {
           user: 'Author',
           uuid: 'author-id',
           text: 'some text',
-          timestamp: ISODate("2018-06-09T23:56:26.367Z"),
+          timestamp: Date('2018-06-09T23:56:26.367Z'),
         },
       };
     });

--- a/website/server/libs/slack.js
+++ b/website/server/libs/slack.js
@@ -11,6 +11,7 @@ const BASE_URL = nconf.get('BASE_URL');
 
 let flagSlack;
 let subscriptionSlack;
+let moment = require('moment');
 
 try {
   flagSlack = new IncomingWebhook(SLACK_FLAGGING_URL);
@@ -29,7 +30,6 @@ function sendFlagNotification ({
   if (!SLACK_FLAGGING_URL) {
     return;
   }
-  let moment = require('moment');
   let titleLink;
   let authorName;
   let timestamp;
@@ -56,7 +56,7 @@ function sendFlagNotification ({
 
   let date = moment(message.timestamp).format('YYYY-MM-DD');
   let time = moment(message.timestamp).utc().format('HH:mm');
-  timestamp = date + " " + time + " UTC";
+  timestamp = `${date} ${time} UTC`;
 
   flagSlack.send({
     text,

--- a/website/server/libs/slack.js
+++ b/website/server/libs/slack.js
@@ -3,6 +3,7 @@ import { IncomingWebhook } from '@slack/client';
 import logger from './logger';
 import { TAVERN_ID } from '../models/group';
 import nconf from 'nconf';
+import moment from 'moment';
 
 const SLACK_FLAGGING_URL = nconf.get('SLACK:FLAGGING_URL');
 const SLACK_FLAGGING_FOOTER_LINK = nconf.get('SLACK:FLAGGING_FOOTER_LINK');
@@ -11,7 +12,6 @@ const BASE_URL = nconf.get('BASE_URL');
 
 let flagSlack;
 let subscriptionSlack;
-let moment = require('moment');
 
 try {
   flagSlack = new IncomingWebhook(SLACK_FLAGGING_URL);
@@ -32,7 +32,6 @@ function sendFlagNotification ({
   }
   let titleLink;
   let authorName;
-  let timestamp;
   let title = `Flag in ${group.name}`;
   let text = `${flagger.profile.name} (${flagger.id}; language: ${flagger.preferences.language}) flagged a message`;
 
@@ -54,9 +53,7 @@ function sendFlagNotification ({
     authorName = `${message.user} - ${authorEmail} - ${message.uuid}`;
   }
 
-  let date = moment(message.timestamp).format('YYYY-MM-DD');
-  let time = moment(message.timestamp).utc().format('HH:mm');
-  timestamp = `${date} ${time} UTC`;
+  const timestamp = `${moment(message.timestamp).utc().format('YYYY-MM-DD HH:mm')} UTC`;
 
   flagSlack.send({
     text,

--- a/website/server/libs/slack.js
+++ b/website/server/libs/slack.js
@@ -29,8 +29,10 @@ function sendFlagNotification ({
   if (!SLACK_FLAGGING_URL) {
     return;
   }
+  let moment = require('moment');
   let titleLink;
   let authorName;
+  let timestamp;
   let title = `Flag in ${group.name}`;
   let text = `${flagger.profile.name} (${flagger.id}; language: ${flagger.preferences.language}) flagged a message`;
 
@@ -52,12 +54,17 @@ function sendFlagNotification ({
     authorName = `${message.user} - ${authorEmail} - ${message.uuid}`;
   }
 
+  let date = moment(message.timestamp).format('YYYY-MM-DD');
+  let time = moment(message.timestamp).utc().format('HH:mm');
+  timestamp = date + " " + time + " UTC";
+
   flagSlack.send({
     text,
     attachments: [{
       fallback: 'Flag Message',
       color: 'danger',
       author_name: authorName,
+      timestamp,
       title,
       title_link: titleLink,
       text: message.text,

--- a/website/server/libs/slack.js
+++ b/website/server/libs/slack.js
@@ -60,8 +60,7 @@ function sendFlagNotification ({
     attachments: [{
       fallback: 'Flag Message',
       color: 'danger',
-      author_name: authorName,
-      timestamp,
+      author_name: `${authorName}\n${timestamp}`,
       title,
       title_link: titleLink,
       text: message.text,


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10441 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Added the date and time (in UTC) to the Slack notification moderators receive when a chat message gets reported. The sendSlackNotification function in website/server/libs/slack.js was changed.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 9ca2bb65-ce6c-4e4c-a367-5ef9b5c7421e
