### PR TITLE
Added questActivity to allowed webhooks in docs.

### DIFF
--- a/website/server/controllers/api-v3/webhook.js
+++ b/website/server/controllers/api-v3/webhook.js
@@ -31,7 +31,7 @@ let api = {};
  * @apiParam (Body) {String} url The webhook's URL
  * @apiParam (Body) {String} [label] A label to remind you what this webhook does
  * @apiParam (Body) {Boolean} [enabled=true] If the webhook should be enabled
- * @apiParam (Body) {Sring="taskActivity","groupChatReceived","userActivity"} [type="taskActivity"] The webhook's type.
+ * @apiParam (Body) {Sring="taskActivity","groupChatReceived","userActivity","questActivity"} [type="taskActivity"] The webhook's type.
  * @apiParam (Body) {Object} [options] The webhook's options. Wil differ depending on type. Required for `groupChatReceived` type. If a webhook supports options, the default values are displayed in the examples below
  * @apiParamExample {json} Task Activity Example
  *   {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
No issue created (single line change to docs, seems verbose to make an issue about it).

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

The documentation did not include `questActivity` as a possible webhook type. Now it does!

(I was going to open an issue to request this feature as advised by @SabreCat in the Report a Bug guild, but then I found it already in the code and deployed into production; it was simply missing in the documentation)

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: ecc53331-4aa1-4b02-b3b3-e794d0ff6827
