### PR TITLE
(WIP) Exp notifs

### DIFF
--- a/test/client/unit/specs/components/notifications.js
+++ b/test/client/unit/specs/components/notifications.js
@@ -1,0 +1,47 @@
+import { shallowMount, createLocalVue } from '@vue/test-utils';
+import NotificationsComponent from 'client/components/notifications.vue';
+import Store from 'client/libs/store';
+
+const localVue = createLocalVue();
+localVue.use(Store);
+
+describe('Notifications', () => {
+  let store;
+
+  beforeEach(() => {
+    store = new Store({
+      state: {
+        user: {
+          data: {
+            stats: {
+              lvl: 0,
+            },
+            flags: {},
+            preferences: {},
+            party: {
+              quest: {
+              },
+            },
+          },
+        },
+      },
+      actions: {
+        'user:fetch': () => {},
+        'tasks:fetchUserTasks': () => {},
+      },
+      getters: {},
+    });
+  });
+
+  it('set user has class computed prop', () => {
+    const wrapper = shallowMount(NotificationsComponent, { store, localVue });
+
+    expect(wrapper.vm.userHasClass).to.be.false;
+
+    store.state.user.data.stats.lvl = 10;
+    store.state.user.data.flags.classSelected = true;
+    store.state.user.data.preferences.disableClasses = false;
+
+    expect(wrapper.vm.userHasClass).to.be.true;
+  });
+});

--- a/test/client/unit/specs/components/notifications.js
+++ b/test/client/unit/specs/components/notifications.js
@@ -1,6 +1,7 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import NotificationsComponent from 'client/components/notifications.vue';
 import Store from 'client/libs/store';
+import { toNextLevel } from 'common/script/statHelpers';
 
 const localVue = createLocalVue();
 localVue.use(Store);
@@ -28,6 +29,7 @@ describe('Notifications', () => {
       actions: {
         'user:fetch': () => {},
         'tasks:fetchUserTasks': () => {},
+        'snackbars:add': () => {},
       },
       getters: {},
     });
@@ -43,5 +45,93 @@ describe('Notifications', () => {
     store.state.user.data.preferences.disableClasses = false;
 
     expect(wrapper.vm.userHasClass).to.be.true;
+  });
+
+  describe.only('user exp notifcation', () => {
+    it('notifies when user gets more exp', () => {
+      const wrapper = shallowMount(NotificationsComponent, { store, localVue });
+      const expSpy = sinon.spy(wrapper.vm, 'exp');
+      store.state.user.data.stats.lvl = 10;
+
+      const userExpBefore = 10;
+      const userExpAfter = 12;
+      wrapper.vm.displayUserExpNotifications(userExpAfter, userExpBefore);
+
+      expect(expSpy).to.be.calledWith(userExpAfter - userExpBefore);
+      expSpy.restore();
+    });
+
+    it('when user levels with exact xp', () => {
+      const wrapper = shallowMount(NotificationsComponent, { store, localVue });
+      const expSpy = sinon.spy(wrapper.vm, 'exp');
+      store.state.user.data.stats.lvl = 10;
+
+      const expEarned = 5;
+      const userExpBefore = toNextLevel(store.state.user.data.stats.lvl - 1) - expEarned;
+      const userExpAfter = 0;
+      wrapper.vm.displayUserExpNotifications(userExpAfter, userExpBefore);
+
+      expect(expSpy).to.be.calledWith(expEarned);
+      expSpy.restore();
+    });
+
+    it('when user levels with exact more exp than needed', () => {
+      const wrapper = shallowMount(NotificationsComponent, { store, localVue });
+      const expSpy = sinon.spy(wrapper.vm, 'exp');
+      store.state.user.data.stats.lvl = 10;
+
+      const expEarned = 10;
+      const expNeeded = 5;
+      const userExpBefore = toNextLevel(store.state.user.data.stats.lvl - 1) - expNeeded;
+      const userExpAfter = 5;
+      wrapper.vm.displayUserExpNotifications(userExpAfter, userExpBefore);
+
+      expect(expSpy).to.be.calledWith(expEarned);
+      expSpy.restore();
+    });
+
+    it('when user has more exp than needed then levels', () => {
+      const wrapper = shallowMount(NotificationsComponent, { store, localVue });
+      const expSpy = sinon.spy(wrapper.vm, 'exp');
+      store.state.user.data.stats.lvl = 10;
+
+      const expEarned = 10;
+      const expNeeded = -5;
+      const userExpBefore = toNextLevel(store.state.user.data.stats.lvl - 1) - expNeeded;
+      const userExpAfter = 15;
+      wrapper.vm.displayUserExpNotifications(userExpAfter, userExpBefore);
+
+      expect(expSpy).to.be.calledWith(expEarned);
+      expSpy.restore();
+    });
+
+    it('when user multilevels', () => {
+      const wrapper = shallowMount(NotificationsComponent, { store, localVue });
+      const expSpy = sinon.spy(wrapper.vm, 'exp');
+      store.state.user.data.stats.lvl = 10;
+
+      const expEarned = 10;
+      const expNeeded = -5;
+      const userExpBefore = toNextLevel(store.state.user.data.stats.lvl - 1) + toNextLevel(store.state.user.data.stats.lvl) - expNeeded;
+      const userExpAfter = 15;
+      wrapper.vm.displayUserExpNotifications(userExpAfter, userExpBefore);
+
+      expect(expSpy).to.be.calledWith(expEarned);
+      expSpy.restore();
+    });
+
+    it('when user dies', () => {
+      const wrapper = shallowMount(NotificationsComponent, { store, localVue });
+      const expSpy = sinon.spy(wrapper.vm, 'exp');
+      store.state.user.data.stats.lvl = 10;
+
+      const expEarned = -20;
+      const userExpBefore = 20;
+      const userExpAfter = 0;
+      wrapper.vm.displayUserExpNotifications(userExpAfter, userExpBefore);
+
+      expect(expSpy).to.be.calledWith(expEarned);
+      expSpy.restore();
+    });
   });
 });

