### PR TITLE
WIP: Update menu component to show proper z-index for modals when coming from static pages, fixes #10475

### DIFF
--- a/website/client/components/header/menu.vue
+++ b/website/client/components/header/menu.vue
@@ -380,10 +380,7 @@ export default {
       modalStack: 'modalStack',
     }),
     navbarZIndexClass () {
-      if (this.modalStack.length > 0) {
-        return 'navbar-z-index-modal';
-      }
-      return 'navbar-z-index-normal';
+      return 'navbar-z-index-modal';
     },
   },
   mounted () {


### PR DESCRIPTION
Fixes #10475 

### Changes
When a user was on a static page like the help pages, then clicked the logo to return back to the tasks page, then opened a modal (e.g., profile, etc.), the modal was getting cut off by the header:
![habitica_bug_10475](https://user-images.githubusercontent.com/22223412/46996115-20b8c880-d0e1-11e8-9ab3-33c322b8cdfb.PNG)

The Vue component `menu.vue` was assigning the wrong z-index to the navbar based on the length of the modalStack, but when coming from static pages, the length of the modalStack is 0. Removing the If block that checked the length of the modalStack solves the problem, and doesn't appear to affect the rest of the app or modals in other circumstances. 
![habitica_fix_10475](https://user-images.githubusercontent.com/22223412/46996118-23b3b900-d0e1-11e8-9dfc-b2b655bce743.PNG)

However, this is a WIP because I want to know if anybody knows if there's a good reason not to remove the code I removed, or if we can safely scrap it, solving the issue. I can't find a reason, but I'm a complete newbie coder and also fairly new to Habitica, so...Anyway, I hypothesize that the If block was written so that the navbar would always be on top of everything in cases where there was no modal, but as it happens, there's never anything else I know of (besides a modal) that would be up that far anyway. 

Also, I don't know much about tests -- I tried to run the test suite but it crashed midway through (although it had passed everything up to that point), so I'll take a look at the Travis CI results per the instructions.



----
UUID: b580cbca-ea45-4db4-bc5f-d990255bb808
