### PR TITLE
refactor filters to work like in guilds/challenges

### DIFF
--- a/website/client/components/inventory/equipment/index.vue
+++ b/website/client/components/inventory/equipment/index.vue
@@ -82,7 +82,7 @@
             )
     div(
       v-for="group in itemsGroups",
-      v-if="viewOptions[group.key].selected",
+      v-if="!anyFilterSelected || viewOptions[group.key].selected",
       :key="group.key",
       :class='group.key',
     )
@@ -383,10 +383,13 @@ export default {
     items () {
       return this.groupBy === 'type' ? this.gearItemsByType : this.gearItemsByClass;
     },
+    anyFilterSelected () {
+      return Object.values(this.viewOptions).some(g => g.selected);
+    },
     itemsGroups () {
       return map(this.groups, (label, group) => {
         this.$set(this.viewOptions, group, {
-          selected: true,
+          selected: false,
           open: false,
           itemsInFirstPosition: [],
           firstRender: true,

--- a/website/client/components/inventory/items/index.vue
+++ b/website/client/components/inventory/items/index.vue
@@ -25,7 +25,7 @@
           b-dropdown-item(@click="sortBy = 'AZ'", :active="sortBy === 'AZ'") {{ $t('AZ') }}
     div(
       v-for="group in groups",
-      v-if="group.selected",
+      v-if="!anyFilterSelected || group.selected",
       :key="group.key",
     )
       h2.mb-3
@@ -225,7 +225,7 @@ const groups = [
   return {
     key: group,
     quantity: 0,
-    selected: true,
+    selected: false,
     classPrefix,
     allowedItems,
   };
@@ -339,6 +339,10 @@ export default {
       }
 
       return itemsByType;
+    },
+
+    anyFilterSelected () {
+      return this.groups.some(g => g.selected);
     },
   },
   methods: {

--- a/website/client/components/inventory/stable/index.vue
+++ b/website/client/components/inventory/stable/index.vue
@@ -69,7 +69,7 @@
       span.badge.badge-pill.badge-default {{countOwnedAnimals(petGroups[0], 'pet')}}
 
     div(v-for="(petGroup, index) in petGroups",
-      v-if="viewOptions[petGroup.key].selected",
+      v-if="!anyFilterSelected || viewOptions[petGroup.key].selected",
       :key="petGroup.key")
       h4(v-if="viewOptions[petGroup.key].animalCount !== 0") {{ petGroup.label }}
 
@@ -103,7 +103,7 @@
       span.badge.badge-pill.badge-default {{countOwnedAnimals(mountGroups[0], 'mount')}}
 
     div(v-for="mountGroup in mountGroups",
-      v-if="viewOptions[mountGroup.key].selected",
+      v-if="!anyFilterSelected || viewOptions[mountGroup.key].selected",
       :key="mountGroup.key")
       h4(v-if="viewOptions[mountGroup.key].animalCount != 0") {{ mountGroup.label }}
 
@@ -469,7 +469,7 @@
 
         petGroups.map((petGroup) => {
           this.$set(this.viewOptions, petGroup.key, {
-            selected: true,
+            selected: false,
             animalCount: 0,
           });
         });
@@ -514,7 +514,7 @@
 
         mountGroups.map((mountGroup) => {
           this.$set(this.viewOptions, mountGroup.key, {
-            selected: true,
+            selected: false,
             animalCount: 0,
           });
         });
@@ -537,6 +537,9 @@
             }),
           },
         ];
+      },
+      anyFilterSelected () {
+        return Object.values(this.viewOptions).some(g => g.selected);
       },
     },
     methods: {


### PR DESCRIPTION
Changed following filters to work like in guilds/challenges:
- Equipment 
- Items
- Stable


Initially unchecked => all visible
once one filter is checked => only show those (current behavior)