### PR TITLE
Ensure profile page gets synced (fixes #11026)

### DIFF
--- a/website/client/components/userMenu/profile.vue
+++ b/website/client/components/userMenu/profile.vue
@@ -495,6 +495,9 @@ export default {
     async userId () {
       this.loadUser();
     },
+    userLoggedIn () {
+      this.loadUser();
+    },
   },
   methods: {
     async loadUser () {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11026

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
In profile.vue, the user in the store was not being directly used - rather, some modifications were being made to it upon load, then the modified user was used. As a result, store updates did not affect the user object, and so any syncs that updated the store did not affect the values of the user. This fix should update the modified user object whenever the user object in the store is updated.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 3c2b1d99-c6f0-4e6e-a67a-bd8e023cfc7e
