### PR TITLE
Added a highlight on today's date in To-Dos cal

### DIFF
--- a/website/client/assets/scss/datepicker.scss
+++ b/website/client/assets/scss/datepicker.scss
@@ -8,7 +8,6 @@
     .cell.selected, 
     .cell.selected.highlighted, 
     .cell.selected:hover {
-        border-radius: 2px;
         color: $white;
         background: $purple-300;
     }
@@ -20,6 +19,7 @@
 
     .cell.highlighted,
     .cell.selected {
+        border-radius: 2px;
         font-weight: bold;
     }
 

--- a/website/client/assets/scss/datepicker.scss
+++ b/website/client/assets/scss/datepicker.scss
@@ -1,0 +1,28 @@
+
+@import '~client/assets/scss/colors.scss';
+
+.vdp-datepicker .vdp-datepicker__calendar  {
+
+    .cell:not(.blank):not(.disabled).day:hover {
+        border-radius: 2px;
+        border: 1px solid $purple-400;
+    }
+    
+    .cell.selected, 
+    .cell.selected.highlighted, 
+    .cell.selected:hover {
+        border-radius: 2px;
+        color: $white;
+        background: $purple-400;
+    }
+
+    .cell.highlighted {
+        background: rgba($purple-400, 0.24);
+    }
+
+    .cell.highlighted,
+    .cell.selected {
+        font-weight: bold;
+    }
+
+}

--- a/website/client/assets/scss/datepicker.scss
+++ b/website/client/assets/scss/datepicker.scss
@@ -1,6 +1,3 @@
-
-@import '~client/assets/scss/colors.scss';
-
 .vdp-datepicker .vdp-datepicker__calendar  {
 
     .cell:not(.blank):not(.disabled).day:hover {
@@ -13,11 +10,12 @@
     .cell.selected:hover {
         border-radius: 2px;
         color: $white;
-        background: $purple-400;
+        background: $purple-300;
     }
 
     .cell.highlighted {
         background: rgba($purple-400, 0.24);
+        color: $purple-200;
     }
 
     .cell.highlighted,

--- a/website/client/assets/scss/index.scss
+++ b/website/client/assets/scss/index.scss
@@ -37,3 +37,4 @@
 @import './iconalert';
 @import './tiers';
 @import './payments';
+@import './datepicker.scss';

--- a/website/client/components/tasks/taskModal.vue
+++ b/website/client/components/tasks/taskModal.vue
@@ -251,7 +251,6 @@
 
 <style lang="scss">
   @import '~client/assets/scss/colors.scss';
-  @import '~client/assets/scss/datepicker.scss';
 
   #task-modal {
     .modal-dialog.modal-sm {

--- a/website/client/components/tasks/taskModal.vue
+++ b/website/client/components/tasks/taskModal.vue
@@ -88,7 +88,8 @@
               :clearButtonText='$t("clear")',
               :todayButton='!challengeAccessRequired',
               :todayButtonText='$t("today")',
-              :disabled-picker='challengeAccessRequired'
+              :disabled-picker='challengeAccessRequired',
+              :highlighted='calendarHighlights'
             )
         .option(v-if="task.type === 'daily'")
           .form-group
@@ -717,6 +718,7 @@ export default {
         con: 'constitution',
         per: 'perception',
       },
+      calendarHighlights: { dates: [new Date()]},
     };
   },
   mounted () {

--- a/website/client/components/tasks/taskModal.vue
+++ b/website/client/components/tasks/taskModal.vue
@@ -100,7 +100,8 @@
               :clearButton="false",
               :todayButton="!challengeAccessRequired",
               :todayButtonText="$t('today')",
-              :disabled-picker="challengeAccessRequired"
+              :disabled-picker="challengeAccessRequired",
+              :highlighted='calendarHighlights'
             )
         .option(v-if="task.type === 'daily'")
           .form-group
@@ -250,6 +251,7 @@
 
 <style lang="scss">
   @import '~client/assets/scss/colors.scss';
+  @import '~client/assets/scss/datepicker.scss';
 
   #task-modal {
     .modal-dialog.modal-sm {


### PR DESCRIPTION
### Changes

Added highlight on today's date on the Datepicker within the To-Dos, using `new Date()`, to help make it easier to know where you are on the calendar. Especially useful for people like me that don't know when today is and base things off of time from today rather than some arbitrary date in the future. Admittedly, this is just a personal wishlist item.

<img width="550" alt="Screen Shot 2019-03-14 at 3 50 00 AM" src="https://user-images.githubusercontent.com/392859/54339822-4dc7c380-460c-11e9-9206-73610b8531c9.png">

----
UUID: 949c048a-c49b-434a-97af-cc7603082dec

Made with ❤️by sergeanthacker
