### PR TITLE
Show deletion feedback for social accounts

### DIFF
--- a/website/client/components/settings/deleteModal.vue
+++ b/website/client/components/settings/deleteModal.vue
@@ -1,31 +1,19 @@
 <template lang="pug">
   b-modal#delete(:title="$t('deleteAccount')", :hide-footer='true' size='md')
-    .regular-delete(v-if='user.auth.local.email')
-      strong {{ $t('deleteLocalAccountText') }}
-        br
-        .row
-          .col-6
-            input.form-control(type='password', v-model='password')
-        br
-        .row
-          #feedback.col-12.form-group
-            label(for='feedbackTextArea') {{ $t('feedback') }}
-            textarea#feedbackTextArea.form-control(v-model='feedback')
-      .modal-footer
-        button.btn.btn-primary(@click='close()') {{ $t('neverMind') }}
-        button.btn.btn-danger(@click='deleteAccount()', :disabled='!password') {{ $t('deleteDo') }}
-        .modal-header
-    .social-delete(v-if='!user.auth.local.email')
-      h4 {{ $t('deleteAccount') }}
-      .modal-body
-        p {{ $t('deleteSocialAccountText', {magicWord: 'DELETE'}) }}
-        br
-        .row
-          .col-md-6
-            input.form-control(type='text', v-model='password')
-      .modal-footer
-        button.btn.btn-secondary(@click='close()') {{ $t('neverMind') }}
-        button.btn.btn-danger(:disabled='!password', @click='deleteAccount()') {{ $t('deleteDo') }}
+    .modal-body
+      br
+      strong(v-if='user.auth.local.email') {{ $t('deleteLocalAccountText') }}
+      strong(v-if='!user.auth.local.email') {{ $t('deleteSocialAccountText', {magicWord: 'DELETE'}) }}
+      .row.mt-3
+        .col-6
+          input.form-control(type='password', v-model='password')
+      .row.mt-3
+        #feedback.col-12.form-group
+          label(for='feedbackTextArea') {{ $t('feedback') }}
+          textarea#feedbackTextArea.form-control(v-model='feedback')
+    .modal-footer
+      button.btn.btn-primary(@click='close()') {{ $t('neverMind') }}
+      button.btn.btn-danger(@click='deleteAccount()', :disabled='!password') {{ $t('deleteDo') }}
 </template>
 
 <script>
@@ -44,7 +32,7 @@ export default {
   },
   methods: {
     close () {
-      this.$root.$emit('bv::hide::modal', 'reset');
+      this.$root.$emit('bv::hide::modal', 'delete');
     },
     async deleteAccount () {
       await axios.delete('/api/v4/user', {
@@ -55,7 +43,7 @@ export default {
       });
       localStorage.clear();
       window.location.href = '/static/home';
-      this.$root.$emit('bv::hide::modal', 'reset');
+      this.$root.$emit('bv::hide::modal', 'delete');
     },
   },
 };


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10465

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

* Displays the feedback form when any user clicks "Delete Account", not just users using the local authentication method.
* Fixes an issue where clicking "Never Mind" on the account deletion modal would not dismiss the modal.
* Minor beautification of the account deletion modal, including removal of a sometimes duplicated heading and better margins for input fields.
* A bit of DRY refactoring of the account deletion modal.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)