### PR TITLE
changed @mentioning-auto-complete from text- to caret-based. (Fixes #9694)

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>habitica</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/website/client/components/chat/autoComplete.vue
+++ b/website/client/components/chat/autoComplete.vue
@@ -99,7 +99,6 @@ export default {
         this.searchActive = true;
         startIndex++;
       } else return currIndex;
-      console.log(startIndex);
       return startIndex;
     },
   },

--- a/website/client/components/chat/autoComplete.vue
+++ b/website/client/components/chat/autoComplete.vue
@@ -48,18 +48,17 @@ export default {
   },
   watch: {
     carPos (newCarPos) {
-      let index = newCarPos - 1;
+      let startIndex = newCarPos - 1;
       let newText = this.text;
-      if (index >= newText.length) index = newText.length - 1;
-      // if ((!newText[index] || newText[index] === ' ') && (!newText[index + 1] || (newText[index + 1] && newText[index + 1] === ' '))) {
-      //   this.searchActive = false;
-      //   return;
-      // }
+      if (startIndex >= newText.length) startIndex = newText.length - 1;
+      if (!newText[startIndex] || newText[startIndex] === ' ') {
+        this.searchActive = false;
+        return;
+      }
       this.searchActive = false;
 
-      let startIndex = index;
       while (newText[startIndex] !== '@' && startIndex >= 0) {
-        // if (!newText[startIndex] || (newText[startIndex] === ' ' && newText[startIndex + 1] === ' ')) return;
+        if (newText[startIndex] === ' ') return;
         startIndex--;
       }
       if (newText[startIndex] === '@') {
@@ -92,8 +91,7 @@ export default {
       }
     },
     select (result) {
-      let index = this.carPos;
-      let startIndex = index;
+      let startIndex = this.carPos;
       while (this.text[startIndex] !== '@' && startIndex >= 0) {
         startIndex--;
       }

--- a/website/client/components/chat/autoComplete.vue
+++ b/website/client/components/chat/autoComplete.vue
@@ -51,13 +51,15 @@ export default {
       let index = newCarPos - 1;
       let newText = this.text;
       if (index >= newText.length) index = newText.length - 1;
-      if (!newText[index] || newText[index] === ' ') {
-        this.searchActive = false;
-        return;
-      }
+      // if ((!newText[index] || newText[index] === ' ') && (!newText[index + 1] || (newText[index + 1] && newText[index + 1] === ' '))) {
+      //   this.searchActive = false;
+      //   return;
+      // }
+      this.searchActive = false;
+
       let startIndex = index;
       while (newText[startIndex] !== '@' && startIndex >= 0) {
-        if (this.text[startIndex] === ' ') break;
+        // if (!newText[startIndex] || (newText[startIndex] === ' ' && newText[startIndex + 1] === ' ')) return;
         startIndex--;
       }
       if (newText[startIndex] === '@') {

--- a/website/client/components/chat/autoComplete.vue
+++ b/website/client/components/chat/autoComplete.vue
@@ -48,23 +48,15 @@ export default {
   },
   watch: {
     carPos (newCarPos) {
-      let startIndex = newCarPos - 1;
+      let index = newCarPos - 1;
       let newText = this.text;
-      if (startIndex >= newText.length) startIndex = newText.length - 1;
-      if (!newText[startIndex] || newText[startIndex] === ' ') {
+      if (index >= newText.length) index = newText.length - 1;
+      if (!newText[index] || newText[index] === ' ') {
         this.searchActive = false;
         return;
       }
       this.searchActive = false;
-
-      while (newText[startIndex] !== '@' && startIndex >= 0) {
-        if (newText[startIndex] === ' ') return;
-        startIndex--;
-      }
-      if (newText[startIndex] === '@') {
-        this.searchActive = true;
-        startIndex++;
-      } else return;
+      let startIndex = this.findStartIndex(index);
       this.currentSearchPosition = startIndex;
     },
     chat () {
@@ -91,14 +83,24 @@ export default {
       }
     },
     select (result) {
-      let startIndex = this.carPos;
-      while (this.text[startIndex] !== '@' && startIndex >= 0) {
-        startIndex--;
-      }
-      startIndex++;
-      let newText = this.text.slice(0, this.currentSearchPosition) + result + this.text.slice(this.currentSearchPosition + index - startIndex);
+      let index = this.carPos;
+      let newText = this.text.slice(0, this.currentSearchPosition) + result + this.text.slice(this.currentSearchPosition + index - this.findStartIndex(index));
       this.searchActive = false;
       this.$emit('select', newText);
+    },
+    findStartIndex (currIndex) {
+      let startIndex = currIndex;
+      let newText = this.text;
+      while (newText[startIndex] !== '@' && startIndex >= 0) {
+        if (newText[startIndex] === ' ') return currIndex;
+        startIndex--;
+      }
+      if (newText[startIndex] === '@') {
+        this.searchActive = true;
+        startIndex++;
+      } else return currIndex;
+      console.log(startIndex);
+      return startIndex;
     },
   },
 };

--- a/website/client/components/chat/autoComplete.vue
+++ b/website/client/components/chat/autoComplete.vue
@@ -83,8 +83,7 @@ export default {
       }
     },
     select (result) {
-      let index = this.carPos;
-      let newText = this.text.slice(0, this.currentSearchPosition) + result + this.text.slice(this.currentSearchPosition + index - this.findStartIndex(index));
+      let newText = this.text.slice(0, this.currentSearchPosition) + result + this.text.slice(this.carPos);
       this.searchActive = false;
       this.$emit('select', newText);
     },

--- a/website/client/components/chat/autoComplete.vue
+++ b/website/client/components/chat/autoComplete.vue
@@ -57,12 +57,14 @@ export default {
       }
       let startIndex = index;
       while (newText[startIndex] !== '@' && startIndex >= 0) {
+        if (this.text[startIndex] === ' ') break;
         startIndex--;
       }
       if (newText[startIndex] === '@') {
         this.searchActive = true;
         startIndex++;
       }
+      else return;
       this.currentSearchPosition = startIndex;
     },
     chat () {

--- a/website/client/components/chat/autoComplete.vue
+++ b/website/client/components/chat/autoComplete.vue
@@ -63,8 +63,7 @@ export default {
       if (newText[startIndex] === '@') {
         this.searchActive = true;
         startIndex++;
-      }
-      else return;
+      } else return;
       this.currentSearchPosition = startIndex;
     },
     chat () {

--- a/website/client/components/chat/autoComplete.vue
+++ b/website/client/components/chat/autoComplete.vue
@@ -48,14 +48,14 @@ export default {
   },
   watch: {
     carPos (newCarPos) {
-      var index = newCarPos - 1;
-      var newText = this.text;
+      let index = newCarPos - 1;
+      let newText = this.text;
       if (index >= newText.length) index = newText.length - 1;
       if (!newText[index] || newText[index] === ' ') {
         this.searchActive = false;
         return;
       }
-      var startIndex = index;
+      let startIndex = index;
       while (newText[startIndex] !== '@' && startIndex >= 0) {
         startIndex--;
       }
@@ -89,8 +89,8 @@ export default {
       }
     },
     select (result) {
-      var index = this.carPos;
-      var startIndex = index;
+      let index = this.carPos;
+      let startIndex = index;
       while (this.text[startIndex] !== '@' && startIndex >= 0) {
         startIndex--;
       }

--- a/website/client/components/groups/chat.vue
+++ b/website/client/components/groups/chat.vue
@@ -7,6 +7,7 @@
         textarea(:placeholder='placeholder',
                   v-model='newMessage',
                   :class='{"user-entry": newMessage}',
+                  ref="textarea",
                   @keydown='updateCarretPosition',
                   @click='updateCarretPosition',
                   @keyup.ctrl.enter='sendMessageShortcut()',
@@ -74,7 +75,7 @@
     },
     methods: {
       // https://medium.com/@_jh3y/how-to-where-s-the-caret-getting-the-xy-position-of-the-caret-a24ba372990a
-      getCoord (e, text) {
+      getCoord (text) {
         let carPos = text.selectionEnd;
         this.carPos = carPos;
         let div = document.createElement('div');
@@ -101,7 +102,7 @@
       }, 250),
       _updateCarretPosition (eventUpdate) {
         let text = eventUpdate.target;
-        this.getCoord(eventUpdate, text);
+        this.getCoord(text);
       },
       async sendMessageShortcut () {
         // If the user recently pasted in the text field, don't submit
@@ -139,8 +140,9 @@
         }, 500);
       },
 
-      selectedAutocomplete (newText) {
+      async selectedAutocomplete (newText) {
         this.newMessage = newText;
+        this.$refs.textarea.focus();
       },
 
       fetchRecentMessages () {

--- a/website/client/components/groups/chat.vue
+++ b/website/client/components/groups/chat.vue
@@ -8,6 +8,7 @@
                   v-model='newMessage',
                   :class='{"user-entry": newMessage}',
                   @keydown='updateCarretPosition',
+                  @click='updateCarretPosition',
                   @keyup.ctrl.enter='sendMessageShortcut()',
                   @paste='disableMessageSendShortcut()',
                   maxlength='3000'
@@ -17,7 +18,8 @@
                 :text='newMessage',
                 v-on:select="selectedAutocomplete",
                 :coords='coords',
-                :chat='group.chat')
+                :chat='group.chat',
+                :carPos = 'carPos')
 
       .row.chat-actions
         .col-6.chat-receive-actions
@@ -62,6 +64,7 @@
           TOP: 0,
           LEFT: 0,
         },
+        carPos: 0,
       };
     },
     computed: {
@@ -73,6 +76,7 @@
       // https://medium.com/@_jh3y/how-to-where-s-the-caret-getting-the-xy-position-of-the-caret-a24ba372990a
       getCoord (e, text) {
         let carPos = text.selectionEnd;
+        this.carPos = carPos;
         let div = document.createElement('div');
         let span = document.createElement('span');
         let copyStyle = getComputedStyle(text);


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #9694
Fixes #10646

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
The bugs described in #9694 were mainly due to the `@mentioning` autocomplete only checking the end of an inputted message for possible tags. Autocomplete suggestions were also only added when the message text itself was edited.

I changed the code so that the autocomplete suggestions update based on caret position instead, similar to how Facebook handles `@mentioning`. The autocomplete suggestions should now be reactive to everything (clicking around on the inputted text, using arrow keys to move the caret, etc.), not just the text itself being updated. This change addresses the bugs in #9694.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 215e51f6-beb1-4617-b359-fcb09681e6fd
