### PR TITLE
always reload completed todos

### DIFF
--- a/website/client/components/header/menu.vue
+++ b/website/client/components/header/menu.vue
@@ -396,12 +396,13 @@ export default {
     toggleUserDropdown () {
       this.isUserDropdownOpen = !this.isUserDropdownOpen;
     },
-    sync () {
+    async sync () {
       this.$root.$emit('habitica::resync-requested');
-      return Promise.all([
+      await Promise.all([
         this.$store.dispatch('user:fetch', {forceLoad: true}),
         this.$store.dispatch('tasks:fetchUserTasks', {forceLoad: true}),
       ]);
+      this.$root.$emit('habitica::resync-completed');
     },
     async getUserGroupPlans () {
       this.$store.state.groupPlans = await this.$store.dispatch('guilds:getGroupPlans');

--- a/website/client/components/tasks/column.vue
+++ b/website/client/components/tasks/column.vue
@@ -449,9 +449,9 @@ export default {
     });
 
     if (this.type !== 'todo') return;
-    this.$root.$on('habitica::resync-requested', () => {
+    this.$root.$on('habitica::resync-completed', () => {
       if (this.activeFilter.label !== 'complete2') return;
-      this.loadCompletedTodos(true);
+      this.loadCompletedTodos();
     });
   },
   destroyed () {

--- a/website/client/store/actions/tasks.js
+++ b/website/client/store/actions/tasks.js
@@ -19,13 +19,13 @@ export function fetchUserTasks (store, options = {}) {
   });
 }
 
-export async function fetchCompletedTodos (store, forceLoad = false) {
+export async function fetchCompletedTodos (store) {
   // Wait for the user to be loaded before deserializing
   // because user.tasksOrder is necessary
   await store.dispatch('tasks:fetchUserTasks');
 
   const loadStatus = store.state.completedTodosStatus;
-  if (loadStatus === 'NOT_LOADED' || forceLoad) {
+  if (loadStatus !== 'LOADING') {
     store.state.completedTodosStatus = 'LOADING';
 
     const response = await axios.get('/api/v4/tasks/user?type=completedTodos');
@@ -36,17 +36,6 @@ export async function fetchCompletedTodos (store, forceLoad = false) {
     tasks.todos.push(...completedTodos);
 
     store.state.completedTodosStatus = 'LOADED';
-  } else if (status === 'LOADED') {
-    return;
-  } else if (loadStatus === 'LOADING') {
-    const watcher = store.watch(state => state.completedTodosStatus, (newLoadingStatus) => {
-      watcher(); // remove the watcher
-      if (newLoadingStatus === 'LOADED') {
-        return;
-      } else {
-        throw new Error(); // TODO add reason?
-      }
-    });
   }
 }
 


### PR DESCRIPTION
fixes #9806 

- always reload completed todos if you select the tab
- reload completed todos after you triggered a re-sync