### PR TITLE
Repair negative quest scrolls on purchase

### DIFF
--- a/website/common/script/ops/buy/buyQuest.js
+++ b/website/common/script/ops/buy/buyQuest.js
@@ -66,7 +66,7 @@ export class BuyQuestWithGoldOperation extends AbstractGoldItemOperation {
   }
 
   executeChanges (user, item, req) {
-    user.items.quests[item.key] = user.items.quests[item.key] || 0;
+    if (!user.items.quests[item.key] || user.items.quests[item.key] < 0) user.items.quests[item.key] = 0;
     user.items.quests[item.key] += this.quantity;
 
     this.subtractCurrency(user, item, this.quantity);


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Previously, in the event that a user's inventory of a quest scroll ended up negative somehow, this would act as a "debt" of sorts. When they purchased another quest, it would bring them closer to 0 rather than giving them a new scroll.

Now, if the user's count of a quest scroll is negative, it will be reset to 0 before incrementing when they buy a new one.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)