### PR TITLE
Fix mismatch between pet and star badge

### DIFF
--- a/website/client/components/inventory/stable/index.vue
+++ b/website/client/components/inventory/stable/index.vue
@@ -92,7 +92,11 @@
             @click="petClicked(item)"
           )
             template(slot="itemBadge", slot-scope="context")
-              starBadge(:selected="item.key === currentPet", :show="isOwned('pet', item)", @click="selectPet(item)")
+              starBadge(
+                :selected="context.item.key === currentPet",
+                :show="isOwned('pet', context.item)",
+                @click="selectPet(context.item)"
+              )
 
       .btn.btn-flat.btn-show-more(@click="setShowMore(petGroup.key)", v-if='petGroup.key !== "specialPets"')
         | {{ $_openedItemRows_isToggled(petGroup.key) ? $t('showLess') : $t('showMore') }}


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
In #10997, some people reported that incorrect pets are equipped if you click on them while searching. It looks like this was due to the incorrect variable being referenced on the star badges - they reference "item", which is a variable from outside the slot's scope, but they should be referencing "context.item", which is the item that the star badge should have access to. To be quite honest, I'm not exactly sure why referencing "item" led to the observed behavior - Vue has a lot of moving parts, and I'm not 100% sure how they all fit together. However, this fix seems to have done the trick.

I have not been able to reproduce all of the reports seen in #10997, and so I can't say for certain whether this will fix the issue. However, it should fix some of the problems.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 3c2b1d99-c6f0-4e6e-a67a-bd8e023cfc7e
