### PR TITLE
Set registered platform on analytics only once

### DIFF
--- a/website/server/libs/analyticsService.js
+++ b/website/server/libs/analyticsService.js
@@ -268,14 +268,10 @@ let _sendPurchaseDataToGoogle = (data) => {
 };
 
 let _setOnce = (data) => {
-  return new Promise((resolve, reject) => {
-    amplitude.identify({
-      user_properties: {
-        $setOnce: data,
-      },
-    })
-      .then(resolve)
-      .catch(reject);
+  return amplitude.identify({
+    user_properties: {
+      $setOnce: data,
+    },
   });
 };
 

--- a/website/server/libs/analyticsService.js
+++ b/website/server/libs/analyticsService.js
@@ -14,7 +14,7 @@ const AMPLITUDE_TOKEN = nconf.get('AMPLITUDE_KEY');
 const GA_TOKEN = nconf.get('GA_ID');
 const GA_POSSIBLE_LABELS = ['gaLabel', 'itemKey'];
 const GA_POSSIBLE_VALUES = ['gaValue', 'gemCost', 'goldCost'];
-const AMPLITUDE_PROPERTIES_TO_SCRUB = ['uuid', 'user', 'purchaseValue', 'gaLabel', 'gaValue', 'headers', 'registeredPlatform'];
+const AMPLITUDE_PROPERTIES_TO_SCRUB = ['uuid', 'user', 'purchaseValue', 'gaLabel', 'gaValue', 'headers', 'registeredThrough'];
 
 const PLATFORM_MAP = Object.freeze({
   'habitica-web': 'Web',
@@ -95,10 +95,6 @@ let _formatUserData = (user) => {
 
   if (user._ABtests) {
     properties.ABtests = toArray(user._ABtests);
-  }
-
-  if (user.registeredThrough) {
-    properties.registeredPlatform = user.registeredThrough;
   }
 
   if (user.loginIncentives) {

--- a/website/server/libs/analyticsService.js
+++ b/website/server/libs/analyticsService.js
@@ -14,7 +14,7 @@ const AMPLITUDE_TOKEN = nconf.get('AMPLITUDE_KEY');
 const GA_TOKEN = nconf.get('GA_ID');
 const GA_POSSIBLE_LABELS = ['gaLabel', 'itemKey'];
 const GA_POSSIBLE_VALUES = ['gaValue', 'gemCost', 'goldCost'];
-const AMPLITUDE_PROPERTIES_TO_SCRUB = ['uuid', 'user', 'purchaseValue', 'gaLabel', 'gaValue', 'headers'];
+const AMPLITUDE_PROPERTIES_TO_SCRUB = ['uuid', 'user', 'purchaseValue', 'gaLabel', 'gaValue', 'headers', 'registeredPlatform'];
 
 const PLATFORM_MAP = Object.freeze({
   'habitica-web': 'Web',


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

**Before**, the `registeredPlatform` analytics property was considered mutable, just like any other user property. This could lead to unintuitive results, where a user who registered under one platform would later have that "registered platform" updated to something else, or worse, have the property removed from their record.

**Now**, when we set this property, we use the [$setOnce key of the identify method](https://amplitude.zendesk.com/hc/en-us/articles/205406617-Identify-API-Modify-User-Properties#keys-for-the-identification-argument) to set the value and leave it read-only thereafter.

**Before**, the `AMPLITUDE_KEY` constant in the server analytics library had a typo, `AMPLIUDE_KEY`.
**Now**, all instances read `AMPLITUDE_KEY`, as intended.
