### PR TITLE
Fix website issues on mobile devices

### DIFF
--- a/website/client/app.vue
+++ b/website/client/app.vue
@@ -246,16 +246,6 @@ export default {
       return !this.bannerHidden && this.user.preferences.sleep;
     },
   },
-  watch: {
-    showRestingBanner () {
-      this.$nextTick(() => {
-        console.log(this.$refs);
-        console.log(this.$refs.restingBanner);
-        console.log(this.showRestingBanner);
-        this.setBannerOffset();
-      });
-    },
-  },
   created () {
     this.$root.$on('playSound', (sound) => {
       let theme = this.user.preferences.sound;
@@ -439,6 +429,14 @@ export default {
 
         this.hideLoadingScreen();
 
+        window.addEventListener('resize', this.setBannerOffset);
+        // Adjust the positioning of the header banners
+        this.$watch('showRestingBanner', () => {
+          this.$nextTick(() => {
+            this.setBannerOffset();
+          });
+        }, {immediate: true});
+
         // Adjust the timezone offset
         if (this.user.preferences.timezoneOffset !== this.browserTimezoneOffset) {
           this.$store.dispatch('user:set', {
@@ -471,8 +469,6 @@ export default {
     // Remove the index.html loading screen and now show the inapp loading
     const loadingScreen = document.getElementById('loading-screen');
     if (loadingScreen) document.body.removeChild(loadingScreen);
-    window.addEventListener('resize', this.setBannerOffset);
-    this.setBannerOffset();
   },
   methods: {
     checkForBannedUser (error) {
@@ -636,7 +632,6 @@ export default {
       if (this.showRestingBanner && this.$refs.restingBanner !== undefined) {
         contentPlacement = this.$refs.restingBanner.clientHeight;
       }
-      console.log(this.showRestingBanner, contentPlacement);
       this.bannerHeight = contentPlacement;
       let smartBanner = document.getElementsByClassName('smartbanner')[0];
       if (smartBanner !== undefined) {

--- a/website/client/app.vue
+++ b/website/client/app.vue
@@ -24,7 +24,7 @@ div
           div.closepadding(@click="hideBanner()")
             span.svg-icon.inline.icon-10(aria-hidden="true", v-html="icons.close")
         notifications-display
-        app-menu(:class='{"restingInn": showRestingBanner}' v-bind:style="{ marginTop: bannerHeight + 'px' }")
+        app-menu(:class='{"restingInn": showRestingBanner}' :style="{ marginTop: bannerHeight + 'px' }")
         .container-fluid
           app-header(:class='{"restingInn": showRestingBanner}')
           buyModal(
@@ -242,7 +242,6 @@ export default {
       return this.$t(`tip${tipNumber}`);
     },
     showRestingBanner () {
-      if (this.user === null) return false;
       return !this.bannerHidden && this.user.preferences.sleep;
     },
   },

--- a/website/client/app.vue
+++ b/website/client/app.vue
@@ -413,11 +413,6 @@ export default {
     this.$store.watch(state => state.title, (title) => {
       document.title = title;
     });
-
-    this.$store.watch(state => state.isUserLoaded, () => {
-      this.setBannerOffset();
-    });
-
     this.$nextTick(() => {
       // Load external scripts after the app has been rendered
       Analytics.load();
@@ -447,7 +442,6 @@ export default {
           setupPayments();
         });
 
-        this.setBannerOffset();
       }).catch((err) => {
         console.error('Impossible to fetch user. Clean up localStorage and refresh.', err); // eslint-disable-line no-console
       });
@@ -463,13 +457,13 @@ export default {
     this.$root.$off('bv::show::modal');
     this.$root.$off('buyModal::showItem');
     this.$root.$off('selectMembersModal::showItem');
+    window.removeEventListener('resize', this.setBannerOffset);
   },
   mounted () {
     // Remove the index.html loading screen and now show the inapp loading
     const loadingScreen = document.getElementById('loading-screen');
     if (loadingScreen) document.body.removeChild(loadingScreen);
-  },
-  updated () {
+    window.addEventListener('resize', this.setBannerOffset);
     this.setBannerOffset();
   },
   methods: {

--- a/website/client/components/settings/site.vue
+++ b/website/client/components/settings/site.vue
@@ -4,7 +4,7 @@
     reset-modal
     delete-modal
     h1.col-12 {{ $t('settings') }}
-    .col-6
+    .col-sm-6
       .form-horizontal
         h5 {{ $t('language') }}
         select.form-control(:value='user.preferences.language',
@@ -105,7 +105,7 @@
               p(v-html="$t('timezoneUTC', {utc: timezoneOffsetToUtc})")
               p(v-html="$t('timezoneInfo')")
 
-    .col-6
+    .col-sm-6
       h2 {{ $t('registration') }}
       .panel-body
         div

--- a/website/common/locales/en/groups.json
+++ b/website/common/locales/en/groups.json
@@ -6,6 +6,7 @@
   "innText": "You're resting in the Inn! While checked-in, your Dailies won't hurt you at the day's end, but they will still refresh every day. Be warned: If you are participating in a Boss Quest, the Boss will still damage you for your Party mates' missed Dailies unless they are also in the Inn! Also, your own damage to the Boss (or items collected) will not be applied until you check out of the Inn.",
   "innTextBroken": "You're resting in the Inn, I guess... While checked-in, your Dailies won't hurt you at the day's end, but they will still refresh every day...  If you are participating in a Boss Quest, the Boss will still damage you for your Party mates' missed Dailies... unless they are also in the Inn... Also, your own damage to the Boss (or items collected) will not be applied until you check out of the Inn... so tired...",
   "innCheckOutBanner": "You are currently checked into the Inn. Your Dailies won't damage you and you won't make progress towards Quests.",
+  "innCheckOutBannerShort": "You are checked into the Inn.",
   "resumeDamage": "Resume Damage",
   "helpfulLinks": "Helpful Links",
   "communityGuidelinesLink": "Community Guidelines",


### PR DESCRIPTION
This is not completely done yet, but addresses the issues in #10695 

The banner for paused dailies now wraps to multiple lines if necessary and has a shorter version on smartphones, so that it doesn't take up 3+ rows there. The content is correctly positioned below the banner.
The settings page now also has only one column on phones, since the layout is unusable otherwise.