### PR TITLE
fixes issue #10758 ("Market incorrect positioning of items: single item on previous line")

### DIFF
--- a/website/client/assets/scss/item.scss
+++ b/website/client/assets/scss/item.scss
@@ -9,6 +9,10 @@
   margin-right: 0px;
 }
 
+.item-rows > .items > div {
+  margin: 6px 12px 6px 12px;
+}
+
 .item-wrapper {
   position: relative;
   display: inline-block;
@@ -24,7 +28,7 @@
   @media only screen and (min-width: 1440px){
     margin-right: 1.71em;
   }
-  
+
   // Desktop L (1280)
   @media only screen and (min-width: 1280px) and (max-width: 1439px) {
     margin-right: 0.43em;


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10758

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
I added a css rule in items.scss.
The rule changes margin in every div that is a child of items that is a child of row-items.
The previous margin remains but is overwritten by this more specific rule.

I apparently also change white space on line 27. But I currently don't know how to easily change that.

Before:
![screenshot 2018-11-10 11 32 50](https://user-images.githubusercontent.com/12159017/48301650-7a9a8b80-e4f1-11e8-974f-7866b745fb91.png)

After:
![screenshot 2018-11-10 11 28 23](https://user-images.githubusercontent.com/12159017/48301645-6fdff680-e4f1-11e8-82be-e127d21ac61b.png)

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: c494f93f-7b9a-4f4a-beb3-b6af7a20712d
