### PR TITLE
refresh gear overview

### DIFF
--- a/website/client/components/shops/seasonal/index.vue
+++ b/website/client/components/shops/seasonal/index.vue
@@ -388,7 +388,9 @@
       },
 
       seasonal () {
+        // vue subscriptions, don't remove
         let backgroundUpdate = this.backgroundUpdate; // eslint-disable-line
+        const myUserVersion = this.user._v; // eslint-disable-line
 
         let seasonal = shops.getSeasonalShop(this.user);
 

--- a/website/common/script/libs/shops.js
+++ b/website/common/script/libs/shops.js
@@ -417,6 +417,8 @@ shops.getSeasonalGearBySet = function getSeasonalGearBySet (user, set, officialP
 shops.getSeasonalShop = function getSeasonalShop (user, language) {
   let officialPinnedItems = getOfficialPinnedItems(user);
 
+  // subscribe to user._V, to let vue refresh the seasonal shop overview
+  // eslint-disable-next-line
   const myUserVersion = user._v;
 
   let resObject = {
@@ -430,8 +432,7 @@ shops.getSeasonalShop = function getSeasonalShop (user, language) {
       text: i18n.t(seasonalShopConfig.featuredSet),
       items: shops.getSeasonalGearBySet(user, seasonalShopConfig.featuredSet, officialPinnedItems, language, true),
     },
-    // return / subscribe to user._V, to let vue refresh the seasonal shop overview
-    _v: myUserVersion,
+
   };
 
   return resObject;

--- a/website/common/script/libs/shops.js
+++ b/website/common/script/libs/shops.js
@@ -417,10 +417,6 @@ shops.getSeasonalGearBySet = function getSeasonalGearBySet (user, set, officialP
 shops.getSeasonalShop = function getSeasonalShop (user, language) {
   let officialPinnedItems = getOfficialPinnedItems(user);
 
-  // subscribe to user._V, to let vue refresh the seasonal shop overview
-  // eslint-disable-next-line
-  const myUserVersion = user._v;
-
   let resObject = {
     identifier: 'seasonalShop',
     text: i18n.t('seasonalShop'),
@@ -432,7 +428,6 @@ shops.getSeasonalShop = function getSeasonalShop (user, language) {
       text: i18n.t(seasonalShopConfig.featuredSet),
       items: shops.getSeasonalGearBySet(user, seasonalShopConfig.featuredSet, officialPinnedItems, language, true),
     },
-
   };
 
   return resObject;

--- a/website/common/script/libs/shops.js
+++ b/website/common/script/libs/shops.js
@@ -417,6 +417,8 @@ shops.getSeasonalGearBySet = function getSeasonalGearBySet (user, set, officialP
 shops.getSeasonalShop = function getSeasonalShop (user, language) {
   let officialPinnedItems = getOfficialPinnedItems(user);
 
+  const myUserVersion = user._v;
+
   let resObject = {
     identifier: 'seasonalShop',
     text: i18n.t('seasonalShop'),
@@ -428,6 +430,8 @@ shops.getSeasonalShop = function getSeasonalShop (user, language) {
       text: i18n.t(seasonalShopConfig.featuredSet),
       items: shops.getSeasonalGearBySet(user, seasonalShopConfig.featuredSet, officialPinnedItems, language, true),
     },
+    // return / subscribe to user._V, to let vue refresh the seasonal shop overview
+    _v: myUserVersion,
   };
 
   return resObject;

--- a/website/common/script/ops/pinnedGearUtils.js
+++ b/website/common/script/ops/pinnedGearUtils.js
@@ -85,30 +85,16 @@ function removePinnedGearByClass (user) {
 }
 
 function removePinnedGearAddPossibleNewOnes (user, itemPath, newItemKey) {
-  let currentPinnedItems = selectGearToPin(user);
-  let removeAndAddAllItems = false;
-
-  for (let item of currentPinnedItems) {
-    let itemInfo = getItemInfo(user, 'marketGear', item);
-
-    if (itemInfo.path === itemPath) {
-      removeAndAddAllItems = true;
-      break;
-    }
-  }
-
   removeItemByPath(user, itemPath);
 
-  if (removeAndAddAllItems) {
-    // an item of the users current "new" gear was bought
-    // remove the old pinned gear items and add the new gear back
-    removePinnedGearByClass(user);
-    user.items.gear.owned[newItemKey] = true;
-    addPinnedGearByClass(user);
-  } else {
-    // just change the new gear to owned
-    user.items.gear.owned[newItemKey] = true;
-  }
+  // an item of the users current "new" gear was bought
+  // remove the old pinned gear items and add the new gear back
+  removePinnedGearByClass(user);
+  user.items.gear.owned[newItemKey] = true;
+  addPinnedGearByClass(user);
+
+  // update the version, so that vue can refresh the seasonal shop
+  user._v++;
 }
 
 /**


### PR DESCRIPTION
fixes #10920

at first I thought it was the the seasonal gear didn't refresh the "pinnedItems", then the refresh in market did update the seasonal pinned gear, but not all unpinned equipment in the seasonal shop

then it was clear, it was "just" the vue watcher that didn't get any updates (e.g. no pinned gear was bought, the pinned array didn't change => no object change => no refresh)

now refreshing `user._v++` (and subscribing in the seasonal market object) fixed the refresh 🎉 