### PR TITLE
Re-enable start quest button

### DIFF
--- a/website/client/components/groups/group.vue
+++ b/website/client/components/groups/group.vue
@@ -546,7 +546,7 @@ export default {
         eventLabel: 'Start a Quest',
       });
 
-      let hasQuests = find(this.user.items.quests, (quest) => {
+      let hasQuests = this.user.items.quests.some((quest) => {
         return quest > 0;
       });
 
@@ -554,7 +554,6 @@ export default {
         this.$root.$emit('bv::show::modal', 'start-quest-modal');
         return;
       }
-      // $rootScope.$state.go('options.inventory.quests');
     },
     showGroupGems () {
       this.$root.$emit('bv::show::modal', 'group-gems-modal');

--- a/website/client/components/groups/group.vue
+++ b/website/client/components/groups/group.vue
@@ -538,23 +538,6 @@ export default {
       this.$store.state.upgradingGroup = this.group;
       this.$router.push('/group-plans');
     },
-    clickStartQuest () {
-      Analytics.track({
-        hitType: 'event',
-        eventCategory: 'button',
-        eventAction: 'click',
-        eventLabel: 'Start a Quest',
-      });
-
-      let hasQuests = this.user.items.quests.some((quest) => {
-        return quest > 0;
-      });
-
-      if (hasQuests) {
-        this.$root.$emit('bv::show::modal', 'start-quest-modal');
-        return;
-      }
-    },
     showGroupGems () {
       this.$root.$emit('bv::show::modal', 'group-gems-modal');
     },

--- a/website/client/components/groups/startQuestModal.vue
+++ b/website/client/components/groups/startQuestModal.vue
@@ -182,13 +182,14 @@ export default {
       let groupId = this.group._id || this.user.party._id;
 
       const key = this.selectedQuest;
-      const response = await this.$store.dispatch('guilds:inviteToQuest', {groupId, key});
-      const quest = response.data.data;
+      try {
+        const response = await this.$store.dispatch('guilds:inviteToQuest', {groupId, key});
+        const quest = response.data.data;
 
-      if (this.$store.state.party.data) this.$store.state.party.data.quest = quest;
-
-      this.loading = false;
-
+        if (this.$store.state.party.data) this.$store.state.party.data.quest = quest;
+      } finally {
+        this.loading = false;
+      }
       this.$root.$emit('bv::hide::modal', 'start-quest-modal');
     },
   },

--- a/website/client/components/groups/startQuestModal.vue
+++ b/website/client/components/groups/startQuestModal.vue
@@ -148,8 +148,13 @@ export default {
     };
   },
   mounted () {
-    let questKeys = Object.keys(this.user.items.quests);
-    this.selectedQuest = questKeys[0];
+    const userQuests = this.user.items.quests;
+    for (const key in userQuests) {
+      if (userQuests[key] > 0) {
+        this.selectedQuest = key;
+        break;
+      }
+    }
 
     this.$root.$on('selectQuest', this.selectQuest);
   },


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #9701

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
- Expanded the flow that determines which quest is pre-selected in the start quest modal. Instead of blindly selecting the first quest in the list, it now selects the first quest the user _has a scroll for_.
- Added a try/catch around the invite-group-to-quest API call so that the invite button is re-enabled if the call errors. 


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 6d7d6651-604d-4e7c-adff-a040770a6768

