### PR TITLE
Fix new party member cannot join pending quest

### DIFF
--- a/website/client/store/actions/quests.js
+++ b/website/client/store/actions/quests.js
@@ -6,15 +6,16 @@ import * as Analytics from 'client/libs/analytics';
 
 export async function sendAction (store, payload) {
   // @TODO: Maybe move this to server
-  let partyData = {
-    partyID: store.state.user.data.party._id,
-    partySize: store.state.partyMembers.data.length,
-  };
-
+  let partyData = {};
   if (store.state.party && store.state.party.data) {
     partyData = {
       partyID: store.state.party.data._id,
       partySize: store.state.party.data.memberCount,
+    };
+  } else {
+    partyData = {
+      partyID: store.state.user.data.party._id,
+      partySize: store.state.partyMembers.data.length,
     };
   }
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #9293

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Well the issue was that for a new member that just joined a party, if a quest is pending , then an error was raised at the allocation of partyData variable. This issue was client side, on the server side, no problem, the user gets added to the quest invitation process when joining a party (https://github.com/HabitRPG/habitica/blob/develop/website/server/controllers/api-v3/groups.js#L552)

It seems store.state.partyMembers.data.length was null => the party ID is set up in store when user joins the party, but not this one (https://github.com/HabitRPG/habitica/blob/develop/website/client/store/actions/guilds.js#L76)

So I check first instead if store.state.party exists, as after joining a guild the players is being redirected to the party page, and I believe this is being fetched like this there : https://github.com/HabitRPG/habitica/blob/develop/website/client/components/groups/group.vue#L457

Sometimes with the new member I get the party buttons (accept / reject) showing up normally, sometimes I need to hit the sync button first to see them (no idea what's the issue there... but seems for a lot o stuff it's like that). But in any case, when I click on 'Accept' it goes through now !

Let me know if there is any concerns here :)

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: bbffb2f4-9bf8-46c4-b749-523e2ca93ef6
