### PR TITLE
Fixes Text overflow on task checklists

### DIFF
--- a/website/client/components/tasks/column.vue
+++ b/website/client/components/tasks/column.vue
@@ -81,6 +81,10 @@
     min-height: 556px;
   }
 
+  .sortable-tasks {
+    word-break: break-word;
+  }
+
   .sortable-tasks + .reward-items {
     margin-top: 16px;
   }


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10429

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
I added the _word-break: break-word;_ property to the _.sortable-tasks_ class.
Made some tests. This error seemed to be exclusive to Google Chrome, but I tested on both Chrome and Firefox.

**Before:** Not Working on Dailies and To Do's
![image](https://user-images.githubusercontent.com/29221732/42195545-b37fc91e-7e4f-11e8-86b4-caaad572bb46.png)

**After:** Working on Dailies and To Do's
![image](https://user-images.githubusercontent.com/29221732/42195538-a4c388ac-7e4f-11e8-86d4-b5ed312de2d6.png)


I chose _break-word_ for usability as _overflow: scroll_ adds a scroll that destroys the purpose of a card.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: c7190c89-8947-45a5-81d5-b6946e55ff15
