### PR TITLE
Fix members modal showing stale data for challenges

### DIFF
--- a/website/client/components/groups/membersModal.vue
+++ b/website/client/components/groups/membersModal.vue
@@ -338,6 +338,9 @@ export default {
       // @TOOD: We might not need this since groupId is computed now
       this.getMembers();
     },
+    challengeId () {
+      this.getMembers();
+    },
     group () {
       this.getMembers();
     },
@@ -377,9 +380,7 @@ export default {
         this.invites = invites;
       }
 
-      if (this.$store.state.memberModalOptions.viewingMembers.length > 0) {
-        this.members = this.$store.state.memberModalOptions.viewingMembers;
-      }
+      this.members = this.$store.state.memberModalOptions.viewingMembers;
     },
     async clickMember (uid, forceShow) {
       let user = this.$store.state.user.data;


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10554

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
The members modal was not updating when looking at challenges because it only did so when the group ID changed, but the group ID for challenges is 'challenge'. I modified it so it also updates when the challenge ID changes.

I also removed the condition to updates members only if viewingMembers.length > 1. It didn't look like there was a need for it. If a group has zero members, which could be true for challenges, then it will still show the previous members list. If it was some type of validation to make sure the property was set correctly, the user would see the previous members list and would not be notified of any issues. 




[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 9bcc7003-ccae-4570-a7f9-1daba63efadd
