### PR TITLE
Keep mystery items synced with server (fixes #11029)

### DIFF
--- a/website/client/components/inventory/items/index.vue
+++ b/website/client/components/inventory/items/index.vue
@@ -465,8 +465,6 @@ export default {
           let openedItem = result.data.data;
           let text = this.content.gear.flat[openedItem.key].text();
           this.drop(this.$t('messageDropMysteryItem', {dropText: text}), openedItem);
-          item.quantity--;
-          this.$forceUpdate();
         } else {
           this.$root.$emit('selectMembersModal::showItem', item);
         }

--- a/website/client/store/actions/user.js
+++ b/website/client/store/actions/user.js
@@ -5,6 +5,7 @@ import axios from 'axios';
 import { togglePinnedItem as togglePinnedItemOp } from 'common/script/ops/pinnedGearUtils';
 import changeClassOp from 'common/script/ops/changeClass';
 import disableClassesOp from 'common/script/ops/disableClasses';
+import openMysteryItemOp from 'common/script/ops/openMysteryItem';
 
 export function fetch (store, options = {}) { // eslint-disable-line no-shadow
   return loadAsyncResource({
@@ -127,7 +128,9 @@ export function castSpell (store, params) {
   return axios.post(spellUrl, data);
 }
 
-export function openMysteryItem () {
+export async function openMysteryItem (store) {
+  let user = store.state.user.data;
+  openMysteryItemOp(user);
   return axios.post('/api/v4/user/open-mystery-item');
 }
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11029

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Mystery items, unlike egg hatching and feeding, were not being synced with the server. This meant that when we opened a mystery item box, we didn't see the mystery item count update, and we didn't automatically get the item added to our inventory.

In the openMysteryItem action in the store, we now call the openMysteryItem() function in common/script/ops, which is the same function that the server calls to update the user object. This ensures that the server and client stay synchronized.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 3c2b1d99-c6f0-4e6e-a67a-bd8e023cfc7e
