### PR TITLE
Allow login buttons to expand vertically - fixes #9861

### DIFF
--- a/website/client/components/auth/authForm.vue
+++ b/website/client/components/auth/authForm.vue
@@ -50,7 +50,6 @@
     .social-button {
       width: 100%;
       height: 100%;
-      
       white-space: inherit;
       text-align: center;
 

--- a/website/client/components/auth/authForm.vue
+++ b/website/client/components/auth/authForm.vue
@@ -49,6 +49,9 @@
 
     .social-button {
       width: 100%;
+      height: 100%;
+      
+      white-space: inherit;
       text-align: center;
 
       .text {

--- a/website/client/components/auth/registerLoginReset.vue
+++ b/website/client/components/auth/registerLoginReset.vue
@@ -21,7 +21,7 @@
       .col-12.col-md-6
         .btn.btn-secondary.social-button(@click='socialAuth("google")')
           .svg-icon.social-icon(v-html="icons.googleIcon")
-          span {{registering ? $t('signUpWithSocial', {social: 'Google'}) : $t('loginWithSocial', {social: 'Google'})}}
+          .text {{registering ? $t('signUpWithSocial', {social: 'Google'}) : $t('loginWithSocial', {social: 'Google'})}}
     .form-group(v-if='registering')
       label(for='usernameInput', v-once) {{$t('username')}}
       input#usernameInput.form-control(type='text', :placeholder='$t("usernamePlaceholder")', v-model='username')
@@ -207,6 +207,8 @@
 
     .social-button {
       width: 100%;
+      height: 100%;
+      white-space: inherit;
       text-align: center;
 
       .text {


### PR DESCRIPTION
Fixes #9861

### Changes
- allowed buttons to expand horizontally in the case of super long text

<img width="757" alt="screen shot 2018-08-24 at 2 00 07 pm" src="https://user-images.githubusercontent.com/4992601/44607995-1a743300-a7a7-11e8-9c19-93b40fde2f52.png">

----
UUID: 495eed5c-2828-4e24-a19d-755ac5e95295
