### PR TITLE
Correct timing on updating Group Plan member quantities

### DIFF
--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -587,14 +587,6 @@ api.joinGroup = {
     }
     if (!isUserInvited) throw new NotAuthorized(res.t('messageGroupRequiresInvite'));
 
-    // @TODO: Review the need for this and if still needed, don't base this on memberCount
-    if (!group.hasNotCancelled() && group.memberCount === 0) group.leader = user._id; // If new user is only member -> set as leader
-
-    if (group.hasNotCancelled())  {
-      await payments.addSubToGroupUser(user, group);
-      await group.updateGroupPlan();
-    }
-
     group.memberCount += 1;
 
     let promises = [group.save(), user.save()];
@@ -637,6 +629,14 @@ api.joinGroup = {
     }
 
     promises = await Promise.all(promises);
+
+    // @TODO: Review the need for this and if still needed, don't base this on memberCount
+    if (!group.hasNotCancelled() && group.memberCount === 0) group.leader = user._id; // If new user is only member -> set as leader
+
+    if (group.hasNotCancelled())  {
+      await payments.addSubToGroupUser(user, group);
+      await group.updateGroupPlan();
+    }
 
     let response = await Group.toJSONCleanChat(promises[0], user);
     let leader = await User.findById(response.leader).select(nameFields).exec();
@@ -790,7 +790,6 @@ api.leaveGroup = {
     }
 
     await group.leave(user, req.query.keep, req.body.keepChallenges);
-    if (group.hasNotCancelled()) await group.updateGroupPlan(true);
     _removeMessagesFromMember(user, group._id);
     await user.save();
 
@@ -804,6 +803,7 @@ api.leaveGroup = {
       await payments.cancelGroupSubscriptionForUser(user, group);
     }
 
+    if (group.hasNotCancelled()) await group.updateGroupPlan(true);
     res.respond(200, {});
   },
 };
@@ -892,10 +892,6 @@ api.removeGroupMember = {
 
     if (isInGroup) {
       group.memberCount -= 1;
-      if (group.hasNotCancelled())  {
-        await group.updateGroupPlan(true);
-        await payments.cancelGroupSubscriptionForUser(member, group, true);
-      }
 
       if (group.quest && group.quest.leader === member._id) {
         group.quest.key = undefined;
@@ -944,6 +940,12 @@ api.removeGroupMember = {
       member.save(),
       group.save(),
     ]);
+
+    if (group.hasNotCancelled())  {
+      await group.updateGroupPlan(true);
+      await payments.cancelGroupSubscriptionForUser(member, group, true);
+    }
+
     res.respond(200, {});
   },
 };

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -631,7 +631,7 @@ api.joinGroup = {
     promises = await Promise.all(promises);
 
     // @TODO: Review the need for this and if still needed, don't base this on memberCount
-    if (!group.hasNotCancelled() && group.memberCount === 0) group.leader = user._id; // If new user is only member -> set as leader
+    if (!group.hasNotCancelled() && group.memberCount === 1) group.leader = user._id; // If new user is only member -> set as leader
 
     if (group.hasNotCancelled())  {
       await payments.addSubToGroupUser(user, group);

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -941,7 +941,7 @@ api.removeGroupMember = {
       group.save(),
     ]);
 
-    if (group.hasNotCancelled())  {
+    if (isInGroup && group.hasNotCancelled())  {
       await group.updateGroupPlan(true);
       await payments.cancelGroupSubscriptionForUser(member, group, true);
     }

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -587,6 +587,9 @@ api.joinGroup = {
     }
     if (!isUserInvited) throw new NotAuthorized(res.t('messageGroupRequiresInvite'));
 
+    // @TODO: Review the need for this and if still needed, don't base this on memberCount
+    if (!group.hasNotCancelled() && group.memberCount === 0) group.leader = user._id; // If new user is only member -> set as leader
+
     group.memberCount += 1;
 
     let promises = [group.save(), user.save()];
@@ -629,9 +632,6 @@ api.joinGroup = {
     }
 
     promises = await Promise.all(promises);
-
-    // @TODO: Review the need for this and if still needed, don't base this on memberCount
-    if (!group.hasNotCancelled() && group.memberCount === 1) group.leader = user._id; // If new user is only member -> set as leader
 
     if (group.hasNotCancelled())  {
       await payments.addSubToGroupUser(user, group);


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Moves some logic when updating Group Plan member counts to later in the relevant functions, hopefully ensuring that the data we're relying on to reconcile the numbers will be up to date when we draw upon it.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)