### PR TITLE
Client: use api v4

### DIFF
--- a/test/client/unit/specs/libs/asyncResource.js
+++ b/test/client/unit/specs/libs/asyncResource.js
@@ -80,12 +80,12 @@ describe('async resource', () => {
       const store = generateStore();
       store.state.user = asyncResourceFactory();
 
-      sandbox.stub(axios, 'get').withArgs('/api/v3/user').returns(Promise.resolve({data: {data: {_id: 1}}}));
+      sandbox.stub(axios, 'get').withArgs('/api/v4/user').returns(Promise.resolve({data: {data: {_id: 1}}}));
 
       const resource = await loadAsyncResource({
         store,
         path: 'user',
-        url: '/api/v3/user',
+        url: '/api/v4/user',
         deserialize (response) {
           return response.data.data;
         },
@@ -101,12 +101,12 @@ describe('async resource', () => {
       const store = generateStore();
       store.state.user.loadingStatus = 'LOADED';
 
-      sandbox.stub(axios, 'get').withArgs('/api/v3/user').returns(Promise.resolve({data: {data: {_id: 1}}}));
+      sandbox.stub(axios, 'get').withArgs('/api/v4/user').returns(Promise.resolve({data: {data: {_id: 1}}}));
 
       const resource = await loadAsyncResource({
         store,
         path: 'user',
-        url: '/api/v3/user',
+        url: '/api/v4/user',
         deserialize (response) {
           return response.data.data;
         },
@@ -123,12 +123,12 @@ describe('async resource', () => {
       const store = generateStore();
       store.state.user.loadingStatus = 'LOADING';
 
-      sandbox.stub(axios, 'get').withArgs('/api/v3/user').returns(Promise.resolve({data: {data: {_id: 1}}}));
+      sandbox.stub(axios, 'get').withArgs('/api/v4/user').returns(Promise.resolve({data: {data: {_id: 1}}}));
 
       const resourcePromise = loadAsyncResource({
         store,
         path: 'user',
-        url: '/api/v3/user',
+        url: '/api/v4/user',
         deserialize (response) {
           return response.data.data;
         },

--- a/test/client/unit/specs/store/actions/shops.js
+++ b/test/client/unit/specs/store/actions/shops.js
@@ -39,7 +39,7 @@ describe('shops actions', () => {
 
       let item = getItemInfo(user, 'marketGear', gearItem, getOfficialPinnedItems(user));
 
-      sandbox.stub(axios, 'post').withArgs('/api/v3/user/buy/armor_rogue_1').returns(Promise.resolve({data: {data: {}}}));
+      sandbox.stub(axios, 'post').withArgs('/api/v4/user/buy/armor_rogue_1').returns(Promise.resolve({data: {data: {}}}));
 
       await store.dispatch('shops:genericPurchase', {
         pinType: item.pinType,

--- a/test/client/unit/specs/store/actions/tasks.js
+++ b/test/client/unit/specs/store/actions/tasks.js
@@ -12,7 +12,7 @@ describe('tasks actions', () => {
     xit('fetches user tasks', async () => {
       expect(store.state.tasks.loadingStatus).to.equal('NOT_LOADED');
       const tasks = [{_id: 1}];
-      sandbox.stub(axios, 'get').withArgs('/api/v3/tasks/user').returns(Promise.resolve({data: {data: tasks}}));
+      sandbox.stub(axios, 'get').withArgs('/api/v4/tasks/user').returns(Promise.resolve({data: {data: tasks}}));
 
       await store.dispatch('tasks:fetchUserTasks');
 
@@ -28,7 +28,7 @@ describe('tasks actions', () => {
       };
 
       const tasks = [{_id: 2}];
-      sandbox.stub(axios, 'get').withArgs('/api/v3/tasks/user').returns(Promise.resolve({data: {data: tasks}}));
+      sandbox.stub(axios, 'get').withArgs('/api/v4/tasks/user').returns(Promise.resolve({data: {data: tasks}}));
 
       await store.dispatch('tasks:fetchUserTasks');
 
@@ -43,7 +43,7 @@ describe('tasks actions', () => {
       };
 
       const tasks = [{_id: 2}];
-      sandbox.stub(axios, 'get').withArgs('/api/v3/tasks/user').returns(Promise.resolve({data: {data: tasks}}));
+      sandbox.stub(axios, 'get').withArgs('/api/v4/tasks/user').returns(Promise.resolve({data: {data: tasks}}));
 
       await store.dispatch('tasks:fetchUserTasks', true);
 

--- a/test/client/unit/specs/store/actions/user.js
+++ b/test/client/unit/specs/store/actions/user.js
@@ -12,7 +12,7 @@ describe('user actions', () => {
     it('loads the user', async () => {
       expect(store.state.user.loadingStatus).to.equal('NOT_LOADED');
       const user = {_id: 1};
-      sandbox.stub(axios, 'get').withArgs('/api/v3/user').returns(Promise.resolve({data: {data: user}}));
+      sandbox.stub(axios, 'get').withArgs('/api/v4/user').returns(Promise.resolve({data: {data: user}}));
 
       await store.dispatch('user:fetch');
 
@@ -28,7 +28,7 @@ describe('user actions', () => {
       };
 
       const user = {_id: 2};
-      sandbox.stub(axios, 'get').withArgs('/api/v3/user').returns(Promise.resolve({data: {data: user}}));
+      sandbox.stub(axios, 'get').withArgs('/api/v4/user').returns(Promise.resolve({data: {data: user}}));
 
       await store.dispatch('user:fetch');
 
@@ -43,7 +43,7 @@ describe('user actions', () => {
       };
 
       const user = {_id: 2};
-      sandbox.stub(axios, 'get').withArgs('/api/v3/user').returns(Promise.resolve({data: {data: user}}));
+      sandbox.stub(axios, 'get').withArgs('/api/v4/user').returns(Promise.resolve({data: {data: user}}));
 
       await store.dispatch('user:fetch', {forceLoad: true});
 

--- a/webpack/config/index.js
+++ b/webpack/config/index.js
@@ -41,8 +41,12 @@ module.exports = {
     assetsPublicPath: '/',
     staticAssetsDirectory,
     proxyTable: {
-      // proxy all requests starting with /api/v3 to IP:PORT as specified in the top-level config
+      // proxy all requests to the server at IP:PORT as specified in the top-level config
       '/api/v3': {
+        target: DEV_BASE_URL,
+        changeOrigin: true,
+      },
+      '/api/v4': {
         target: DEV_BASE_URL,
         changeOrigin: true,
       },

--- a/website/client/app.vue
+++ b/website/client/app.vue
@@ -306,7 +306,7 @@ export default {
         // Don't show errors from getting user details. These users have delete their account,
         // but their chat message still exists.
         let configExists = Boolean(error.response) && Boolean(error.response.config);
-        if (configExists && error.response.config.method === 'get' && error.response.config.url.indexOf('/api/v3/members/') !== -1) {
+        if (configExists && error.response.config.method === 'get' && error.response.config.url.indexOf('/api/v4/members/') !== -1) {
           // @TODO: We resolve the promise because we need our caching to cache this user as tried
           // Chat paging should help this, but maybe we can also find another solution..
           return Promise.resolve(error);
@@ -348,20 +348,20 @@ export default {
       const url = response.config.url;
       const method = response.config.method;
 
-      const isApiCall = url.indexOf('api/v3') !== -1;
+      const isApiCall = url.indexOf('api/v4') !== -1;
       const userV = response.data && response.data.userV;
-      const isCron = url.indexOf('/api/v3/cron') === 0 && method === 'post';
+      const isCron = url.indexOf('/api/v4/cron') === 0 && method === 'post';
 
       if (this.isUserLoaded && isApiCall && userV) {
         const oldUserV = this.user._v;
         this.user._v = userV;
 
         // Do not sync again if already syncing
-        const isUserSync = url.indexOf('/api/v3/user') === 0 && method === 'get';
-        const isTasksSync = url.indexOf('/api/v3/tasks/user') === 0 && method === 'get';
+        const isUserSync = url.indexOf('/api/v4/user') === 0 && method === 'get';
+        const isTasksSync = url.indexOf('/api/v4/tasks/user') === 0 && method === 'get';
         // exclude chat seen requests because with real time chat they would be too many
         const isChatSeen = url.indexOf('/chat/seen') !== -1  && method === 'post';
-        // exclude POST /api/v3/cron because the user is synced automatically after cron runs
+        // exclude POST /api/v4/cron because the user is synced automatically after cron runs
 
         // Something has changed on the user object that was not tracked here, sync the user
         if (userV - oldUserV > 1 && !isCron && !isChatSeen && !isUserSync && !isTasksSync) {

--- a/website/client/components/achievements/death.vue
+++ b/website/client/components/achievements/death.vue
@@ -66,7 +66,7 @@ export default {
       this.$root.$emit('bv::hide::modal', 'death');
     },
     async revive () {
-      await axios.post('/api/v3/user/revive');
+      await axios.post('/api/v4/user/revive');
       revive(this.user);
       this.close();
     },

--- a/website/client/components/achievements/newStuff.vue
+++ b/website/client/components/achievements/newStuff.vue
@@ -40,7 +40,7 @@
     async mounted () {
       this.$root.$on('bv::show::modal', async (modalId) => {
         if (modalId !== 'new-stuff') return;
-        let response = await axios.get('/api/v3/news');
+        let response = await axios.get('/api/v4/news');
         this.html = response.data.html;
       });
     },

--- a/website/client/components/appFooter.vue
+++ b/website/client/components/appFooter.vue
@@ -308,7 +308,7 @@ export default {
 
       let date = moment(this.user.lastCron).subtract(numberOfDays, 'days').toDate();
 
-      await axios.post('/api/v3/debug/set-cron', {
+      await axios.post('/api/v4/debug/set-cron', {
         lastCron: date,
       });
 
@@ -316,12 +316,12 @@ export default {
       // @TODO: Sync user?
     },
     async addTenGems () {
-      await axios.post('/api/v3/debug/add-ten-gems');
+      await axios.post('/api/v4/debug/add-ten-gems');
       // @TODO: Notification.text('+10 Gems!');
       this.user.balance += 2.5;
     },
     async addHourglass () {
-      await axios.post('/api/v3/debug/add-hourglass');
+      await axios.post('/api/v4/debug/add-hourglass');
       // @TODO: Sync?
     },
     addGold () {
@@ -356,13 +356,13 @@ export default {
       });
     },
     async addQuestProgress () {
-      await axios.post('/api/v3/debug/quest-progress');
+      await axios.post('/api/v4/debug/quest-progress');
 
       //  @TODO:  Notification.text('Quest progress increased');
       //  @TODO:  User.sync();
     },
     async makeAdmin  () {
-      await axios.post('/api/v3/debug/make-admin');
+      await axios.post('/api/v4/debug/make-admin');
 
       // @TODO: Notification.text('You are now an admin! Go to the Hall of Heroes to change your contributor level.');
       // @TODO: sync()

--- a/website/client/components/auth/registerLoginReset.vue
+++ b/website/client/components/auth/registerLoginReset.vue
@@ -370,7 +370,7 @@ export default {
       }
 
       // @TODO: implement langauge and invite accepting
-      // var url = ApiUrl.get() + "/api/v3/user/auth/local/register";
+      // var url = ApiUrl.get() + "/api/v4/user/auth/local/register";
       // if (location.search && location.search.indexOf('Invite=') !== -1) { // matches groupInvite and partyInvite
       //   url += location.search;
       // }
@@ -481,7 +481,7 @@ export default {
         return;
       }
 
-      await axios.post('/api/v3/user/reset-password', {
+      await axios.post('/api/v4/user/reset-password', {
         email: this.username,
       });
 
@@ -499,7 +499,7 @@ export default {
         return;
       }
 
-      const res = await axios.post('/api/v3/user/auth/reset-password-set-new-one', {
+      const res = await axios.post('/api/v4/user/auth/reset-password-set-new-one', {
         newPassword: this.password,
         confirmPassword: this.passwordConfirm,
         code: this.resetPasswordSetNewOneData.code,

--- a/website/client/components/challenges/challengeDetail.vue
+++ b/website/client/components/challenges/challengeDetail.vue
@@ -381,7 +381,7 @@ export default {
       // let response = await this.$store.dispatch('challenges:exportChallengeCsv', {
       //   challengeId: this.searchId,
       // });
-      window.location = `/api/v3/challenges/${this.searchId}/export/csv`;
+      window.location = `/api/v4/challenges/${this.searchId}/export/csv`;
     },
     cloneChallenge () {
       this.$root.$emit('habitica:clone-challenge', {

--- a/website/client/components/challenges/challengeMemberProgressModal.vue
+++ b/website/client/components/challenges/challengeMemberProgressModal.vue
@@ -38,7 +38,7 @@ export default {
         reward: [],
       };
 
-      let response = await axios.get(`/api/v3/challenges/${this.challengeId}/members/${this.memberId}`);
+      let response = await axios.get(`/api/v4/challenges/${this.challengeId}/members/${this.memberId}`);
       let tasks = response.data.data.tasks;
       tasks.forEach((task) => {
         this.tasksByType[task.type].push(task);

--- a/website/client/components/chat/chatCard.vue
+++ b/website/client/components/chat/chatCard.vue
@@ -253,7 +253,7 @@ export default {
       this.$emit('message-removed', message);
 
       if (this.inbox) {
-        axios.delete(`/api/v3/user/messages/${message.id}`);
+        axios.delete(`/api/v4/user/messages/${message.id}`);
         this.$delete(this.user.inbox.messages, message.id);
         return;
       }

--- a/website/client/components/chat/chatMessages.vue
+++ b/website/client/components/chat/chatMessages.vue
@@ -164,7 +164,7 @@ export default {
         if (Boolean(uuid) && !this.cachedProfileData[uuid] && !aboutToCache[uuid]) {
           if (uuid === 'system' || this.currentProfileLoadedCount === this.currentProfileLoadedEnd) return;
           aboutToCache[uuid] = {};
-          promises.push(axios.get(`/api/v3/members/${uuid}`));
+          promises.push(axios.get(`/api/v4/members/${uuid}`));
           this.currentProfileLoadedCount += 1;
         }
       });

--- a/website/client/components/creatorIntro.vue
+++ b/website/client/components/creatorIntro.vue
@@ -1441,7 +1441,7 @@ export default {
       });
 
       // @TODO: Move to the action
-      let response = await axios.post('/api/v3/tasks/user', tasksToCreate);
+      let response = await axios.post('/api/v4/tasks/user', tasksToCreate);
       let tasks = response.data.data;
       tasks.forEach(task => {
         this.$store.state.user.data.tasksOrder[`${task.type}s`].unshift(task._id);
@@ -1512,7 +1512,7 @@ export default {
         }
       }
 
-      await axios.post(`/api/v3/user/unlock?path=${path}`);
+      await axios.post(`/api/v4/user/unlock?path=${path}`);
       try {
         unlock(this.user, {
           query: {

--- a/website/client/components/header/userDropdown.vue
+++ b/website/client/components/header/userDropdown.vue
@@ -98,7 +98,7 @@ export default {
     },
     showInbox () {
       markPMSRead(this.user);
-      axios.post('/api/v3/user/mark-pms-read');
+      axios.post('/api/v4/user/mark-pms-read');
       this.$root.$emit('bv::show::modal', 'inbox-modal');
     },
     showProfile (startingPage) {

--- a/website/client/components/inventory/items/cards-modal.vue
+++ b/website/client/components/inventory/items/cards-modal.vue
@@ -54,7 +54,7 @@ export default {
   },
   methods: {
     async readCard () {
-      await axios.post(`/api/v3/user/read-card/${this.cardType}`);
+      await axios.post(`/api/v4/user/read-card/${this.cardType}`);
       this.user.items.special[`${this.cardType}Received`].shift();
       this.user.flags.cardReceived = false;
       this.close();

--- a/website/client/components/modifyInventory.vue
+++ b/website/client/components/modifyInventory.vue
@@ -294,7 +294,7 @@ export default {
       }
     },
     async modifyInventory  () {
-      await axios.post('/api/v3/debug/modify-inventory', {
+      await axios.post('/api/v4/debug/modify-inventory', {
         gear: this.showInv.gear ? this.inv.gear : null,
         special: this.showInv.special ? this.inv.special : null,
         pets: this.showInv.pets ? this.inv.pets : null,

--- a/website/client/components/notifications.vue
+++ b/website/client/components/notifications.vue
@@ -399,7 +399,7 @@ export default {
     },
     async runYesterDailiesAction () {
       // Run Cron
-      await axios.post('/api/v3/cron');
+      await axios.post('/api/v4/cron');
 
       // Notifications
 
@@ -532,7 +532,7 @@ export default {
       let userReadNotifsPromise = false;
 
       if (notificationsToRead.length > 0) {
-        await axios.post('/api/v3/notifications/read', {
+        await axios.post('/api/v4/notifications/read', {
           notificationIds: notificationsToRead,
         });
       }

--- a/website/client/components/payments/amazonModal.vue
+++ b/website/client/components/payments/amazonModal.vue
@@ -206,7 +206,7 @@ export default {
         let url = '/amazon/subscribe';
 
         if (this.amazonPayments.groupToCreate) {
-          url = '/api/v3/groups/create-plan';
+          url = '/api/v4/groups/create-plan';
         }
 
         try {

--- a/website/client/components/settings/deleteModal.vue
+++ b/website/client/components/settings/deleteModal.vue
@@ -47,7 +47,7 @@ export default {
       this.$root.$emit('bv::hide::modal', 'reset');
     },
     async deleteAccount () {
-      await axios.delete('/api/v3/user', {
+      await axios.delete('/api/v4/user', {
         data: {
           password: this.password,
           feedback: this.feedback,

--- a/website/client/components/settings/promoCode.vue
+++ b/website/client/components/settings/promoCode.vue
@@ -40,7 +40,7 @@ export default {
     ...mapState({user: 'user.data', credentials: 'credentials'}),
     getCodesUrl () {
       if (!this.user) return '';
-      return `/api/v3/coupons?_id=${this.user._id}&apiToken=${this.credentials.API_TOKEN}`;
+      return `/api/v4/coupons?_id=${this.user._id}&apiToken=${this.credentials.API_TOKEN}`;
     },
   },
   methods: {
@@ -53,7 +53,7 @@ export default {
       //   })
     },
     async enterCoupon () {
-      let code = await axios.post(`/api/v3/coupons/enter/${this.couponCode}`);
+      let code = await axios.post(`/api/v4/coupons/enter/${this.couponCode}`);
       if (!code) return;
 
       this.$store.state.user.data = code.data.data;

--- a/website/client/components/settings/resetModal.vue
+++ b/website/client/components/settings/resetModal.vue
@@ -20,7 +20,7 @@ export default {
       this.$root.$emit('bv::hide::modal', 'reset');
     },
     async reset () {
-      let response = await axios.post('/api/v3/user/reset');
+      let response = await axios.post('/api/v4/user/reset');
       // @TODO: Not sure if this is correct
       this.$store.user = response.data.data.user;
       this.$router.push('/');

--- a/website/client/components/settings/site.vue
+++ b/website/client/components/settings/site.vue
@@ -335,7 +335,7 @@ export default {
     },
     async saveDayStart () {
       this.user.preferences.dayStart = this.newDayStart;
-      await axios.post('/api/v3/user/custom-day-start', {
+      await axios.post('/api/v4/user/custom-day-start', {
         dayStart: this.newDayStart,
       });
       // @TODO
@@ -348,7 +348,7 @@ export default {
       setTimeout(() => window.location.reload(true));
     },
     async changeUser (attribute, updates) {
-      await axios.put(`/api/v3/user/auth/update-${attribute}`, updates);
+      await axios.put(`/api/v4/user/auth/update-${attribute}`, updates);
       alert(this.$t(`${attribute}Success`));
       this.user[attribute] = updates[attribute];
     },
@@ -362,7 +362,7 @@ export default {
       this.$root.$emit('bv::show::modal', 'delete');
     },
     async deleteSocialAuth (network) {
-      await axios.delete(`/api/v3/user/auth/social/${network.key}`);
+      await axios.delete(`/api/v4/user/auth/social/${network.key}`);
       this.text(this.$t('detachedSocial', {network: network.name}));
     },
     async socialAuth (network) {
@@ -378,13 +378,13 @@ export default {
       if (confirmationNeeded && !confirm(this.$t('changeClassConfirmCost'))) return;
       try {
         changeClass(this.user);
-        await axios.post('/api/v3/user/change-class');
+        await axios.post('/api/v4/user/change-class');
       } catch (e) {
         alert(e.message);
       }
     },
     addLocalAuth () {
-      axios.post('/api/v3/user/auth/local/register', this.localAuth, 'addedLocalAuth');
+      axios.post('/api/v4/user/auth/local/register', this.localAuth, 'addedLocalAuth');
     },
   },
 };

--- a/website/client/components/settings/subscription.vue
+++ b/website/client/components/settings/subscription.vue
@@ -248,7 +248,7 @@ export default {
       });
     },
     async applyCoupon (coupon) {
-      const response = await axios.post(`/api/v3/coupons/validate/${coupon}`);
+      const response = await axios.post(`/api/v4/coupons/validate/${coupon}`);
 
       if (!response.data.data.valid) return;
 

--- a/website/client/components/static/newStuff.vue
+++ b/website/client/components/static/newStuff.vue
@@ -16,7 +16,7 @@ export default {
     };
   },
   async mounted () {
-    let response = await axios.get('/api/v3/news');
+    let response = await axios.get('/api/v4/news');
     this.html = response.data.html;
   },
 };

--- a/website/client/components/tasks/task.vue
+++ b/website/client/components/tasks/task.vue
@@ -718,7 +718,7 @@ export default {
       if (task.group.approval.required) task.group.approval.requested = true;
 
       Analytics.updateUser();
-      const response = await axios.post(`/api/v3/tasks/${task._id}/score/${direction}`);
+      const response = await axios.post(`/api/v4/tasks/${task._id}/score/${direction}`);
       const tmp = response.data.data._tmp || {}; // used to notify drops, critical hits and other bonuses
       const crit = tmp.crit;
       const drop = tmp.drop;

--- a/website/client/components/userMenu/profile.vue
+++ b/website/client/components/userMenu/profile.vue
@@ -507,12 +507,12 @@ export default {
     },
     blockUser () {
       this.userLoggedIn.inbox.blocks.push(this.user._id);
-      axios.post(`/api/v3/user/block/${this.user._id}`);
+      axios.post(`/api/v4/user/block/${this.user._id}`);
     },
     unblockUser () {
       let index = this.userLoggedIn.inbox.blocks.indexOf(this.user._id);
       this.userLoggedIn.inbox.blocks.splice(index, 1);
-      axios.post(`/api/v3/user/block/${this.user._id}`);
+      axios.post(`/api/v4/user/block/${this.user._id}`);
     },
     openSendGemsModal () {
       this.userReceivingGems = this.user;

--- a/website/client/components/userMenu/profileStats.vue
+++ b/website/client/components/userMenu/profileStats.vue
@@ -305,7 +305,7 @@
           if (this.statUpdates[stat] > 0) statUpdates[stat] = this.statUpdates[stat];
         });
 
-        await axios.post('/api/v3/user/allocate-bulk', {
+        await axios.post('/api/v4/user/allocate-bulk', {
           stats: statUpdates,
         });
 

--- a/website/client/index.html
+++ b/website/client/index.html
@@ -24,6 +24,6 @@
 
     <script type="text/javascript" src="//cloudfront.loggly.com/js/loggly.tracker-latest.min.js" async></script>
     <!-- Translations -->
-    <script type='text/javascript' src='/api/v3/i18n/browser-script'></script>
+    <script type='text/javascript' src='/api/v4/i18n/browser-script'></script>
   </body>
 </html>

--- a/website/client/mixins/payments.js
+++ b/website/client/mixins/payments.js
@@ -73,7 +73,7 @@ export default {
           let url = '/stripe/checkout?a=a'; // just so I can concat &x=x below
 
           if (data.groupToCreate) {
-            url = '/api/v3/groups/create-plan?a=a';
+            url = '/api/v4/groups/create-plan?a=a';
             res.groupToCreate = data.groupToCreate;
             res.paymentType = 'Stripe';
           }

--- a/website/client/store/actions/auth.js
+++ b/website/client/store/actions/auth.js
@@ -4,7 +4,7 @@ const LOCALSTORAGE_AUTH_KEY = 'habit-mobile-settings';
 const LOCALSTORAGE_SOCIAL_AUTH_KEY = 'hello'; // Used by hello.js for social auth
 
 export async function register (store, params) {
-  let url = '/api/v3/user/auth/local/register';
+  let url = '/api/v4/user/auth/local/register';
 
   if (params.groupInvite) url += `?groupInvite=${params.groupInvite}`;
 
@@ -27,7 +27,7 @@ export async function register (store, params) {
 }
 
 export async function login (store, params) {
-  let url = '/api/v3/user/auth/local/login';
+  let url = '/api/v4/user/auth/local/login';
   let result = await axios.post(url, {
     username: params.username,
     // email: params.email,
@@ -47,7 +47,7 @@ export async function login (store, params) {
 }
 
 export async function socialAuth (store, params) {
-  let url = '/api/v3/user/auth/social';
+  let url = '/api/v4/user/auth/social';
   let result = await axios.post(url, {
     network: params.auth.network,
     authResponse: params.auth.authResponse,

--- a/website/client/store/actions/challenges.js
+++ b/website/client/store/actions/challenges.js
@@ -3,27 +3,27 @@ import omit from 'lodash/omit';
 import encodeParams from 'client/libs/encodeParams';
 
 export async function createChallenge (store, payload) {
-  let response = await axios.post('/api/v3/challenges', payload.challenge);
+  let response = await axios.post('/api/v4/challenges', payload.challenge);
   let newChallenge = response.data.data;
 
   return newChallenge;
 }
 
 export async function cloneChallenge (store, payload) {
-  const response = await axios.post(`/api/v3/challenges/${payload.cloningChallengeId}/clone`, payload.challenge);
+  const response = await axios.post(`/api/v4/challenges/${payload.cloningChallengeId}/clone`, payload.challenge);
   const newChallenge = response.data.data.clonedChallenge;
 
   return newChallenge;
 }
 
 export async function joinChallenge (store, payload) {
-  let response = await axios.post(`/api/v3/challenges/${payload.challengeId}/join`);
+  let response = await axios.post(`/api/v4/challenges/${payload.challengeId}/join`);
 
   return response.data.data;
 }
 
 export async function leaveChallenge (store, payload) {
-  let url = `/api/v3/challenges/${payload.challengeId}/leave`;
+  let url = `/api/v4/challenges/${payload.challengeId}/leave`;
   let response = await axios.post(url, {
     keep: payload.keep,
   });
@@ -32,7 +32,7 @@ export async function leaveChallenge (store, payload) {
 }
 
 export async function getUserChallenges (store, payload) {
-  let url = '/api/v3/challenges/user';
+  let url = '/api/v4/challenges/user';
   let {
     member,
     page,
@@ -55,19 +55,19 @@ export async function getUserChallenges (store, payload) {
 }
 
 export async function getGroupChallenges (store, payload) {
-  let response = await axios.get(`/api/v3/challenges/groups/${payload.groupId}`);
+  let response = await axios.get(`/api/v4/challenges/groups/${payload.groupId}`);
 
   return response.data.data;
 }
 
 export async function getChallenge (store, payload) {
-  let response = await axios.get(`/api/v3/challenges/${payload.challengeId}`);
+  let response = await axios.get(`/api/v4/challenges/${payload.challengeId}`);
 
   return response.data.data;
 }
 
 export async function exportChallengeCsv (store, payload) {
-  let response = await axios.get(`/api/v3/challenges/${payload.challengeId}/export/csv`);
+  let response = await axios.get(`/api/v4/challenges/${payload.challengeId}/export/csv`);
 
   return response.data.data;
 }
@@ -78,19 +78,19 @@ export async function updateChallenge (store, payload) {
 
   if (challengeDataToSend.leader && challengeDataToSend.leader._id) challengeDataToSend.leader = challengeDataToSend.leader._id;
 
-  let response = await axios.put(`/api/v3/challenges/${payload.challenge._id}`, challengeDataToSend);
+  let response = await axios.put(`/api/v4/challenges/${payload.challenge._id}`, challengeDataToSend);
 
   return response.data.data;
 }
 
 export async function deleteChallenge (store, payload) {
-  let response = await axios.delete(`/api/v3/challenges/${payload.challengeId}`);
+  let response = await axios.delete(`/api/v4/challenges/${payload.challengeId}`);
 
   return response.data.data;
 }
 
 export async function selectChallengeWinner (store, payload) {
-  let response = await axios.post(`/api/v3/challenges/${payload.challengeId}/selectWinner/${payload.winnerId}`);
+  let response = await axios.post(`/api/v4/challenges/${payload.challengeId}/selectWinner/${payload.winnerId}`);
 
   return response.data.data;
 }

--- a/website/client/store/actions/chat.js
+++ b/website/client/store/actions/chat.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 import * as Analytics from 'client/libs/analytics';
 
 export async function getChat (store, payload) {
-  let response = await axios.get(`/api/v3/groups/${payload.groupId}/chat`);
+  let response = await axios.get(`/api/v4/groups/${payload.groupId}/chat`);
 
   return response.data.data;
 }
@@ -10,7 +10,7 @@ export async function getChat (store, payload) {
 export async function postChat (store, payload) {
   const group = payload.group;
 
-  let url = `/api/v3/groups/${group._id}/chat`;
+  let url = `/api/v4/groups/${group._id}/chat`;
 
   if (payload.previousMsg) {
     url += `?previousMsg=${payload.previousMsg}`;
@@ -52,7 +52,7 @@ export async function postChat (store, payload) {
 }
 
 export async function deleteChat (store, payload) {
-  let url = `/api/v3/groups/${payload.groupId}/chat/${payload.chatId}`;
+  let url = `/api/v4/groups/${payload.groupId}/chat/${payload.chatId}`;
 
   if (payload.previousMsg) {
     url += `?previousMsg=${payload.previousMsg}`;
@@ -63,13 +63,13 @@ export async function deleteChat (store, payload) {
 }
 
 export async function like (store, payload) {
-  let url = `/api/v3/groups/${payload.groupId}/chat/${payload.chatId}/like`;
+  let url = `/api/v4/groups/${payload.groupId}/chat/${payload.chatId}/like`;
   let response = await axios.post(url);
   return response.data.data;
 }
 
 export async function flag (store, payload) {
-  const url = `/api/v3/groups/${payload.groupId}/chat/${payload.chatId}/flag`;
+  const url = `/api/v4/groups/${payload.groupId}/chat/${payload.chatId}/flag`;
   const response = await axios.post(url, {
     comment: payload.comment,
   });
@@ -77,14 +77,14 @@ export async function flag (store, payload) {
 }
 
 export async function clearFlagCount (store, payload) {
-  let url = `/api/v3/groups/${payload.groupId}/chat/${payload.chatId}/clearflags`;
+  let url = `/api/v4/groups/${payload.groupId}/chat/${payload.chatId}/clearflags`;
   let response = await axios.post(url);
   return response.data.data;
 }
 
 export async function markChatSeen (store, payload) {
   if (store.state.user.newMessages) delete store.state.user.newMessages[payload.groupId];
-  let url = `/api/v3/groups/${payload.groupId}/chat/seen`;
+  let url = `/api/v4/groups/${payload.groupId}/chat/seen`;
   let response = await axios.post(url);
   return response.data.data;
 }

--- a/website/client/store/actions/common.js
+++ b/website/client/store/actions/common.js
@@ -7,7 +7,7 @@ export function equip (store, params) {
   const user = store.state.user.data;
   equipOp(user, {params});
   axios
-    .post(`/api/v3/user/equip/${params.type}/${params.key}`);
+    .post(`/api/v4/user/equip/${params.type}/${params.key}`);
   // TODO
   // .then((res) => console.log('equip', res))
   // .catch((err) => console.error('equip', err));
@@ -17,7 +17,7 @@ export function hatch (store, params) {
   const user = store.state.user.data;
   hatchOp(user, {params});
   axios
-    .post(`/api/v3/user/hatch/${params.egg}/${params.hatchingPotion}`);
+    .post(`/api/v4/user/hatch/${params.egg}/${params.hatchingPotion}`);
   // TODO
   // .then((res) => console.log('equip', res))
   // .catch((err) => console.error('equip', err));
@@ -27,6 +27,6 @@ export async function feed (store, params) {
   const user = store.state.user.data;
   feedOp(user, {params});
   const response = await axios
-    .post(`/api/v3/user/feed/${params.pet}/${params.food}`);
+    .post(`/api/v4/user/feed/${params.pet}/${params.food}`);
   return response.data;
 }

--- a/website/client/store/actions/guilds.js
+++ b/website/client/store/actions/guilds.js
@@ -17,7 +17,7 @@ export async function getPublicGuilds (store, payload) {
   if (payload.member) params.member = payload.member;
   if (payload.search) params.search = payload.search;
 
-  let response = await axios.get('/api/v3/groups', {
+  let response = await axios.get('/api/v4/groups', {
     params,
   });
 
@@ -29,7 +29,7 @@ export async function getMyGuilds (store) {
     type: 'guilds',
   };
 
-  let response = await axios.get('/api/v3/groups', { params });
+  let response = await axios.get('/api/v4/groups', { params });
 
   let guilds = response.data.data;
   store.state.myGuilds = guilds;
@@ -38,7 +38,7 @@ export async function getMyGuilds (store) {
 }
 
 export async function getGroup (store, payload) {
-  let response = await axios.get(`/api/v3/groups/${payload.groupId}`);
+  let response = await axios.get(`/api/v4/groups/${payload.groupId}`);
   // @TODO: should we store the active group for modifying?
   // let guilds = response.data.data;
   // store.state.myGuilds = guilds;
@@ -57,7 +57,7 @@ export async function join (store, payload) {
 
   let response;
   try {
-    response = await axios.post(`/api/v3/groups/${groupId}/join`);
+    response = await axios.post(`/api/v4/groups/${groupId}/join`);
   } catch (err) {
     alert(err.response.data.message);
     return;
@@ -87,7 +87,7 @@ export async function leave (store, payload) {
     keep: payload.keep,
     keepChallenges: payload.keepChallenges,
   };
-  let response = await axios.post(`/api/v3/groups/${payload.groupId}/leave`, data);
+  let response = await axios.post(`/api/v4/groups/${payload.groupId}/leave`, data);
 
   // @TODO: update for party
   let index = store.state.user.data.guilds.indexOf(payload.groupId);
@@ -107,7 +107,7 @@ export async function leave (store, payload) {
 }
 
 export async function create (store, payload) {
-  let response = await axios.post('/api/v3/groups/', payload.group);
+  let response = await axios.post('/api/v4/groups/', payload.group);
   let newGroup = response.data.data;
 
   if (newGroup.leader._id === store.state.user.data._id || newGroup.privacy === 'private') {
@@ -124,7 +124,7 @@ export async function update (store, payload) {
   let groupDetailsToSend = omit(payload.group, ['chat', 'challenges', 'members', 'invites']);
   if (groupDetailsToSend.leader && groupDetailsToSend.leader._id) groupDetailsToSend.leader = groupDetailsToSend.leader._id;
 
-  let response = await axios.put(`/api/v3/groups/${payload.group.id}`, groupDetailsToSend);
+  let response = await axios.put(`/api/v4/groups/${payload.group.id}`, groupDetailsToSend);
 
   let updatedGroup = response.data.data;
 
@@ -137,7 +137,7 @@ export async function rejectInvite (store, payload) {
   const user = store.state.user.data;
   const invitations = user.invitations;
 
-  let response = await axios.post(`/api/v3/groups/${groupId}/reject-invite`);
+  let response = await axios.post(`/api/v4/groups/${groupId}/reject-invite`);
 
   if (type === 'guild') {
     const invitationI = invitations.guilds.findIndex(i => i.id === groupId);
@@ -151,7 +151,7 @@ export async function rejectInvite (store, payload) {
 }
 
 export async function removeMember (store, payload) {
-  let response = await axios.post(`/api/v3/groups/${payload.groupId}/removeMember/${payload.memberId}`, {
+  let response = await axios.post(`/api/v4/groups/${payload.groupId}/removeMember/${payload.memberId}`, {
     message: payload.message,
   });
 
@@ -161,7 +161,7 @@ export async function removeMember (store, payload) {
 }
 
 export async function invite (store, payload) {
-  let response = await axios.post(`/api/v3/groups/${payload.groupId}/invite`, {
+  let response = await axios.post(`/api/v4/groups/${payload.groupId}/invite`, {
     uuids: payload.invitationDetails.uuids,
     emails: payload.invitationDetails.emails,
   });
@@ -172,7 +172,7 @@ export async function invite (store, payload) {
 }
 
 export async function inviteToQuest (store, payload) {
-  let response = await axios.post(`/api/v3/groups/${payload.groupId}/quests/invite/${payload.key}`);
+  let response = await axios.post(`/api/v4/groups/${payload.groupId}/quests/invite/${payload.key}`);
 
   // @TODO: Any updates?
 
@@ -180,7 +180,7 @@ export async function inviteToQuest (store, payload) {
 }
 
 export async function addManager (store, payload) {
-  let response = await axios.post(`/api/v3/groups/${payload.groupId}/add-manager/`, {
+  let response = await axios.post(`/api/v4/groups/${payload.groupId}/add-manager/`, {
     managerId: payload.memberId,
   });
 
@@ -190,7 +190,7 @@ export async function addManager (store, payload) {
 }
 
 export async function removeManager  (store, payload) {
-  let response = await axios.post(`/api/v3/groups/${payload.groupId}/remove-manager/`, {
+  let response = await axios.post(`/api/v4/groups/${payload.groupId}/remove-manager/`, {
     managerId: payload.memberId,
   });
 
@@ -200,6 +200,6 @@ export async function removeManager  (store, payload) {
 }
 
 export async function getGroupPlans () {
-  let response = await axios.get('/api/v3/group-plans');
+  let response = await axios.get('/api/v4/group-plans');
   return response.data.data;
 }

--- a/website/client/store/actions/hall.js
+++ b/website/client/store/actions/hall.js
@@ -1,19 +1,19 @@
 import axios from 'axios';
 
 export async function getHeroes  () {
-  let url = '/api/v3/hall/heroes';
+  let url = '/api/v4/hall/heroes';
   let response = await axios.get(url);
   return response.data.data;
 }
 
 export async function getHero  (store, payload) {
-  let url = `/api/v3/hall/heroes/${payload.uuid}`;
+  let url = `/api/v4/hall/heroes/${payload.uuid}`;
   let response = await axios.get(url);
   return response.data.data;
 }
 
 export async function updateHero  (store, payload) {
-  let url = `/api/v3/hall/heroes/${payload.heroDetails._id}`;
+  let url = `/api/v4/hall/heroes/${payload.heroDetails._id}`;
   let response = await axios.put(url, payload.heroDetails);
   return response.data.data;
 }
@@ -22,7 +22,7 @@ export async function getPatrons (store, payload) {
   let page = 0;
   if (payload.page) page = payload.page;
 
-  let url = `/api/v3/hall/patrons/?page=${page}`;
+  let url = `/api/v4/hall/patrons/?page=${page}`;
   let response = await axios.get(url);
   return response.data.data;
 }

--- a/website/client/store/actions/members.js
+++ b/website/client/store/actions/members.js
@@ -2,10 +2,10 @@ import axios from 'axios';
 // import omit from 'lodash/omit';
 // import findIndex from 'lodash/findIndex';
 
-let apiV3Prefix = '/api/v3';
+let apiv4Prefix = '/api/v4';
 
 export async function getGroupMembers (store, payload) {
-  let url = `${apiV3Prefix}/groups/${payload.groupId}/members`;
+  let url = `${apiv4Prefix}/groups/${payload.groupId}/members`;
 
   const params = {};
 
@@ -26,13 +26,13 @@ export async function getGroupMembers (store, payload) {
 }
 
 export async function fetchMember (store, payload) {
-  let url = `${apiV3Prefix}/members/${payload.memberId}`;
+  let url = `${apiv4Prefix}/members/${payload.memberId}`;
   let response = await axios.get(url);
   return response;
 }
 
 export async function getGroupInvites (store, payload) {
-  let url = `${apiV3Prefix}/groups/${payload.groupId}/invites`;
+  let url = `${apiv4Prefix}/groups/${payload.groupId}/invites`;
   if (payload.includeAllPublicFields) {
     url += '?includeAllPublicFields=true';
   }
@@ -41,7 +41,7 @@ export async function getGroupInvites (store, payload) {
 }
 
 export async function getChallengeMembers (store, payload) {
-  let url = `${apiV3Prefix}/challenges/${payload.challengeId}/members`;
+  let url = `${apiv4Prefix}/challenges/${payload.challengeId}/members`;
 
   const params = {};
 
@@ -62,13 +62,13 @@ export async function getChallengeMembers (store, payload) {
 }
 
 export async function getChallengeMemberProgress (store, payload) {
-  let url = `${apiV3Prefix}/challenges/${payload.challengeId}/members/${payload.memberId}`;
+  let url = `${apiv4Prefix}/challenges/${payload.challengeId}/members/${payload.memberId}`;
   let response = await axios.get(url);
   return response;
 }
 
 export async function sendPrivateMessage (store, payload) {
-  let url = `${apiV3Prefix}/members/send-private-message`;
+  let url = `${apiv4Prefix}/members/send-private-message`;
   let data = {
     message: payload.message,
     toUserId: payload.toUserId,
@@ -78,7 +78,7 @@ export async function sendPrivateMessage (store, payload) {
 }
 
 export async function transferGems (store, payload) {
-  let url = `${apiV3Prefix}/members/transfer-gems`;
+  let url = `${apiv4Prefix}/members/transfer-gems`;
   let data = {
     message: payload.message,
     toUserId: payload.toUserId,
@@ -90,7 +90,7 @@ export async function transferGems (store, payload) {
 }
 
 export async function removeMember (store, payload) {
-  let url = `${apiV3Prefix}/groups/${payload.groupId}/removeMember/${payload.memberId}`;
+  let url = `${apiv4Prefix}/groups/${payload.groupId}/removeMember/${payload.memberId}`;
   let data = {
     message: payload.message,
   };

--- a/website/client/store/actions/notifications.js
+++ b/website/client/store/actions/notifications.js
@@ -1,13 +1,13 @@
 import axios from 'axios';
 
 export async function readNotification (store, payload) {
-  let url = `/api/v3/notifications/${payload.notificationId}/read`;
+  let url = `/api/v4/notifications/${payload.notificationId}/read`;
   let response = await axios.post(url);
   return response.data.data;
 }
 
 export async function readNotifications (store, payload) {
-  let url = '/api/v3/notifications/read';
+  let url = '/api/v4/notifications/read';
   let response = await axios.post(url, {
     notificationIds: payload.notificationIds,
   });
@@ -15,13 +15,13 @@ export async function readNotifications (store, payload) {
 }
 
 export async function seeNotification (store, payload) {
-  let url = `/api/v3/notifications/${payload.notificationId}/see`;
+  let url = `/api/v4/notifications/${payload.notificationId}/see`;
   let response = await axios.post(url);
   return response.data.data;
 }
 
 export async function seeNotifications (store, payload) {
-  let url = '/api/v3/notifications/see';
+  let url = '/api/v4/notifications/see';
   let response = await axios.post(url, {
     notificationIds: payload.notificationIds,
   });

--- a/website/client/store/actions/party.js
+++ b/website/client/store/actions/party.js
@@ -4,7 +4,7 @@ export function getMembers (store, forceLoad = false) {
   return loadAsyncResource({
     store,
     path: 'partyMembers',
-    url: '/api/v3/groups/party/members?includeAllPublicFields=true',
+    url: '/api/v4/groups/party/members?includeAllPublicFields=true',
     deserialize (response) {
       return response.data.data;
     },
@@ -16,7 +16,7 @@ export function getParty (store, forceLoad = false) {
   return loadAsyncResource({
     store,
     path: 'party',
-    url: '/api/v3/groups/party',
+    url: '/api/v4/groups/party',
     deserialize (response) {
       return response.data.data;
     },

--- a/website/client/store/actions/quests.js
+++ b/website/client/store/actions/quests.js
@@ -20,7 +20,7 @@ export async function sendAction (store, payload) {
 
   Analytics.updateUser(partyData);
 
-  let response = await axios.post(`/api/v3/groups/${payload.groupId}/${payload.action}`);
+  let response = await axios.post(`/api/v4/groups/${payload.groupId}/${payload.action}`);
 
   // @TODO: Update user?
   //  User.sync();

--- a/website/client/store/actions/shops.js
+++ b/website/client/store/actions/shops.js
@@ -25,7 +25,7 @@ function buyItem (store, params) {
 
   return {
     result: opResult,
-    httpCall: axios.post(`/api/v3/user/buy/${params.key}`),
+    httpCall: axios.post(`/api/v4/user/buy/${params.key}`),
   };
 }
 
@@ -40,7 +40,7 @@ export function buyQuestItem (store, params) {
 
   return {
     result: opResult,
-    httpCall: axios.post(`/api/v3/user/buy/${params.key}`, {type: 'quest', quantity}),
+    httpCall: axios.post(`/api/v4/user/buy/${params.key}`, {type: 'quest', quantity}),
   };
 }
 
@@ -49,7 +49,7 @@ async function buyArmoire (store, params) {
   let armoire = content.armoire;
 
   // We need the server result because Armoire has random item in the result
-  let result = await axios.post('/api/v3/user/buy/armoire', {
+  let result = await axios.post('/api/v4/user/buy/armoire', {
     type: 'armoire',
     quantity,
   });
@@ -94,7 +94,7 @@ export function purchase (store, params) {
 
   return {
     result: opResult,
-    httpCall: axios.post(`/api/v3/user/purchase/${params.type}/${params.key}`, {quantity}),
+    httpCall: axios.post(`/api/v4/user/purchase/${params.type}/${params.key}`, {quantity}),
   };
 }
 
@@ -104,7 +104,7 @@ export function purchaseMysterySet (store, params) {
 
   return {
     result: opResult,
-    httpCall: axios.post(`/api/v3/user/buy/${params.key}`, {type: 'mystery'}),
+    httpCall: axios.post(`/api/v4/user/buy/${params.key}`, {type: 'mystery'}),
   };
 }
 
@@ -114,7 +114,7 @@ export function purchaseHourglassItem (store, params) {
 
   return {
     result: opResult,
-    httpCall: axios.post(`/api/v3/user/purchase-hourglass/${params.type}/${params.key}`),
+    httpCall: axios.post(`/api/v4/user/purchase-hourglass/${params.type}/${params.key}`),
   };
 }
 
@@ -124,7 +124,7 @@ export function unlock (store, params) {
 
   return {
     result: opResult,
-    httpCall: axios.post(`/api/v3/user/unlock?path=${params.query.path}`),
+    httpCall: axios.post(`/api/v4/user/unlock?path=${params.query.path}`),
   };
 }
 
@@ -138,7 +138,7 @@ export async function genericPurchase (store, params) {
     case 'fortify': {
       let rerollResult = rerollOp(store.state.user.data, store.state.tasks.data);
 
-      await axios.post('/api/v3/user/reroll');
+      await axios.post('/api/v4/user/reroll');
       await Promise.all([
         store.dispatch('user:fetch', {forceLoad: true}),
         store.dispatch('tasks:fetchUserTasks', {forceLoad: true}),
@@ -173,20 +173,20 @@ export async function genericPurchase (store, params) {
 export function sellItems (store, params) {
   const user = store.state.user.data;
   sellOp(user, {params, query: {amount: params.amount}});
-  axios.post(`/api/v3/user/sell/${params.type}/${params.key}?amount=${params.amount}`);
+  axios.post(`/api/v4/user/sell/${params.type}/${params.key}?amount=${params.amount}`);
 }
 
 export function releasePets (store, params) {
   releasePetsOp(params.user);
-  axios.post('/api/v3/user/release-pets');
+  axios.post('/api/v4/user/release-pets');
 }
 
 export function releaseMounts (store, params) {
   releaseMountsOp(params.user);
-  axios.post('/api/v3/user/release-mounts');
+  axios.post('/api/v4/user/release-mounts');
 }
 
 export function releaseBoth (store, params) {
   releaseBothOp(params.user);
-  axios.post('/api/v3/user/release-both');
+  axios.post('/api/v4/user/release-both');
 }

--- a/website/client/store/actions/tags.js
+++ b/website/client/store/actions/tags.js
@@ -1,13 +1,13 @@
 import axios from 'axios';
 
 export async function getTags () {
-  let url = 'api/v3/tags';
+  let url = 'api/v4/tags';
   let response = await axios.get(url);
   return response.data.data;
 }
 
 export async function createTag (store, payload) {
-  let url = 'api/v3/tags';
+  let url = 'api/v4/tags';
   let response = await axios.post(url, {
     tagDetails: payload.tagDetails,
   });
@@ -15,13 +15,13 @@ export async function createTag (store, payload) {
 }
 
 export async function getTag  (store, payload) {
-  let url = `api/v3/tags/${payload.tagId}`;
+  let url = `api/v4/tags/${payload.tagId}`;
   let response = await axios.get(url);
   return response.data.data;
 }
 
 export async function updateTag (store, payload) {
-  let url = `api/v3/tags/${payload.tagId}`;
+  let url = `api/v4/tags/${payload.tagId}`;
   let response = await axios.put(url, {
     tagDetails: payload.tagDetails,
   });
@@ -29,7 +29,7 @@ export async function updateTag (store, payload) {
 }
 
 export async function sortTag  (store, payload) {
-  let url = 'api/v3/reorder-tags';
+  let url = 'api/v4/reorder-tags';
   let response = await axios.post(url, {
     tagDetails: payload.tagDetails,
     to: payload.to,
@@ -38,7 +38,7 @@ export async function sortTag  (store, payload) {
 }
 
 export async function deleteTag  (store, payload) {
-  let url = `api/v3/tags/${payload.tagId}`;
+  let url = `api/v4/tags/${payload.tagId}`;
   let response = await axios.delete(url);
   return response.data.data;
 }

--- a/website/client/store/actions/tasks.js
+++ b/website/client/store/actions/tasks.js
@@ -7,7 +7,7 @@ export function fetchUserTasks (store, options = {}) {
   return loadAsyncResource({
     store,
     path: 'tasks',
-    url: '/api/v3/tasks/user',
+    url: '/api/v4/tasks/user',
     deserialize (response) {
       // Wait for the user to be loaded before deserializing
       // because user.tasksOrder is necessary
@@ -28,7 +28,7 @@ export async function fetchCompletedTodos (store, forceLoad = false) {
   if (loadStatus === 'NOT_LOADED' || forceLoad) {
     store.state.completedTodosStatus = 'LOADING';
 
-    const response = await axios.get('/api/v3/tasks/user?type=completedTodos');
+    const response = await axios.get('/api/v4/tasks/user?type=completedTodos');
     const completedTodos = response.data.data;
     const tasks = store.state.tasks.data;
     // Remove existing completed todos
@@ -51,7 +51,7 @@ export async function fetchCompletedTodos (store, forceLoad = false) {
 }
 
 export async function clearCompletedTodos (store) {
-  await axios.post('/api/v3/tasks/clearCompletedTodos');
+  await axios.post('/api/v4/tasks/clearCompletedTodos');
   store.state.tasks.data.todos = store.state.tasks.data.todos.filter(task => {
     return !task.completed;
   });
@@ -116,7 +116,7 @@ export async function create (store, createdTask) {
     store.state.user.data.tasksOrder[type].unshift(t._id);
   });
 
-  const response = await axios.post('/api/v3/tasks/user', payload);
+  const response = await axios.post('/api/v4/tasks/user', payload);
   const data = Array.isArray(response.data.data) ? response.data.data : [response.data.data];
 
   data.forEach(taskRes => {
@@ -135,17 +135,17 @@ export async function save (store, editedTask) {
   if (originalTask) Object.assign(originalTask, editedTask);
 
   const taskDataToSend = omit(editedTask, ['history']);
-  const response = await axios.put(`/api/v3/tasks/${taskId}`, taskDataToSend);
+  const response = await axios.put(`/api/v4/tasks/${taskId}`, taskDataToSend);
   if (originalTask) Object.assign(originalTask, response.data.data);
 }
 
 export async function scoreChecklistItem (store, {taskId, itemId}) {
-  await axios.post(`/api/v3/tasks/${taskId}/checklist/${itemId}/score`);
+  await axios.post(`/api/v4/tasks/${taskId}/checklist/${itemId}/score`);
 }
 
 export async function collapseChecklist (store, task) {
   task.collapseChecklist = !task.collapseChecklist;
-  await axios.put(`/api/v3/tasks/${task._id}`, {
+  await axios.put(`/api/v4/tasks/${task._id}`, {
     collapseChecklist: task.collapseChecklist,
   });
 }
@@ -158,51 +158,51 @@ export async function destroy (store, task) {
     list.splice(taskIndex, 1);
   }
 
-  await axios.delete(`/api/v3/tasks/${task._id}`);
+  await axios.delete(`/api/v4/tasks/${task._id}`);
 }
 
 export async function getChallengeTasks (store, payload) {
-  let response = await axios.get(`/api/v3/tasks/challenge/${payload.challengeId}`);
+  let response = await axios.get(`/api/v4/tasks/challenge/${payload.challengeId}`);
   return response.data.data;
 }
 
 export async function createChallengeTasks (store, payload) {
-  let response = await axios.post(`/api/v3/tasks/challenge/${payload.challengeId}`, payload.tasks);
+  let response = await axios.post(`/api/v4/tasks/challenge/${payload.challengeId}`, payload.tasks);
   return response.data.data;
 }
 
 export async function getGroupTasks (store, payload) {
-  let response = await axios.get(`/api/v3/tasks/group/${payload.groupId}`);
+  let response = await axios.get(`/api/v4/tasks/group/${payload.groupId}`);
   return response.data.data;
 }
 
 export async function createGroupTasks (store, payload) {
-  let response = await axios.post(`/api/v3/tasks/group/${payload.groupId}`, payload.tasks);
+  let response = await axios.post(`/api/v4/tasks/group/${payload.groupId}`, payload.tasks);
   return response.data.data;
 }
 
 export async function assignTask (store, payload) {
-  let response = await axios.post(`/api/v3/tasks/${payload.taskId}/assign/${payload.userId}`);
+  let response = await axios.post(`/api/v4/tasks/${payload.taskId}/assign/${payload.userId}`);
   return response.data.data;
 }
 
 export async function unassignTask (store, payload) {
-  let response = await axios.post(`/api/v3/tasks/${payload.taskId}/unassign/${payload.userId}`);
+  let response = await axios.post(`/api/v4/tasks/${payload.taskId}/unassign/${payload.userId}`);
   return response.data.data;
 }
 
 export async function needsWork (store, payload) {
-  let response = await axios.post(`/api/v3/tasks/${payload.taskId}/needs-work/${payload.userId}`);
+  let response = await axios.post(`/api/v4/tasks/${payload.taskId}/needs-work/${payload.userId}`);
   return response.data.data;
 }
 
 export async function getGroupApprovals (store, payload) {
-  let response = await axios.get(`/api/v3/approvals/group/${payload.groupId}`);
+  let response = await axios.get(`/api/v4/approvals/group/${payload.groupId}`);
   return response.data.data;
 }
 
 export async function approve (store, payload) {
-  let response = await axios.post(`/api/v3/tasks/${payload.taskId}/approve/${payload.userId}`);
+  let response = await axios.post(`/api/v4/tasks/${payload.taskId}/approve/${payload.userId}`);
   return response.data.data;
 }
 
@@ -217,22 +217,22 @@ export async function unlinkOneTask (store, payload) {
     list.splice(taskIndex, 1);
   }
 
-  let response = await axios.post(`/api/v3/tasks/unlink-one/${payload.task._id}?keep=${payload.keep}`);
+  let response = await axios.post(`/api/v4/tasks/unlink-one/${payload.task._id}?keep=${payload.keep}`);
   return response.data.data;
 }
 
 export async function unlinkAllTasks (store, payload) {
   if (!payload.keep) payload.keep = 'keep-all';
-  let response = await axios.post(`/api/v3/tasks/unlink-all/${payload.challengeId}?keep=${payload.keep}`);
+  let response = await axios.post(`/api/v4/tasks/unlink-all/${payload.challengeId}?keep=${payload.keep}`);
   return response.data.data;
 }
 
 export async function move (store, payload) {
-  let response = await axios.post(`/api/v3/tasks/${payload.taskId}/move/to/${payload.position}`);
+  let response = await axios.post(`/api/v4/tasks/${payload.taskId}/move/to/${payload.position}`);
   return response.data.data;
 }
 
 export async function moveGroupTask (store, payload) {
-  let response = await axios.post(`/api/v3/group-tasks/${payload.taskId}/move/to/${payload.position}`);
+  let response = await axios.post(`/api/v4/group-tasks/${payload.taskId}/move/to/${payload.position}`);
   return response.data.data;
 }

--- a/website/client/store/actions/user.js
+++ b/website/client/store/actions/user.js
@@ -10,7 +10,7 @@ export function fetch (store, options = {}) { // eslint-disable-line no-shadow
   return loadAsyncResource({
     store,
     path: 'user',
-    url: '/api/v3/user',
+    url: '/api/v4/user',
     deserialize (response) {
       return response.data.data;
     },
@@ -50,7 +50,7 @@ export async function set (store, changes) {
     }
   }
 
-  axios.put('/api/v3/user', changes);
+  axios.put('/api/v4/user', changes);
   // TODO
   // .then((res) => console.log('set', res))
   // .catch((err) => console.error('set', err));
@@ -61,22 +61,22 @@ export async function sleep (store) {
 
   user.preferences.sleep = !user.preferences.sleep;
 
-  let response = await axios.post('/api/v3/user/sleep');
+  let response = await axios.post('/api/v4/user/sleep');
   return response.data.data;
 }
 
 export async function addWebhook (store, payload) {
-  let response = await axios.post('/api/v3/user/webhook', payload.webhookInfo);
+  let response = await axios.post('/api/v4/user/webhook', payload.webhookInfo);
   return response.data.data;
 }
 
 export async function updateWebhook (store, payload) {
-  let response = await axios.put(`/api/v3/user/webhook/${payload.webhook.id}`, payload.webhook);
+  let response = await axios.put(`/api/v4/user/webhook/${payload.webhook.id}`, payload.webhook);
   return response.data.data;
 }
 
 export async function deleteWebhook (store, payload) {
-  let response = await axios.delete(`/api/v3/user/webhook/${payload.webhook.id}`);
+  let response = await axios.delete(`/api/v4/user/webhook/${payload.webhook.id}`);
   return response.data.data;
 }
 
@@ -86,7 +86,7 @@ export async function changeClass (store, params) {
   changeClassOp(user, params);
   user.flags.classSelected = true;
 
-  let response = await axios.post(`/api/v3/user/change-class?class=${params.query.class}`);
+  let response = await axios.post(`/api/v4/user/change-class?class=${params.query.class}`);
   return response.data.data;
 }
 
@@ -94,7 +94,7 @@ export async function disableClasses (store) {
   const user = store.state.user.data;
 
   disableClassesOp(user);
-  let response = await axios.post('/api/v3/user/disable-classes');
+  let response = await axios.post('/api/v4/user/disable-classes');
   return response.data.data;
 }
 
@@ -103,7 +103,7 @@ export function togglePinnedItem (store, params) {
 
   let addedItem = togglePinnedItemOp(user, params);
 
-  axios.get(`/api/v3/user/toggle-pinned-item/${params.type}/${params.path}`);
+  axios.get(`/api/v4/user/toggle-pinned-item/${params.type}/${params.path}`);
   // TODO
   // .then((res) => console.log('equip', res))
   // .catch((err) => console.error('equip', err));
@@ -112,12 +112,12 @@ export function togglePinnedItem (store, params) {
 }
 
 export async function movePinnedItem (store, params) {
-  let response = await axios.post(`/api/v3/user/move-pinned-item/${params.path}/move/to/${params.position}`);
+  let response = await axios.post(`/api/v4/user/move-pinned-item/${params.path}/move/to/${params.position}`);
   return response.data.data;
 }
 
 export function castSpell (store, params) {
-  let spellUrl = `/api/v3/user/class/cast/${params.key}`;
+  let spellUrl = `/api/v4/user/class/cast/${params.key}`;
 
   const data = {};
 
@@ -128,16 +128,16 @@ export function castSpell (store, params) {
 }
 
 export function openMysteryItem () {
-  return axios.post('/api/v3/user/open-mystery-item');
+  return axios.post('/api/v4/user/open-mystery-item');
 }
 
 export function newStuffLater (store) {
   store.state.user.data.flags.newStuff = false;
-  return axios.post('/api/v3/news/tell-me-later');
+  return axios.post('/api/v4/news/tell-me-later');
 }
 
 export async function rebirth () {
-  let result = await axios.post('/api/v3/user/rebirth');
+  let result = await axios.post('/api/v4/user/rebirth');
 
   window.location.reload(true);
 
@@ -145,7 +145,7 @@ export async function rebirth () {
 }
 
 export async function togglePrivateMessagesOpt (store) {
-  let response = await axios.put('/api/v3/user',
+  let response = await axios.put('/api/v4/user',
     {
       'inbox.optOut': !store.state.user.data.inbox.optOut,
     }

--- a/website/client/store/actions/world-state.js
+++ b/website/client/store/actions/world-state.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 export async function getWorldState () {
-  const url = '/api/v3/world-state';
+  const url = '/api/v4/world-state';
   const response = await axios.get(url);
   return response.data.data;
 }


### PR DESCRIPTION
To be merged after #10453 

This PR switches the client side to use `/api(v4` instead of `/api/v3` for all server requests