### PR TITLE
Prevent text overflow on failed login notification (#10447)

### DIFF
--- a/website/client/components/snackbars/notification.vue
+++ b/website/client/components/snackbars/notification.vue
@@ -50,6 +50,10 @@ transition(name="fade")
 
   .error {
     background-color: #f74e52;
+    border-radius: 60px;
+    width: 320px !important;
+    padding: 10px 5px;
+    margin-left: 0;
     color: #fff;
   }
 


### PR DESCRIPTION
Fixes #10447 

### Changes
The error notification width has been increased slightly along with the addition of some padding and a reduction in border-radius. I've also made sure the text doesn't overflow in other languages!

Before:
![screenshot 2018-06-15 13 10 26](https://user-images.githubusercontent.com/30320536/41467239-995e360c-709d-11e8-8c16-723ec8809f3c.jpg)

After:
![screenshot 2018-06-15 13 13 28](https://user-images.githubusercontent.com/30320536/41467327-fd3361f2-709d-11e8-8e44-da355e9b59f8.jpg)

----
UUID: 7187b35d-3ae8-4b5c-8578-be7f582ff437
