### PR TITLE
Fixing misspelling and inconsistent punctuation in the api doc

### DIFF
--- a/website/server/controllers/api-v3/challenges.js
+++ b/website/server/controllers/api-v3/challenges.js
@@ -329,7 +329,7 @@ api.leaveChallenge = {
 };
 
 /**
- * @api {get} /api/v3/challenges/user Get challenges for a user.
+ * @api {get} /api/v3/challenges/user Get challenges for a user
  * @apiName GetUserChallenges
  * @apiGroup Challenge
  * @apiDescription Get challenges the user has access to. Includes public challenges, challenges belonging to the user's group, and challenges the user has already joined.
@@ -640,7 +640,7 @@ api.exportChallengeCsv = {
 };
 
 /**
- * @api {put} /api/v3/challenges/:challengeId Update the name, description, or leader of a challenge.
+ * @api {put} /api/v3/challenges/:challengeId Update the name, description, or leader of a challenge
  *
  * @apiName UpdateChallenge
  * @apiGroup Challenge

--- a/website/server/controllers/api-v3/user.js
+++ b/website/server/controllers/api-v3/user.js
@@ -147,7 +147,7 @@ api.getBuyList = {
 };
 
 /**
- * @api {get} /api/v3/user/in-app-rewards Get the in app items appaearing in the user's reward column
+ * @api {get} /api/v3/user/in-app-rewards Get the in app items appearing in the user's reward column
  * @apiName UserGetInAppRewards
  * @apiGroup User
  *


### PR DESCRIPTION
### Changes
Fixing misspelling and inconsistent punctuation in the api doc 

----
UUID: 6c4ef2c1-2ae1-41a4-85cc-35228c926366
