### PR TITLE
Attach client to chat messages

### DIFF
--- a/website/client/components/chat/chatCard.vue
+++ b/website/client/components/chat/chatCard.vue
@@ -15,7 +15,8 @@ div
     p.time
       span.mr-1(v-if="msg.username") @{{ msg.username }}
       span.mr-1(v-if="msg.username") •
-      span(v-b-tooltip="", :title="msg.timestamp | date") {{ msg.timestamp | timeAgo }}
+      span(v-b-tooltip="", :title="msg.timestamp | date") {{ msg.timestamp | timeAgo }}&nbsp;
+      span(v-if="msg.client && user.contributor.level >= 4") by {{ msg.client }}
     .text(v-html='atHighlight(parseMarkdown(msg.text))')
     hr
     .d-flex(v-if='msg.id')

--- a/website/client/components/chat/chatCard.vue
+++ b/website/client/components/chat/chatCard.vue
@@ -16,7 +16,7 @@ div
       span.mr-1(v-if="msg.username") @{{ msg.username }}
       span.mr-1(v-if="msg.username") •
       span(v-b-tooltip="", :title="msg.timestamp | date") {{ msg.timestamp | timeAgo }}&nbsp;
-      span(v-if="msg.client && user.contributor.level >= 4") by {{ msg.client }}
+      span(v-if="msg.client && user.contributor.level >= 4") with {{ msg.client }}
     .text(v-html='atHighlight(parseMarkdown(msg.text))')
     hr
     .d-flex(v-if='msg.id')

--- a/website/client/components/chat/chatCard.vue
+++ b/website/client/components/chat/chatCard.vue
@@ -16,7 +16,7 @@ div
       span.mr-1(v-if="msg.username") @{{ msg.username }}
       span.mr-1(v-if="msg.username") •
       span(v-b-tooltip="", :title="msg.timestamp | date") {{ msg.timestamp | timeAgo }}&nbsp;
-      span(v-if="msg.client && user.contributor.level >= 4") with {{ msg.client }}
+      span(v-if="msg.client && user.contributor.level >= 4")  ({{ msg.client }})
     .text(v-html='atHighlight(parseMarkdown(msg.text))')
     hr
     .d-flex(v-if='msg.id')

--- a/website/server/controllers/api-v3/chat.js
+++ b/website/server/controllers/api-v3/chat.js
@@ -175,7 +175,10 @@ api.postChat = {
       throw new NotAuthorized(res.t('messageGroupChatSpam'));
     }
 
-    const client = req.headers['x-client'].replace('habitica-', '');
+    let client = req.headers['x-client'] || '3rd Party';
+    if (client) {
+      client = client.replace('habitica-', '');
+    }
     const newChatMessage = group.sendChat(req.body.message, user, null, client);
     let toSave = [newChatMessage.save()];
 

--- a/website/server/controllers/api-v3/chat.js
+++ b/website/server/controllers/api-v3/chat.js
@@ -175,7 +175,8 @@ api.postChat = {
       throw new NotAuthorized(res.t('messageGroupChatSpam'));
     }
 
-    const newChatMessage = group.sendChat(req.body.message, user, null, req.headers['x-client']);
+    const client = req.headers['x-client'].replace('habitica-', '');
+    const newChatMessage = group.sendChat(req.body.message, user, null, client);
     let toSave = [newChatMessage.save()];
 
     if (group.type === 'party') {

--- a/website/server/controllers/api-v3/chat.js
+++ b/website/server/controllers/api-v3/chat.js
@@ -175,7 +175,7 @@ api.postChat = {
       throw new NotAuthorized(res.t('messageGroupChatSpam'));
     }
 
-    const newChatMessage = group.sendChat(req.body.message, user);
+    const newChatMessage = group.sendChat(req.body.message, user, null, req.headers['x-client']);
     let toSave = [newChatMessage.save()];
 
     if (group.type === 'party') {

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -480,8 +480,8 @@ schema.methods.getMemberCount = async function getMemberCount () {
   return await User.count(query).exec();
 };
 
-schema.methods.sendChat = function sendChat (message, user, metaData) {
-  let newMessage = messageDefaults(message, user);
+schema.methods.sendChat = function sendChat (message, user, metaData, client) {
+  let newMessage = messageDefaults(message, user, client);
   let newChatMessage = new Chat();
   newChatMessage = Object.assign(newChatMessage, newMessage);
   newChatMessage.groupId = this._id;

--- a/website/server/models/message.js
+++ b/website/server/models/message.js
@@ -19,6 +19,7 @@ const defaultSchema = () => ({
   flags: {$type: mongoose.Schema.Types.Mixed, default: {}},
   flagCount: {$type: Number, default: 0},
   likes: {$type: mongoose.Schema.Types.Mixed},
+  client: String,
   _meta: {$type: mongoose.Schema.Types.Mixed},
 });
 
@@ -100,7 +101,7 @@ export function setUserStyles (newMessage, user) {
   newMessage.markModified('userStyles');
 }
 
-export function messageDefaults (msg, user) {
+export function messageDefaults (msg, user, client) {
   const id = uuid();
   const message = {
     id,
@@ -110,6 +111,7 @@ export function messageDefaults (msg, user) {
     likes: {},
     flags: {},
     flagCount: 0,
+    client,
   };
 
   if (user) {


### PR DESCRIPTION
Small change that attaches the content of the x-client header to a chat message. The content of that field is also displayed to all users with a contributor level higher than 3. Reasoning being, that this will hopefully simplify user support a little bit, by allowing socialites and mods to see what client the user is using. I set it to only show to users above a certain tier, since this information isn't relevant for most users and only adds more noise/clutter to chat.

![screenshot 2018-11-16 at 19 00 05](https://user-images.githubusercontent.com/298062/48638805-fc972280-e9d1-11e8-9f39-c661060dfd24.png)

