### PR TITLE
Fix advanced settings from always starting collapsed

### DIFF
--- a/website/client/components/tasks/taskModal.vue
+++ b/website/client/components/tasks/taskModal.vue
@@ -714,6 +714,9 @@ export default {
       },
     };
   },
+  mounted () {
+    this.showAdvancedOptions = !this.user.preferences.advancedCollapsed;
+  },
   watch: {
     task () {
       this.syncTask();


### PR DESCRIPTION
Fixes  #10556

### Changes
Updated the taskModal to initialize showAdvancedOptions with the user's preference.




----
UUID: 9bcc7003-ccae-4570-a7f9-1daba63efadd