### PR TITLE
Show snackbar on client-side purchase-checks

### DIFF
--- a/website/client/mixins/buy.js
+++ b/website/client/mixins/buy.js
@@ -1,13 +1,27 @@
 export default {
   methods: {
-    makeGenericPurchase (item, type = 'buyModal', quantity = 1) {
-      this.$store.dispatch('shops:genericPurchase', {
-        pinType: item.pinType,
-        type: item.purchaseType,
-        key: item.key,
-        currency: item.currency,
-        quantity,
-      });
+    async makeGenericPurchase (item, type = 'buyModal', quantity = 1) {
+      try {
+        await this.$store.dispatch('shops:genericPurchase', {
+          pinType: item.pinType,
+          type: item.purchaseType,
+          key: item.key,
+          currency: item.currency,
+          quantity,
+        });
+      } catch (e) {
+        if (!e.request) {
+          // axios request errors already handled by app.vue
+          this.$store.dispatch('snackbars:add', {
+            title: '',
+            text: e.message,
+            type: 'error',
+          });
+          return;
+        } else {
+          throw e;
+        }
+      }
 
       this.$root.$emit('playSound', 'Reward');
 


### PR DESCRIPTION
Some purchases are checked on the client-side first, this error wasn't catched before so it never shown a message to the user

fixes #10519