### PR TITLE
WIP: Amazon and Paypal in-page

### DIFF
--- a/website/client/app.vue
+++ b/website/client/app.vue
@@ -190,6 +190,8 @@ import spellsMixin from 'client/mixins/spells';
 import svgClose from 'assets/svg/close.svg';
 import bannedAccountModal from 'client/components/bannedAccountModal';
 
+import { CONSTANTS, getLocalSetting, removeLocalSetting } from 'client/libs/userlocalManager';
+
 const COMMUNITY_MANAGER_EMAIL = process.env.EMAILS.COMMUNITY_MANAGER_EMAIL; // eslint-disable-line
 
 export default {
@@ -607,7 +609,18 @@ export default {
       this.$root.$emit('bv::hide::modal', 'select-member-modal');
     },
     hideLoadingScreen () {
+      this.restoreAppState();
       this.loading = false;
+    },
+    // When the app state was saved, for example when redirected back from a payment provider
+    // restore it
+    restoreAppState () {
+      let previousAppState = getLocalSetting(CONSTANTS.savedAppStateValues.SAVED_APP_STATE);
+      if (!previousAppState) return;
+      previousAppState = JSON.parse(previousAppState);
+      removeLocalSetting(CONSTANTS.savedAppStateValues.SAVED_APP_STATE);
+
+      this.$router.replace(previousAppState.path);
     },
     hideBanner () {
       this.bannerHidden = true;

--- a/website/client/components/payments/buyGemsModal.vue
+++ b/website/client/components/payments/buyGemsModal.vue
@@ -75,7 +75,7 @@
               .card-body
                 .mx-auto(v-html='icons.creditCard', style='"height: 56px; width: 159px; margin-top: 1em;"')
             .card.text-center.payment-method
-              a.card-body.paypal(:href='paypalCheckoutLink')
+              a.card-body.paypal(@click="openPaypal(paypalCheckoutLink)")
                 img(src='~assets/images/paypal.png')
             .card.text-center.payment-method(@click="amazonPaymentsInit({type: 'single'})")
               .card-body.amazon
@@ -158,7 +158,7 @@
                 .card-body(@click='showStripe({subscription: subscriptionPlan})')
                   .mx-auto(v-html='icons.creditCard', style='"height: 56px; width: 159px; margin-top: 1em;"')
               .card.text-center.payment-method
-                a.card-body.paypal(:href='paypalSubscriptionLink')
+                a.card-body.paypal(@click="openPaypal(paypalSubscriptionLink)")
                   img(src='~assets/images/paypal.png')
               .card.text-center.payment-method
                 .card-body.amazon(@click="amazonPaymentsInit({type: 'subscription', subscription: subscriptionPlan})")

--- a/website/client/components/payments/buyGemsModal.vue
+++ b/website/client/components/payments/buyGemsModal.vue
@@ -75,7 +75,7 @@
               .card-body
                 .mx-auto(v-html='icons.creditCard', style='"height: 56px; width: 159px; margin-top: 1em;"')
             .card.text-center.payment-method
-              a.card-body.paypal(:href='paypalCheckoutLink', target='_blank')
+              a.card-body.paypal(:href='paypalCheckoutLink')
                 img(src='~assets/images/paypal.png')
             .card.text-center.payment-method(@click="amazonPaymentsInit({type: 'single'})")
               .card-body.amazon
@@ -158,7 +158,7 @@
                 .card-body(@click='showStripe({subscription: subscriptionPlan})')
                   .mx-auto(v-html='icons.creditCard', style='"height: 56px; width: 159px; margin-top: 1em;"')
               .card.text-center.payment-method
-                a.card-body.paypal(:href='paypalSubscriptionLink', target='_blank')
+                a.card-body.paypal(:href='paypalSubscriptionLink')
                   img(src='~assets/images/paypal.png')
               .card.text-center.payment-method
                 .card-body.amazon(@click="amazonPaymentsInit({type: 'subscription', subscription: subscriptionPlan})")

--- a/website/client/components/settings/subscription.vue
+++ b/website/client/components/settings/subscription.vue
@@ -77,7 +77,7 @@
             .col-md-4
               button.purchase.btn.btn-primary(@click='showStripe({subscription:subscription.key, coupon:subscription.coupon})', :disabled='!subscription.key') {{ $t('card') }}
             .col-md-4
-              a.purchase(:href='paypalPurchaseLink', :disabled='!subscription.key', target='_blank')
+              a.purchase(:href='paypalPurchaseLink', :disabled='!subscription.key')
                 img(src='https://www.paypalobjects.com/webstatic/en_US/i/buttons/pp-acceptance-small.png', :alt="$t('paypal')")
             .col-md-4
               a.btn.btn-secondary.purchase(@click="payWithAmazon()")

--- a/website/client/components/settings/subscription.vue
+++ b/website/client/components/settings/subscription.vue
@@ -77,7 +77,7 @@
             .col-md-4
               button.purchase.btn.btn-primary(@click='showStripe({subscription:subscription.key, coupon:subscription.coupon})', :disabled='!subscription.key') {{ $t('card') }}
             .col-md-4
-              a.purchase(:href='paypalPurchaseLink', :disabled='!subscription.key')
+              a.purchase(@click="openPaypal(paypalPurchaseLink)", :disabled='!subscription.key')
                 img(src='https://www.paypalobjects.com/webstatic/en_US/i/buttons/pp-acceptance-small.png', :alt="$t('paypal')")
             .col-md-4
               a.btn.btn-secondary.purchase(@click="payWithAmazon()")

--- a/website/client/libs/userlocalManager.js
+++ b/website/client/libs/userlocalManager.js
@@ -14,6 +14,9 @@ const CONSTANTS = {
     COSTUME_TAB: 'costume-tab',
     EQUIPMENT_TAB: 'equipment-tab',
   },
+  savedAppStateValues: {
+    SAVED_APP_STATE: 'saved-app-state',
+  },
 };
 
 function setLocalSetting (key, value) {
@@ -24,8 +27,14 @@ function getLocalSetting (key) {
   return localStorage.getItem(key);
 }
 
+function removeLocalSetting (key) {
+  return localStorage.removeItem(key);
+}
+
+
 export {
   CONSTANTS,
   getLocalSetting,
   setLocalSetting,
+  removeLocalSetting,
 };

--- a/website/client/mixins/payments.js
+++ b/website/client/mixins/payments.js
@@ -41,7 +41,7 @@ export default {
       let gift = this.encodeGift(data.giftedTo, data.gift);
       const url = `/paypal/checkout?gift=${gift}`;
 
-      window.open(url, '_blank');
+      window.open(url);
     },
     showStripe (data) {
       if (!this.checkGemAmount(data)) return;

--- a/website/client/mixins/payments.js
+++ b/website/client/mixins/payments.js
@@ -6,12 +6,12 @@ import { mapState } from 'client/libs/store';
 import encodeParams from 'client/libs/encodeParams';
 import notificationsMixin from 'client/mixins/notifications';
 import * as Analytics from 'client/libs/analytics';
+import { CONSTANTS, setLocalSetting } from 'client/libs/userlocalManager';
 
 export default {
   mixins: [notificationsMixin],
   computed: {
     ...mapState(['credentials']),
-    // @TODO refactor into one single computed property
     paypalCheckoutLink () {
       return '/paypal/checkout';
     },
@@ -41,7 +41,15 @@ export default {
       let gift = this.encodeGift(data.giftedTo, data.gift);
       const url = `/paypal/checkout?gift=${gift}`;
 
-      window.open(url);
+      this.openPaypal(url);
+    },
+    openPaypal (url) {
+      const appState = {
+        path: this.$route.fullPath,
+        paymentMethod: 'paypal',
+      };
+      setLocalSetting(CONSTANTS.savedAppStateValues.SAVED_APP_STATE, JSON.stringify(appState));
+      location.href = url;
     },
     showStripe (data) {
       if (!this.checkGemAmount(data)) return;


### PR DESCRIPTION
- [x] paypal open in page
- [ ] amazon open in page
- [ ] restore state
    - [x] url paypal
    - [x] url amazon

```
-    Entry from the Gems icon in the navigation
    -    Lands on the Buy Gems tab of the Support Habitica modal
    -    Can also subscribe from the Subscribe tab
-    Entry from "Buy Gems" button in the purchase item modal
    -    Lands on the Buy Gems tab of the Support Habitica modal
-    Entry from "Subscription" menu item in the User menu
    -    Lands on the Settings page with the Subscription tab active
-    Donate button on Static pages when a user is logged in.
    -    Lands on the Support Habitica modal with the Subscription tab active```
-    Gift modal
-    Group plan
```