### PR TITLE
Only notify if pushedItems isn't empty - fixes #10496

### DIFF
--- a/website/server/libs/payments/subscriptions.js
+++ b/website/server/libs/payments/subscriptions.js
@@ -37,7 +37,9 @@ function revealMysteryItems (user) {
     }
   });
 
-  user.addNotification('NEW_MYSTERY_ITEMS', { items: pushedItems });
+  if (pushedItems.length !== 0) {
+    user.addNotification('NEW_MYSTERY_ITEMS', { items: pushedItems });
+  }
 }
 
 // @TODO: Abstract to payment helper


### PR DESCRIPTION
Fixes #10496

### Changes
- Checked to make sure pushedItems wasn't empty before user.addNotification() is called

----
UUID: 495eed5c-2828-4e24-a19d-755ac5e95295