### PR TITLE
Press kit pointer cursor

### DIFF
--- a/website/client/components/static/pressKit.vue
+++ b/website/client/components/static/pressKit.vue
@@ -17,13 +17,11 @@
             img.img-fluid.img-rendering-auto.press-img(:src="`/static/presskit/${category}/${secondaryCategory}/${img}`")
 
     h1 {{ $t('FAQ') }}
-
     #faq(role='tablist')
       .faq-question(v-for='(QA, index) in faq')
         h2(v-b-toggle="QA.question", tabindex="0", role="button", v-html="$t(QA.question)")
         b-collapse(:id="QA.question", accordion="pkAccordian", role="tabpanel")
           p(v-html="$t(QA.answer)")
-
     p {{ $t('pkMoreQuestions') }}
 </template>
 

--- a/website/client/components/static/pressKit.vue
+++ b/website/client/components/static/pressKit.vue
@@ -17,15 +17,21 @@
             img.img-fluid.img-rendering-auto.press-img(:src="`/static/presskit/${category}/${secondaryCategory}/${img}`")
 
     h1 {{ $t('FAQ') }}
-    
+
     #faq(role='tablist')
-      div(v-for='(QA, index) in faq')
+      .faq-question(v-for='(QA, index) in faq')
         h2(v-b-toggle="QA.question", tabindex="0", role="button", v-html="$t(QA.question)")
         b-collapse(:id="QA.question", accordion="pkAccordian", role="tabpanel")
           p(v-html="$t(QA.answer)")
-    
+
     p {{ $t('pkMoreQuestions') }}
 </template>
+
+<style lang="scss" scoped>
+  .faq-question {
+    cursor: pointer;
+  }
+</style>
 
 <script>
   // @TODO: EMAILS.PRESS_ENQUIRY_EMAIL


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
On the press kit page (https://habitica.com/static/press-kit), hovering over the FAQ will now show a pointer cursor instead of a text cursor. I felt that it makes it easier to recognize that these FAQ are links that you can click, instead of it being just text. 


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

UUID: 70c6bc6f-3edc-40e1-b9bc-0b7289484f42

