### PR TITLE
Center allocatable stat points

### DIFF
--- a/website/client/components/userMenu/profileStats.vue
+++ b/website/client/components/userMenu/profileStats.vue
@@ -123,8 +123,8 @@
           h3(v-if='userLevel100Plus', v-once, v-html="$t('noMoreAllocate')")
           h3
             | {{$t('statPoints')}}
-            .counter.badge(v-if='user.stats.points || userLevel100Plus')
-              | {{pointsRemaining}}&nbsp;
+            .counter.badge.badge-pill(v-if='user.stats.points || userLevel100Plus')
+              | {{pointsRemaining}}
         .col-12.col-md-6
           .float-right
             toggle-switch(
@@ -409,9 +409,6 @@
       color: #fff;
       background-color: #ff944c;
       box-shadow: 0 1px 1px 0 rgba(26, 24, 29, 0.12);
-      width: 24px;
-      height: 24px;
-      border-radius: 50%;
     }
 
     .box {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11049

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
In the Stats page, there's an orange badge displaying the number of allocatable stat points. It's currently off-center; this fix should center it.

Before:
![image](https://user-images.githubusercontent.com/8535555/53988397-38b4d700-40d8-11e9-856c-99af298ad149.png)

After:
![image](https://user-images.githubusercontent.com/8535555/53988759-1ec7c400-40d9-11e9-80e6-da3ce3f811ce.png)

I don't have much experience with CSS, so please let me know if there's anything I should fix. Thanks!


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 3c2b1d99-c6f0-4e6e-a67a-bd8e023cfc7e
