### PR TITLE
Make private message character limit obvious on client

### DIFF
--- a/website/client/components/userMenu/inbox.vue
+++ b/website/client/components/userMenu/inbox.vue
@@ -57,7 +57,7 @@
             @keyup.ctrl.enter='sendPrivateMessage()',
             maxlength='3000'
           )
-          button.btn.btn-secondary(@click='sendPrivateMessage()') Send
+          button.btn.btn-secondary(@click='sendPrivateMessage()') {{$t('send')}}
           .row
             span.ml-3 {{ currentLength }} / 3000
 </template>

--- a/website/client/components/userMenu/inbox.vue
+++ b/website/client/components/userMenu/inbox.vue
@@ -52,8 +52,14 @@
         // @TODO: Implement new message header here when we fix the above
 
         .new-message-row(v-if='selectedConversation.key && !user.flags.chatRevoked')
-          textarea(v-model='newMessage', @keyup.ctrl.enter='sendPrivateMessage()')
+          textarea(
+            v-model='newMessage',
+            @keyup.ctrl.enter='sendPrivateMessage()',
+            maxlength='3000'
+          )
           button.btn.btn-secondary(@click='sendPrivateMessage()') Send
+          .row
+            span.ml-3 {{ currentLength }} / 3000
 </template>
 
 <style lang="scss" scoped>
@@ -321,6 +327,9 @@ export default {
       return filter(this.conversations, (conversation) => {
         return conversation.name.toLowerCase().indexOf(this.search.toLowerCase()) !== -1;
       });
+    },
+    currentLength () {
+      return this.newMessage.length;
     },
     placeholderTexts () {
       if (this.user.flags.chatRevoked) {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10549 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Adds character count to inbox messaging, in the same style as the character counter on group chat, halting input at the limit of 3000 (ala #10494).

Also changes one client string (the "Send" button in inbox) to use an internationalized string token instead of hardcoded English.