### PR TITLE
Creating default encryption test to improve coverage

### DIFF
--- a/test/api/unit/libs/password.test.js
+++ b/test/api/unit/libs/password.test.js
@@ -107,6 +107,25 @@ describe('Password Utilities', () => {
       }
     });
 
+    it('defaults to SHA1 encryption if salt is provided', async () => {
+      let textPassword = 'mySecretPassword';
+      let salt = sha1MakeSalt();
+      let hashedPassword = sha1EncryptPassword(textPassword, salt);
+
+      let user = {
+        auth: {
+          local: {
+            hashed_password: hashedPassword,
+            salt,
+            passwordHashMethod: '',
+          },
+        },
+      };
+
+      let isValidPassword = await compare(user, textPassword);
+      expect(isValidPassword).to.eql(true);
+    });
+
     it('throws an error if an invalid hashing method is used', async () => {
       try {
         await compare({


### PR DESCRIPTION
### Changes
Added a new unit test for default password encryption when using salt. This seemed to be the only branch missing to get 100% coverage on this file.



----
UUID: 535a72cc-f949-4ba6-8570-639c5f763da8
