### PR TITLE
 Don't show "no guilds" texts while loading

### DIFF
--- a/website/client/components/challenges/myChallenges.vue
+++ b/website/client/components/challenges/myChallenges.vue
@@ -57,6 +57,7 @@
     }
 
     .svg-icon {
+      color: #C3C0C7;
       width: 88.7px;
       margin: 1em auto;
     }

--- a/website/client/components/challenges/myChallenges.vue
+++ b/website/client/components/challenges/myChallenges.vue
@@ -49,11 +49,11 @@
   }
 
   .no-challenges {
-    color: $gray-300;
+    color: $gray-200;
     margin-top: 10em;
 
     h2 {
-      color: $gray-300;
+      color: $gray-200;
     }
 
     .svg-icon {

--- a/website/client/components/challenges/myChallenges.vue
+++ b/website/client/components/challenges/myChallenges.vue
@@ -7,6 +7,7 @@
     .row.header-row
       .col-md-8.text-left
         h1(v-once) {{$t('myChallenges')}}
+        h2(v-if='loading && challenges.length === 0') {{ $t('loading') }}
       .col-md-4
         // @TODO: implement sorting span.dropdown-label {{ $t('sortBy') }}
           b-dropdown(:text="$t('sort')", right=true)
@@ -16,7 +17,7 @@
           span(v-once) {{$t('createChallenge')}}
 
     .row
-      .no-challenges.text-center.col-md-6.offset-3(v-if='filteredChallenges.length === 0')
+      .no-challenges.text-center.col-md-6.offset-3(v-if='!loading && challenges.length === 0')
         .svg-icon(v-html="icons.challengeIcon")
         h2(v-once) {{$t('noChallengeTitle')}}
         p(v-once) {{$t('challengeDescription1')}}
@@ -84,6 +85,7 @@ export default {
         challengeIcon,
         positiveIcon,
       }),
+      loading: false,
       challenges: [],
       sort: 'none',
       sortOptions: [
@@ -113,7 +115,7 @@ export default {
     };
   },
   mounted () {
-    this.loadchallanges();
+    this.loadChallenges();
   },
   computed: {
     filteredChallenges () {
@@ -138,10 +140,12 @@ export default {
       this.$store.state.challengeOptions.workingChallenge = {};
       this.$root.$emit('bv::show::modal', 'challenge-modal');
     },
-    async loadchallanges () {
+    async loadChallenges () {
+      this.loading = true;
       this.challenges = await this.$store.dispatch('challenges:getUserChallenges', {
         member: true,
       });
+      this.loading = false;
     },
     challengeCreated (challenge) {
       this.challenges.push(challenge);

--- a/website/client/components/groups/myGuilds.vue
+++ b/website/client/components/groups/myGuilds.vue
@@ -2,18 +2,11 @@
 .row
   sidebar(v-on:search="updateSearch", v-on:filter="updateFilters")
 
-  .no-guilds.standard-page(v-if='filteredGuilds.length === 0')
-    .no-guilds-wrapper
-      .svg-icon(v-html='icons.greyBadge')
-      h2 {{$t('noGuildsTitle')}}
-      p {{$t('noGuildsParagraph1')}}
-      p {{$t('noGuildsParagraph2')}}
-      span(v-if='loading') {{ $t('loading') }}
-
-  .standard-page(v-if='filteredGuilds.length > 0')
+  .standard-page
     .row
-      .col-md-8
-        h1.page-header.float-left(v-once) {{ $t('myGuilds') }}
+      .col-md-8.text-left
+        h1.page-header(v-once) {{ $t('myGuilds') }}
+        h2(v-if='loading && guilds.length === 0') {{ $t('loading') }}
       .col-4
         button.btn.btn-secondary.create-group-button.float-right(@click='createGroup()')
           .svg-icon.positive-icon(v-html="icons.positiveIcon")
@@ -22,6 +15,14 @@
           span.dropdown-label {{ $t('sortBy') }}
           b-dropdown(:text="$t('sort')", right=true)
             b-dropdown-item(v-for='sortOption in sortOptions', :key="sortOption.value", @click='sort(sortOption.value)') {{sortOption.text}}
+
+    .row
+      .no-guilds.text-center.col-md-6.offset-md-3(v-if='!loading && guilds.length === 0')
+        .svg-icon(v-html='icons.greyBadge')
+        h2(v-once) {{$t('noGuildsTitle')}}
+        p(v-once) {{$t('noGuildsParagraph1')}}
+        p(v-once) {{$t('noGuildsParagraph2')}}
+
     .row
       .col-md-12
         public-guild-item(v-for="guild in filteredGuilds", :key='guild._id', :guild="guild", :display-gem-bank='true')
@@ -41,29 +42,16 @@
   }
 
   .no-guilds {
-    text-align: center;
-    color: $gray-200;
-    margin-top: 15em;
+    color: $gray-300;
+    margin-top: 10em;
 
-    p {
-      font-size: 14px;
-      line-height: 1.43;
+    h2 {
+      color: $gray-300;
     }
 
-    .no-guilds-wrapper {
-      width: 400px;
-      margin: 0 auto;
-
-      .svg-icon {
-        width: 60px;
-        margin: 0 auto;
-      }
-    }
-  }
-
-  @media only screen and (max-width: 768px) {
-    .no-guilds-wrapper {
-      width: 100% !important;
+    .svg-icon {
+      width: 88.7px;
+      margin: 1em auto;
     }
   }
 </style>

--- a/website/client/components/groups/myGuilds.vue
+++ b/website/client/components/groups/myGuilds.vue
@@ -42,11 +42,11 @@
   }
 
   .no-guilds {
-    color: $gray-300;
+    color: $gray-200;
     margin-top: 10em;
 
     h2 {
-      color: $gray-300;
+      color: $gray-200;
     }
 
     .svg-icon {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10662

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Previously My Guilds page displayed the "You aren't member of any Guilds" message (and My Challenges page displayed "You don't have any challenges" message) while it was still loading them from the API and also when filtering so that there are no matches.

This PR adds loading indicator (just text "Loading..." as used in Discover Guilds and Discover Challenges pages) that is displayed while the API request is pending and only shows "no guilds" or "no challenges" message after loading is finished. Also, when filtering is used and there are no matches (but user has guilds/challenges), then nothing is shown (as in Discover Guilds and Discover Challenges pages). 


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: fa756acf-9127-4a3c-8dac-8ff627d30073

