### PR TITLE
fix open flag modal

### DIFF
--- a/website/client/components/chat/reportFlagModal.vue
+++ b/website/client/components/chat/reportFlagModal.vue
@@ -96,16 +96,10 @@ export default {
     };
   },
   created () {
-    this.$root.$on('habitica::report-chat', data => {
-      if (!data.message || !data.groupId) return;
-      this.abuseObject = data.message;
-      this.groupId = data.groupId;
-      this.reportComment = '';
-      this.$root.$emit('bv::show::modal', 'report-flag');
-    });
+    this.$root.$on('habitica::report-chat', this.handleReport);
   },
   destroyed () {
-    this.$root.$off('habitica::report-chat');
+    this.$root.$off('habitica::report-chat', this.handleReport);
   },
   methods: {
     close () {
@@ -128,6 +122,13 @@ export default {
         chatId: this.abuseObject.id,
       });
       this.close();
+    },
+    handleReport (data) {
+      if (!data.message || !data.groupId) return;
+      this.abuseObject = data.message;
+      this.groupId = data.groupId;
+      this.reportComment = '';
+      this.$root.$emit('bv::show::modal', 'report-flag');
     },
   },
 };


### PR DESCRIPTION
If you switch between chats (tavern, party, group), the `reportFlagModal` was created and destroyed per view, and I think if we unsubscribe on all events it kinda removed all of them.

But it only happened once I tried to report a message twice.

fixes #10637