### PR TITLE
Add username to challenge csv export (Fixes #10955)

### DIFF
--- a/test/api/v3/integration/challenges/GET-challenges_challengeId_export_csv.test.js
+++ b/test/api/v3/integration/challenges/GET-challenges_challengeId_export_csv.test.js
@@ -65,11 +65,11 @@ describe('GET /challenges/:challengeId/export/csv', () => {
     const sortedMembers = _.sortBy([members[0], members[1], members[2], groupLeader], '_id');
     const splitRes = res.split('\n');
 
-    expect(splitRes[0]).to.equal('UUID,name,Task,Value,Notes,Streak,Task,Value,Notes,Streak');
-    expect(splitRes[1]).to.equal(`${sortedMembers[0]._id},${sortedMembers[0].profile.name},habit:Task 1,0,,0,todo:Task 2,0,,0`);
-    expect(splitRes[2]).to.equal(`${sortedMembers[1]._id},${sortedMembers[1].profile.name},habit:Task 1,0,,0,todo:Task 2,0,,0`);
-    expect(splitRes[3]).to.equal(`${sortedMembers[2]._id},${sortedMembers[2].profile.name},habit:Task 1,0,,0,todo:Task 2,0,,0`);
-    expect(splitRes[4]).to.equal(`${sortedMembers[3]._id},${sortedMembers[3].profile.name},habit:Task 1,0,,0,todo:Task 2,0,,0`);
+    expect(splitRes[0]).to.equal('UUID,Display Name,Username,Task,Value,Notes,Streak,Task,Value,Notes,Streak');
+    expect(splitRes[1]).to.equal(`${sortedMembers[0]._id},${sortedMembers[0].profile.name},${sortedMembers[0].auth.local.username},habit:Task 1,0,,0,todo:Task 2,0,,0`);
+    expect(splitRes[2]).to.equal(`${sortedMembers[1]._id},${sortedMembers[1].profile.name},${sortedMembers[1].auth.local.username},habit:Task 1,0,,0,todo:Task 2,0,,0`);
+    expect(splitRes[3]).to.equal(`${sortedMembers[2]._id},${sortedMembers[2].profile.name},${sortedMembers[2].auth.local.username},habit:Task 1,0,,0,todo:Task 2,0,,0`);
+    expect(splitRes[4]).to.equal(`${sortedMembers[3]._id},${sortedMembers[3].profile.name},${sortedMembers[3].auth.local.username},habit:Task 1,0,,0,todo:Task 2,0,,0`);
     expect(splitRes[5]).to.equal('');
   });
 
@@ -78,10 +78,10 @@ describe('GET /challenges/:challengeId/export/csv', () => {
     const res = await members[1].get(`/challenges/${challenge._id}/export/csv`);
     const sortedMembers = _.sortBy([members[1], members[2], groupLeader], '_id');
     const splitRes = res.split('\n');
-    expect(splitRes[0]).to.equal('UUID,name,Task,Value,Notes,Streak,Task,Value,Notes,Streak');
-    expect(splitRes[1]).to.equal(`${sortedMembers[0]._id},${sortedMembers[0].profile.name},habit:Task 1,0,,0,todo:Task 2,0,,0`);
-    expect(splitRes[2]).to.equal(`${sortedMembers[1]._id},${sortedMembers[1].profile.name},habit:Task 1,0,,0,todo:Task 2,0,,0`);
-    expect(splitRes[3]).to.equal(`${sortedMembers[2]._id},${sortedMembers[2].profile.name},habit:Task 1,0,,0,todo:Task 2,0,,0`);
+    expect(splitRes[0]).to.equal('UUID,Display Name,Username,Task,Value,Notes,Streak,Task,Value,Notes,Streak');
+    expect(splitRes[1]).to.equal(`${sortedMembers[0]._id},${sortedMembers[0].profile.name},${sortedMembers[0].auth.local.username},habit:Task 1,0,,0,todo:Task 2,0,,0`);
+    expect(splitRes[2]).to.equal(`${sortedMembers[1]._id},${sortedMembers[1].profile.name},${sortedMembers[1].auth.local.username},habit:Task 1,0,,0,todo:Task 2,0,,0`);
+    expect(splitRes[3]).to.equal(`${sortedMembers[2]._id},${sortedMembers[2].profile.name},${sortedMembers[2].auth.local.username},habit:Task 1,0,,0,todo:Task 2,0,,0`);
     expect(splitRes[4]).to.equal('');
   });
 });

--- a/website/server/controllers/api-v3/challenges.js
+++ b/website/server/controllers/api-v3/challenges.js
@@ -577,7 +577,7 @@ api.exportChallengeCsv = {
         .lean().exec(),
     ]);
 
-    let resArray = members.map(member => [member._id, member.profile.name]);
+    let resArray = members.map(member => [member._id, member.profile.name, member.auth.local.username]);
 
     let lastUserId;
     let index = -1;
@@ -606,7 +606,7 @@ api.exportChallengeCsv = {
     let challengeTasks = _.reduce(challenge.tasksOrder.toObject(), (result, array) => {
       return result.concat(array);
     }, []).sort();
-    resArray.unshift(['UUID', 'name']);
+    resArray.unshift(['UUID', 'Display Name', 'Username']);
 
     _.times(challengeTasks.length, () => resArray[0].push('Task', 'Value', 'Notes', 'Streak'));
 


### PR DESCRIPTION
- Adds the member's username to the challenge csv
- Updates to unit tests

Supports the ability for challenge owners to judge challenge winners
after the added functionality enabling users to modify their name
(display name). The added field ties the user to their results by
their username.

[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10955 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

![challege_export_before](https://user-images.githubusercontent.com/5703010/51446100-50c4c880-1cdb-11e9-948e-8990e3f222f5.png)

![challege_export_after](https://user-images.githubusercontent.com/5703010/51446105-5a4e3080-1cdb-11e9-8992-c9141d642b7c.png)

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: ca561633-c0bb-4544-adf4-dda0aaa23795