### PR TITLE
confirm new password setting using enter key - fixes #10669

### DIFF
--- a/website/client/components/auth/registerLoginReset.vue
+++ b/website/client/components/auth/registerLoginReset.vue
@@ -328,10 +328,10 @@ export default {
   },
   computed: {
     registering () {
-      if (this.$route.path.startsWith('/login')) {
-        return false;
+      if (this.$route.path.startsWith('/register')) {
+        return true;
       }
-      return true;
+      return false;
     },
     resetPasswordSetNewOne () {
       if (this.$route.path.startsWith('/reset-password')) {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)


[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10669

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
The registering flag was incorrectly set when setting new password. It resulted in code trying to use handler for registering a user, rather than setting a new password on clicking Enter key.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 
