### PR TITLE
Fix drag scrolling tasks when character has abilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ dist-client
 test/client/unit/coverage
 test/client/e2e/reports
 test/client-old/spec/mocks/translations.js
+yarn.lock
 
 # Elastic Beanstalk Files
 .elasticbeanstalk/*

--- a/website/client/components/tasks/column.vue
+++ b/website/client/components/tasks/column.vue
@@ -37,7 +37,7 @@
     draggable.sortable-tasks(
       ref="tasksList",
       @update='taskSorted',
-      :options='{disabled: activeFilter.label === "scheduled"}',
+      :options='{disabled: activeFilter.label === "scheduled", scrollSensitivity: 64}',
       class="sortable-tasks"
     )
       task(


### PR DESCRIPTION
The default scroll sensitivity of the task columns is 30 px from the bottom of the screen. The collapsed spells drawer renders 32 px from the bottom of the screen intercepting most drag events. Increases the scroll sensitivity to double the height of the blocking element.

Also ignores the Yarn lockfile. `yarn --ignore-engines` builds successfully and tests pass with Node 10.6.0 and MongoDB 4.0.0.
