### PR TITLE
Fix text overflow in failed login notification

### DIFF
--- a/website/client/components/snackbars/notification.vue
+++ b/website/client/components/snackbars/notification.vue
@@ -37,7 +37,7 @@ transition(name="fade")
     background-color: #24cc8f;
     box-shadow: 0 2px 2px 0 rgba(26, 24, 29, 0.16), 0 1px 4px 0 rgba(26, 24, 29, 0.12);
     color: white;
-    width: 300px;
+    width: 340px;
     margin-left: 1em;
     margin-bottom: 1em;
   }


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10447

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Changed the width of the notification div from 300px to 340px. Tried also adding padding to the text div but this looked IMHO better. 

#### Before
![screenshot from 2018-07-05 21-16-02](https://user-images.githubusercontent.com/13316308/42343729-47075476-809a-11e8-81e3-b25ae3fe7402.png)

#### After
![screenshot from 2018-07-05 21-29-24](https://user-images.githubusercontent.com/13316308/42343820-8a241208-809a-11e8-9b48-7c480a848370.png)


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 11577d82-c690-45b0-a950-38566555ec7a