--- a/test/client/unit/specs/components/sidebarSection.js
+++ b/test/client/unit/specs/components/sidebarSection.js
@@ -1,4 +1,4 @@
-import {shallow} from '@vue/test-utils';
+import { shallow } from '@vue/test-utils';
 
 import SidebarSection from 'client/components/sidebarSection.vue';
 

--- a/website/client/components/notifications.vue
+++ b/website/client/components/notifications.vue
@@ -199,6 +199,9 @@ export default {
     userClassSelect () {
       return !this.user.flags.classSelected && this.user.stats.lvl >= 10;
     },
+    userHasClass () {
+      return this.user.stats.lvl >= 10 && this.user.flags.classSelected && !this.user.preferences.disableClasses;
+    },
     invitedToQuest () {
       return this.user.party.quest.RSVPNeeded && !this.user.party.quest.completed;
     },
@@ -252,9 +255,9 @@ export default {
       if (after === before) return;
       if (!this.$store.getters['members:hasClass'](this.user)) return;
 
-      let mana = after - before;
+      const mana = after - before;
 
-      if (this.user.stats.lvl < 10) return;
+      if (!this.userHasClass) return;
       this.mp(mana);
     },
     userLvl (after, before) {
@@ -508,7 +511,7 @@ export default {
           case 'CRON':
             if (notification.data) {
               if (notification.data.hp) this.hp(notification.data.hp, 'hp');
-              if (notification.data.mp && this.user.stats.lvl >= 10) this.mp(notification.data.mp);
+              if (notification.data.mp && !this.userHasClass) this.mp(notification.data.mp);
             }
             break;
           case 'SCORED_TASK':

--- a/website/client/components/notifications.vue
+++ b/website/client/components/notifications.vue
@@ -253,6 +253,8 @@ export default {
       if (!this.$store.getters['members:hasClass'](this.user)) return;
 
       let mana = after - before;
+
+      if (this.user.stats.lvl < 10) return;
       this.mp(mana);
     },
     userLvl (after, before) {
@@ -506,7 +508,7 @@ export default {
           case 'CRON':
             if (notification.data) {
               if (notification.data.hp) this.hp(notification.data.hp, 'hp');
-              if (notification.data.mp) this.mp(notification.data.mp);
+              if (notification.data.mp && this.user.stats.lvl >= 10) this.mp(notification.data.mp);
             }
             break;
           case 'SCORED_TASK':


### PR DESCRIPTION
Fixes #10635

- this depends on a PR that is going to be merged soon that contains the test base
- I found a few cases we were not correctly displaying for
- From the current context, we can't determine if the user levels up with exact xp or if they died. Both of these cases result in the scenario where after === 0 and before is either 0 or greater.
- The above is b/c we simply set the exp to 0 rather than always accumulated xp and displaying a 0 value

Soooo, see the test for examples, but two ways to fix this:
- Change xp to never go to 0 (on the user object) and display the current xp minus all gained xp 
- Or, change stat notifications to view the whole state delta

We will probably go with the latter solution since it is easier and still somewhat correct