### PR TITLE
Allocate stats on level

### DIFF
--- a/website/client/components/achievements/levelUp.vue
+++ b/website/client/components/achievements/levelUp.vue
@@ -8,6 +8,7 @@
       p.text {{ $t('levelup') }}
 
       stat-allocation(
+        v-if='!user.preferences.automaticAllocation',
         :user='user',
         :statUpdates='statUpdates',
         @statUpdate='statUpdate')

--- a/website/client/components/achievements/levelUp.vue
+++ b/website/client/components/achievements/levelUp.vue
@@ -111,6 +111,81 @@
       margin-bottom: .2em;
     }
   }
+
+  #statAllocation {
+    .title-row {
+      margin-top: 1em;
+      margin-bottom: 1em;
+    }
+
+    .counter.badge {
+      position: relative;
+      top: -0.25em;
+      left: 0.5em;
+      color: #fff;
+      background-color: #ff944c;
+      box-shadow: 0 1px 1px 0 rgba(26, 24, 29, 0.12);
+      width: 24px;
+      height: 24px;
+      border-radius: 50%;
+    }
+
+    .box {
+      width: 148px;
+      height: 84px;
+      padding: .5em;
+      margin: 0 auto;
+
+      div {
+        margin-top: 0;
+      }
+
+      .number {
+        font-size: 40px;
+        text-align: left;
+        color: #686274;
+        display: inline-block;
+      }
+
+      .points {
+        display: inline-block;
+        font-weight: bold;
+        line-height: 1.67;
+        text-align: left;
+        color: #878190;
+        margin-left: .5em;
+      }
+
+      .up, .down {
+        border: solid #a5a1ac;
+        border-width: 0 3px 3px 0;
+        display: inline-block;
+        padding: 3px;
+      }
+
+      .up:hover, .down:hover {
+        cursor: pointer;
+      }
+
+      .up {
+        transform: rotate(-135deg);
+        -webkit-transform: rotate(-135deg);
+        margin-top: 1em;
+      }
+
+      .down {
+        transform: rotate(45deg);
+        -webkit-transform: rotate(45deg);
+      }
+    }
+
+    .white {
+      border-radius: 2px;
+      background: #FFFFFF;
+      box-shadow: 0 2px 2px 0 rgba(26, 24, 29, 0.15), 0 1px 4px 0 rgba(26, 24, 29, 0.1);
+      border: 1px solid transparent;
+    }
+  }
 </style>
 
 <style scoped>

