### PR TITLE
allow moderators/staff to always see Report button for a flagged message

### DIFF
--- a/website/client/components/chat/chatCard.vue
+++ b/website/client/components/chat/chatCard.vue
@@ -20,7 +20,7 @@ div
       .action.d-flex.align-items-center(v-if='!inbox', @click='copyAsTodo(msg)')
         .svg-icon(v-html="icons.copy")
         div {{$t('copyAsTodo')}}
-      .action.d-flex.align-items-center(v-if='(inbox || (user.flags.communityGuidelinesAccepted && msg.uuid !== "system")) && !isMessageReported', @click='report(msg)')
+      .action.d-flex.align-items-center(v-if='(inbox || (user.flags.communityGuidelinesAccepted && msg.uuid !== "system")) && (!isMessageReported || user.contributor.admin)', @click='report(msg)')
         .svg-icon(v-html="icons.report", v-once)
         div(v-once) {{$t('report')}}
       .action.d-flex.align-items-center(v-if='msg.uuid === user._id || inbox || user.contributor.admin', @click='remove()')


### PR DESCRIPTION
Currently, when a moderator flags a message, the "Report" button disappears, which means they can't unflag. This behaviour started with the recent flagging change but it's my fault for not testing that functionality.

This PR causes the "Report" button to always be visible for a moderator.

