### PR TITLE
prevent buying market gear if class doesn't match - fixes #10183

### DIFF
--- a/website/common/script/ops/buy/buyMarketGear.js
+++ b/website/common/script/ops/buy/buyMarketGear.js
@@ -24,16 +24,16 @@ export class BuyMarketGearOperation extends AbstractGoldItemOperation {
     return false;
   }
 
+  canUserPurchase (user, item) {
+    return super.canUserPurchase(user, item) && (item.klass !== 'special' && item.klass !== user.stats.class);
+  }
+
   extractAndValidateParams (user, req) {
     let key = this.key = get(req, 'params.key');
     if (!key) throw new BadRequest(errorMessage('missingKeyParam'));
 
     let item = content.gear.flat[key];
     if (!item) throw new NotFound(errorMessage('itemNotFound', {key}));
-
-    if (item.klass && item.klass !== 'special' && item.klass !== user.stats.class) {
-      throw new NotAuthorized(this.i18n('cannotBuyItem'));
-    }
 
     this.canUserPurchase(user, item);
 

--- a/website/common/script/ops/buy/buyMarketGear.js
+++ b/website/common/script/ops/buy/buyMarketGear.js
@@ -31,6 +31,10 @@ export class BuyMarketGearOperation extends AbstractGoldItemOperation {
     let item = content.gear.flat[key];
     if (!item) throw new NotFound(errorMessage('itemNotFound', {key}));
 
+    if (item.klass && user.stats.class !== item.klass) {
+      throw new NotAuthorized(this.i18n('cannotBuyItem'));
+    }
+
     this.canUserPurchase(user, item);
 
     if (user.items.gear.owned[item.key]) {

--- a/website/common/script/ops/buy/buyMarketGear.js
+++ b/website/common/script/ops/buy/buyMarketGear.js
@@ -31,7 +31,7 @@ export class BuyMarketGearOperation extends AbstractGoldItemOperation {
     let item = content.gear.flat[key];
     if (!item) throw new NotFound(errorMessage('itemNotFound', {key}));
 
-    if (item.klass && user.stats.class !== item.klass) {
+    if (item.klass && item.klass !== 'special' && item.klass !== user.stats.class) {
       throw new NotAuthorized(this.i18n('cannotBuyItem'));
     }
 


### PR DESCRIPTION
Fixes #10183

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
- Check to make sure the item class matches the user class in the buyMarketGear functionality

Tested directly with the api with my warrior:
> $ curl 'http://localhost:8080/api/v4/user/buy/armor_rogue_1' -X POST -H 'Origin: http://localhost:8080' -H 'Accept-Encoding: gzip, deflate, br' -H 'Accept-Language: en-US,en;q=0.9,la;q=0.8' -H 'Cookie: logglytrackingsession=*****; connect:*****; connect:*****; language=en_US; amazon-pay-connectedAuth=lwa_general; session-set=true' -H 'Connection: keep-alive' -H 'x-api-user: *****' -H 'x-client: habitica-web' -H 'Content-Length: 0' -H 'Pragma: no-cache' -H 'x-user-timezoneOffset: 420' -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36' -H 'Accept: application/json, text/plain, */*' -H 'Cache-Control: no-cache' -H 'Referer: http://localhost:8080/shops/market' -H 'DNT: 1' -H 'x-api-key: *****' --compressed
>> {"success":false,"error":"NotAuthorized","message":"You can't buy this item."}

Without this update, the call goes through.

----
UUID: 495eed5c-2828-4e24-a19d-755ac5e95295
