### PR TITLE
remove unused tests about purging private messages

### DIFF
--- a/test/api/unit/libs/cron.test.js
+++ b/test/api/unit/libs/cron.test.js
@@ -1589,27 +1589,6 @@ describe('cron', () => {
         flagCount: 0,
       };
     });
-
-    xit('does not clear pms under 200', () => {
-      cron({user, tasksByType, daysMissed, analytics});
-      expect(user.inbox.messages[lastMessageId]).to.exist;
-    });
-
-    xit('clears pms over 200', () => {
-      let messageId = common.uuid();
-      user.inbox.messages[messageId] = {
-        id: messageId,
-        text: `test ${messageId}`,
-        timestamp: Number(new Date()),
-        likes: {},
-        flags: {},
-        flagCount: 0,
-      };
-
-      cron({user, tasksByType, daysMissed, analytics});
-
-      expect(user.inbox.messages[messageId]).to.not.exist;
-    });
   });
 
   describe('login incentives', () => {


### PR DESCRIPTION
This removes two `xit` tests that won't be needed because we are no longer planning to purge priivate messages, as stated by paglias here: https://github.com/HabitRPG/habitica/issues/7940#issuecomment-406489506

It's a tiny change but it slightly reduces the ignorable warnings when we run lint.