### PR TITLE
Fix #10907 - Removes Grey Disabled style from Challenge Progress

### DIFF
--- a/test/client/unit/specs/store/getters/tasks/getTaskClasses.js
+++ b/test/client/unit/specs/store/getters/tasks/getTaskClasses.js
@@ -1,7 +1,7 @@
 import generateStore from 'client/store';
 
 describe('getTaskClasses getter', () => {
-  let store, getTaskClasses;
+  let store, getTaskClasses, getDisabledClassObject;
 
   beforeEach(() => {
     store = generateStore();
@@ -11,6 +11,15 @@ describe('getTaskClasses getter', () => {
     };
 
     getTaskClasses = store.getters['tasks:getTaskClasses'];
+
+    getDisabledClassObject = function () {
+      return {
+        bg: 'task-disabled-daily-todo-control-bg',
+        checkbox: 'task-disabled-daily-todo-control-checkbox',
+        inner: 'task-disabled-daily-todo-control-inner',
+        content: 'task-disabled-daily-todo-control-content',
+      };
+    };
   });
 
   it('returns reward edit-modal-bg class', () => {
@@ -137,5 +146,38 @@ describe('getTaskClasses getter', () => {
         inner: 'task-disabled-habit-control-inner',
       },
     });
+  });
+
+  it('returns completed daily classes from challege progress modal', () => {
+    const task = {type: 'daily', value: 4, completed: true};
+    expect(getTaskClasses(task, 'control', undefined, 'challenge')).to.deep.equal({
+      bg: 'task-good-control-bg',
+      checkbox: 'task-good-control-checkbox',
+      inner: 'task-good-control-inner-daily-todo',
+    });
+  });
+
+  it('returns completed todo classes from challege progress modal', () => {
+    const task = {type: 'todo', value: -11, completed: true};
+    expect(getTaskClasses(task, 'control', undefined, 'challenge'))
+      .to.deep.not.equal(getDisabledClassObject());
+  });
+
+  it('returns completed daily classes from tasks page', () => {
+    const task = {type: 'daily', value: 3, completed: true};
+    expect(getTaskClasses(task, 'control', undefined, 'tasks'))
+      .to.deep.equal(getDisabledClassObject());
+  });
+
+  it('returns completed todo classes from tasks page', () => {
+    const task = {type: 'todo', value: 4, completed: true};
+    expect(getTaskClasses(task, 'control', undefined, 'tasks'))
+      .to.deep.equal(getDisabledClassObject());
+  });
+
+  it('returns completed todo classes from guild task board', () => {
+    const task = {type: 'todo', value: 4, completed: true};
+    expect(getTaskClasses(task, 'control', undefined, 'groupPlanDetailTaskInformation'))
+      .to.deep.equal(getDisabledClassObject());
   });
 });

--- a/website/client/components/tasks/task.vue
+++ b/website/client/components/tasks/task.vue
@@ -598,13 +598,13 @@ export default {
       return false;
     },
     controlClass () {
-      return this.getTaskClasses(this.task, 'control', this.dueDate);
+      return this.getTaskClasses(this.task, 'control', this.dueDate, this.$route.name);
     },
     contentClass () {
       const type = this.task.type;
 
       const classes = [];
-      classes.push(this.getTaskClasses(this.task, 'control', this.dueDate).content);
+      classes.push(this.getTaskClasses(this.task, 'control', this.dueDate, this.$route.name).content);
 
       if (type === 'reward' || type === 'habit') {
         classes.push('no-right-border');

--- a/website/client/store/getters/tasks.js
+++ b/website/client/store/getters/tasks.js
@@ -52,7 +52,7 @@ export function getTaskClasses (store) {
   // Edit Modal: edit-modal-bg, edit-modal-text, edit-modal-icon
   // Create Modal: create-modal-bg, create-modal-text, create-modal-icon
   // Control: 'control'
-  return (task, purpose, dueDate) => {
+  return (task, purpose, dueDate, loc) => {
     if (!dueDate) dueDate = new Date();
     const type = task.type;
     const color = getTaskColor(task);
@@ -82,12 +82,14 @@ export function getTaskClasses (store) {
       case 'control':
         if (type === 'todo' || type === 'daily') {
           if (task.completed || !shouldDo(dueDate, task, userPreferences) && type === 'daily') {
-            return {
-              bg: 'task-disabled-daily-todo-control-bg',
-              checkbox: 'task-disabled-daily-todo-control-checkbox',
-              inner: 'task-disabled-daily-todo-control-inner',
-              content: 'task-disabled-daily-todo-control-content',
-            };
+            if (!(loc === 'challenge')) {
+              return {
+                bg: 'task-disabled-daily-todo-control-bg',
+                checkbox: 'task-disabled-daily-todo-control-checkbox',
+                inner: 'task-disabled-daily-todo-control-inner',
+                content: 'task-disabled-daily-todo-control-content',
+              };
+            }
           }
 
           return {


### PR DESCRIPTION
- Includes a fix that displays task styles based on tab location
- Adds unit test coverage to ensure styles exist (or do not exist) depending on location
- Fixes #10907 

### Changes

Approach:
Since the behaviors were different depending on the location, I passed the route's path name to the task class creation functionality so that it was aware of where the request originated.  I was then able to ensure that todo and daily tasks originating from the challenge page did not get the disabled style applied. 

I added unit tests testing the functionality from the tasks page, the guild/group task board and the challenge page.

#### Before

![image](https://user-images.githubusercontent.com/5703010/52168481-fc691200-26f8-11e9-99ca-a460fe4b81c1.png)

#### After

![image](https://user-images.githubusercontent.com/5703010/52168456-98464e00-26f8-11e9-9354-b94edd1530d7.png)

![image](https://user-images.githubusercontent.com/5703010/52168534-6d102e80-26f9-11e9-87d6-93394cfa7e17.png)

#### Regression: User Tasks View (Completed Todo/Daily Tasks are still grey)
![image](https://user-images.githubusercontent.com/5703010/52168506-36d2af00-26f9-11e9-970a-da9e2c9930cd.png)

----
UUID: 

ca561633-c0bb-4544-adf4-dda0aaa23795