### PR TITLE
Reduce margin-bottom of checklist-item from 10px to -3px (fixes #10569)

### DIFF
--- a/website/client/components/tasks/task.vue
+++ b/website/client/components/tasks/task.vue
@@ -282,7 +282,7 @@
     color: $gray-50;
     font-size: 14px;
     line-height: 1.43;
-    margin-bottom: 10px;
+    margin-bottom: -3px;
     min-height: 0px;
     width: 100%;
     margin-left: 8px;


### PR DESCRIPTION
Fixes #10569.

### Changes

The bottom margin of the checklist-item CSS class was reduced from 10 to -3px.

Before:

<img width="311" alt="before" src="https://user-images.githubusercontent.com/14891322/45586937-a8d26500-b8cc-11e8-8d76-c093d84507ec.png">

After:

<img width="304" alt="after" src="https://user-images.githubusercontent.com/14891322/45586938-b0920980-b8cc-11e8-9350-969b420be32b.png">

I've tested this on Chrome and Safari.

----
UUID: bd2b5eb2-04d4-4604-a972-e19ae09de30d