### PR TITLE
Correct Challenges tooltip in Guild view

### DIFF
--- a/website/client/components/groups/group.vue
+++ b/website/client/components/groups/group.vue
@@ -62,7 +62,7 @@
         p(v-markdown='group.description')
       sidebar-section(
         :title="$t('challenges')",
-        :tooltip="isParty ? $t('challengeDetails') : $t('privateDescription')"
+        :tooltip="$t('challengeDetails')"
       )
         group-challenges(:groupId='searchId')
     div.text-center


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)


### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Tooltip icon next to the **Challenges** heading in Guild view displayed incorrect tooltip text (the one that belongs next to the "Private Guild" checkbox in Create Guild view). Don't know if there should be a different one vs. the one that's shown in Party view, I did look around in the translations file and didn't see anything that should belong there and the same one seemed appropriate for both views. So I just removed the ternary to always show the same text `Challenges are community events in which players compete and earn prizes by completing a group of related tasks.`.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: fa756acf-9127-4a3c-8dac-8ff627d30073

