### PR TITLE
Don't timeshift Time Travelers background without Hourglass

### DIFF
--- a/website/client/components/shops/timeTravelers/index.vue
+++ b/website/client/components/shops/timeTravelers/index.vue
@@ -22,7 +22,7 @@
           )
     .standard-page
       div.featuredItems
-        .background
+        .background(:class="{'background-closed': closed, 'background-open': !closed }")
           div.npc(:class="{'closed': closed }")
             div.featured-label
               span.rectangle
@@ -33,8 +33,6 @@
               span.rectangle
               span.text(v-once) {{ $t('timeTravelersPopoverNoSubMobile') }}
               span.rectangle
-
-      h1.mb-4.page-header(v-once) {{ $t('timeTravelers') }}
 
       .clearfix(v-if="!closed")
         div.float-right
@@ -164,12 +162,9 @@
       height: 216px;
 
       .background {
-        background: url('~assets/images/npc/#{$npc_timetravelers_flavor}/time_travelers_background.png');
-
         background-repeat: repeat-x;
 
         width: 100%;
-        height: 216px;
         position: absolute;
 
         top: 0;
@@ -179,6 +174,14 @@
         flex-direction: column;
         justify-content: center;
         align-items: center;
+      }
+      .background-open {
+        background: url('~assets/images/npc/#{$npc_timetravelers_flavor}/time_travelers_background.png');
+        height: 188px;
+      }
+      .background-closed {
+        background: url('~assets/images/npc/normal/time_travelers_background.png');
+        height: 216px;
       }
 
       .content {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10463 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

* Always shows the "normal" Time Travelers background if the user does not have a Mystic Hourglass, even during seasonal Galas, to better match the NPC image.
* Removes a redundant header from the Time Travelers page.