### PR TITLE
Point links in achievement modal share buttons to home page - fixes #10675

### DIFF
--- a/website/client/components/achievements/achievementFooter.vue
+++ b/website/client/components/achievements/achievementFooter.vue
@@ -70,9 +70,9 @@ export default {
         facebook,
       }),
       tweet,
-      achievementLink: `${BASE_URL}/social/achievement`,
-      twitterLink: `https://twitter.com/intent/tweet?text=${tweet}&via=habitica&url=${BASE_URL}/social/achievement&count=none`,
-      facebookLink: `https://www.facebook.com/sharer/sharer.php?text=${tweet}&u=${BASE_URL}/social/achievement`,
+      achievementLink: `${BASE_URL}`,
+      twitterLink: `https://twitter.com/intent/tweet?text=${tweet}&via=habitica&url=${BASE_URL}&count=none`,
+      facebookLink: `https://www.facebook.com/sharer/sharer.php?text=${tweet}&u=${BASE_URL}`,
     };
   },
 };


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10675

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
I just deleted the tails on the Habitica URL's in the social share buttons so they only point to the main page (the BASE_URL variable). Pretty straightforward, I think.

Manual testing confirms that social links in achievement modals now point to the home page.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 16461457-c020-42e1-ae2a-2236f5a04431
