### PR TITLE
Fixing healing light not being castable when user full hp

### DIFF
--- a/test/api/v3/integration/user/POST-user_class_cast_spellId.test.js
+++ b/test/api/v3/integration/user/POST-user_class_cast_spellId.test.js
@@ -58,6 +58,21 @@ describe('POST /user/class/cast/:spellId', () => {
       });
   });
 
+  it('returns an error if use Healing Light spell with full health', async () => {
+    await user.update({
+      'stats.class': 'healer',
+      'stats.lvl': 11,
+      'stats.hp': 50,
+      'stats.mp': 200
+    });
+    await expect(user.post('/user/class/cast/heal'))
+      .to.eventually.be.rejected.and.eql({
+        code: 401,
+        error: 'NotAuthorized',
+        message: t('messageHealthAlreadyMax'),
+      });
+  });
+
   it('returns an error if spell.lvl > user.level', async () => {
     await user.update({'stats.mp': 200, 'stats.class': 'wizard'});
     await expect(user.post('/user/class/cast/earth'))

--- a/test/api/v3/integration/user/POST-user_class_cast_spellId.test.js
+++ b/test/api/v3/integration/user/POST-user_class_cast_spellId.test.js
@@ -63,7 +63,7 @@ describe('POST /user/class/cast/:spellId', () => {
       'stats.class': 'healer',
       'stats.lvl': 11,
       'stats.hp': 50,
-      'stats.mp': 200
+      'stats.mp': 200,
     });
     await expect(user.post('/user/class/cast/heal'))
       .to.eventually.be.rejected.and.eql({

--- a/test/common/ops/spells.js
+++ b/test/common/ops/spells.js
@@ -10,29 +10,29 @@ import i18n from '../../../website/common/script/i18n';
 // TODO complete the test suite...
 
 describe('shared.ops.spells', () => {
-    let user;
+  let user;
 
-    beforeEach(() => {
-        user = generateUser();
-    });
+  beforeEach(() => {
+    user = generateUser();
+  });
 
-    it('returns an error when healer tries to cast Healing Light with full health', (done) => {
-        user.stats.class = 'healer';
-        user.stats.lvl = 11;
-        user.stats.hp = 50;
-        user.stats.mp = 200;
+  it('returns an error when healer tries to cast Healing Light with full health', (done) => {
+    user.stats.class = 'healer';
+    user.stats.lvl = 11;
+    user.stats.hp = 50;
+    user.stats.mp = 200;
 
-        let spell = spells['healer']['heal'];
+    let spell = spells.healer.heal;
 
-        try {
-            spell.cast(user);
-        } catch (err) {
-            expect(err).to.be.an.instanceof(NotAuthorized);
-            expect(err.message).to.equal(i18n.t('messageHealthAlreadyMax'));
-            expect(user.stats.hp).to.eql(50);
-            expect(user.stats.mp).to.eql(200);
+    try {
+      spell.cast(user);
+    } catch (err) {
+      expect(err).to.be.an.instanceof(NotAuthorized);
+      expect(err.message).to.equal(i18n.t('messageHealthAlreadyMax'));
+      expect(user.stats.hp).to.eql(50);
+      expect(user.stats.mp).to.eql(200);
 
-            done();
-        }
-    });
+      done();
+    }
+  });
 });

--- a/test/common/ops/spells.js
+++ b/test/common/ops/spells.js
@@ -1,0 +1,38 @@
+import {
+  generateUser,
+} from '../../helpers/common.helper';
+import spells from '../../../website/common/script/content/spells';
+import {
+  NotAuthorized,
+} from '../../../website/common/script/libs/errors';
+import i18n from '../../../website/common/script/i18n';
+
+// TODO complete the test suite...
+
+describe('shared.ops.spells', () => {
+    let user;
+
+    beforeEach(() => {
+        user = generateUser();
+    });
+
+    it('returns an error when healer tries to cast Healing Light with full health', (done) => {
+        user.stats.class = 'healer';
+        user.stats.lvl = 11;
+        user.stats.hp = 50;
+        user.stats.mp = 200;
+
+        let spell = spells['healer']['heal'];
+
+        try {
+            spell.cast(user);
+        } catch (err) {
+            expect(err).to.be.an.instanceof(NotAuthorized);
+            expect(err.message).to.equal(i18n.t('messageHealthAlreadyMax'));
+            expect(user.stats.hp).to.eql(50);
+            expect(user.stats.mp).to.eql(200);
+
+            done();
+        }
+    });
+});

--- a/website/client/mixins/spells.js
+++ b/website/client/mixins/spells.js
@@ -85,7 +85,20 @@ export default {
 
       // the selected member doesn't have the flags property which sets `cardReceived`
       if (spell.pinType !== 'card') {
-        spell.cast(this.user, target);
+        try {
+          spell.cast(this.user, target);
+        } catch (e) {
+          if (!e.request) {
+            this.$store.dispatch('snackbars:add', {
+              title: '',
+              text: e.message,
+              type: 'error',
+            });
+            return;
+          } else {
+            throw e;
+          }
+        }
       }
 
       let targetId = target ? target._id : null;

--- a/website/common/script/content/spells.js
+++ b/website/common/script/content/spells.js
@@ -211,6 +211,7 @@ spells.healer = {
     target: 'self',
     notes: t('spellHealerHealNotes'),
     cast (user) {
+      if (user.stats.hp >= 50) throw new NotAuthorized(t('messageHealthAlreadyMax')(user.language));
       user.stats.hp += (statsComputed(user).con + statsComputed(user).int + 5) * 0.075;
       if (user.stats.hp > 50) user.stats.hp = 50;
     },


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10548

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Prevent the user to be able to cast Healing light as a Healer if he has full health already (50 HP). The check is being made in the common script both used by client and server sides. 

Added some tests cases as well.

Wondering too if it wouldn't be better to send the cast request to the server first before casting it on client side as well (current logic seems to be that it's first being casted on client's side).

EDIT : Apologies for the non-respect of the ESLint syntax... Fixed!

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: bbffb2f4-9bf8-46c4-b749-523e2ca93ef6
