### PR TITLE
Filter dailies by due/not due in group plan and challenge page

### DIFF
--- a/website/client/components/tasks/column.vue
+++ b/website/client/components/tasks/column.vue
@@ -362,7 +362,7 @@ export default {
           type: this.type,
           filterType: this.activeFilter.label,
         }) :
-        this.filterByCompleted(this.taskListOverride, this.activeFilter.label);
+        this.filterByLabel(this.taskListOverride, this.activeFilter.label);
 
       let taggedList = this.filterByTagList(filteredTaskList, this.selectedTags);
       let searchedList = this.filterBySearchText(taggedList, this.searchText);
@@ -598,10 +598,12 @@ export default {
         }
       });
     },
-    filterByCompleted (taskList, filter) {
+    filterByLabel (taskList, filter) {
       if (!taskList) return [];
       return taskList.filter(task => {
         if (filter === 'complete2') return task.completed;
+        if (filter === 'due') return task.isDue;
+        if (filter === 'notDue') return !task.isDue;
         return !task.completed;
       });
     },

--- a/website/client/components/tasks/taskModal.vue
+++ b/website/client/components/tasks/taskModal.vue
@@ -929,10 +929,12 @@ export default {
           });
           this.$emit('taskCreated', this.task);
         } else if (this.groupId) {
-          await this.$store.dispatch('tasks:createGroupTasks', {
+          const response = await this.$store.dispatch('tasks:createGroupTasks', {
             groupId: this.groupId,
             tasks: [this.task],
           });
+
+          Object.assign(this.task, response);
 
           let promises = this.assignedMembers.map(memberId => {
             return this.$store.dispatch('tasks:assignTask', {

--- a/website/client/components/tasks/taskModal.vue
+++ b/website/client/components/tasks/taskModal.vue
@@ -923,19 +923,18 @@ export default {
 
       if (this.purpose === 'create') {
         if (this.challengeId) {
-          this.$store.dispatch('tasks:createChallengeTasks', {
+          const response = await this.$store.dispatch('tasks:createChallengeTasks', {
             challengeId: this.challengeId,
             tasks: [this.task],
           });
+          Object.assign(this.task, response);
           this.$emit('taskCreated', this.task);
         } else if (this.groupId) {
           const response = await this.$store.dispatch('tasks:createGroupTasks', {
             groupId: this.groupId,
             tasks: [this.task],
           });
-
           Object.assign(this.task, response);
-
           let promises = this.assignedMembers.map(memberId => {
             return this.$store.dispatch('tasks:assignTask', {
               taskId: this.task._id,


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10444

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Dailies in the group plan and challenge page can now be filtered by whether or not they're due.

~However, it doesn't seem to work for newly added tasks because they don't have the `isDue` field until you refresh the page.~

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 9ca2bb65-ce6c-4e4c-a367-5ef9b5c7421e