### PR TITLE
Add errors for any param validation failures (not just authentication) to the snackbar

### DIFF
--- a/website/client/app.vue
+++ b/website/client/app.vue
@@ -331,23 +331,13 @@ export default {
         if (notificationNotFoundMessage.indexOf(errorMessage) !== -1) snackbarTimeout = true;
 
         let errorsToShow = [];
-        let usernameCheck = false;
-        let emailCheck = false;
-        let passwordCheck = false;
         // show only the first error for each param
+        let paramErrorsFound = {};
         if (errorData.errors) {
           for (let e of errorData.errors) {
-            if (!usernameCheck && e.param === 'username') {
+            if (!paramErrorsFound[e.param]) {
               errorsToShow.push(e.message);
-              usernameCheck = true;
-            }
-            if (!emailCheck && e.param === 'email') {
-              errorsToShow.push(e.message);
-              emailCheck = true;
-            }
-            if (!passwordCheck && e.param === 'password') {
-              errorsToShow.push(e.message);
-              passwordCheck = true;
+              paramErrorsFound[e.param] = true;
             }
           }
         } else {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10723

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
#
Changes how parameter validation errors are handled by the client.

Context: The client receives a list of parameter validation errors if any validation check fails. It then produces a single snackbar with error messages separated by spaces.

Previous behaviour: For each of `'username'`, `'email'` and `'password'`, the first error (if any) is added to the list of errors. If there are two or more errors for any parameter, only the first is displayed. Any other parameters are ignored, causing an empty snackbar to be shown if the parameter failing validation is not one of these three options.

New behaviour: For each validation error, the error is added to the list of errors, unless an error for that parameter has already been found. This is identical to the previous behaviour when creating a new account, but means when you try to send a blank message, the snackbar says 'You cannot send a blank message', fixing #10723.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 62b5b263-cb73-4519-8149-d214c798c17f
