### PR TITLE
Remember equipment drawer tab

### DIFF
--- a/website/client/components/inventory/equipment/index.vue
+++ b/website/client/components/inventory/equipment/index.vue
@@ -218,22 +218,21 @@ export default {
     }, 250),
   },
   mounted () {
-    const values = CONSTANTS.valueConstants;
     const drawerState = getLocalSetting(CONSTANTS.keyConstants.EQUIPMENT_DRAWER_STATE);
-    if (drawerState === values.DRAWER_CLOSED) {
+    if (drawerState === CONSTANTS.drawerStateValues.DRAWER_CLOSED) {
       this.$store.state.equipmentDrawerOpen = false;
     }
 
-    this.costumeMode = getLocalSetting(CONSTANTS.keyConstants.CURRENT_EQUIPMENT_DRAWER_TAB) === values.COSTUME_TAB ? true : false;
+    this.costumeMode = getLocalSetting(CONSTANTS.keyConstants.CURRENT_EQUIPMENT_DRAWER_TAB) === CONSTANTS.equipmentDrawerTabValues.COSTUME_TAB ? true : false;
   },
   methods: {
     selectDrawerTab (tabName) {
       let tabNameValue;
       if (tabName === 'costume') {
-        tabNameValue = CONSTANTS.valueConstants.COSTUME_TAB;
+        tabNameValue = CONSTANTS.equipmentDrawerTabValues.COSTUME_TAB;
         this.costumeMode = true;
       } else {
-        tabNameValue = CONSTANTS.valueConstants.EQUIPMENT_TAB;
+        tabNameValue = CONSTANTS.equipmentDrawerTabValues.EQUIPMENT_TAB;
         this.costumeMode = false;
       }
       setLocalSetting(CONSTANTS.keyConstants.CURRENT_EQUIPMENT_DRAWER_TAB, tabNameValue);
@@ -274,11 +273,11 @@ export default {
       this.$store.state.equipmentDrawerOpen = newState;
 
       if (newState) {
-        setLocalSetting(CONSTANTS.keyConstants.EQUIPMENT_DRAWER_STATE, CONSTANTS.valueConstants.DRAWER_OPEN);
+        setLocalSetting(CONSTANTS.keyConstants.EQUIPMENT_DRAWER_STATE, CONSTANTS.drawerStateValues.DRAWER_OPEN);
         return;
       }
 
-      setLocalSetting(CONSTANTS.keyConstants.EQUIPMENT_DRAWER_STATE, CONSTANTS.valueConstants.DRAWER_CLOSED);
+      setLocalSetting(CONSTANTS.keyConstants.EQUIPMENT_DRAWER_STATE, CONSTANTS.drawerStateValues.DRAWER_CLOSED);
     },
   },
   computed: {

--- a/website/client/components/tasks/spells.vue
+++ b/website/client/components/tasks/spells.vue
@@ -190,7 +190,7 @@ export default {
   mounted () {
     // @TODO: should we abstract the drawer state/local store to a library and mixing combo? We use a similar pattern in equipment
     const spellDrawerState = getLocalSetting(CONSTANTS.keyConstants.SPELL_DRAWER_STATE);
-    if (spellDrawerState === CONSTANTS.valueConstants.DRAWER_CLOSED) {
+    if (spellDrawerState === CONSTANTS.drawerStateValues.DRAWER_CLOSED) {
       this.$store.state.spellOptions.spellDrawOpen = false;
     }
   },
@@ -205,11 +205,11 @@ export default {
       this.$store.state.spellOptions.spellDrawOpen = newState;
 
       if (newState) {
-        setLocalSetting(CONSTANTS.keyConstants.SPELL_DRAWER_STATE, CONSTANTS.valueConstants.DRAWER_OPEN);
+        setLocalSetting(CONSTANTS.keyConstants.SPELL_DRAWER_STATE, CONSTANTS.drawerStateValues.DRAWER_OPEN);
         return;
       }
 
-      setLocalSetting(CONSTANTS.keyConstants.SPELL_DRAWER_STATE, CONSTANTS.valueConstants.DRAWER_CLOSED);
+      setLocalSetting(CONSTANTS.keyConstants.SPELL_DRAWER_STATE, CONSTANTS.drawerStateValues.DRAWER_CLOSED);
     },
     spellDisabled (skill) {
       if (skill === 'frost' && this.user.stats.buffs.streaks) {

--- a/website/client/libs/userlocalManager.js
+++ b/website/client/libs/userlocalManager.js
@@ -5,9 +5,11 @@ const CONSTANTS = {
     EQUIPMENT_DRAWER_STATE: 'equipment-drawer-state',
     CURRENT_EQUIPMENT_DRAWER_TAB: 'current-equipment-drawer-tab',
   },
-  valueConstants: {
+  drawerStateValues: {
     DRAWER_CLOSED: 'drawer-closed',
     DRAWER_OPEN: 'drawer-open',
+  },
+  equipmentDrawerTabValues: {
     COSTUME_TAB: 'costume-tab',
     EQUIPMENT_TAB: 'equipment-tab',
   },

--- a/website/client/libs/userlocalManager.js
+++ b/website/client/libs/userlocalManager.js
@@ -3,10 +3,13 @@ const CONSTANTS = {
   keyConstants: {
     SPELL_DRAWER_STATE: 'spell-drawer-state',
     EQUIPMENT_DRAWER_STATE: 'equipment-drawer-state',
+    CURRENT_EQUIPMENT_DRAWER_TAB: 'current-equipment-drawer-tab',
   },
   valueConstants: {
     DRAWER_CLOSED: 'drawer-closed',
     DRAWER_OPEN: 'drawer-open',
+    COSTUME_TAB: 'costume-tab',
+    EQUIPMENT_TAB: 'equipment-tab',
   },
 };
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10434 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
I added `CURRENT_EQUIPMENT_DRAWER_TAB` to `userLocalManager.js`. I then use that value while rendering the equipment drawer to determine which tab to open on load. 

For clarity, I also split the value constants exported by `userLocalManager`. Not sure whether you agree this is the the most versatile solution though, let me know if you prefer a different approach. 


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 6d7d6651-604d-4e7c-adff-a040770a6768
