### PR TITLE
Guild textarea at list positioning

### DIFF
--- a/website/client/components/chat/autoComplete.vue
+++ b/website/client/components/chat/autoComplete.vue
@@ -14,7 +14,7 @@ div.autocomplete-selection(v-if='searchResults.length > 0', :style='autocomplete
 import groupBy from 'lodash/groupBy';
 
 export default {
-  props: ['selections', 'text', 'coords', 'chat'],
+  props: ['selections', 'text', 'coords', 'chat', 'textbox'],
   data () {
     return {
       currentSearch: '',
@@ -25,12 +25,12 @@ export default {
   },
   computed: {
     autocompleteStyle () {
-      function heightToUse (topCoords) {
-        let textAreaHeight = document.getElementsByClassName('user-entry')[0].clientHeight;
-        return topCoords < textAreaHeight ? topCoords + 30 : textAreaHeight + 10;
+      function heightToUse (textBox, topCoords) {
+        let textBoxHeight = textBox['user-entry'].clientHeight;
+        return topCoords < textBoxHeight ? topCoords + 30 : textBoxHeight + 10;
       }
       return {
-        top: `${heightToUse(this.coords.TOP)}px`,
+        top: `${heightToUse(this.textbox, this.coords.TOP)}px`,
         left: `${this.coords.LEFT + 30}px`,
         marginLeft: '-28px',
         marginTop: '28px',

--- a/website/client/components/chat/autoComplete.vue
+++ b/website/client/components/chat/autoComplete.vue
@@ -25,9 +25,15 @@ export default {
   },
   computed: {
     autocompleteStyle () {
+      function heightToUse (topCoords) {
+        let textAreaHeight = document.getElementsByClassName('user-entry')[0].clientHeight;
+        return topCoords < textAreaHeight ? topCoords + 30: textAreaHeight + 10;
+      }
       return {
-        top: `${this.coords.TOP + 30}px`,
+        top: `${heightToUse(this.coords.TOP)}px`,
         left: `${this.coords.LEFT + 30}px`,
+        marginLeft: '-28px',
+        marginTop: '28px',
         position: 'absolute',
         minWidth: '100px',
         minHeight: '100px',
@@ -42,6 +48,7 @@ export default {
         return option.toLowerCase().indexOf(currentSearch.toLowerCase()) !== -1;
       });
     },
+
   },
   mounted () {
     this.grabUserNames();

--- a/website/client/components/chat/autoComplete.vue
+++ b/website/client/components/chat/autoComplete.vue
@@ -27,7 +27,7 @@ export default {
     autocompleteStyle () {
       function heightToUse (topCoords) {
         let textAreaHeight = document.getElementsByClassName('user-entry')[0].clientHeight;
-        return topCoords < textAreaHeight ? topCoords + 30: textAreaHeight + 10;
+        return topCoords < textAreaHeight ? topCoords + 30 : textAreaHeight + 10;
       }
       return {
         top: `${heightToUse(this.coords.TOP)}px`,

--- a/website/client/components/groups/chat.vue
+++ b/website/client/components/groups/chat.vue
@@ -6,6 +6,7 @@
       .row
         textarea(:placeholder='placeholder',
                   v-model='newMessage',
+                  ref='user-entry',
                   :class='{"user-entry": newMessage}',
                   @keydown='updateCarretPosition',
                   @keyup.ctrl.enter='sendMessageShortcut()',
@@ -16,6 +17,7 @@
         autocomplete(
                 :text='newMessage',
                 v-on:select="selectedAutocomplete",
+                :textbox='textbox',
                 :coords='coords',
                 :chat='group.chat')
 
@@ -62,6 +64,7 @@
           TOP: 0,
           LEFT: 0,
         },
+        textbox: this.$refs,
       };
     },
     computed: {

--- a/website/client/components/groups/chat.vue
+++ b/website/client/components/groups/chat.vue
@@ -187,7 +187,7 @@
     position: relative;
 
     textarea {
-      height: 150px;
+      min-height: 150px;
       width: 100%;
       background-color: $white;
       border: solid 1px $gray-400;


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10612

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Username @ list chat is now positioned so that if at the end of the text box, the @ list will line up right below the text box. 
Didn't make the change where the text box height increases as you add more text.

**Before:**
![screen shot 2018-09-05 at 12 46 24 pm](https://user-images.githubusercontent.com/4088176/45117192-c869d080-b109-11e8-80c2-34d79943e022.png)

**After:**
![screen shot 2018-09-05 at 12 45 32 pm](https://user-images.githubusercontent.com/4088176/45117204-cd2e8480-b109-11e8-94d2-280f7a1c8a5f.png)

Also added minimum height to text box.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 70c6bc6f-3edc-40e1-b9bc-0b7289484f42
