### PR TITLE
remove unused UNSUBSCRIBED code (a `challenge.broken` and `group.broken` value)

### DIFF
--- a/website/client/components/tasks/brokenTaskModal.vue
+++ b/website/client/components/tasks/brokenTaskModal.vue
@@ -16,13 +16,6 @@
         div
           button.btn.btn-primary(@click='unlink("keep-all")') {{ $t('keepThem') }}
           button.btn.btn-danger(@click='unlink("remove-all")') {{ $t('removeThem') }}
-      // @TODO: I ported this over, but do we use it anymore?
-      //div(v-if='brokenChallengeTask.challenge.broken === "UNSUBSCRIBED"')
-        p {{ $t('unsubChallenge') }}
-        p
-          a(@click="unlink('keep-all')") {{ $t('keepThem') }}
-          | &nbsp;|&nbsp;
-          a(@click="unlink('remove-all')") {{ $t('removeThem') }}
 </template>
 
 <style scoped>

--- a/website/server/models/task.js
+++ b/website/server/models/task.js
@@ -94,13 +94,13 @@ export let TaskSchema = new Schema({
     shortName: {type: String},
     id: {type: String, ref: 'Challenge', validate: [validator.isUUID, 'Invalid uuid.']}, // When set (and userId not set) it's the original task
     taskId: {type: String, ref: 'Task', validate: [validator.isUUID, 'Invalid uuid.']}, // When not set but challenge.id defined it's the original task
-    broken: {type: String, enum: ['CHALLENGE_DELETED', 'TASK_DELETED', 'UNSUBSCRIBED', 'CHALLENGE_CLOSED', 'CHALLENGE_TASK_NOT_FOUND']}, // CHALLENGE_TASK_NOT_FOUND comes from v3 migration
+    broken: {type: String, enum: ['CHALLENGE_DELETED', 'TASK_DELETED', 'CHALLENGE_CLOSED', 'CHALLENGE_TASK_NOT_FOUND']}, // CHALLENGE_TASK_NOT_FOUND comes from v3 migration
     winner: String, // user.profile.name of the winner
   },
 
   group: {
     id: {type: String, ref: 'Group', validate: [validator.isUUID, 'Invalid uuid.']},
-    broken: {type: String, enum: ['GROUP_DELETED', 'TASK_DELETED', 'UNSUBSCRIBED']},
+    broken: {type: String, enum: ['GROUP_DELETED', 'TASK_DELETED']},
     assignedUsers: [{type: String, ref: 'User', validate: [validator.isUUID, 'Invalid uuid.']}],
     taskId: {type: String, ref: 'Task', validate: [validator.isUUID, 'Invalid uuid.']},
     approval: {


### PR DESCRIPTION
DO NOT MERGE YET: might need discussion; will need a data search and maybe a small migration.

This removes some incomplete code for an "UNSUBSCRIBED" value for `challenge.broken` in the task schema. 

It looks like that code might have been previously used in cases when a user had left a challenge but I don't know when - it must have been a very long time ago, if indeed it was ever fully implemented, because I don't recall seeing it used in all the time I've been troubleshooting challenge task problems.

There's no need for it anymore in normal use (when a user leaves a challenge, all tasks are immediately deleted or converted to non-challenge tasks), and if it's manually added to a challenge task by an admin, the user is still unable to delete the task since there's no enabled support  for it ("CHALLENGE_DELETED" can be used for that, which is strictly inaccurate but since it's for cases where the user is in a bug-ridden situation anyway, I don't think that matters).

Removing it from the schema could be considered a breaking change but since it's not in use in official tools, I don't see that that matters either. Third-party tools should not be using it. I checked the Android and iOS source code to ensure it's not used there.

NOTE that before (if) this is merged, we should check all tasks to ensure it's not used in any of them. I can do that.