### PR TITLE
add verified Usernames to inbox and chat messages.

### DIFF
--- a/test/api/v3/integration/chat/POST-chat.test.js
+++ b/test/api/v3/integration/chat/POST-chat.test.js
@@ -448,6 +448,22 @@ describe('POST /chat', () => {
     expect(messageBackerInfo.tokensApplied).to.equal(backerInfo.tokensApplied);
   });
 
+  it('adds username if user has verified', async () => {
+    const newMessage = await user.post(`/groups/${groupWithChat._id}/chat`, { message: testMessage});
+
+    expect(newMessage.message.username).to.equal(user.auth.local.username);
+  });
+
+  it('does not add username if user has not verified', async () => {
+    const unverifiedUser = await generateUser({
+      'flags.verifiedUsername': false,
+    });
+    await unverifiedUser.sync();
+    const newMessage = await unverifiedUser.post(`/groups/${groupWithChat._id}/chat`, { message: testMessage});
+
+    expect(newMessage.message.username).to.not.exist;
+  });
+
   it('sends group chat received webhooks', async () => {
     let userUuid = generateUUID();
     let memberUuid = generateUUID();

--- a/test/api/v3/integration/members/POST-send_private_message.test.js
+++ b/test/api/v3/integration/members/POST-send_private_message.test.js
@@ -151,13 +151,16 @@ describe('POST /members/send-private-message', () => {
     let sendersMessageInSendersInbox = _.find(updatedSender.inbox.messages, (message) => {
       return message.uuid === receiver._id && message.text === messageToSend;
     });
-    expect(response.message.username).to.equal(userToSendMessage.auth.local.username);
+    expect(response.message.username).to.equal(receiver.auth.local.username);
     expect(sendersMessageInReceiversInbox.username).to.equal(userToSendMessage.auth.local.username);
-    expect(sendersMessageInSendersInbox.username).to.equal(userToSendMessage.auth.local.username);
+    expect(sendersMessageInSendersInbox.username).to.equal(receiver.auth.local.username);
   });
 
   it('does not add username if user has not verified', async () => {
-    let receiver = await generateUser();
+    let receiver = await generateUser({
+      'flags.verifiedUsername': false,
+    });
+    receiver.sync();
     const unverifiedUser = await generateUser({
       'flags.verifiedUsername': false,
     });

--- a/website/server/controllers/api-v3/chat.js
+++ b/website/server/controllers/api-v3/chat.js
@@ -177,6 +177,11 @@ api.postChat = {
     }
 
     const newChatMessage = group.sendChat(req.body.message, user);
+
+    if (user.flags.verifiedUsername === true) {
+      newChatMessage.username = user.auth.local.username;
+    }
+
     let toSave = [newChatMessage.save()];
 
     if (group.type === 'party') {

--- a/website/server/controllers/api-v3/chat.js
+++ b/website/server/controllers/api-v3/chat.js
@@ -178,7 +178,7 @@ api.postChat = {
 
     const newChatMessage = group.sendChat(req.body.message, user);
 
-    if (user.flags.verifiedUsername === true) {
+    if (user.flags && user.flags.verifiedUsername === true) {
       newChatMessage.username = user.auth.local.username;
     }
 

--- a/website/server/models/message.js
+++ b/website/server/models/message.js
@@ -117,7 +117,7 @@ export function messageDefaults (msg, user) {
       backer: user.backer && user.backer.toObject(),
       user: user.profile.name,
     });
-    if (user.flags.verifiedUsername === true) {
+    if (user.flags && user.flags.verifiedUsername === true) {
       message.username = user.auth.local.username;
     }
   } else {

--- a/website/server/models/message.js
+++ b/website/server/models/message.js
@@ -10,6 +10,7 @@ const defaultSchema = () => ({
 
   // sender properties
   user: String, // profile name
+  username: String, // unique username
   contributor: {type: mongoose.Schema.Types.Mixed},
   backer: {type: mongoose.Schema.Types.Mixed},
   uuid: String, // sender uuid

--- a/website/server/models/message.js
+++ b/website/server/models/message.js
@@ -117,6 +117,9 @@ export function messageDefaults (msg, user) {
       backer: user.backer && user.backer.toObject(),
       user: user.profile.name,
     });
+    if (user.flags.verifiedUsername === true) {
+      message.username = user.auth.local.username;
+    }
   } else {
     message.uuid = 'system';
   }

--- a/website/server/models/user/methods.js
+++ b/website/server/models/user/methods.js
@@ -117,6 +117,9 @@ schema.methods.sendMessage = async function sendMessage (userToReceiveMessage, o
   });
   Object.assign(newReceiverMessage, messageDefaults(options.receiverMsg, sender));
   setUserStyles(newReceiverMessage, sender);
+  if (sender.flags.verifiedUsername === true) {
+    newReceiverMessage.username = sender.auth.local.username;
+  }
 
   userToReceiveMessage.inbox.newMessages++;
   userToReceiveMessage._v++;
@@ -148,6 +151,8 @@ schema.methods.sendMessage = async function sendMessage (userToReceiveMessage, o
   // Do not add the message twice when sending it to yourself
   let newSenderMessage;
 
+  const promises = [newReceiverMessage.save()];
+
   if (!sendingToYourself) {
     newSenderMessage = new Inbox({
       sent: true,
@@ -155,10 +160,11 @@ schema.methods.sendMessage = async function sendMessage (userToReceiveMessage, o
     });
     Object.assign(newSenderMessage, messageDefaults(senderMsg, userToReceiveMessage));
     setUserStyles(newSenderMessage, sender);
+    if (sender.flags.verifiedUsername === true) {
+      newSenderMessage.username = sender.auth.local.username;
+    }
+    promises.push(newSenderMessage.save());
   }
-
-  const promises = [newReceiverMessage.save()];
-  if (!sendingToYourself) promises.push(newSenderMessage.save());
 
   if (saveUsers) {
     promises.push(sender.save());

--- a/website/server/models/user/methods.js
+++ b/website/server/models/user/methods.js
@@ -117,9 +117,6 @@ schema.methods.sendMessage = async function sendMessage (userToReceiveMessage, o
   });
   Object.assign(newReceiverMessage, messageDefaults(options.receiverMsg, sender));
   setUserStyles(newReceiverMessage, sender);
-  if (sender.flags.verifiedUsername === true) {
-    newReceiverMessage.username = sender.auth.local.username;
-  }
 
   userToReceiveMessage.inbox.newMessages++;
   userToReceiveMessage._v++;
@@ -160,9 +157,6 @@ schema.methods.sendMessage = async function sendMessage (userToReceiveMessage, o
     });
     Object.assign(newSenderMessage, messageDefaults(senderMsg, userToReceiveMessage));
     setUserStyles(newSenderMessage, sender);
-    if (sender.flags.verifiedUsername === true) {
-      newSenderMessage.username = sender.auth.local.username;
-    }
     promises.push(newSenderMessage.save());
   }
 


### PR DESCRIPTION
This adds a users username to inbox and chat messages as long as they have a verified username. This will eventually be needed for displaying the username on messages and also for @messaging. It should be added before we release those features, so that on release there are already messages with usernames which improves how those features work at launch.