### PR TITLE
Show accurate XP gain in notification on level up

### DIFF
--- a/website/client/components/notifications.vue
+++ b/website/client/components/notifications.vue
@@ -88,6 +88,7 @@ import axios from 'axios';
 import moment from 'moment';
 import throttle from 'lodash/throttle';
 
+import { toNextLevel } from '../../common/script/statHelpers';
 import { shouldDo } from '../../common/script/cron';
 import { mapState } from 'client/libs/store';
 import notifications from 'client/mixins/notifications';
@@ -222,7 +223,12 @@ export default {
     userExp (after, before) {
       if (after === before) return;
       if (this.user.stats.lvl === 0) return;
-      this.exp(after - before);
+
+      let exp = after - before;
+      if (exp < -50) { // recalculate exp if user level up
+        exp = toNextLevel(this.user.stats.lvl - 1) - before + after;
+      }
+      this.exp(exp);
     },
     userGp (after, before) {
       if (after === before) return;

--- a/website/client/libs/notifications.js
+++ b/website/client/libs/notifications.js
@@ -47,6 +47,6 @@ export function round (number, nDigits) {
 }
 
 export function getXPMessage (val) {
-  if (val < -50) return; // don't show when they level up (resetting their exp)
+  if (val < -50) return; // don't show when they multi-level up (resetting their exp)
   return `${getSign(val)} ${round(val)}`;
 }


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10297

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Fixing the issue by recalculating the experience needed to level up from the previous level, then substracting the previous state of XP to it then adding the new state of XP to it.  

I think there is an edge case though, like if the user levels up more than once, the result might likely be wrong (as the notifications are working on the previous and new state of XP in this case, I don't see how we can see if we get many level ups in there). But that case should happen rarely? (like a low level user in a party that just slayed a big monster perhaps?). Let me know what you think of it...


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: bbffb2f4-9bf8-46c4-b749-523e2ca93ef6
