### PR TITLE
Check pet can be hatched before highlighting

### DIFF
--- a/website/client/components/inventory/items/index.vue
+++ b/website/client/components/inventory/items/index.vue
@@ -373,9 +373,12 @@ export default {
       if (potion === null || egg === null)
         return false;
 
-      let petKey = `${egg.key}-${potion.key}`;
+      const petKey = `${egg.key}-${potion.key}`;
 
-      if (!this.content.petInfo[petKey])
+      const petInfo = this.content.petInfo[petKey];
+
+      // Check pet exists and is hatchable
+      if (!petInfo || !petInfo.potion)
         return false;
 
       return !this.userHasPet(potion.key, egg.key);


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10253

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

The function that checks if a potion/egg combination is valid now checks that the pet has an associated potion, so is hatchable. This means special pets are excluded, fixing the problem where Royal Purple Potion + Gryphon is highlighted as a valid combination. These changes are only visual, it was already impossible to hatch a Royal Purple Gryphon like this.

There were other ways (instead of checking existence of petInfo.potion) to fix this particular case, but this seemed most general and least likely to cause other problems.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 62b5b263-cb73-4519-8149-d214c798c17f