--- a/website/client/components/achievements/levelUp.vue
+++ b/website/client/components/achievements/levelUp.vue
@@ -234,16 +234,20 @@ export default {
       this.statUpdates[stat] += delta;
     },
     close () {
-      for (const stat in this.statUpdates) {
-        if (this.statUpdates[stat] > 0) {
-          allocateBulk(this.user, { body: { stats: this.statUpdates } });
+      // reset this.statUpdates before request to avoid display errors while waiting for server
+      const statUpdates = this.statUpdates;
+      this.statUpdates = { str: 0, int: 0, con: 0, per: 0 };
+
+      this.$root.$emit('bv::hide::modal', 'level-up');
+      for (const stat in statUpdates) {
+        if (statUpdates[stat] > 0) {
+          allocateBulk(this.user, { body: { stats: statUpdates } });
 
           axios.post('/api/v4/user/allocate-bulk', {
-            stats: this.statUpdates,
+            stats: statUpdates,
           });
         }
       }
-      this.$root.$emit('bv::hide::modal', 'level-up');
     },
     loadWidgets () {
       // @TODO:

--- a/website/client/components/achievements/levelUp.vue
+++ b/website/client/components/achievements/levelUp.vue
@@ -7,7 +7,7 @@
 
       p.text {{ $t('levelup') }}
 
-      stat-allocation(
+      stat-allocation#levelUpStatAllocation(
         v-if='!user.preferences.automaticAllocation',
         :user='user',
         :statUpdates='statUpdates',
@@ -33,13 +33,16 @@
 </template>
 
 <style lang="scss">
+  @import '~client/assets/scss/colors.scss';
+
   #level-up {
     h2 {
-      color: #4f2a93;
+      color: $purple-200;
     }
 
     .modal-content {
       min-width: 28em;
+      background-color: $gray-700;
     }
 
     .modal-body {
@@ -67,7 +70,7 @@
     .text {
       font-size: 14px;
       text-align: center;
-      color: #686274;
+      color: $gray-100;
       margin-top: 1em;
       min-height: 0px;
     }
@@ -83,16 +86,16 @@
       padding: .5em;
       border-radius: 2px;
       text-align: center;
-      color: #fff;
+      color: $white;
     }
 
     .fb-share-button {
-      background-color: #2995cd;
+      background-color: $blue-10;
     }
 
     .twitter-share-button {
       margin-right: .5em;
-      background-color: #3bcad7;
+      background-color: $teal-50;
     }
 
     .social-icon {
@@ -112,83 +115,65 @@
     }
   }
 
-  #statAllocation {
-    .title-row {
-      margin-top: 1em;
-      margin-bottom: 1em;
+  #levelUpStatAllocation {
+    font-size: 12px;
+    margin-bottom: 1em;
+
+    .minimize {
+      padding: 0px 5px 0px 5px;
+    }
+
+    h3 {
+      font-size: 14px;
     }
 
     .counter.badge {
       position: relative;
-      top: -0.25em;
-      left: 0.5em;
-      color: #fff;
-      background-color: #ff944c;
+      top: -0.5em;
+      left: 0.25em;
+      color: $white;
+      background-color: $orange-100;
       box-shadow: 0 1px 1px 0 rgba(26, 24, 29, 0.12);
-      width: 24px;
-      height: 24px;
+      width: 16px;
+      height: 16px;
       border-radius: 50%;
+      font-size: 10px;
+      padding: 2px;
     }
 
     .box {
-      width: 148px;
-      height: 84px;
-      padding: .5em;
+      max-width: 80px;
       margin: 0 auto;
+      padding: .5em;
+      font-size: 11px;
+
+      .stat-title {
+        width: 100%;
+        height: 20px;
+        line-height: 20px;
+      }
 
       div {
-        margin-top: 0;
+        padding: 0;
       }
 
       .number {
-        font-size: 40px;
-        text-align: left;
-        color: #686274;
+        font-size: 24px;
+        color: $gray-100;
         display: inline-block;
       }
 
       .points {
         display: inline-block;
         font-weight: bold;
-        line-height: 1.67;
-        text-align: left;
-        color: #878190;
+        color: $gray-200;
         margin-left: .5em;
       }
-
-      .up, .down {
-        border: solid #a5a1ac;
-        border-width: 0 3px 3px 0;
-        display: inline-block;
-        padding: 3px;
-      }
-
-      .up:hover, .down:hover {
-        cursor: pointer;
-      }
-
-      .up {
-        transform: rotate(-135deg);
-        -webkit-transform: rotate(-135deg);
-        margin-top: 1em;
-      }
-
-      .down {
-        transform: rotate(45deg);
-        -webkit-transform: rotate(45deg);
-      }
-    }
-
-    .white {
-      border-radius: 2px;
-      background: #FFFFFF;
-      box-shadow: 0 2px 2px 0 rgba(26, 24, 29, 0.15), 0 1px 4px 0 rgba(26, 24, 29, 0.1);
-      border: 1px solid transparent;
     }
   }
 </style>
 
-<style scoped>
+<style lang='scss' scoped>
   .avatar {
     margin-left: 6.8em;
   }
@@ -247,7 +232,7 @@ export default {
   methods: {
     statUpdate (stat, delta) {
       this.statUpdates[stat] += delta;
-    },      
+    },
     close () {
       for (const stat in this.statUpdates) {
         if (this.statUpdates[stat] > 0) {

--- a/website/client/components/ui/toggleSwitch.vue
+++ b/website/client/components/ui/toggleSwitch.vue
@@ -34,6 +34,7 @@
 
   .toggle-switch-description {
     height: 20px;
+    line-height: 20px;
 
     &.hasPopOver {
       border-bottom: 1px dashed $gray-200;

--- a/website/client/components/userMenu/profile.vue
+++ b/website/client/components/userMenu/profile.vue
@@ -138,7 +138,6 @@ div
     profileStats(
       :user='user',
       v-show='selectedPage === "stats"',
-      :showAllocation='showAllocation()',
       v-if='user.preferences')
   send-gems-modal(:userReceivingGems='userReceivingGems')
 </template>
@@ -452,9 +451,6 @@ export default {
     startingPageOption () {
       return this.$store.state.profileOptions.startingPage;
     },
-    hasClass () {
-      return this.$store.getters['members:hasClass'](this.userLoggedIn);
-    },
   },
   watch: {
     startingPageOption () {
@@ -558,10 +554,6 @@ export default {
       this.hero = await this.$store.dispatch('hall:getHero', { uuid: this.user._id });
       this.adminToolsLoaded = true;
     },
-    showAllocation () {
-      return this.user._id === this.userLoggedIn._id && this.hasClass;
-    },
-
   },
 };
 </script>

--- a/website/client/components/userMenu/profileStats.vue
+++ b/website/client/components/userMenu/profileStats.vue
@@ -117,7 +117,7 @@
               li
                 strong {{$t('buffs')}}:
                 | {{user.stats.buffs[stat]}}
-    stat-allocation(
+    stat-allocation#profileStatAllocation(
       :user='user',
       :statUpdates='statUpdates',
       @statUpdate='statUpdate')
@@ -400,7 +400,7 @@
     border: 1px solid transparent;
   }
 
-  #statAllocation {
+  #profileStatAllocation {
     .title-row {
       margin-top: 1em;
       margin-bottom: 1em;
@@ -419,10 +419,14 @@
     }
 
     .box {
-      width: 148px;
+      max-width: 148px;
       height: 84px;
       padding: .5em;
       margin: 0 auto;
+
+      .stat-title {
+        margin-left: 12px;
+      }
 
       div {
         margin-top: 0;
@@ -442,28 +446,6 @@
         text-align: left;
         color: $gray-200;
         margin-left: .5em;
-      }
-
-      .up, .down {
-        border: solid $gray-300;
-        border-width: 0 3px 3px 0;
-        display: inline-block;
-        padding: 3px;
-      }
-
-      .up:hover, .down:hover {
-        cursor: pointer;
-      }
-
-      .up {
-        transform: rotate(-135deg);
-        -webkit-transform: rotate(-135deg);
-        margin-top: 1em;
-      }
-
-      .down {
-        transform: rotate(45deg);
-        -webkit-transform: rotate(45deg);
       }
     }
   }

--- a/website/client/components/userMenu/profileStats.vue
+++ b/website/client/components/userMenu/profileStats.vue
@@ -368,13 +368,6 @@
     border: dotted 1px #c3c0c7;
   }
 
-  .white {
-    border-radius: 2px;
-    background: #FFFFFF;
-    box-shadow: 0 2px 2px 0 rgba(26, 24, 29, 0.15), 0 1px 4px 0 rgba(26, 24, 29, 0.1);
-    border: 1px solid transparent;
-  }
-
   .item-wrapper {
     h3 {
       text-align: center;
@@ -392,5 +385,82 @@
 
   .save-row {
     margin-top: 1em;
+  }
+</style>
+
+<style lang="scss">
+  #statAllocation {
+    .title-row {
+      margin-top: 1em;
+      margin-bottom: 1em;
+    }
+
+    .counter.badge {
+      position: relative;
+      top: -0.25em;
+      left: 0.5em;
+      color: #fff;
+      background-color: #ff944c;
+      box-shadow: 0 1px 1px 0 rgba(26, 24, 29, 0.12);
+      width: 24px;
+      height: 24px;
+      border-radius: 50%;
+    }
+
+    .box {
+      width: 148px;
+      height: 84px;
+      padding: .5em;
+      margin: 0 auto;
+
+      div {
+        margin-top: 0;
+      }
+
+      .number {
+        font-size: 40px;
+        text-align: left;
+        color: #686274;
+        display: inline-block;
+      }
+
+      .points {
+        display: inline-block;
+        font-weight: bold;
+        line-height: 1.67;
+        text-align: left;
+        color: #878190;
+        margin-left: .5em;
+      }
+
+      .up, .down {
+        border: solid #a5a1ac;
+        border-width: 0 3px 3px 0;
+        display: inline-block;
+        padding: 3px;
+      }
+
+      .up:hover, .down:hover {
+        cursor: pointer;
+      }
+
+      .up {
+        transform: rotate(-135deg);
+        -webkit-transform: rotate(-135deg);
+        margin-top: 1em;
+      }
+
+      .down {
+        transform: rotate(45deg);
+        -webkit-transform: rotate(45deg);
+      }
+    }
+  }
+
+  .white {
+    border-radius: 2px;
+    background: #FFFFFF;
+    box-shadow: 0 2px 2px 0 rgba(26, 24, 29, 0.15), 0 1px 4px 0 rgba(26, 24, 29, 0.1);
+    border: 1px solid transparent;
   }
 </style>

--- a/website/client/components/userMenu/profileStats.vue
+++ b/website/client/components/userMenu/profileStats.vue
@@ -119,7 +119,6 @@
                 | {{user.stats.buffs[stat]}}
     stat-allocation(
       :user='user',
-      :showAllocation='showAllocation',
       :statUpdates='statUpdates',
       @statUpdate='statUpdate')
     .row.save-row(v-if='showStatsSave')
@@ -144,7 +143,7 @@
   const DROP_ANIMALS = keys(Content.pets);
   const TOTAL_NUMBER_OF_DROP_ANIMALS = DROP_ANIMALS.length;
   export default {
-    props: ['user', 'showAllocation'],
+    props: ['user'],
     components: {
       attributesGrid,
       statAllocation,

--- a/website/client/components/userMenu/profileStats.vue
+++ b/website/client/components/userMenu/profileStats.vue
@@ -218,13 +218,8 @@
           if (this.statUpdates[stat] > 0) statUpdates[stat] = this.statUpdates[stat];
         });
 
-        // reset statUpdates before request to avoid display errors while waiting for server
-        this.statUpdates = {
-          str: 0,
-          int: 0,
-          con: 0,
-          per: 0,
-        };
+        // reset this.statUpdates before request to avoid display errors while waiting for server
+        this.statUpdates = { str: 0, int: 0, con: 0, per: 0 };
 
         allocateBulk(this.user, { body: { stats: statUpdates } });
 

--- a/website/client/components/userMenu/profileStats.vue
+++ b/website/client/components/userMenu/profileStats.vue
@@ -220,11 +220,11 @@
 
         // reset statUpdates before request to avoid display errors while waiting for server
         this.statUpdates = {
-          str: 0, 
+          str: 0,
           int: 0,
           con: 0,
           per: 0,
-        }
+        };
 
         allocateBulk(this.user, { body: { stats: statUpdates } });
 
@@ -292,6 +292,8 @@
 </script>
 
 <style lang="scss" scoped>
+  @import '~client/assets/scss/colors.scss';
+
   #stats {
     .box div {
       margin: 0 auto;
@@ -301,7 +303,7 @@
 
   .stats-column {
     border-radius: 2px;
-    background-color: #ffffff;
+    background-color: $white;
     padding: .5em;
     margin-bottom: 1em;
 
@@ -319,26 +321,26 @@
   }
 
   .str {
-    color: #f74e52;
+    color: $red-50;
   }
 
   .int {
-    color: #2995cd;
+    color: $blue-10;
   }
 
   .con {
-    color: #ffa623;
+    color: $yellow-10;
   }
 
   .per {
-    color: #4f2a93;
+    color: $purple-200;
   }
 
   #attributes {
     .number {
       font-size: 64px;
       font-weight: bold;
-      color: #686274;
+      color: $gray-100;
     }
 
     .attribute-label {
@@ -347,7 +349,7 @@
   }
 
   .well {
-    background-color: #edecee;
+    background-color: $gray-600;
     border-radius: 2px;
     padding: 0.4em;
     padding-top: 1em;
@@ -365,7 +367,7 @@
     width: 94px;
     height: 92px;
     border-radius: 2px;
-    border: dotted 1px #c3c0c7;
+    border: dotted 1px $gray-400;
   }
 
   .item-wrapper {
@@ -389,6 +391,15 @@
 </style>
 
 <style lang="scss">
+  @import '~client/assets/scss/colors.scss';
+
+  .white {
+    border-radius: 2px;
+    background: $white;
+    box-shadow: 0 2px 2px 0 rgba(26, 24, 29, 0.15), 0 1px 4px 0 rgba(26, 24, 29, 0.1);
+    border: 1px solid transparent;
+  }
+
   #statAllocation {
     .title-row {
       margin-top: 1em;
@@ -399,8 +410,8 @@
       position: relative;
       top: -0.25em;
       left: 0.5em;
-      color: #fff;
-      background-color: #ff944c;
+      color: $white;
+      background-color: $orange-100;
       box-shadow: 0 1px 1px 0 rgba(26, 24, 29, 0.12);
       width: 24px;
       height: 24px;
@@ -420,7 +431,7 @@
       .number {
         font-size: 40px;
         text-align: left;
-        color: #686274;
+        color: $gray-100;
         display: inline-block;
       }
 
@@ -429,12 +440,12 @@
         font-weight: bold;
         line-height: 1.67;
         text-align: left;
-        color: #878190;
+        color: $gray-200;
         margin-left: .5em;
       }
 
       .up, .down {
-        border: solid #a5a1ac;
+        border: solid $gray-300;
         border-width: 0 3px 3px 0;
         display: inline-block;
         padding: 3px;
@@ -455,12 +466,5 @@
         -webkit-transform: rotate(45deg);
       }
     }
-  }
-
-  .white {
-    border-radius: 2px;
-    background: #FFFFFF;
-    box-shadow: 0 2px 2px 0 rgba(26, 24, 29, 0.15), 0 1px 4px 0 rgba(26, 24, 29, 0.1);
-    border: 1px solid transparent;
   }
 </style>

--- a/website/client/components/userMenu/statAllocation.vue
+++ b/website/client/components/userMenu/statAllocation.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-  div(v-if='showAllocation')
+  div(v-if='hasClass')
     .row.title-row
       .col-12.col-md-6
         h3(v-if='userLevel100Plus', v-once, v-html="$t('noMoreAllocate')")
@@ -32,7 +32,7 @@
   import toggleSwitch from 'client/components/ui/toggleSwitch';
 
   export default {
-    props: ['user', 'showAllocation', 'statUpdates'],
+    props: ['user', 'statUpdates'],
     components: {
       toggleSwitch,
     },
@@ -74,6 +74,9 @@
           points -= value;
         });
         return points;
+      },
+      hasClass () {
+        return this.$store.getters['members:hasClass'](this.user);
       },
     },
     methods: {

--- a/website/client/components/userMenu/statAllocation.vue
+++ b/website/client/components/userMenu/statAllocation.vue
@@ -19,7 +19,7 @@
         .col-9
           .number {{totalAllocatedStats(stat)}}
           .points {{$t('pts')}}
-        .col-3
+        .col-3(v-if='user.stats.points')
           span.up(@click='allocate(stat)')
           span.down(@click='deallocate(stat)')
 </template>

--- a/website/client/components/userMenu/statAllocation.vue
+++ b/website/client/components/userMenu/statAllocation.vue
@@ -1,0 +1,220 @@
+<template lang="pug">
+  div(v-if='showAllocation')
+    .row.title-row
+      .col-12.col-md-6
+        h3(v-if='userLevel100Plus', v-once, v-html="$t('noMoreAllocate')")
+        h3
+          | {{$t('statPoints')}}
+          .counter.badge(v-if='user.stats.points || userLevel100Plus')
+            | {{pointsRemaining}}&nbsp;
+      .col-12.col-md-6
+        .float-right
+          toggle-switch(
+            :label="$t('autoAllocation')",
+            v-model='user.preferences.automaticAllocation',
+            @change='setAutoAllocate()'
+          )
+    .row
+      .col-12.col-md-3(v-for='(statInfo, stat) in allocateStatsList')
+        .box.white.row.col-12
+          .col-9
+            div(:class='stat') {{ $t(stats[stat].title) }}
+            .number {{totalAllocatedStats(stat)}}
+            .points {{$t('pts')}}
+          .col-3
+            div
+              .up(v-if='showStatsSave', @click='allocate(stat)')
+            div
+              .down(v-if='showStatsSave', @click='deallocate(stat)')
+    .row.save-row(v-if='showStatsSave')
+      .col-12.col-md-6.offset-md-3.text-center
+        button.btn.btn-primary(@click='saveAttributes()', :disabled='loading') {{ this.loading ?  $t('loading') : $t('save') }}
+</template>
+
+<script>
+  import toggleSwitch from 'client/components/ui/toggleSwitch';
+  import allocateBulk from  '../../../common/script/ops/stats/allocateBulk';
+  import axios from 'axios';
+
+  export default {
+    props: ['user', 'showAllocation'],
+    components: {
+      toggleSwitch,
+    },
+    data () {
+      return {
+        loading: false,
+        allocateStatsList: {
+          str: { title: 'allocateStr', popover: 'strengthText', allocatepop: 'allocateStrPop' },
+          int: { title: 'allocateInt', popover: 'intText', allocatepop: 'allocateIntPop' },
+          con: { title: 'allocateCon', popover: 'conText', allocatepop: 'allocateConPop' },
+          per: { title: 'allocatePer', popover: 'perText', allocatepop: 'allocatePerPop' },
+        },
+        statUpdates: {
+          str: 0,
+          int: 0,
+          con: 0,
+          per: 0,
+        },
+
+        stats: {
+          str: {
+            title: 'strength',
+            popover: 'strengthText',
+          },
+          int: {
+            title: 'intelligence',
+            popover: 'intText',
+          },
+          con: {
+            title: 'constitution',
+            popover: 'conText',
+          },
+          per: {
+            title: 'perception',
+            popover: 'perText',
+          },
+        },
+      };
+    },
+    computed: {
+      userLevel100Plus () {
+        return this.user.stats.lvl >= 100;
+      },
+      showStatsSave () {
+        return Boolean(this.user.stats.points);
+      },
+      pointsRemaining () {
+        let points = this.user.stats.points;
+        Object.values(this.statUpdates).forEach(value => {
+          points -= value;
+        });
+        return points;
+      },
+    },
+    methods: {
+      totalAllocatedStats (stat) {
+        return this.user.stats[stat] + this.statUpdates[stat];
+      },
+      setAutoAllocate () {
+        let settings = {
+          'preferences.automaticAllocation': Boolean(this.user.preferences.automaticAllocation),
+          'preferences.allocationMode': 'taskbased',
+        };
+
+        this.$store.dispatch('user:set', settings);
+      },
+      allocate (stat) {
+        if (this.pointsRemaining === 0) return;
+        this.statUpdates[stat]++;
+      },
+      deallocate (stat) {
+        if (this.statUpdates[stat] === 0) return;
+        this.statUpdates[stat]--;
+      },
+      async saveAttributes () {
+        this.loading = true;
+
+        const statUpdates = {};
+        ['str', 'int', 'per', 'con'].forEach(stat => {
+          if (this.statUpdates[stat] > 0) statUpdates[stat] = this.statUpdates[stat];
+        });
+
+        // reset statUpdates to zero before request to avoid display errors while waiting for server
+        this.statUpdates = {
+          str: 0,
+          int: 0,
+          con: 0,
+          per: 0,
+        };
+
+        allocateBulk(this.user, { body: { stats: statUpdates } });
+
+        await axios.post('/api/v4/user/allocate-bulk', {
+          stats: statUpdates,
+        });
+
+        this.loading = false;
+      },
+    },
+  };
+</script>
+
+<style lang="scss" scoped>
+  .title-row {
+    margin-top: 1em;
+    margin-bottom: 1em;
+  }
+
+  .counter.badge {
+    position: relative;
+    top: -0.25em;
+    left: 0.5em;
+    color: #fff;
+    background-color: #ff944c;
+    box-shadow: 0 1px 1px 0 rgba(26, 24, 29, 0.12);
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+  }
+
+  .box {
+    width: 148px;
+    height: 84px;
+    padding: .5em;
+    margin: 0 auto;
+
+    div {
+      margin-top: 0;
+    }
+
+    .number {
+      font-size: 40px;
+      text-align: left;
+      color: #686274;
+      display: inline-block;
+    }
+
+    .points {
+      display: inline-block;
+      font-weight: bold;
+      line-height: 1.67;
+      text-align: left;
+      color: #878190;
+      margin-left: .5em;
+    }
+
+    .up, .down {
+      border: solid #a5a1ac;
+      border-width: 0 3px 3px 0;
+      display: inline-block;
+      padding: 3px;
+    }
+
+    .up:hover, .down:hover {
+      cursor: pointer;
+    }
+
+    .up {
+      transform: rotate(-135deg);
+      -webkit-transform: rotate(-135deg);
+      margin-top: 1em;
+    }
+
+    .down {
+      transform: rotate(45deg);
+      -webkit-transform: rotate(45deg);
+    }
+  }
+
+  .white {
+    border-radius: 2px;
+    background: #FFFFFF;
+    box-shadow: 0 2px 2px 0 rgba(26, 24, 29, 0.15), 0 1px 4px 0 rgba(26, 24, 29, 0.1);
+    border: 1px solid transparent;
+  }
+
+  .save-row {
+    margin-top: 1em;
+  }
+</style>

--- a/website/client/components/userMenu/statAllocation.vue
+++ b/website/client/components/userMenu/statAllocation.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-  #statAllocation(v-if='hasClass')
+  div(v-if='hasClass')
     .row.title-row
       .col-12.col-md-6
         h3(v-if='userLevel100Plus', v-once, v-html="$t('noMoreAllocate')")
@@ -7,25 +7,21 @@
           | {{$t('statPoints')}}
           .counter.badge(v-if='user.stats.points || userLevel100Plus')
             | {{pointsRemaining}}&nbsp;
-      .col-12.col-md-6
-        .float-right
-          toggle-switch(
-            :label="$t('autoAllocation')",
-            v-model='user.preferences.automaticAllocation',
-            @change='setAutoAllocate()'
-          )
-    .row
-      .col-12.col-md-3(v-for='(statInfo, stat) in allocateStatsList')
-        .box.white.row.col-12
-          .col-9
-            div(:class='stat') {{ $t(stats[stat].title) }}
-            .number {{totalAllocatedStats(stat)}}
-            .points {{$t('pts')}}
-          .col-3
-            div
-              .up(@click='allocate(stat)')
-            div
-              .down(@click='deallocate(stat)')
+      .col-12.col-md-6.minimize
+        toggle-switch.float-right(
+          :label="$t('autoAllocation')",
+          v-model='user.preferences.automaticAllocation',
+          @change='setAutoAllocate()'
+        )
+    .row      
+      .box.white.row.col-12.col-md-3(v-for='(statInfo, stat) in allocateStatsList')
+        div(:class='`stat-title ${stat}`') {{ $t(stats[stat].title) }}
+        .col-9
+          .number {{totalAllocatedStats(stat)}}
+          .points {{$t('pts')}}
+        .col-3
+          span.up(@click='allocate(stat)')
+          span.down(@click='deallocate(stat)')
 </template>
 
 <script>
@@ -103,7 +99,7 @@
   };
 </script>
 
-<style lang='scss'>
+<style lang='scss' scoped>
   @import '~client/assets/scss/colors.scss';
 
   .str {
@@ -120,5 +116,27 @@
 
   .per {
     color: $purple-200;
+  }
+
+  .up, .down {
+    border: solid $gray-300;
+    border-width: 0 3px 3px 0;
+    display: inline-block;
+    padding: 3px;
+  }
+
+  .up:hover, .down:hover {
+    cursor: pointer;
+  }
+
+  .up {
+    transform: rotate(-135deg);
+    -webkit-transform: rotate(-135deg);
+    margin-top: 1em;
+  }
+
+  .down {
+    transform: rotate(45deg);
+    -webkit-transform: rotate(45deg);
   }
 </style>

--- a/website/client/components/userMenu/statAllocation.vue
+++ b/website/client/components/userMenu/statAllocation.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-  div(v-if='hasClass')
+  #statAllocation(v-if='hasClass')
     .row.title-row
       .col-12.col-md-6
         h3(v-if='userLevel100Plus', v-once, v-html="$t('noMoreAllocate')")
@@ -102,78 +102,3 @@
     },
   };
 </script>
-
-<style lang="scss" scoped>
-  .title-row {
-    margin-top: 1em;
-    margin-bottom: 1em;
-  }
-
-  .counter.badge {
-    position: relative;
-    top: -0.25em;
-    left: 0.5em;
-    color: #fff;
-    background-color: #ff944c;
-    box-shadow: 0 1px 1px 0 rgba(26, 24, 29, 0.12);
-    width: 24px;
-    height: 24px;
-    border-radius: 50%;
-  }
-
-  .box {
-    width: 148px;
-    height: 84px;
-    padding: .5em;
-    margin: 0 auto;
-
-    div {
-      margin-top: 0;
-    }
-
-    .number {
-      font-size: 40px;
-      text-align: left;
-      color: #686274;
-      display: inline-block;
-    }
-
-    .points {
-      display: inline-block;
-      font-weight: bold;
-      line-height: 1.67;
-      text-align: left;
-      color: #878190;
-      margin-left: .5em;
-    }
-
-    .up, .down {
-      border: solid #a5a1ac;
-      border-width: 0 3px 3px 0;
-      display: inline-block;
-      padding: 3px;
-    }
-
-    .up:hover, .down:hover {
-      cursor: pointer;
-    }
-
-    .up {
-      transform: rotate(-135deg);
-      -webkit-transform: rotate(-135deg);
-      margin-top: 1em;
-    }
-
-    .down {
-      transform: rotate(45deg);
-      -webkit-transform: rotate(45deg);
-    }
-  }
-
-  .white {
-    border-radius: 2px;
-    background: #FFFFFF;
-    box-shadow: 0 2px 2px 0 rgba(26, 24, 29, 0.15), 0 1px 4px 0 rgba(26, 24, 29, 0.1);
-    border: 1px solid transparent;
-  }
-</style>

--- a/website/client/components/userMenu/statAllocation.vue
+++ b/website/client/components/userMenu/statAllocation.vue
@@ -102,3 +102,23 @@
     },
   };
 </script>
