### PR TITLE
Verify username as valid if user is re-checking their current name

### DIFF
--- a/website/server/controllers/api-v4/auth.js
+++ b/website/server/controllers/api-v4/auth.js
@@ -74,7 +74,7 @@ api.verifyUsername = {
   url: '/user/auth/verify-username',
   async handler (req, res) {
     const user = res.locals.user;
-    
+
     req.checkBody({
       username: {
         notEmpty: {errorMessage: res.t('missingUsername')},
@@ -87,7 +87,7 @@ api.verifyUsername = {
     const issues = verifyUsername(req.body.username, res);
 
     const existingUser = await User.findOne({ 'auth.local.lowerCaseUsername': req.body.username.toLowerCase() }, {auth: 1}).exec();
-    if (existingUser !== undefined && existingUser !== null && existingUser._id !== user._id) {
+    if (existingUser && existingUser._id !== user._id) {
       issues.push(res.t('usernameTaken'));
     }
 

--- a/website/server/controllers/api-v4/auth.js
+++ b/website/server/controllers/api-v4/auth.js
@@ -73,6 +73,8 @@ api.verifyUsername = {
   method: 'POST',
   url: '/user/auth/verify-username',
   async handler (req, res) {
+    const user = res.locals.user;
+    
     req.checkBody({
       username: {
         notEmpty: {errorMessage: res.t('missingUsername')},
@@ -84,8 +86,10 @@ api.verifyUsername = {
 
     const issues = verifyUsername(req.body.username, res);
 
-    const count = await User.count({ 'auth.local.lowerCaseUsername': req.body.username.toLowerCase() });
-    if (count > 0)  issues.push(res.t('usernameTaken'));
+    const existingUser = await User.findOne({ 'auth.local.lowerCaseUsername': req.body.username.toLowerCase() }, {auth: 1}).exec();
+    if (existingUser !== undefined && existingUser !== null && existingUser._id !== user._id) {
+      issues.push(res.t('usernameTaken'));
+    }
 
     if (issues.length > 0) {
       res.respond(200, { isUsable: false, issues });


### PR DESCRIPTION
Right now there is an error that the username is already taken if a user tries to enter their current username. The website partially already handles this by not sending a verify request if the entered name matches the users current name, but that does not work if the user changes the case of letters to upper or lowercase. Changing the validation on the server side is a better approach for handling this.