### PR TITLE
Fix text overflow issue on task checklists

### DIFF
--- a/website/client/components/tasks/task.vue
+++ b/website/client/components/tasks/task.vue
@@ -302,6 +302,7 @@
       margin-left: 6px;
       padding-top: 0px;
       min-width: 0px;
+      width: 100%;
     }
   }
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10429 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Set `width: 100%` on the `.custom-control-label`.

Although `overflow-wrap: break-word` is set on the parent `.checklist-item` element, it doesn't seem to take effect on the label containing the text for the checklist item unless a width is set on the label.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: c5085c21-2d4a-4707-a178-0d547329095a
