### PR TITLE
No matching Guilds/Challenges message

### DIFF
--- a/website/client/components/challenges/findChallenges.vue
+++ b/website/client/components/challenges/findChallenges.vue
@@ -22,8 +22,9 @@
     .row
       .col-12.col-md-6(v-for='challenge in filteredChallenges')
         challenge-item(:challenge='challenge')
+
     .row
-      .col-12.text-center
+      .col-12.text-center(v-if='!loading && filteredChallenges.length > 0')
         button.btn.btn-secondary(@click='loadMore()') {{ $t('loadMore') }}
 </template>
 

--- a/website/client/components/challenges/findChallenges.vue
+++ b/website/client/components/challenges/findChallenges.vue
@@ -14,6 +14,11 @@
         button.btn.btn-secondary.create-challenge-button.float-right(@click='createChallenge()')
           .svg-icon.positive-icon(v-html="icons.positiveIcon")
           span(v-once) {{$t('createChallenge')}}
+
+    .row
+      .no-challenges.text-center.col-md-6.offset-3(v-if='!loading && filteredChallenges.length === 0')
+        h2(v-once) {{$t('noChallengeMatchFilters')}}
+
     .row
       .col-12.col-md-6(v-for='challenge in filteredChallenges')
         challenge-item(:challenge='challenge')
@@ -39,6 +44,15 @@
       width: 10px;
       display: inline-block;
       margin-right: .5em;
+    }
+  }
+
+  .no-challenges {
+    color: $gray-200;
+    margin-top: 10em;
+
+    h2 {
+      color: $gray-200;
     }
   }
 </style>

--- a/website/client/components/challenges/myChallenges.vue
+++ b/website/client/components/challenges/myChallenges.vue
@@ -24,6 +24,10 @@
         p(v-once) {{$t('challengeDescription2')}}
 
     .row
+      .no-challenges.text-center.col-md-6.offset-3(v-if='!loading && challenges.length > 0 && filteredChallenges.length === 0')
+        h2(v-once) {{$t('noChallengeMatchFilters')}}
+
+    .row
       .col-12.col-md-6(v-for='challenge in filteredChallenges')
         challenge-item(:challenge='challenge')
 </template>

--- a/website/client/components/groups/discovery.vue
+++ b/website/client/components/groups/discovery.vue
@@ -14,6 +14,11 @@
         button.btn.btn-secondary.create-group-button.float-right(@click='createGroup()')
           .svg-icon.positive-icon(v-html="icons.positiveIcon")
           span(v-once) {{$t('createGuild2')}}
+
+    .row
+      .no-guilds.text-center.col-md-6.offset-md-3(v-if='!loading && filteredGuilds.length === 0')
+        h2(v-once) {{$t('noGuildsMatchFilters')}}
+
     .row
       .col-md-12
         public-guild-item(v-for="guild in filteredGuilds", :key='guild._id', :guild="guild", :display-leave='true')
@@ -38,6 +43,15 @@
     width: 10px;
     display: inline-block;
     margin-right: .5em;
+  }
+
+  .no-guilds {
+    color: $gray-200;
+    margin-top: 10em;
+
+    h2 {
+      color: $gray-200;
+    }
   }
 </style>
 

--- a/website/client/components/groups/myGuilds.vue
+++ b/website/client/components/groups/myGuilds.vue
@@ -24,6 +24,10 @@
         p(v-once) {{$t('noGuildsParagraph2')}}
 
     .row
+      .no-guilds.text-center.col-md-6.offset-md-3(v-if='!loading && guilds.length > 0 && filteredGuilds.length === 0')
+        h2(v-once) {{$t('noGuildsMatchFilters')}}
+
+    .row
       .col-md-12
         public-guild-item(v-for="guild in filteredGuilds", :key='guild._id', :guild="guild", :display-gem-bank='true')
 </template>

--- a/website/client/components/groups/sidebar.vue
+++ b/website/client/components/groups/sidebar.vue
@@ -139,8 +139,6 @@ export default {
       this.emitFilters();
     },
     searchTerm: throttle(function searchTerm (newSearch) {
-      if (newSearch.length <= 1) return; // @TODO: eh, should we limit based on length?
-
       this.$emit('search', {
         searchTerm: newSearch,
       });

--- a/website/common/locales/en/challenge.json
+++ b/website/common/locales/en/challenge.json
@@ -100,6 +100,7 @@
   "noChallengeTitle": "You don't have any Challenges.",
   "challengeDescription1": "Challenges are community events in which players compete and earn prizes by completing a group of related tasks.",
   "challengeDescription2": "Find recommended Challenges based on your interests, browse Habitica's public Challenges, or create your own Challenges.",
+  "noChallengeMatchFilters": "We couldn't find any matching Challenges.",
   "createdBy": "Created By",
   "joinChallenge": "Join Challenge",
   "leaveChallenge": "Leave Challenge",

--- a/website/common/locales/en/groups.json
+++ b/website/common/locales/en/groups.json
@@ -400,6 +400,7 @@
   "noGuildsTitle": "You aren't a member of any Guilds.",
   "noGuildsParagraph1": "Guilds are social groups created by other players that can offer you support,  accountability, and encouraging chat.",
   "noGuildsParagraph2": "Click the Discover tab to see recommended Guilds based on your interests, browse Habitica's public Guilds, or create your own Guild.",
+  "noGuildsMatchFilters": "We couldn't find any matching Guilds.",
   "privateDescription": "A private Guild will not be displayed in Habitica's Guild directory. New members can be added by invitation only.",
   "removeInvite": "Remove Invitation",
   "removeMember": "Remove Member",


### PR DESCRIPTION
See previous discussion here: https://github.com/HabitRPG/habitica/pull/10665#discussion_r219885307

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Display "We couldn't find any matching Guilds." message on 
* My Guilds page when user has Guilds but filters don't match anything
* Discover Guilds page when filters don't match anything

![screenshot from 2018-10-09 09-46-05](https://user-images.githubusercontent.com/1764167/46651434-a9e37300-cba8-11e8-822c-2606cd6d6749.png)


Display "We couldn't find any matching Challenges." message on 
* My Challenges page when user has Challenges but filters don't match anything
* Discover Challenges page when filters don't match anything

![screenshot from 2018-10-09 09-45-23](https://user-images.githubusercontent.com/1764167/46651444-b49e0800-cba8-11e8-933e-0fcf26143b94.png)

Also, hide the "Load More" button in Discover Challenges page when 
* there is nothing to load (filters don't match anything)
* while already loading.

----
UUID: fa756acf-9127-4a3c-8dac-8ff627d30073
