### PR TITLE
Fix Modal Stack - reopening modals

### DIFF
--- a/website/client/app.vue
+++ b/website/client/app.vue
@@ -475,7 +475,6 @@ export default {
       });
 
       this.$root.$on('bv::modal::hidden', (bvEvent) => {
-
         let modalId = bvEvent.target && bvEvent.target.id;
 
         // sometimes the target isn't passed to the hidden event, fallback is the vueTarget

--- a/website/client/app.vue
+++ b/website/client/app.vue
@@ -483,40 +483,24 @@ export default {
         }
 
         if (!modalId) {
-          console.error('There is no id to on this hidden event');
-          debugger;
           return;
-        } else {
-          console.warn(`Hidden: ModalId = ${modalId}`);
         }
 
         const modalStack = this.$store.state.modalStack;
 
         const modalOnTop = modalStack[modalStack.length - 1];
 
-        console.info('Stack', modalStack, 'modalOnTop', modalOnTop);
-
         // Check for invalid modal. Event systems can send multiples
-        if (!this.validStack(modalStack)) {
-          console.warn(`Hidden: ModalId = ${modalId} was invalid so isn't removed`);
-          return;
-        }
+        if (!this.validStack(modalStack)) return;
 
         // If we are moving forward
-        if (modalOnTop && modalOnTop.prev === modalId) {
-          console.warn(`Hidden: ModalId = ${modalId} modalOnTop.prev === modalId`);
-          return;
-        }
-
-        console.warn(`Hidden: ModalId = ${modalId} - the last modal on stack is removed`);
+        if (modalOnTop && modalOnTop.prev === modalId) return;
 
         // Remove modal from stack
         this.$store.state.modalStack.pop();
 
         // Get previous modal
         const modalBefore = modalOnTop ? modalOnTop.prev : undefined;
-
-        console.info('modalBefore', modalBefore, 'show modal');
 
         if (modalBefore) this.$root.$emit('bv::show::modal', modalBefore, {fromRoot: true});
       });

--- a/website/client/app.vue
+++ b/website/client/app.vue
@@ -105,7 +105,7 @@ div
   @import '~client/assets/scss/colors.scss';
 
   /* @TODO: The modal-open class is not being removed. Let's try this for now */
-  .modal, .modal-open {
+  .modal {
     overflow-y: scroll !important;
   }
 
@@ -475,7 +475,14 @@ export default {
       });
 
       this.$root.$on('bv::modal::hidden', (bvEvent) => {
-        const modalId = bvEvent.target && bvEvent.target.id;
+
+        let modalId = bvEvent.target && bvEvent.target.id;
+
+        // sometimes the target isn't passed to the hidden event, fallback is the vueTarget
+        if (!modalId) {
+          modalId = bvEvent.vueTarget && bvEvent.vueTarget.id;
+        }
+
         if (!modalId) return;
 
         const modalStack = this.$store.state.modalStack;

--- a/website/client/app.vue
+++ b/website/client/app.vue
@@ -482,23 +482,42 @@ export default {
           modalId = bvEvent.vueTarget && bvEvent.vueTarget.id;
         }
 
-        if (!modalId) return;
+        if (!modalId) {
+          console.error('There is no id to on this hidden event');
+          debugger;
+          return;
+        } else {
+          console.warn(`Hidden: ModalId = ${modalId}`);
+        }
 
         const modalStack = this.$store.state.modalStack;
 
         const modalOnTop = modalStack[modalStack.length - 1];
 
+        console.info('Stack', modalStack, 'modalOnTop', modalOnTop);
+
         // Check for invalid modal. Event systems can send multiples
-        if (!this.validStack(modalStack)) return;
+        if (!this.validStack(modalStack)) {
+          console.warn(`Hidden: ModalId = ${modalId} was invalid so isn't removed`);
+          return;
+        }
 
         // If we are moving forward
-        if (modalOnTop && modalOnTop.prev === modalId) return;
+        if (modalOnTop && modalOnTop.prev === modalId) {
+          console.warn(`Hidden: ModalId = ${modalId} modalOnTop.prev === modalId`);
+          return;
+        }
+
+        console.warn(`Hidden: ModalId = ${modalId} - the last modal on stack is removed`);
 
         // Remove modal from stack
         this.$store.state.modalStack.pop();
 
         // Get previous modal
         const modalBefore = modalOnTop ? modalOnTop.prev : undefined;
+
+        console.info('modalBefore', modalBefore, 'show modal');
+
         if (modalBefore) this.$root.$emit('bv::show::modal', modalBefore, {fromRoot: true});
       });
     },

--- a/website/client/components/notifications.vue
+++ b/website/client/components/notifications.vue
@@ -485,7 +485,9 @@ export default {
             break;
           case 'CHALLENGE_JOINED_ACHIEVEMENT':
             this.playSound('Achievement_Unlocked');
-            this.$root.$emit('bv::show::modal', 'joined-challenge');
+            this.text(`${this.$t('achievement')}: ${this.$t('joinedChallenge')}`, () => {
+              this.$root.$emit('bv::show::modal', 'joined-challenge');
+            }, false);
             break;
           case 'INVITED_FRIEND_ACHIEVEMENT':
             this.playSound('Achievement_Unlocked');

--- a/website/client/components/snackbars/notification.vue
+++ b/website/client/components/snackbars/notification.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 transition(name="fade")
-  .notification.callout.animated(:class="classes", v-if='show', @click='show = false')
+  .notification.callout.animated(:class="classes", v-if='show', @click='handleOnClick()')
     .row(v-if='notification.type === "error"')
       .text.col-12
         div(v-html='notification.text')
@@ -141,6 +141,15 @@ export default {
   },
   beforeDestroy () {
     clearTimeout(this.timer);
+  },
+  methods: {
+    handleOnClick () {
+      if (typeof this.notification.onClick === 'function') {
+        this.notification.onClick();
+      }
+
+      this.show = false;
+    },
   },
   watch: {
     show () {

--- a/website/client/mixins/notifications.js
+++ b/website/client/mixins/notifications.js
@@ -56,9 +56,9 @@ export default {
     streak (val) {
       this.notify(`${val}`, 'streak');
     },
-    text (val, onClick) {
+    text (val, onClick, timeout) {
       if (!val) return;
-      this.notify(val, 'info', null, null, onClick);
+      this.notify(val, 'info', null, null, onClick, timeout);
     },
     sign (number) {
       return getSign(number);
@@ -66,14 +66,19 @@ export default {
     round (number, nDigits) {
       return round(number, nDigits);
     },
-    notify (html, type, icon, sign) {
+    notify (html, type, icon, sign, onClick, timeout) {
+      if (typeof timeout === 'undefined') {
+        timeout = true;
+      }
+
       this.$store.dispatch('snackbars:add', {
         title: '',
         text: html,
         type,
         icon,
         sign,
-        timeout: true,
+        onClick,
+        timeout,
       });
     },
   },

--- a/website/common/locales/en/achievements.json
+++ b/website/common/locales/en/achievements.json
@@ -1,4 +1,5 @@
 {
+  "achievement": "Achievement",
   "share": "Share",
   "onwards": "Onwards!",
   "levelup": "By accomplishing your real life goals, you leveled up and are now fully healed!",


### PR DESCRIPTION
fixes #9986 - use fallback target.id - the normal target is sometimes empty, which results in having the last opened modal not removed from the stack

this also removes the second scrollbar when a modal is open (only the modal itself will now scroll)