### PR TITLE
Fix user receiving Joined Challenged achievement when creating a challenge

### DIFF
--- a/test/api/v3/integration/challenges/POST-challenges.test.js
+++ b/test/api/v3/integration/challenges/POST-challenges.test.js
@@ -304,14 +304,14 @@ describe('POST /challenges', () => {
       expect(groupLeader.challenges.length).to.equal(0);
     });
 
-    it('awards achievement if this is creator\'s first challenge', async () => {
+    it('does not award joinedChallenge achievement for creating a challenge', async () => {
       await groupLeader.post('/challenges', {
         group: group._id,
         name: 'Test Challenge',
         shortName: 'TC Label',
       });
       groupLeader = await groupLeader.sync();
-      expect(groupLeader.achievements.joinedChallenge).to.be.true;
+      expect(groupLeader.achievements.joinedChallenge).to.not.be.true;
     });
 
     it('sets summary to challenges name when not supplied', async () => {

--- a/website/server/libs/challenges/index.js
+++ b/website/server/libs/challenges/index.js
@@ -79,8 +79,6 @@ export async function createChallenge (user, req, res) {
   let challengeValidationErrors = challenge.validateSync();
   if (challengeValidationErrors) throw challengeValidationErrors;
 
-  addUserJoinChallengeNotification(user);
-
   let results = await Promise.all([challenge.save({
     validateBeforeSave: false, // already validated
   }), group.save(), user.save()]);


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10544

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
I removed the call to addUserJoinChallengeNotification when creating a challenge and modified the integration test to reflect that change. I also looked at the tests for joining a challenge and saw that it already checks that an achievement is awarded. 

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 9bcc7003-ccae-4570-a7f9-1daba63efadd
