### PR TITLE
Fixed the unnecessary whitespace to the right of landing page (#10435)

### DIFF
--- a/website/client/components/static/home.vue
+++ b/website/client/components/static/home.vue
@@ -115,7 +115,7 @@
             .fast-company.svg-icon(v-html='icons.fastCompany')
             .discover.svg-icon(v-html='icons.discover')
       .container-fluid
-        .seamless_stars_varied_opacity_repeat
+        .row.seamless_stars_varied_opacity_repeat
 </template>
 
 <style lang='scss'>


### PR DESCRIPTION
[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10435 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
I added the missing '.row' class in the 'div' element that was making the bootstrap create unnecessary whitespace in the landing page.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: ce778944-6f28-4306-be6d-c62bc15b07f9
