### PR TITLE
Fixed Inn banner and nav bar behave oddly when scrolling

### DIFF
--- a/website/client/app.vue
+++ b/website/client/app.vue
@@ -116,7 +116,7 @@ div
 
   /* Push progress bar above modals */
   #nprogress .bar {
-    z-index: 1090 !important; /* Must stay above nav bar */
+    z-index: 1600 !important; /* Must stay above nav bar */
   }
 
   .restingInn {
@@ -136,7 +136,7 @@ div
     background-color: $blue-10;
     position: fixed;
     top: 0;
-    z-index: 1030;
+    z-index: 1300;
     display: flex;
 
     .content {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10437

### Changes
I've changed the **z-index property** of the **.resting-banner** class:
from _1030_ to _1300_.
Tested on Mozilla Firefox and Google Chrome.

I've changed the **z-index property** of the **#progress .bar** class:
from _1090_ to _1600_.
Changed this so the progress/sync bar stays on top of the resting-banner, so the user can still see his sync progress, even if resting.
Tested on Mozilla Firefox and Google Chrome.

![image](https://user-images.githubusercontent.com/29221732/42174249-0812d794-7df8-11e8-9418-0cee7276ade5.png)
The picture shows the results:
1. Presence of the progress-bar on top.
2. The resting-banner right under it.
3. The main-menu under everything.

----
UUID: c7190c89-8947-45a5-81d5-b6946e55ff15
