### PR TITLE
Add error notification for deleted user

### DIFF
--- a/website/client/components/chat/chatMessages.vue
+++ b/website/client/components/chat/chatMessages.vue
@@ -205,7 +205,7 @@ export default {
         if (result.response && result.response.status === 404) {
           return this.$store.dispatch('snackbars:add', {
             title: 'Habitica',
-            text: 'Sorry, this user has deleted their account.',
+            text: this.$t('messageDeletedUser'),
             type: 'error',
             timeout: false,
           });

--- a/website/client/components/chat/chatMessages.vue
+++ b/website/client/components/chat/chatMessages.vue
@@ -202,8 +202,17 @@ export default {
 
       if (!profile._id) {
         const result = await this.$store.dispatch('members:fetchMember', { memberId });
-        this.cachedProfileData[memberId] = result.data.data;
-        profile = result.data.data;
+        if (!result.data) {
+          return this.$store.dispatch('snackbars:add', {
+            title: 'Habitica',
+            text: 'Sorry, this user has deleted their account.',
+            type: 'error',
+            timeout: false,
+          });
+        } else {
+          this.cachedProfileData[memberId] = result.data.data;
+          profile = result.data.data;
+        }
       }
 
       // Open the modal only if the data is available

--- a/website/client/components/chat/chatMessages.vue
+++ b/website/client/components/chat/chatMessages.vue
@@ -202,7 +202,7 @@ export default {
 
       if (!profile._id) {
         const result = await this.$store.dispatch('members:fetchMember', { memberId });
-        if (!result.data) {
+        if (result.response && result.response.status === 404) {
           return this.$store.dispatch('snackbars:add', {
             title: 'Habitica',
             text: 'Sorry, this user has deleted their account.',

--- a/website/common/locales/en/messages.json
+++ b/website/common/locales/en/messages.json
@@ -69,5 +69,7 @@
   "notificationsRequired": "Notification ids are required.",
   "unallocatedStatsPoints": "You have <span class=\"notification-bold-blue\"><%= points %> unallocated Stat Points</span>",
 
-  "beginningOfConversation": "This is the beginning of your conversation with <%= userName %>. Remember to be kind, respectful, and follow the Community Guidelines!"
+  "beginningOfConversation": "This is the beginning of your conversation with <%= userName %>. Remember to be kind, respectful, and follow the Community Guidelines!",
+
+  "messageDeletedUser": "Sorry, this user has deleted their account."
 }


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10433 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

An error notification now shows up when attempting to open the profile of a deleted user.

![deleteduser](https://user-images.githubusercontent.com/30595954/44105557-146152fc-9fc0-11e8-885b-c368799eb794.gif)

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 9ca2bb65-ce6c-4e4c-a367-5ef9b5c7421e