### PR TITLE
Fix initial position item info when selecting one item after another (fixes #10077)

### DIFF
--- a/website/client/components/inventory/items/index.vue
+++ b/website/client/components/inventory/items/index.vue
@@ -405,6 +405,8 @@ export default {
         this.currentDraggingEgg = egg;
         this.eggClickMode = true;
 
+        // Wait for the div.eggInfo.mouse node to be added to the DOM before
+        // changing its position.
         this.$nextTick(() => {
           this.mouseMoved(lastMouseMoveEvent);
         });
@@ -427,6 +429,8 @@ export default {
         this.currentDraggingPotion = potion;
         this.potionClickMode = true;
 
+        // Wait for the div.hatchingPotionInfo.mouse node to be added to the
+        // DOM before changing its position.
         this.$nextTick(() => {
           this.mouseMoved(lastMouseMoveEvent);
         });
@@ -471,6 +475,11 @@ export default {
     },
 
     mouseMoved ($event) {
+      // Keep track of the last mouse position even in click mode so that we
+      // know where to position the dragged potion/egg info on item click.
+      lastMouseMoveEvent = $event;
+
+      // Update the potion/egg popover if we are already dragging it.
       if (this.potionClickMode) {
         // dragging potioninfo is 180px wide (90 would be centered)
         this.$refs.clickPotionInfo.style.left = `${$event.x - 60}px`;
@@ -479,8 +488,6 @@ export default {
         // dragging eggInfo is 180px wide (90 would be centered)
         this.$refs.clickEggInfo.style.left = `${$event.x - 60}px`;
         this.$refs.clickEggInfo.style.top = `${$event.y + 10}px`;
-      } else {
-        lastMouseMoveEvent = $event;
       }
     },
   },

--- a/website/client/components/inventory/stable/index.vue
+++ b/website/client/components/inventory/stable/index.vue
@@ -849,11 +849,12 @@
         }
       },
       mouseMoved ($event) {
+        // Keep track of the last mouse position even in click mode so that we
+        // know where to position the dragged food icon on click.
+        lastMouseMoveEvent = $event;
         if (this.foodClickMode) {
           this.$refs.clickFoodInfo.style.left = `${$event.x - 70}px`;
           this.$refs.clickFoodInfo.style.top = `${$event.y}px`;
-        } else {
-          lastMouseMoveEvent = $event;
         }
       },
     },


### PR DESCRIPTION
Fixes #10077.

### Changes
While dragging the potion/egg, the variable `lastMouseMoveEvent`, which was keeping track of the mouse position, was not updated so if a second item was selected while dragging another the variable was still pointing at the position of the first click.

This changes the code to update `lastMouseMoveEvent` even while dragging another object. I've also added a couple of comments to help people that read that code for the first time. I hope that's welcomed.

----
UUID: bd2b5eb2-04d4-4604-a972-e19ae09de30d