### PR TITLE
member-details: Only add 1px margin when condensed

### DIFF
--- a/website/client/components/memberDetails.vue
+++ b/website/client/components/memberDetails.vue
@@ -48,7 +48,6 @@
   .member-stats {
     padding-left: 12px;
     padding-right: 24px;
-    margin-right: 1px;
     opacity: 1;
     transition: width 0.15s ease-out;
   }
@@ -148,6 +147,7 @@
       right: 100%;
       height: calc(100% + 18px);
       margin-top: -9px;
+      margin-right: 1px;
       padding-top: 9px;
       padding-bottom: 24px;
       padding-right: 16px;


### PR DESCRIPTION
As reported in #10502, adding a 1 pixel right margin to *all* nodes with the `member-stats` class will affect the display when you click on the avatar as well, which will then break the layout because of that additional margin.

Instead of adding the margin to `.member-stats` in general, let's just add it to the condensed version so that it really just addresses the flickering on Chrome/Chromium as reported in #10379.

I've tested whether the flickering still happens via a small `xdotool`-loop (just to make sure I don't get too shaky with the mouse):

```sh-session
$ for i in $(seq 500 508); do xdotool mousemove "$i" 250; sleep 5; done
```

The flickering doesn't happen anymore and the layout in the party members overview and the stats overview when you click on the avatar is no longer distorted.

Fixes #10502 
Fixes #10510