### PR TITLE
Update conditional render to only show Apply Sort... text in party modals. fixes #10968 

### DIFF
--- a/website/client/components/groups/membersModal.vue
+++ b/website/client/components/groups/membersModal.vue
@@ -20,7 +20,7 @@ div
           select.form-control(@change='changeSortDirection($event)')
             option(v-for='sortDirection in sortDirections', :value='sortDirection.value') {{sortDirection.text}}
 
-    .row.apply-options.d-flex.justify-content-center(v-if='sortDirty')
+    .row.apply-options.d-flex.justify-content-center(v-if='sortDirty && group.type === "party"')
       a(@click='applySortOptions()') {{ $t('applySortToHeader') }}
     .row(v-if='invites.length > 0')
       .col-6.offset-3.nav


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

fixes #10968 

### Changes
I've gone ahead and modified the conditional render `v-if` code in `membersModal.vue` to only render the "Apply Sort Options to Party Header" link button if the current group is of type 'party'. This group data was already accessible, so no changes needed to be changed to get new data to the page. 

I've manually tested locally by creating two user accounts, a party, and a guild, making sure that the Apply Sort Options to Party Header link only displays after changing the filter options within a party.

I ran the automated tests (using `npm run test`) on both develop and my new branch and I've attached images of the results. Looks like there are some failing tests on `develop` that my branch also encounters.

Let me know if there's anything else I need to do or am missing on this issue!

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
![new-branch-failed-tests](https://user-images.githubusercontent.com/6538311/52538414-462caa80-2d40-11e9-883a-97bd71676430.png)
![failed_tests_develop](https://user-images.githubusercontent.com/6538311/52538415-462caa80-2d40-11e9-8eaa-d42f65e0b4ca.png)


UUID: 003b1968-38ba-4bcc-9cf6-25926c4d5f11
 
