### PR TITLE
Issue 10728: sort equipment by stat descending on Market page

### DIFF
--- a/website/client/components/shops/market/equipmentSection.vue
+++ b/website/client/components/shops/market/equipmentSection.vue
@@ -63,6 +63,7 @@ layout-section(:title="$t('equipment')")
 
   import _filter from 'lodash/filter';
   import _sortBy from 'lodash/sortBy';
+  import _reverse from 'lodash/reverse';
   import pinUtils from '../../../mixins/pinUtils';
 
   const sortGearTypes = ['sortByType', 'sortByPrice', 'sortByCon', 'sortByPer', 'sortByStr', 'sortByInt'].map(g => ({id: g}));
@@ -137,9 +138,17 @@ layout-section(:title="$t('equipment')")
           return !this.userItems.gear.owned[gear.key];
         });
 
-        // first all unlocked
-        // then the selected sort
-        result = _sortBy(result, [(item) => item.locked, sortGearTypeMap[this.selectedSortGearBy.id]]);
+        let selectedSortKey = sortGearTypeMap[this.selectedSortGearBy.id];
+
+        result = _sortBy(result, selectedSortKey);
+
+        if (selectedSortKey !== 'type' && selectedSortKey !== 'value') {
+          // sorting by a stat, need to reverse to get high-to-low sort
+          result = _reverse(result);
+        }
+
+        // put unlocked items first
+        result = _sortBy(result, (item) => item.locked);
 
         return result;
       },

--- a/website/client/components/shops/market/equipmentSection.vue
+++ b/website/client/components/shops/market/equipmentSection.vue
@@ -118,9 +118,38 @@ layout-section(:title="$t('equipment')")
         return this.marketGearCategories.filter(c => c.id === this.selectedGroupGearByClass)[0];
       },
       sortedGearItems () {
-        let category = _filter(this.marketGearCategories, ['identifier', this.selectedGroupGearByClass]);
+        let result = this.filterGearItems();
+        let selectedSortKey = sortGearTypeMap[this.selectedSortGearBy.id];
 
-        let result = _filter(category[0].items, (gear) => {
+        result = _sortBy(result, selectedSortKey);
+
+        if (selectedSortKey !== 'type' && selectedSortKey !== 'value') {
+          // sorting by a stat, need to reverse to get high-to-low sort
+          result = _reverse(result);
+        }
+
+        // put unlocked items first
+        return _sortBy(result, (item) => item.locked);
+      },
+    },
+    methods: {
+      getClassName (classType) {
+        if (classType === 'wizard') {
+          return this.$t('mage');
+        } else {
+          return this.$t(classType);
+        }
+      },
+      gearSelected (item) {
+        if (!item.locked) {
+          this.$root.$emit('buyModal::showItem', item);
+        }
+      },
+      filterGearItems () {
+        let category = _filter(this.marketGearCategories, ['identifier', this.selectedGroupGearByClass]);
+        let items = category[0].items;
+
+        return _filter(items, (gear) => {
           if (this.hideLocked && gear.locked) {
             return false;
           }
@@ -138,34 +167,6 @@ layout-section(:title="$t('equipment')")
           // hide already owned
           return !this.userItems.gear.owned[gear.key];
         });
-
-        let selectedSortKey = sortGearTypeMap[this.selectedSortGearBy.id];
-
-        result = _sortBy(result, selectedSortKey);
-
-        if (selectedSortKey !== 'type' && selectedSortKey !== 'value') {
-          // sorting by a stat, need to reverse to get high-to-low sort
-          result = _reverse(result);
-        }
-
-        // put unlocked items first
-        result = _sortBy(result, (item) => item.locked);
-
-        return result;
-      },
-    },
-    methods: {
-      getClassName (classType) {
-        if (classType === 'wizard') {
-          return this.$t('mage');
-        } else {
-          return this.$t(classType);
-        }
-      },
-      gearSelected (item) {
-        if (!item.locked) {
-          this.$root.$emit('buyModal::showItem', item);
-        }
       },
     },
     created () {

--- a/website/client/components/shops/market/equipmentSection.vue
+++ b/website/client/components/shops/market/equipmentSection.vue
@@ -72,6 +72,7 @@ layout-section(:title="$t('equipment')")
     sortByType: 'type',
     sortByPrice: 'value',
     sortByCon: 'con',
+    sortByPer: 'per',
     sortByStr: 'str',
     sortByInt: 'int',
   };

--- a/website/client/components/shops/market/equipmentSection.vue
+++ b/website/client/components/shops/market/equipmentSection.vue
@@ -62,8 +62,7 @@ layout-section(:title="$t('equipment')")
   import svgHealer from 'assets/svg/healer.svg';
 
   import _filter from 'lodash/filter';
-  import _sortBy from 'lodash/sortBy';
-  import _reverse from 'lodash/reverse';
+  import _orderBy from 'lodash/orderBy';
   import pinUtils from '../../../mixins/pinUtils';
 
   const sortGearTypes = ['sortByType', 'sortByPrice', 'sortByCon', 'sortByPer', 'sortByStr', 'sortByInt'].map(g => ({id: g}));
@@ -120,16 +119,11 @@ layout-section(:title="$t('equipment')")
       sortedGearItems () {
         let result = this.filterGearItems();
         let selectedSortKey = sortGearTypeMap[this.selectedSortGearBy.id];
+        let sortingByStat = selectedSortKey !== 'type' && selectedSortKey !== 'value';
+        let order = sortingByStat ? 'desc' : 'asc';
 
-        result = _sortBy(result, selectedSortKey);
-
-        if (selectedSortKey !== 'type' && selectedSortKey !== 'value') {
-          // sorting by a stat, need to reverse to get high-to-low sort
-          result = _reverse(result);
-        }
-
-        // put unlocked items first
-        return _sortBy(result, (item) => item.locked);
+        // split into unlocked and locked, then apply selected sort
+        return _orderBy(result, ['locked', selectedSortKey], ['asc', order]);
       },
     },
     methods: {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10728 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
I changed the `sortGearItems()` computed property of the `equipmentSection.vue` component of the Market screen to reverse the order of the items when sorting by a stat. This will display the highest-stat items first, the same as on the Equipment section of the Inventory. (The alternative would be to sort in ascending order on both pages, which seems to make less sense)

While I was making changes, I noticed that sorting by PER was not actually implemented. I couldn't find an open issue related to this, but I went ahead and included the fix.

I also took the liberty of moving the filtering part of `sortGearItems()` into its own method, since `sortGearItems()` was getting fairly long and complicated, and the filtering logic seems to stand on its own. I'm not super familiar with Vue, though, so maybe it makes more sense as a computed property than a method?

I'm open to feedback on all of these changes!

Also, I didn't see any obvious place to add tests for this, so I didn't, which is probably bad :eyes: 

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 7620c72a-bb5a-4798-b3c0-846dacb2b44d
