### PR TITLE
Make profile modal nav tabs better responsive

### DIFF
--- a/website/client/components/userMenu/profile.vue
+++ b/website/client/components/userMenu/profile.vue
@@ -228,7 +228,7 @@ div
 
   .nav {
     font-weight: bold;
-    height: 40px;
+    min-height: 40px;
     justify-content: center;
   }
 

--- a/website/client/components/userMenu/profile.vue
+++ b/website/client/components/userMenu/profile.vue
@@ -33,7 +33,7 @@ div
         .col-12
           member-details(:member="user")
     .row
-      .col-12.col-md-6.offset-md-3.text-center.nav
+      .col-12.text-center.nav
         .nav-item(@click='selectPage("profile")', :class="{active: selectedPage === 'profile'}") {{ $t('profile') }}
         .nav-item(@click='selectPage("stats")', :class="{active: selectedPage === 'stats'}") {{ $t('stats') }}
         .nav-item(@click='selectPage("achievements")', :class="{active: selectedPage === 'achievements'}") {{ $t('achievements') }}
@@ -229,11 +229,12 @@ div
   .nav {
     font-weight: bold;
     height: 40px;
+    justify-content: center;
   }
 
   .nav-item {
     display: inline-block;
-    margin: 0 auto;
+    margin: 0 1.2em;
     padding: 1em;
   }
 


### PR DESCRIPTION



[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10944

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Remove offset & specific width  and use flexbox centering for Profile modal tabs

**Before:** https://www.dropbox.com/s/us5pqwws0wbb90w/Screencast%202019-01-12%2018%3A24%3A13.mp4?dl=0

**After:** https://www.dropbox.com/s/1lijytlhwpgqty1/Screencast%202019-01-12%2018%3A26%3A10.mp4?dl=0

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: fa756acf-9127-4a3c-8dac-8ff627d30073
