### PR TITLE
Add else block so items with warning notes will not display sell options - fixes #9596

### DIFF
--- a/website/client/components/shops/market/sellModal.vue
+++ b/website/client/components/shops/market/sellModal.vue
@@ -25,19 +25,20 @@
           div.text {{ item.sellWarningNote() }}
           br
 
-        div(v-once)
-          div.text {{ item.notes() }}
+        div(v-else)
+          div(v-once)
+            div.text {{ item.notes() }}
 
-          div
-            b.how-many-to-sell {{ $t('howManyToSell') }}
+            div
+              b.how-many-to-sell {{ $t('howManyToSell') }}
 
-          div
-            b-input.itemsToSell(type="number", v-model="selectedAmountToSell", :max="itemContextToSell.itemCount", min="1", @keyup.native="preventNegative($event)", step="1")
+            div
+              b-input.itemsToSell(type="number", v-model="selectedAmountToSell", :max="itemContextToSell.itemCount", min="1", @keyup.native="preventNegative($event)", step="1")
 
-            span.svg-icon.inline.icon-32(aria-hidden="true", v-html="icons.gold")
-            span.value {{ item.value }}
+              span.svg-icon.inline.icon-32(aria-hidden="true", v-html="icons.gold")
+              span.value {{ item.value }}
 
-          button.btn.btn-primary(@click="sellItems()") {{ $t('sell') }}
+            button.btn.btn-primary(@click="sellItems()") {{ $t('sell') }}
 
     div.clearfix(slot="modal-footer")
       span.balance.float-left {{ $t('yourBalance') }}


### PR DESCRIPTION
[//]: #9596  (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #9596 

### Changes
It looked like the else block was missing in the code. Added an else block so items with sellWarningNote() will not have sell options displayed in the modal. 

![image](https://user-images.githubusercontent.com/39242483/51536056-45ad9c00-1e85-11e9-8793-b4951c56fff8.png)

[//]: #cf6b1c9e-6257-46d5-8e44-da48fc954282
 (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: cf6b1c9e-6257-46d5-8e44-da48fc954282