+
+<style lang='scss'>
+  @import '~client/assets/scss/colors.scss';
+
+  .str {
+    color: $red-50;
+  }
+
+  .int {
+    color: $blue-10;
+  }
+
+  .con {
+    color: $yellow-10;
+  }
+
+  .per {
+    color: $purple-200;
+  }
+</style>


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10795

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
I duplicated the stat allocation section of the stats overview page in the level up pop-up. 
![levelupstatallocation](https://user-images.githubusercontent.com/13566991/47866591-7b4f6580-ddff-11e8-8f35-0a1af345a3ec.png)
Step-by-step overview:
- Extracted stat allocation section into it's own component. 
- Externalized the functionality that commits the changes so that each parent component can implement a different save action. 
- Wired save functionality into the 'Onwards' button. 
- Made it so that the component is only displayed in the level up dialog if `autoAllocation === false`.
- Externalized most of the styling of the new component so that each parent can apply its own CSS. 
- Tweak/implement style sheets for both parents that use the new component.

Miscellaneous fixes/changes I made on the way:
- Rooted out `showAllocation`, which was passed as a parameter to `profileStats` to cover what seemed like a corner case to me. It's entirely possible I'm wrong though, in which case I'd be glad to reinstate it. 
- Removed a number of redundant `style`s and `div`s. 
- Replaced hard-coded hex colors with variables from `colors.scss` in every file I touched. 


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 6d7d6651-604d-4e7c-adff-a040770a6768
