### PR TITLE
Saved sort selection into local storage for later use - fixes #10432

### DIFF
--- a/website/client/components/inventory/stable/index.vue
+++ b/website/client/components/inventory/stable/index.vue
@@ -399,6 +399,8 @@
   import openedItemRowsMixin from 'client/mixins/openedItemRows';
   import petMixin from 'client/mixins/petMixin';
 
+  import { CONSTANTS, setLocalSetting, getLocalSetting } from 'client/libs/userlocalManager';
+
   // TODO Normalize special pets and mounts
   // import Store from 'client/store';
   // import deepFreeze from 'client/libs/deepFreeze';
@@ -430,8 +432,7 @@
       mousePosition: MouseMoveDirective,
     },
     data () {
-      let savedSelectedSortBy = 'standard';
-      if (localStorage.getItem('selectedSortBy')) savedSelectedSortBy = JSON.parse(localStorage.getItem('selectedSortBy'));
+      const stableSortState = getLocalSetting(CONSTANTS.keyConstants.STABLE_SORT_STATE) || 'standard';
 
       return {
         viewOptions: {},
@@ -439,7 +440,7 @@
         searchText: null,
         searchTextThrottled: '',
         // sort has the translation-keys as values
-        selectedSortBy: savedSelectedSortBy,
+        selectedSortBy: stableSortState,
         sortByItems: [
           'standard',
           'AZ',
@@ -466,9 +467,8 @@
       }, 250),
       selectedSortBy: {
         handler () {
-          localStorage.setItem('selectedSortBy', JSON.stringify(this.selectedSortBy));
+          setLocalSetting(CONSTANTS.keyConstants.STABLE_SORT_STATE, this.selectedSortBy);
         },
-        deep: true,
       },
     },
     computed: {

--- a/website/client/components/inventory/stable/index.vue
+++ b/website/client/components/inventory/stable/index.vue
@@ -430,13 +430,16 @@
       mousePosition: MouseMoveDirective,
     },
     data () {
+      let savedSelectedSortBy = 'standard';
+      if (localStorage.getItem('selectedSortBy')) savedSelectedSortBy = JSON.parse(localStorage.getItem('selectedSortBy'));
+
       return {
         viewOptions: {},
         hideMissing: false,
         searchText: null,
         searchTextThrottled: '',
         // sort has the translation-keys as values
-        selectedSortBy: 'standard',
+        selectedSortBy: savedSelectedSortBy,
         sortByItems: [
           'standard',
           'AZ',
@@ -461,6 +464,12 @@
         let search = this.searchText.toLowerCase();
         this.searchTextThrottled = search;
       }, 250),
+      selectedSortBy: {
+        handler () {
+          localStorage.setItem('selectedSortBy', JSON.stringify(this.selectedSortBy));
+        },
+        deep: true,
+      },
     },
     computed: {
       ...mapState({

--- a/website/client/libs/userlocalManager.js
+++ b/website/client/libs/userlocalManager.js
@@ -4,6 +4,7 @@ const CONSTANTS = {
     SPELL_DRAWER_STATE: 'spell-drawer-state',
     EQUIPMENT_DRAWER_STATE: 'equipment-drawer-state',
     CURRENT_EQUIPMENT_DRAWER_TAB: 'current-equipment-drawer-tab',
+    STABLE_SORT_STATE: 'stable-sort-state',
   },
   drawerStateValues: {
     DRAWER_CLOSED: 'drawer-closed',


### PR DESCRIPTION
Fixes #10432

### Changes
- save the sort selection into local storage
- read back from local storage when displaying the stable and sorting

----
UUID: 495eed5c-2828-4e24-a19d-755ac5e95295
