### PR TITLE
Remove items with a class that have been lost from Class:None in shop

### DIFF
--- a/website/common/script/libs/shops.js
+++ b/website/common/script/libs/shops.js
@@ -188,8 +188,7 @@ shops.getMarketGearCategories = function getMarketGear (user, language) {
   };
 
   let specialNonClassGear = filter(content.gear.flat, (gear) => {
-    return user.items.gear.owned[gear.key] === false ||
-      !user.items.gear.owned[gear.key] &&
+    return !user.items.gear.owned[gear.key] &&
       content.classes.indexOf(gear.klass) === -1 &&
       content.classes.indexOf(gear.specialClass) === -1 &&
       (gear.canOwn && gear.canOwn(user));


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
I think fix #10727

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Previously, in the shop:
 * Items that had been bought and then lost were shown in Class:None, whether or not they belonged to a class.
 * This could cause some confusion, see the attached issue.

Now:
 * Items that have never been bought or have been lost appear in the shop under Class:None, but only if they have no classes.

I'm not sure if this was a good change to make, but it seemed easier to make a tiny pull request and see than try to discuss the proposed changes in words with a time delay. If the previous behaviour was correct, feel free to close the request.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 62b5b263-cb73-4519-8149-d214c798c17f
