### PR TITLE
Fix filter checkboxes in seasonal shop

### DIFF
--- a/website/client/components/shops/seasonal/index.vue
+++ b/website/client/components/shops/seasonal/index.vue
@@ -7,13 +7,13 @@
       .form
         h2(v-once) {{ $t('filter') }}
         .form-group
-          .form-check(
+          checkbox(
             v-for="category in filterCategories",
             :key="category.key",
+            :id="`category-${category.key}`",
+            :checked.sync="viewOptions[category.key].selected",
+            :text="category.value"
           )
-            .custom-control.custom-checkbox
-              input.custom-control-input(type="checkbox", v-model="viewOptions[category.key].selected", :id="`category-${category.identifier}`")
-              label.custom-control-label(v-once, :for="`category-${category.identifier}`") {{ category.value }}
 
         div.form-group.clearfix
           h3.float-left(v-once) {{ $t('hidePinned') }}
@@ -290,6 +290,7 @@
   import Item from 'client/components/inventory/item';
   import CountBadge from 'client/components/ui/countBadge';
   import ItemRows from 'client/components/ui/itemRows';
+  import Checkbox from 'client/components/ui/checkbox';
   import toggleSwitch from 'client/components/ui/toggleSwitch';
   import Avatar from 'client/components/avatar';
   import buyMixin from 'client/mixins/buy';
@@ -326,6 +327,7 @@
       CountBadge,
       ItemRows,
       toggleSwitch,
+      Checkbox,
 
       Avatar,
     },


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10791

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Changes `category.identifier` to `category.key` in the filters for the seasonal shop, as this seemed to be causing the checkboxes not to work properly before.

Also changes the code to use the checkbox component as is used in the market. Let me know if this needs reversing.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 62b5b263-cb73-4519-8149-d214c798c17f
