### PR TITLE
(#10743) Pinned gala gear showing as pinned in the market

### DIFF
--- a/website/common/script/libs/getItemInfo.js
+++ b/website/common/script/libs/getItemInfo.js
@@ -338,7 +338,7 @@ module.exports = function getItemInfo (user, type, item, officialPinnedItems, la
 
   if (itemInfo) {
     itemInfo.isSuggested = isItemSuggested(officialPinnedItems, itemInfo);
-    itemInfo.pinned = isPinned(user, itemInfo);
+    itemInfo.pinned = isPinned(user, itemInfo, officialPinnedItems);
   } else {
     throw new BadRequest(i18n.t('wrongItemType', {type}, language));
   }


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10743

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
The code for getting the gear to display in the market now checks for seasonal items which are automatically pinned and haven't been unpinned by the user. This was already implemented in `isPinned`, but it is now passed the information it needs to do the check.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 62b5b263-cb73-4519-8149-d214c798c17f
