### PR TITLE
add top margin on all modals to prevent overlap with nav/messaging - fixes #10475

### DIFF
--- a/website/client/assets/scss/modal.scss
+++ b/website/client/assets/scss/modal.scss
@@ -13,6 +13,7 @@
 
 .modal-dialog {
   width: auto;
+  margin-top: 100px;
 
   .title {
     min-height: 24px;

--- a/website/client/assets/scss/modal.scss
+++ b/website/client/assets/scss/modal.scss
@@ -13,7 +13,7 @@
 
 .modal-dialog {
   width: auto;
-  margin-top: 100px;
+  margin-top: 60px;
 
   .title {
     min-height: 24px;
@@ -36,6 +36,10 @@
     overflow-y: hidden;
     text-overflow: ellipsis;
   }
+}
+
+.restingInn .modal-dialog {
+  margin-top: 100px;
 }
 
 #start-quest-modal, #buy-quest-modal {

--- a/website/client/assets/scss/modal.scss
+++ b/website/client/assets/scss/modal.scss
@@ -11,9 +11,12 @@
   }
 }
 
+.modal {
+  z-index: 1300;
+}
+
 .modal-dialog {
   width: auto;
-  margin-top: 60px;
 
   .title {
     min-height: 24px;
@@ -36,10 +39,6 @@
     overflow-y: hidden;
     text-overflow: ellipsis;
   }
-}
-
-.restingInn .modal-dialog {
-  margin-top: 100px;
 }
 
 #start-quest-modal, #buy-quest-modal {


### PR DESCRIPTION
Fixes #10475

### Changes
- Added 100px top margin on all modals to prevent overlap issues with the nav and message banner

<img width="906" alt="screen shot 2018-08-24 at 9 34 12 pm" src="https://user-images.githubusercontent.com/4992601/44615096-10bdf000-a7e6-11e8-822a-e24abef7815b.png">

----
UUID: 495eed5c-2828-4e24-a19d-755ac5e95295
