### PR TITLE
Assign username to user on auth if absent

### DIFF
--- a/test/api/unit/middlewares/auth.test.js
+++ b/test/api/unit/middlewares/auth.test.js
@@ -36,5 +36,39 @@ describe('auth middleware', () => {
         done();
       });
     });
+
+    it('assigns a username if user does not have one', (done) => {
+      const authWithHeaders = authWithHeadersFactory();
+      delete res.locals.user.auth.local.username;
+
+      req.headers['x-api-user'] = user._id;
+      req.headers['x-api-key'] = user.apiToken;
+
+      authWithHeaders(req, res, (err) => {
+        if (err) return done(err);
+
+        const userToJSON = res.locals.user.toJSON();
+        expect(userToJSON.auth.local.username).to.exist;
+
+        done();
+      });
+    });
+
+    it('does not change existing username if user has one', (done) => {
+      const authWithHeaders = authWithHeadersFactory();
+      const existingUsername = res.locals.user.auth.local.username;
+
+      req.headers['x-api-user'] = user._id;
+      req.headers['x-api-key'] = user.apiToken;
+
+      authWithHeaders(req, res, (err) => {
+        if (err) return done(err);
+
+        const userToJSON = res.locals.user.toJSON();
+        expect(userToJSON.auth.local.username).to.eql(existingUsername);
+
+        done();
+      });
+    });
   });
 });

--- a/website/server/middlewares/auth.js
+++ b/website/server/middlewares/auth.js
@@ -8,7 +8,7 @@ import nconf from 'nconf';
 import url from 'url';
 import {
   generateUsername,
-} from '../libs/auth';
+} from '../libs/auth/utils';
 
 const COMMUNITY_MANAGER_EMAIL = nconf.get('EMAILS:COMMUNITY_MANAGER_EMAIL');
 

--- a/website/server/middlewares/auth.js
+++ b/website/server/middlewares/auth.js
@@ -6,6 +6,9 @@ import {
 } from '../models/user';
 import nconf from 'nconf';
 import url from 'url';
+import {
+  generateUsername,
+} from '../libs/auth';
 
 const COMMUNITY_MANAGER_EMAIL = nconf.get('EMAILS:COMMUNITY_MANAGER_EMAIL');
 
@@ -14,6 +17,7 @@ function getUserFields (options, req) {
   // Must be an array
   if (options.userFieldsToExclude) {
     return options.userFieldsToExclude.map(field => {
+      if (field.indexOf('auth.local') !== -1) return;
       return `-${field}`; // -${field} means exclude ${field} in mongodb
     }).join(' ');
   }
@@ -59,9 +63,13 @@ export function authWithHeaders (options = {}) {
 
     return findPromise
       .exec()
-      .then((user) => {
+      .then(async (user) => {
         if (!user) throw new NotAuthorized(res.t('invalidCredentials'));
         if (user.auth.blocked) throw new NotAuthorized(res.t('accountSuspended', {communityManagerEmail: COMMUNITY_MANAGER_EMAIL, userId: user._id}));
+        if (!user.auth.local.username) {
+          user.auth.local.username = generateUsername();
+          await user.save();
+        }
 
         res.locals.user = user;
 

--- a/website/server/middlewares/auth.js
+++ b/website/server/middlewares/auth.js
@@ -67,7 +67,9 @@ export function authWithHeaders (options = {}) {
         if (!user) throw new NotAuthorized(res.t('invalidCredentials'));
         if (user.auth.blocked) throw new NotAuthorized(res.t('accountSuspended', {communityManagerEmail: COMMUNITY_MANAGER_EMAIL, userId: user._id}));
         if (!user.auth.local.username) {
-          user.auth.local.username = generateUsername();
+          const generatedUsername = generateUsername();
+          user.auth.local.username = generatedUsername;
+          user.auth.local.lowerCaseUsername = generatedUsername;
           await user.save();
         }
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes https://github.com/HabitRPG/habitica-private/issues/5

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Adds a step during authentication middleware to create a username for a user if they don't yet have one. This helps cover users who use social authentication whose accounts were too long inactive to be caught in the username-assigning migration who then return to Habitica. (New social-auth accounts should already be receiving usernames on signup.)