### PR TITLE
Fixes issue #10857 ("Tags have extra space at the bottom when they should be centered")

### DIFF
--- a/website/client/components/tasks/task.vue
+++ b/website/client/components/tasks/task.vue
@@ -94,7 +94,7 @@
               .tags-popover
                 .d-flex.align-items-center.tags-container
                   .tags-popover-title(v-once) {{ `${$t('tags')}:` }}
-                  .tag-label(v-for="tag in getTagsFor(task)") {{tag}}
+                  .tag-label(v-for="tag in getTagsFor(task)", v-markdown="tag")
 
       // Habits right side control
       .right-control.d-flex.align-items-center.justify-content-center(v-if="task.type === 'habit'", :class="controlClass.down.bg")
@@ -490,6 +490,11 @@
       white-space: nowrap;
       margin-top: 3px;
       margin-bottom: 3px;
+
+      // Applies to v-markdown generated p tag.
+      p {
+        margin-bottom: 0px;
+      }
     }
   }
 </style>

--- a/website/client/components/tasks/taskModal.vue
+++ b/website/client/components/tasks/taskModal.vue
@@ -144,7 +144,7 @@
                   .tags-none {{$t('none')}}
                   .dropdown-toggle
                 span.category-select(v-else)
-                  .category-label(v-for='tagName in truncatedSelectedTags', :title="tagName", v-markdown='tagName')
+                  .category-label(v-for='tagName in truncatedSelectedTags', :title="tagName") {{ tagName }}
                   .tags-more(v-if='remainingSelectedTags.length > 0') +{{ $t('more', { count: remainingSelectedTags.length }) }}
                   .dropdown-toggle
           tags-popup(ref="popup", v-if="showTagsSelect", :tags="user.tags", v-model="task.tags", @close='closeTagsPopup()')

--- a/website/client/components/tasks/taskModal.vue
+++ b/website/client/components/tasks/taskModal.vue
@@ -144,7 +144,7 @@
                   .tags-none {{$t('none')}}
                   .dropdown-toggle
                 span.category-select(v-else)
-                  .category-label(v-for='tagName in truncatedSelectedTags', :title="tagName") {{ tagName }}
+                  .category-label(v-for='tagName in truncatedSelectedTags', :title="tagName", v-markdown='tagName')
                   .tags-more(v-if='remainingSelectedTags.length > 0') +{{ $t('more', { count: remainingSelectedTags.length }) }}
                   .dropdown-toggle
           tags-popup(ref="popup", v-if="showTagsSelect", :tags="user.tags", v-model="task.tags", @close='closeTagsPopup()')
@@ -478,12 +478,17 @@
 
             .category-label {
               min-width: 68px;
-              overflow: hidden;
               padding: .5em 1em;
-              text-overflow: ellipsis;
-              white-space: nowrap;
               width: 68px;
-              word-wrap: break-word;
+
+              // Applies to v-markdown generated p tag.
+              p {
+                margin-bottom: 0px;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+                word-wrap: break-word;
+              }
             }
           }
         }


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10857 
Fixes #10856 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Change from my previous pull request: Restored the v-markdown directive as suggested to ensure that markdown shows.  Removed the interpolation since it is not needed when v-markdown is present. (v-markdown generates a p tag with the data)

#10857 fix: edited taskModal.vue.  Added p tag CSS under .category-label class.  Moved applicable .category-label CSS into p tag.

Before:
![image](https://user-images.githubusercontent.com/20934998/48877127-abfb3d00-edb6-11e8-83e0-255a150cd753.png)

After:
![image](https://user-images.githubusercontent.com/20934998/48877532-8a02ba00-edb8-11e8-91d5-6d83145201a5.png)


#10856 fix: edited task.vue file.  Added v-markdown directive in .tag-label div.  Also removed interpolation for .tag-label since v-markdown generates a p tag with the correct data.  Added CSS for p-tag under the .tag-label CSS section so that p tag text is centered.

Before:
![image](https://user-images.githubusercontent.com/20934998/48877281-6f7c1100-edb7-11e8-8820-d83e8e8589a5.png)

After:
![image](https://user-images.githubusercontent.com/20934998/48877359-bd911480-edb7-11e8-84ce-05814cd94f81.png)


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: f1a11121-325d-45b1-b20c-1371df18c8b9
