### PR TITLE
"Very large Guild member counts overflow the badge" partial fix for #10753

### DIFF
--- a/website/client/mixins/groupsUtilities.js
+++ b/website/client/mixins/groupsUtilities.js
@@ -4,7 +4,7 @@ export default {
   filters: {
     // https://stackoverflow.com/questions/2685911/is-there-a-way-to-round-numbers-into-a-reader-friendly-format-e-g-1-1k
     abbrNum: (number) => {
-      let decPlaces = 2;
+      let decPlaces = 1;
       decPlaces = Math.pow(10, decPlaces);
 
       let abbrev = ['k', 'm', 'b', 't'];
@@ -12,7 +12,7 @@ export default {
         let size = Math.pow(10, (i + 1) * 3);
 
         if (size <= number) {
-          number = Math.round(number * decPlaces / size) / decPlaces;
+          number = Math.floor(number * decPlaces / size) / decPlaces;
 
           if (number === 1000 && i < abbrev.length - 1) {
             number = 1;


### PR DESCRIPTION
### Description

> When a Guild reaches something like 100,000 members, it stops displaying nicely in its member count badge

Issue reproduced.

Count display in the member count badge overflows - reproduced after I changed the Guild Member count to 100 010 and more.
Count display in the Guild info overflows- reproduced after I changed desktop resolution to value below 1024x768 or after I reduced the size of the window + I changed the Guild Member count to 1010 and more.

The necessary ingredient is to have more than 1k members and the second to last digit is not 0.

Thus, 1100 is displayed as 1.1k which is ok, 1101 as 1.1k as well which is ok, but 1010 as 1.01k which is not ok since it overflows.


### Changes
partial fix for #10753 

Reducing the amount of decimal numbers to 1 resolved the first issue - Count display in the member count badge overflows.

With the same solution the second issue - Count display in the Guild info overflows - is resolved for resolution 1024x768.

For 800x600 however, the issue still persists. Removing the decimals completely would result in slight overflow for 800x600 resolution.

Moreover, I used floor function instead of the round function to avoid rounding up.
Eg. If the guild has 4567 members, it shouldn't show 4.6k. It will show 4.5k (which makes more sense).


### Another solution
Regarding the second solution proposed by @SabreCat , the badge would have to be increased in size by at least 15px for the text appear inside the text area. The badge however shouldn't change size, a new badge image with wider text area could be created for Guilds with more than 100k members.

The main root cause of the second issue - Count display in the Guild info overflows - is that while the graphical components are browser responsive, the text is not. This way the text area is shrinking with the decrease of resolution and the text overflows.