### PR TITLE
add participant list to collection quests

### DIFF
--- a/website/client/components/groups/questSidebarSection.vue
+++ b/website/client/components/groups/questSidebarSection.vue
@@ -24,6 +24,9 @@ sidebar-section(:title="$t('questDetailsTitle')")
       h3(v-once) {{ questData.text() }}
       .quest-box
         .collect-info(v-if='questData.collect')
+          .row
+            .col-12
+              a.float-right(@click="openParticipantList()") {{ $t('participantsTitle') }}
           .row(v-for='(value, key) in questData.collect')
             .col-2
               div(:class="'quest_' + questData.key + '_' + key")
@@ -72,14 +75,6 @@ sidebar-section(:title="$t('questDetailsTitle')")
 
   .quest-boss {
     margin: 0 auto;
-  }
-
-  .boss-info {
-    a {
-      font-family: 'Roboto Condensed', sans-serif;
-      font-weight: bold;
-      color: $gray-10;
-    }
   }
 
   .boss-health-bar {
@@ -141,6 +136,12 @@ sidebar-section(:title="$t('questDetailsTitle')")
       width: 100%;
       padding: .5em;
       margin-bottom: 1em;
+
+      a {
+        font-family: 'Roboto Condensed', sans-serif;
+        font-weight: bold;
+        color: $gray-10;
+      }
 
       svg: {
         width: 100%;


### PR DESCRIPTION
No issue exists for this; I only just noticed the problem.

Currently, active collection quests don't have "Participants" in the quest box. This PR adds the Participants link. It works the same way it does for boss quests (as implemented in https://github.com/HabitRPG/habitica/pull/10531) - i.e., when you click on "Participants" for a collection quest, you see the new participants modal.

Before:
![selection_003](https://user-images.githubusercontent.com/1495809/43454149-7b8c25e0-94ff-11e8-96f8-1ba7c4d3f1ac.png)

After:
![selection_004](https://user-images.githubusercontent.com/1495809/43454160-8192e4ce-94ff-11e8-8d4c-863e4552c724.png)

----

This PR doesn't change the appearance or behaviour for boss quests.

Before:
![selection_006](https://user-images.githubusercontent.com/1495809/43454232-b90d917e-94ff-11e8-9545-ecbc39e52799.png)


After:
![selection_005](https://user-images.githubusercontent.com/1495809/43454210-a58e762c-94ff-11e8-855f-9995f0759a36.png)

----

If possible, it would be good for this to go live at the same time as https://github.com/HabitRPG/habitica/pull/10531 which has already been merged, so that we don't have to field questions about why the new participant list feature doesn't work on collection quests.