### PR TITLE
fix for #10496: Newly subscribed accounts receive erroneous notification that they have Mystery Items

### DIFF
--- a/test/api/unit/libs/payments/payments.test.js
+++ b/test/api/unit/libs/payments/payments.test.js
@@ -434,7 +434,7 @@ describe('payments/index', () => {
         fakeClock.restore();
       });
 
-      it('does not awards mystery items when not within the timeframe for a mystery item', async () => {
+      it('does not add a notification for mystery items if none was awarded', async () => {
         const noMysteryItemTimeframe = 1462183920000; // May 2nd 2016
         let fakeClock = sinon.useFakeTimers(noMysteryItemTimeframe);
         data = { paymentMethod: 'PaymentMethod', user, sub: { key: 'basic_3mo' } };
@@ -442,6 +442,7 @@ describe('payments/index', () => {
         await api.createSubscription(data);
 
         expect(user.purchased.plan.mysteryItems).to.have.a.lengthOf(0);
+        expect(user.notifications.find(n => n.type === 'NEW_MYSTERY_ITEMS')).to.be.undefined;
 
         fakeClock.restore();
       });

--- a/test/api/unit/libs/payments/payments.test.js
+++ b/test/api/unit/libs/payments/payments.test.js
@@ -434,6 +434,18 @@ describe('payments/index', () => {
         fakeClock.restore();
       });
 
+      it('does not awards mystery items when not within the timeframe for a mystery item', async () => {
+        const noMysteryItemTimeframe = 1462183920000; // May 2nd 2016
+        let fakeClock = sinon.useFakeTimers(noMysteryItemTimeframe);
+        data = { paymentMethod: 'PaymentMethod', user, sub: { key: 'basic_3mo' } };
+
+        await api.createSubscription(data);
+
+        expect(user.purchased.plan.mysteryItems).to.have.a.lengthOf(0);
+
+        fakeClock.restore();
+      });
+
       it('does not add a notification for mystery items if none was awarded', async () => {
         const noMysteryItemTimeframe = 1462183920000; // May 2nd 2016
         let fakeClock = sinon.useFakeTimers(noMysteryItemTimeframe);

--- a/website/server/libs/payments/subscriptions.js
+++ b/website/server/libs/payments/subscriptions.js
@@ -36,8 +36,9 @@ function revealMysteryItems (user) {
       pushedItems.push(item.key);
     }
   });
-
-  user.addNotification('NEW_MYSTERY_ITEMS', { items: pushedItems });
+  if (pushedItems.length > 0) {
+    user.addNotification('NEW_MYSTERY_ITEMS', { items: pushedItems });
+  }
 }
 
 // @TODO: Abstract to payment helper


### PR DESCRIPTION
Fixes #10496

Issue #10496: Newly subscribed accounts receive erroneous notification that they have Mystery Items

Hi, I've fixed this issue but I'm stuck on implementing the automated unit test. Sorry about wasting your precious time. Although I studied Javascript, I have no experience with any of its frameworks or an app of this scale. Automated unit testing is also new for me. This is what I've done so far.

## Reproducing the issue: 
1. Created testHabitica account
2. Granted that account's guild (testGuild) a group subscription using the mongodb command 
3. Created testHabitica2 account
4. invited testHabitica2 by id to the testGuild
5. The erroneous notification appears.
Note: This doesn't appear on the test user that was granted 1 month of sub using the mongodb command.

## Fix:

```
if (pushedItems.length > 0) {
user.addNotification('NEW_MYSTERY_ITEMS', { items: pushedItems });
}
```
in revealMysteryItems() in subscriptions.js.

## Concerns (Need help):

I tested this manually using a third new account, ran through ```npm run test```. I'm currently in the process of writing an automated test for this but I'm completely lost.

The closest thing I could find to revealMysteryItems() in the unit tests is context('Mystery Items'). I'm not sure if this is what I should be adding my unit test to.

I'm also unfamiliar with the BDD and unit testing syntax. I cobbled together the following based on what I would like to test, but I have no idea how to properly write it.

```
it('does not send notification if pushedItems is empty', async () => {
    if (user.purchased.plan.mysteryItems.length == 0) {
        expect(user.addNotification('NEW_MYSTERY_ITEMS', { items: pushedItems })).to.not.have.been.called;
    }
});
```
Thanks for your patience. I have a lot to learn.
