### PR TITLE
Fix lostMasterclasser achievement issue

### DIFF
--- a/test/api/unit/models/group.test.js
+++ b/test/api/unit/models/group.test.js
@@ -1405,8 +1405,7 @@ describe('Group Model', () => {
         expect(updatedParticipatingMember.achievements.quests[quest.key]).to.eql(1);
       });
 
-      // Disable test, it fails on TravisCI, but only there
-      xit('gives out super awesome Masterclasser achievement to the deserving', async () => {
+      it('gives out super awesome Masterclasser achievement to the deserving', async () => {
         quest = questScrolls.lostMasterclasser4;
         party.quest.key = quest.key;
 
@@ -1442,8 +1441,7 @@ describe('Group Model', () => {
         expect(updatedParticipatingMember.achievements.lostMasterclasser).to.not.eql(true);
       });
 
-      // Disable test, it fails on TravisCI, but only there
-      xit('gives out super awesome Masterclasser achievement when quests done out of order', async () => {
+      it('gives out super awesome Masterclasser achievement when quests done out of order', async () => {
         quest = questScrolls.lostMasterclasser1;
         party.quest.key = quest.key;
 

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -913,22 +913,6 @@ schema.methods.finishQuest = async function finishQuest (quest) {
     'lostMasterclasser4',
   ];
 
-  if (masterClasserQuests.includes(questK)) {
-    let lostMasterclasserQuery = {
-      'achievements.lostMasterclasser': {$ne: true},
-    };
-    masterClasserQuests.forEach(questName => {
-      lostMasterclasserQuery[`achievements.quests.${questName}`] = {$gt: 0};
-    });
-    let lostMasterclasserUpdate = {
-      $set: {'achievements.lostMasterclasser': true},
-    };
-
-    promises = promises.concat(participants.map(userId => {
-      return _updateUserWithRetries(userId, lostMasterclasserUpdate, null, lostMasterclasserQuery);
-    }));
-  }
-
   // Send webhooks in background
   // @TODO move the find users part to a worker as well, not just the http request
   User.find({
@@ -954,7 +938,24 @@ schema.methods.finishQuest = async function finishQuest (quest) {
       });
     });
 
-  return await Promise.all(promises);
+  await Promise.all(promises);
+
+  if (masterClasserQuests.includes(questK)) {
+    let lostMasterclasserQuery = {
+      'achievements.lostMasterclasser': {$ne: true},
+    };
+    masterClasserQuests.forEach(questName => {
+      lostMasterclasserQuery[`achievements.quests.${questName}`] = {$gt: 0};
+    });
+    let lostMasterclasserUpdate = {
+      $set: {'achievements.lostMasterclasser': true},
+    };
+
+    let lostMasterClasserPromises = participants.map(userId => {
+      return _updateUserWithRetries(userId, lostMasterclasserUpdate, null, lostMasterclasserQuery);
+    });
+    await Promise.all(lostMasterClasserPromises);
+  }
 };
 
 function _isOnQuest (user, progress, group) {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10398

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
To fix this issue, I just run the updates regarding the quest completion first, then runs the extra ones in an other `Promises.all` for the achievement award. I also put back the related tests to it, as I think it was failing on Travis for the exact same reason (that I managed to reproduce on local too... achievement update running before quest completion update). It shouldn't fail anymore now.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: bbffb2f4-9bf8-46c4-b749-523e2ca93ef6
