### PR TITLE
Multiple checks for pinnedItems

### DIFF
--- a/test/common/libs/inAppRewards.js
+++ b/test/common/libs/inAppRewards.js
@@ -62,6 +62,18 @@ describe('inAppRewards', () => {
     expect(result[9].path).to.eql('potion');
   });
 
+  it('ignores null/undefined entries', () => {
+    user.pinnedItems = testPinnedItems;
+    user.pinnedItems.push(null);
+    user.pinnedItems.push(undefined);
+    user.pinnedItemsOrder = testPinnedItemsOrder;
+
+    let result = inAppRewards(user);
+
+    expect(result[2].path).to.eql('armoire');
+    expect(result[9].path).to.eql('potion');
+  });
+
   it('does not return seasonal items which have been unpinned', () => {
     if (officialPinnedItems.length === 0) {
       return; // if no seasonal items, this test is not applicable

--- a/test/common/ops/pinnedGearUtils.js
+++ b/test/common/ops/pinnedGearUtils.js
@@ -1,0 +1,18 @@
+import {
+  generateUser,
+} from '../../helpers/common.helper';
+import {addPinnedGear} from '../../../website/common/script/ops/pinnedGearUtils';
+
+describe('shared.ops.pinnedGearUtils.addPinnedGear', () => {
+  let user;
+
+  beforeEach(() => {
+    user = generateUser();
+  });
+
+  it('not adds an item with empty properties to pinnedItems', () => {
+    addPinnedGear(user, undefined, undefined);
+
+    expect(user.pinnedItems.length).to.be.eql(0);
+  });
+});

--- a/website/client/components/ui/drawer.vue
+++ b/website/client/components/ui/drawer.vue
@@ -174,7 +174,9 @@ export default {
       let minPaddingBottom = 20;
       let drawerHeight = this.$el.offsetHeight;
       let standardPage = document.getElementsByClassName('standard-page')[0];
-      standardPage.style.paddingBottom = `${drawerHeight + minPaddingBottom}px`;
+      if (standardPage) {
+        standardPage.style.paddingBottom = `${drawerHeight + minPaddingBottom}px`;
+      }
     },
     toggle () {
       this.open = !this.isOpen;

--- a/website/client/store/actions/shops.js
+++ b/website/client/store/actions/shops.js
@@ -20,9 +20,6 @@ function buyItem (store, params) {
 
   let opResult = buyOp(user, {params, quantity});
 
-  user.pinnedItems = opResult[0].pinnedItems;
-
-
   return {
     result: opResult,
     httpCall: axios.post(`/api/v4/user/buy/${params.key}`),

--- a/website/common/script/libs/inAppRewards.js
+++ b/website/common/script/libs/inAppRewards.js
@@ -4,6 +4,7 @@ import getOfficialPinnedItems from './getOfficialPinnedItems';
 import compactArray from 'lodash/compact';
 
 import getItemByPathAndType from './getItemByPathAndType';
+import {checkPinnedAreasForNullEntries} from '../ops/pinnedGearUtils';
 
 /**
  * Orders the pinned items so we always get our inAppRewards in the order
@@ -32,6 +33,8 @@ function sortInAppRewards (user, items) {
 }
 
 module.exports = function getPinnedItems (user) {
+  checkPinnedAreasForNullEntries(user);
+
   let officialPinnedItems = getOfficialPinnedItems(user);
 
   const officialPinnedItemsNotUnpinned = officialPinnedItems.filter(officialPin => {
@@ -41,11 +44,13 @@ module.exports = function getPinnedItems (user) {
 
   const pinnedItems = officialPinnedItemsNotUnpinned.concat(user.pinnedItems);
 
-  let items = pinnedItems.map(({type, path}) => {
-    let item = getItemByPathAndType(type, path);
+  let items = pinnedItems
+    .filter(item => Boolean(item)) // filter out nullable entries, which shouldn't be even possible
+    .map(({type, path}) => {
+      let item = getItemByPathAndType(type, path);
 
-    return getItemInfo(user, type, item, officialPinnedItems);
-  });
+      return getItemInfo(user, type, item, officialPinnedItems);
+    });
 
   shops.checkMarketGearLocked(user, items);
 

--- a/website/common/script/libs/inAppRewards.js
+++ b/website/common/script/libs/inAppRewards.js
@@ -45,7 +45,6 @@ module.exports = function getPinnedItems (user) {
   const pinnedItems = officialPinnedItemsNotUnpinned.concat(user.pinnedItems);
 
   let items = pinnedItems
-    .filter(item => Boolean(item)) // filter out nullable entries, which shouldn't be even possible
     .map(({type, path}) => {
       let item = getItemByPathAndType(type, path);
 

--- a/website/common/script/libs/shops.js
+++ b/website/common/script/libs/shops.js
@@ -107,7 +107,8 @@ function getClassName (classType, language) {
 // TODO Refactor the `.locked` logic
 shops.checkMarketGearLocked = function checkMarketGearLocked (user, items) {
   let result = filter(items, ['pinType', 'marketGear']);
-  let availableGear = map(updateStore(user), (item) => getItemInfo(user, 'marketGear', item).path);
+  const officialPinnedItems = getOfficialPinnedItems(user);
+  let availableGear = map(updateStore(user), (item) => getItemInfo(user, 'marketGear', item, officialPinnedItems).path);
   for (let gear of result) {
     if (gear.klass !== user.stats.class) {
       gear.locked = true;

--- a/website/common/script/ops/pinnedGearUtils.js
+++ b/website/common/script/ops/pinnedGearUtils.js
@@ -123,9 +123,6 @@ const PATHS_WITHOUT_ITEM = ['special.gems', 'special.rebirth_orb', 'special.fort
  * @returns {boolean} TRUE added the item / FALSE removed it
  */
 function togglePinnedItem (user, {item, type, path}, req = {}) {
-  // ensure no nullable entries exist
-  checkPinnedAreasForNullEntries(user);
-
   let arrayToChange;
   let officialPinnedItems = getOfficialPinnedItems(user);
 

--- a/website/common/script/ops/pinnedGearUtils.js
+++ b/website/common/script/ops/pinnedGearUtils.js
@@ -27,6 +27,15 @@ function pathExistsInArray (array, path) {
   });
 }
 
+function checkForNullEntries (array) {
+  return array.filter(e => Boolean(e));
+}
+
+function checkPinnedAreasForNullEntries (user) {
+  user.pinnedItems = checkForNullEntries(user.pinnedItems);
+  user.unpinnedItems = checkForNullEntries(user.unpinnedItems);
+}
+
 function selectGearToPin (user) {
   let changes = [];
 
@@ -41,11 +50,10 @@ function selectGearToPin (user) {
   return sortBy(changes, (change) => sortOrder[change.type]);
 }
 
-
 function addPinnedGear (user, type, path) {
   const foundIndex = pathExistsInArray(user.pinnedItems, path);
 
-  if (foundIndex === -1) {
+  if (foundIndex === -1 && type && path) {
     user.pinnedItems.push({
       type,
       path,
@@ -115,6 +123,9 @@ const PATHS_WITHOUT_ITEM = ['special.gems', 'special.rebirth_orb', 'special.fort
  * @returns {boolean} TRUE added the item / FALSE removed it
  */
 function togglePinnedItem (user, {item, type, path}, req = {}) {
+  // ensure no nullable entries exist
+  checkPinnedAreasForNullEntries(user);
+
   let arrayToChange;
   let officialPinnedItems = getOfficialPinnedItems(user);
 
@@ -176,5 +187,6 @@ module.exports = {
   togglePinnedItem,
   removeItemByPath,
   selectGearToPin,
+  checkPinnedAreasForNullEntries,
   isPinned,
 };


### PR DESCRIPTION
This adds some additional checks for the pinnedItems - issue occurred in #10134

- check the pinnedItems for null/undefined entries and remove them on toggle
- filters out undefined items when getting the reward-items

- also fixed the drawer error which was also in #10134 

@paglias @Alys any other ideas where that undefined could be from?

Fixes #10134