### PR TITLE
10282: Added code for blocking party and guild invitations from block…

### DIFF
--- a/test/api/v3/integration/groups/POST-groups_invite.test.js
+++ b/test/api/v3/integration/groups/POST-groups_invite.test.js
@@ -114,7 +114,7 @@ describe('Post /groups/:groupId/invite', () => {
         });
     });
 
-    it.only('returns error when recipient has blocked the senders', async () => {
+    it('returns error when recipient has blocked the senders', async () => {
       const inviterNoBlocks = await inviter.update({'inbox.blocks': []});
       let userWithBlockedInviter = await generateUser({'inbox.blocks': [inviter._id]});
       await expect(inviterNoBlocks.post(`/groups/${group._id}/invite`, {

--- a/test/api/v3/integration/groups/POST-groups_invite.test.js
+++ b/test/api/v3/integration/groups/POST-groups_invite.test.js
@@ -114,6 +114,19 @@ describe('Post /groups/:groupId/invite', () => {
         });
     });
 
+    it.only('returns error when recipient has blocked the sendersss****TODO:FINISH', async () => {
+      const inviterNoBlocks = await inviter.update({'inbox.blocks': []});
+      let userWithBlockedInviter = await generateUser({'inbox.blocks': [inviter._id]});
+      await expect(inviterNoBlocks.post(`/groups/${group._id}/invite`, {
+        uuids: [userWithBlockedInviter._id],
+      }))
+        .to.eventually.be.rejected.and.eql({
+          code: 401,
+          error: 'NotAuthorized',
+          message: t('notAuthorizedToSendMessageToThisUser'),
+        });
+    });
+
     it('invites a user to a group by uuid', async () => {
       let userToInvite = await generateUser();
 

--- a/test/api/v3/integration/groups/POST-groups_invite.test.js
+++ b/test/api/v3/integration/groups/POST-groups_invite.test.js
@@ -114,7 +114,7 @@ describe('Post /groups/:groupId/invite', () => {
         });
     });
 
-    it.only('returns error when recipient has blocked the sendersss****TODO:FINISH', async () => {
+    it.only('returns error when recipient has blocked the senders', async () => {
       const inviterNoBlocks = await inviter.update({'inbox.blocks': []});
       let userWithBlockedInviter = await generateUser({'inbox.blocks': [inviter._id]});
       await expect(inviterNoBlocks.post(`/groups/${group._id}/invite`, {

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -957,6 +957,11 @@ async function _inviteByUUID (uuid, group, inviter, req, res) {
     throw new BadRequest(res.t('cannotInviteSelfToGroup'));
   }
 
+  const objections = inviter.getObjectionsToInteraction('group-invitation', userToInvite);
+  if (objections.length > 0) {
+    throw new NotAuthorized(res.t(objections[0], { userId: uuid, username: userToInvite.profile.name}));
+  }
+
   if (group.type === 'guild') {
     if (_.includes(userToInvite.guilds, group._id)) {
       throw new NotAuthorized(res.t('userAlreadyInGroup', { userId: uuid, username: userToInvite.profile.name}));
@@ -1159,6 +1164,7 @@ async function _inviteByEmail (invite, group, inviter, req, res) {
  * @apiError (401) {NotAuthorized} UserAlreadyInvited The user has already been invited to the group.
  * @apiError (401) {NotAuthorized} UserAlreadyInGroup The user is already a member of the group.
  * @apiError (401) {NotAuthorized} CannotInviteWhenMuted You cannot invite anyone to a guild or party because your chat privileges have been revoked.
+ * @apiError (401) {NotAuthorized} NotAuthorizedToSendMessageToThisUser You can't send a message to this player because they have chosen to block messages.
  *
  * @apiUse GroupNotFound
  * @apiUse UserNotFound
@@ -1167,9 +1173,7 @@ async function _inviteByEmail (invite, group, inviter, req, res) {
 api.inviteToGroup = {
   method: 'POST',
   url: '/groups/:groupId/invite',
-  middlewares: [authWithHeaders({
-    userFieldsToExclude: ['inbox'],
-  })],
+  middlewares: [authWithHeaders({})],
   async handler (req, res) {
     let user = res.locals.user;
 

--- a/website/server/models/user/methods.js
+++ b/website/server/models/user/methods.js
@@ -59,6 +59,10 @@ const INTERACTION_CHECKS = Object.freeze({
     // Unlike private messages, gems can't be sent to oneself
     (sndr, rcvr) => rcvr._id === sndr._id && 'cannotSendGemsToYourself',
   ],
+
+  'group-invitation': [
+    // uses the checks that are in the 'always' array
+  ],
 });
 /* eslint-enable no-unused-vars */
 


### PR DESCRIPTION
…ed players, added tests

[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: #10282
Fixes #10282 

### Changes
[//]: #10282 Removed `inbox` from being excluded as a user field. And now checks the `user.inbox.blocks` array to see if the sender or receiver or a guild/party invite should be blocked. Also added a test to ensure this is working.



[//]: #4b9dc32d-ad7d-4d2e-aaad-0543472f87f6

----
UUID: 4b9dc32d-ad7d-4d2e-aaad-0543472f87f6
