### PR TITLE
Apply 30 day max age to cache favicon - fixes 9372

### DIFF
--- a/webpack/dev-server.js
+++ b/webpack/dev-server.js
@@ -61,6 +61,9 @@ app.use(hotMiddleware);
 
 // serve pure static assets
 const staticPath = path.posix.join(config.dev.assetsPublicPath, config.dev.assetsSubDirectory);
+app.use('/static/icons', express.static(path.posix.join(config.dev.staticAssetsDirectory, 'icons/'), {
+  maxage: '30d',
+}));
 app.use(staticPath, express.static(config.dev.staticAssetsDirectory));
 
 module.exports = app.listen(port, (err) => {

--- a/website/server/middlewares/static.js
+++ b/website/server/middlewares/static.js
@@ -12,6 +12,7 @@ module.exports = function staticMiddleware (expressApp) {
   expressApp.use('/static/css', express.static(`${BASE_DIR}/dist-client/static/css`, { maxAge: MAX_AGE }));
   expressApp.use('/static/svg', express.static(`${BASE_DIR}/dist-client/static/svg`, { maxAge: MAX_AGE }));
   expressApp.use('/static/images', express.static(`${BASE_DIR}/dist-client/static/images`, { maxAge: MAX_AGE }));
+  expressApp.use('/static/icons', express.static(`${BASE_DIR}/dist-client/static/icons`, { maxAge: MAX_AGE }));
 
   // @TODO img/js/css under /static have their names hashed after every change so they can be cached
   // Not files in /audio and /sprites, that's why we don't cache them.


### PR DESCRIPTION
Fixes #9372

### Changes
- Added a static path specifically for the favicons with a 30 day cache

> $ curl -I "http://localhost:8080/static/icons/favicon.ico"
> HTTP/1.1 200 OK
> X-Powered-By: Express
> Accept-Ranges: bytes
> Cache-Control: public, max-age=2592000
> Last-Modified: Fri, 31 Aug 2018 02:13:23 GMT
> ETag: W/"3aee-1658dc1a649"
> Content-Type: image/x-icon
> Content-Length: 15086
> Date: Fri, 31 Aug 2018 04:01:05 GMT
> Connection: keep-alive

----
UUID: 495eed5c-2828-4e24-a19d-755ac5e95295
