### PR TITLE
Mana bar no longer shown on profile if user has opted out of class system

### DIFF
--- a/test/api/v3/integration/groups/GET-groups_groupId_members.test.js
+++ b/test/api/v3/integration/groups/GET-groups_groupId_members.test.js
@@ -77,7 +77,7 @@ describe('GET /groups/:groupId/members', () => {
     expect(Object.keys(memberRes.auth)).to.eql(['timestamps']);
     expect(Object.keys(memberRes.preferences).sort()).to.eql([
       'size', 'hair', 'skin', 'shirt',
-      'chair', 'costume', 'sleep', 'background', 'tasks',
+      'chair', 'costume', 'sleep', 'background', 'tasks', 'disableClasses',
     ].sort());
 
     expect(memberRes.stats.maxMP).to.exist;
@@ -98,7 +98,7 @@ describe('GET /groups/:groupId/members', () => {
     expect(Object.keys(memberRes.auth)).to.eql(['timestamps']);
     expect(Object.keys(memberRes.preferences).sort()).to.eql([
       'size', 'hair', 'skin', 'shirt',
-      'chair', 'costume', 'sleep', 'background', 'tasks',
+      'chair', 'costume', 'sleep', 'background', 'tasks', 'disableClasses',
     ].sort());
 
     expect(memberRes.stats.maxMP).to.exist;

--- a/test/api/v3/integration/members/GET-members_id.test.js
+++ b/test/api/v3/integration/members/GET-members_id.test.js
@@ -37,7 +37,7 @@ describe('GET /members/:memberId', () => {
     expect(Object.keys(memberRes.auth)).to.eql(['timestamps']);
     expect(Object.keys(memberRes.preferences).sort()).to.eql([
       'size', 'hair', 'skin', 'shirt',
-      'chair', 'costume', 'sleep', 'background', 'tasks',
+      'chair', 'costume', 'sleep', 'background', 'tasks', 'disableClasses',
     ].sort());
 
     expect(memberRes.stats.maxMP).to.exist;

--- a/website/server/models/user/index.js
+++ b/website/server/models/user/index.js
@@ -7,7 +7,7 @@ require('./methods');
 
 // A list of publicly accessible fields (not everything from preferences because there are also a lot of settings tha should remain private)
 export let publicFields = `preferences.size preferences.hair preferences.skin preferences.shirt
-  preferences.chair preferences.costume preferences.sleep preferences.background preferences.tasks profile stats
+  preferences.chair preferences.costume preferences.sleep preferences.background preferences.tasks preferences.disableClasses profile stats
   achievements party backer contributor auth.timestamps items inbox.optOut loginIncentives flags.classSelected`;
 
 // The minimum amount of data needed when populating multiple users


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10558

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

`preferences.disableClasses` was added as a public field so it wouldn't be undefined in the following `hasClass` check that controls the appearance of the mana bar:

https://github.com/HabitRPG/habitica/blob/9205ec10b3b2a18e5e09522f9e33d6dffca9c240/website/client/store/getters/members.js#L10

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 9ca2bb65-ce6c-4e4c-a367-5ef9b5c7421e