### PR TITLE
Fix Modal positioning wrong in specific cases

### DIFF
--- a/website/client/assets/scss/modal.scss
+++ b/website/client/assets/scss/modal.scss
@@ -12,8 +12,16 @@
 }
 
 .modal {
-  top: 75px;
+  top: 50px;
 }
+
+.restingInn {
+  .modal {
+    top: 90px;
+  }
+}
+
+
 
 .modal-dialog {
   width: auto;

--- a/website/client/assets/scss/modal.scss
+++ b/website/client/assets/scss/modal.scss
@@ -11,6 +11,10 @@
   }
 }
 
+.modal {
+  top: 50px;
+}
+
 .modal-dialog {
   width: auto;
 

--- a/website/client/assets/scss/modal.scss
+++ b/website/client/assets/scss/modal.scss
@@ -12,7 +12,7 @@
 }
 
 .modal {
-  top: 50px;
+  top: 75px;
 }
 
 .modal-dialog {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10475

### Changes
Created a _.modal_ class and set it's properties to:
_top: 50px;_
Tested on Mozilla Firefox and Google Chrome.

**More details, please check the #10475 discussion.**

Some personal thoughts:
I couldn't find a way to give this property to all modals without duplicating this CSS class, as the original one comes from Bootstrap. Checked if it gets duplicated on production environment, and it does too. This is the simplest solution I've found, but I'll be checking here to see if anyone has a better idea. Thank you.

----
UUID: c7190c89-8947-45a5-81d5-b6946e55ff15