### PR TITLE
Special Pets that you don't own will only show GreyPaw print | Fixes #10866

### DIFF
--- a/website/client/components/inventory/stable/petItem.vue
+++ b/website/client/components/inventory/stable/petItem.vue
@@ -73,7 +73,7 @@ div
 <script>
   import uuid from 'uuid';
   import { mapState } from 'client/libs/store';
-  import {isAllowedToFeed, isHatchable, isOwned} from '../../../libs/createAnimal';
+  import {isAllowedToFeed, isHatchable, isOwned, isSpecial} from '../../../libs/createAnimal';
 
   export default {
     props: {
@@ -116,6 +116,10 @@ div
           return `Pet Pet-${this.item.key} ${this.item.eggKey}`;
         }
 
+        if (!this.isOwned() && this.isSpecial()) {
+          return 'GreyedOut PixelPaw';
+        }
+
         if (this.isHatchable()) {
           return 'PixelPaw';
         }
@@ -137,6 +141,9 @@ div
       },
       mountOwned () {
         return isOwned('mount', this.item, this.userItems);
+      },
+      isSpecial () {
+        return isSpecial(this.item);
       },
     },
     computed: {

--- a/website/client/components/inventory/stable/petItem.vue
+++ b/website/client/components/inventory/stable/petItem.vue
@@ -1,33 +1,33 @@
 <template lang="pug">
-div
-  .item-wrapper(@click="click()", :id="itemId")
-    .item.pet-slot(
+  div
+    .item-wrapper(@click="click()", :id="itemId")
+      .item.pet-slot(
       :class="{'item-empty': !isOwned(), 'highlight': highlightBorder}",
-    )
-      slot(name="itemBadge", :item="item")
-      span.item-content.hatchAgain(v-if="mountOwned() && isHatchable()")
-        span.egg(:class="eggClass")
-        span.potion(:class="potionClass")
-      span.item-content(v-else, :class="getPetItemClass()")
-      span.pet-progress-background(v-if="isAllowedToFeed() && progress() > 0")
-        div.pet-progress-bar(v-bind:style="{width: 100 * progress()/50 + '%' }")
-    span.item-label(v-if="label") {{ label }}
+      )
+        slot(name="itemBadge", :item="item")
+        span.item-content.hatchAgain(v-if="mountOwned() && isHatchable() && !item.isSpecial()")
+          span.egg(:class="eggClass")
+          span.potion(:class="potionClass")
+        span.item-content(v-else, :class="getPetItemClass()")
+        span.pet-progress-background(v-if="isAllowedToFeed() && progress() > 0")
+          div.pet-progress-bar(v-bind:style="{width: 100 * progress()/50 + '%' }")
+      span.item-label(v-if="label") {{ label }}
 
-  b-popover(
+    b-popover(
     :target="itemId",
     :triggers="showPopover ? 'hover' : ''",
     :placement="popoverPosition",
-  )
-    div.hatchablePopover(v-if="item.isHatchable()")
-      h4.popover-content-title {{ item.name }}
-      div.popover-content-text(v-html="$t('haveHatchablePet', { potion: item.potionName, egg: item.eggName })")
-      div.potionEggGroup
-        div.potionEggBackground
-          div(:class="potionClass")
-        div.potionEggBackground
-          div(:class="eggClass")
-    div(v-else)
-      h4.popover-content-title {{ item.name }}
+    )
+      div.hatchablePopover(v-if="item.isHatchable()")
+        h4.popover-content-title {{ item.name }}
+        div.popover-content-text(v-html="$t('haveHatchablePet', { potion: item.potionName, egg: item.eggName })")
+        div.potionEggGroup
+          div.potionEggBackground
+            div(:class="potionClass")
+          div.potionEggBackground
+            div(:class="eggClass")
+      div(v-else)
+        h4.popover-content-title {{ item.name }}
 
 </template>
 

--- a/website/client/libs/createAnimal.js
+++ b/website/client/libs/createAnimal.js
@@ -27,6 +27,10 @@ export function isAllowedToFeed (animal, userItems) {
     !isOwned('mount', animal, userItems);
 }
 
+export function isSpecial (animal) {
+  return specialPets.includes(animal.key);
+}
+
 export function createAnimal (egg, potion, type, _content, userItems) {
   let animalKey = `${egg.key}-${potion.key}`;
 
@@ -49,6 +53,9 @@ export function createAnimal (egg, potion, type, _content, userItems) {
     },
     isHatchable () {
       return isHatchable(this, userItems);
+    },
+    isSpecial () {
+      return isSpecial(this);
     },
   };
 }


### PR DESCRIPTION
Fixes #10866 

### Changes
This PR aims to adjust the decision logic with which the type of icon of the animal to be shown is chosen. 
This PR is the clean duplicate of [https://github.com/HabitRPG/habitica/pull/10879](https://github.com/HabitRPG/habitica/pull/10879) since it became messed up with commits from develop.

The possibilities of an icon are:

| Icon | Description |
| --- | --- |
| PixelPaw  | The pet __is hatchable__ in some way |
| GreyedOut PixelPaw | The pet __is not hatchable__ in any way |
| Pet  | The pet __is owned__ |
| GreyedOut Pet | The __mount__ relative to the pet __is owned__ |
| PetEgg HatchingPotion | The __mount__ relative to the pet __is owned__ and the pet  __is hatchable__ in some way|

To make sure that the icon shown in case of a special animal not owned was __GreyedOut PixelPaw__ I checked if the pet was not owned and if it was a special one `!isOwned && isSpecial`.

To make sure that the icon shown in case of mount relative to the pet owned and the pet is hatchable was __GreyedOut PixelPaw__ and not __PetEgg HatchingPotion__ I checked if the pet was a special one `!isSpecial` in the `v-if` check.

Here some screenshots to demonstrate the changes:
#### Previously incorrect situation
![previously-incorrect-situation](https://user-images.githubusercontent.com/18326387/49283447-0ae54400-f492-11e8-9068-f2334c4c024a.png)

#### Currently correct situation
![currently-correct-situation](https://user-images.githubusercontent.com/18326387/51186450-f2ae7480-18d9-11e9-9dea-3994b4389be2.png)

----
UUID: ef6803f9-7cf4-4659-8eef-ccf345c1d933

