### PR TITLE
Streak-Achievement notification/modal timeout 

### DIFF
--- a/website/client/components/notifications.vue
+++ b/website/client/components/notifications.vue
@@ -569,10 +569,8 @@ export default {
             break;
           case 'STREAK_ACHIEVEMENT':
             this.text(`${this.$t('streaks')}: ${this.user.achievements.streak}`, () => {
-              if (!this.user.preferences.suppressModals.streak) {
-                this.$root.$emit('bv::show::modal', 'streak');
-              }
-            });
+              this.$root.$emit('bv::show::modal', 'streak');
+            }, this.user.preferences.suppressModals.streak);
             this.playSound('Achievement_Unlocked');
             break;
           case 'ULTIMATE_GEAR_ACHIEVEMENT':


### PR DESCRIPTION
removes the timeout if the `suppressModals.streak` option is not enabled

fixes #10813