### PR TITLE
prevent Quest progress message in Party chat when user is Resting in the Inn

### DIFF
--- a/test/api/unit/models/group.test.js
+++ b/test/api/unit/models/group.test.js
@@ -542,8 +542,8 @@ describe('Group Model', () => {
             updatedSleepingParticipatingMember,
           ] = await Promise.all([
             User.findById(questLeader._id),
-            User.findById(sleepingParticipatingMember._id),
             User.findById(participatingMember._id),
+            User.findById(sleepingParticipatingMember._id),
           ]);
 
           expect(updatedLeader.achievements.quests[party.quest.key]).to.eql(1);

--- a/test/api/unit/models/group.test.js
+++ b/test/api/unit/models/group.test.js
@@ -1524,6 +1524,7 @@ describe('Group Model', () => {
 
         expect(updatedLeader.achievements.lostMasterclasser).to.eql(true);
         expect(updatedParticipatingMember.achievements.lostMasterclasser).to.not.eql(true);
+        expect(updatedSleepingParticipatingMember.achievements.lostMasterclasser).to.not.eql(true);
       });
 
       it('gives out super awesome Masterclasser achievement when quests done out of order', async () => {

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -1091,6 +1091,8 @@ schema.methods._processCollectionQuest = async function processCollectionQuest (
 };
 
 schema.statics.processQuestProgress = async function processQuestProgress (user, progress) {
+  if (user.preferences.sleep) return;
+
   let group = await this.getGroup({user, groupId: 'party'});
 
   if (!_isOnQuest(user, progress, group)) return;
@@ -1101,7 +1103,7 @@ schema.statics.processQuestProgress = async function processQuestProgress (user,
 
   let questType = quest.boss ? 'Boss' : 'Collection';
 
-  await group[`_process${questType}Quest`]({
+  await group[`_process${questType}Quest`]({ // processBossQuest, processCollectionQuest
     user,
     progress,
     group,
@@ -1131,6 +1133,7 @@ process.nextTick(() => {
 // returns a promise
 schema.statics.tavernBoss = async function tavernBoss (user, progress) {
   if (!progress) return;
+  if (user.preferences.sleep) return;
 
   // hack: prevent crazy damage to world boss
   let dmg = Math.min(900, Math.abs(progress.up || 0));

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -1103,7 +1103,7 @@ schema.statics.processQuestProgress = async function processQuestProgress (user,
 
   let questType = quest.boss ? 'Boss' : 'Collection';
 
-  await group[`_process${questType}Quest`]({ // processBossQuest, processCollectionQuest
+  await group[`_process${questType}Quest`]({ // _processBossQuest, _processCollectionQuest
     user,
     progress,
     group,


### PR DESCRIPTION
Currently, if you're on a Quest and are Resting in the Inn, when cron runs it posts a message to Party chat: "Player attacks Boss for 0.0 damage. Boss attacks party for 0.0 damage." The attack numbers are always zero and user.party.quest.progress is not changed, so the bug is just that the message is posted. 

This PR fixes that.

The bug is a side-effect of https://github.com/HabitRPG/habitica/pull/10577 - my fault, I'm sorry. :(
