### PR TITLE
combine cron's Resting in the Inn code with non-sleeping code - fixes #5232 etc

### DIFF
--- a/test/api/unit/libs/cron.test.js
+++ b/test/api/unit/libs/cron.test.js
@@ -1017,7 +1017,7 @@ describe('cron', () => {
         expect(tasksByType.habits[0].counterDown).to.equal(0);
       });
 
-      it('should reset habit counters even if user is resting in the Inn', () => {
+      it('should reset habit counters even if user is sleeping', () => {
         user.preferences.sleep = true;
         tasksByType.habits[0].counterUp = 1;
         tasksByType.habits[0].counterDown = 1;
@@ -1568,7 +1568,7 @@ describe('cron', () => {
       expect(user.loginIncentives).to.eql(1);
     });
 
-    it('increments loginIncentives by 1 even if user has Dailies paused', () => {
+    it('increments loginIncentives by 1 even if user is sleeping', () => {
       user.preferences.sleep = true;
       cron({user, tasksByType, daysMissed, analytics});
       expect(user.loginIncentives).to.eql(1);

--- a/website/server/libs/cron.js
+++ b/website/server/libs/cron.js
@@ -489,19 +489,6 @@ export function cron (options = {}) {
     mp: user.stats.mp - beforeCronStats.mp - (oldCronNotif ? oldCronNotif.data.mp : 0),
   });
 
-  // TODO: Clean PMs - keep 200 for subscribers and 50 for free users. Should also be done while resting in the inn
-  // let numberOfPMs = Object.keys(user.inbox.messages).length;
-  // if (numberOfPMs > maxPMs) {
-  //   _(user.inbox.messages)
-  //     .sortBy('timestamp')
-  //     .takeRight(numberOfPMs - maxPMs)
-  //     .forEach(pm => {
-  //       delete user.inbox.messages[pm.id];
-  //     })
-  //
-  //   user.markModified('inbox.messages');
-  // }
-
   // Analytics
   user.flags.cronCount++;
   trackCronAnalytics(analytics, user, _progress, options);

--- a/website/server/libs/cron.js
+++ b/website/server/libs/cron.js
@@ -321,7 +321,8 @@ export function cron (options = {}) {
     todoTally += task.value;
   });
 
-  // For incomplete Dailys, add value (further incentive), deduct health, keep records for later decreasing the nightly mana gain
+  // For incomplete Dailys, add value (further incentive), deduct health, keep records for later decreasing the nightly mana gain.
+  // The negative effects are not done when resting in the inn.
   let dailyChecked = 0; // how many dailies were checked?
   let dailyDueUnchecked = 0; // how many dailies were un-checked?
   let atLeastOneDailyDue = false; // were any dailies due?
@@ -438,10 +439,10 @@ export function cron (options = {}) {
       return taskType._id === taskOrderId && taskType.completed === false;
     });
   });
+  // TODO also adjust tasksOrder arrays to remove deleted tasks of any kind (including rewards), ensure that all existing tasks are in the arrays, no tasks IDs are duplicated -- https://github.com/HabitRPG/habitica/issues/7645
 
   // preen user history so that it doesn't become a performance problem
   // also for subscribed users but differently
-  // TODO also do while resting in the inn. Note that later we'll be allowing the value/color of tasks to change while sleeping (https://github.com/HabitRPG/habitica/issues/5232), so the code in performSleepTasks() might be best merged back into here for that. Perhaps wait until then to do preen history for sleeping users.
   preenUserHistory(user, tasksByType);
 
   if (perfect && atLeastOneDailyDue) {
@@ -471,10 +472,9 @@ export function cron (options = {}) {
   progress.down = -1300;
   _.merge(progress, {down: 0, up: 0, collectedItems: 0});
 
-  // Send notification for changes in HP and MP
-
-  // First remove a possible previous cron notification
-  // we don't want to flood the users with many cron notifications at once
+  // Send notification for changes in HP and MP.
+  // First remove a possible previous cron notification because
+  // we don't want to flood the users with many cron notifications at once.
   let oldCronNotif = user.notifications.find((notif, index) => {
     if (notif && notif.type === 'CRON') {
       user.notifications.splice(index, 1);

--- a/website/server/libs/cron.js
+++ b/website/server/libs/cron.js
@@ -445,7 +445,6 @@ export function cron (options = {}) {
   if (!user.preferences.sleep) {
     let progress = user.party.quest.progress;
     _progress = progress.toObject(); // clone the old progress object
-    progress.down = -1300;
     _.merge(progress, {down: 0, up: 0, collectedItems: 0});
   }
 


### PR DESCRIPTION
This PR combines the cron code for resting in the inn with the normal cron code, as described at https://github.com/HabitRPG/habitica/pull/9627#discussion_r156749416 and https://github.com/HabitRPG/habitica/issues/6941#issuecomment-387927531
The intention is to:
- make it clearer which cron actions are not performed when sleeping (very few of them!)
- remove some bugs (e.g., cronCount was not being incremented when sleeping)
- prevent future bugs (we had a habit of adding new cron code to the non-sleeping section and forgetting to add it to `performSleepTasks`)
- remove the blocker for https://github.com/HabitRPG/habitica/issues/6941 / https://github.com/HabitRPG/habitica/issues/9231 ("Repeat Every X Days Since Last Completed" / "Due until Completed, X times every Y intervals") - that's an example of the previous item (the current code in the gamma site doesn't run when the user is Resting) 
- fix https://github.com/HabitRPG/habitica/issues/5232 ("Allow Habits and To-Dos to "age" while Resting in the Inn") - kind of an incidental fix since aging while sleeping happens automatically now that the code has been combined.
- allow the Perfect Day buff to be obtained when Resting in the Inn if you have completed all your due Dailies.

----

_As notes to myself for after/if this goes live:_
- [ ] _edit the [cron section of the Rest in the Inn wiki page](https://habitica.wikia.com/wiki/Rest_in_the_Inn?action=edit&section=4)_
- [ ] _tell socialites about some of the changes (e.g., perfect day is now given when resting; aging of tasks)_
- [ ] _see about getting the code merged into the blocked PR mentioned above_
