### PR TITLE
Fixes #11062 Display information message when social authentication account uses password to login

### DIFF
--- a/test/api/v3/integration/user/auth/POST-login-local.test.js
+++ b/test/api/v3/integration/user/auth/POST-login-local.test.js
@@ -110,4 +110,22 @@ describe('POST /user/auth/local/login', () => {
     let isValidPassword = await bcryptCompare(textPassword, user.auth.local.hashed_password);
     expect(isValidPassword).to.equal(true);
   });
+
+  it('user uses social authentication and has no password', async () => {
+    await user.unset({
+      'auth.local.hashed_password': 1,
+    });
+
+    await user.sync();
+    expect(user.auth.local.hashed_password).to.be.undefined;
+
+    await expect(api.post(endpoint, {
+      username: user.auth.local.username,
+      password: 'any-password',
+    })).to.eventually.be.rejected.and.eql({
+      code: 401,
+      error: 'NotAuthorized',
+      message: t('invalidLoginCredentialsLong'),
+    });
+  });
 });

--- a/test/helpers/api-integration/api-classes.js
+++ b/test/helpers/api-integration/api-classes.js
@@ -4,6 +4,7 @@ import { requester } from './requester';
 import {
   getDocument as getDocumentFromMongo,
   updateDocument as updateDocumentInMongo,
+  unsetDocument as unsetDocumentInMongo,
 } from '../mongo';
 import {
   assign,
@@ -25,6 +26,18 @@ class ApiObject {
     await updateDocumentInMongo(this._docType, this, options);
 
     _updateLocalParameters(this, options);
+
+    return this;
+  }
+
+  async unset (options) {
+    if (isEmpty(options)) {
+      return;
+    }
+
+    await unsetDocumentInMongo(this._docType, this, options);
+
+    _updateLocalParameters((this, options));
 
     return this;
   }

--- a/test/helpers/mongo.js
+++ b/test/helpers/mongo.js
@@ -98,6 +98,19 @@ export async function updateDocument (collectionName, doc, update) {
   });
 }
 
+// Unset a property in the database.
+// Useful for testing.
+export async function unsetDocument (collectionName, doc, update) {
+  let collection = mongoose.connection.db.collection(collectionName);
+
+  return new Promise((resolve) => {
+    collection.updateOne({ _id: doc._id }, { $unset: update }, (updateErr) => {
+      if (updateErr) throw new Error(`Error updating ${collectionName}: ${updateErr}`);
+      resolve();
+    });
+  });
+}
+
 export async function getDocument (collectionName, doc) {
   let collection = mongoose.connection.db.collection(collectionName);
 

--- a/website/common/locales/en/front.json
+++ b/website/common/locales/en/front.json
@@ -276,7 +276,6 @@
   "usernameTOSRequirements": "Usernames must conform to our <a href='/static/terms' target='_blank'>Terms of Service</a> and <a href='/static/community-guidelines' target='_blank'>Community Guidelines</a>. If you didn’t previously set a login name, your username was auto-generated.",
   "usernameTaken": "Username already taken.",
   "passwordConfirmationMatch": "Password confirmation doesn't match password.",
-  "invalidLoginCredentials": "Incorrect username and/or email and/or password.",
   "passwordResetPage": "Reset Password",
   "passwordReset": "If we have your email on file, instructions for setting a new password have been sent to your email.",
   "passwordResetEmailSubject": "Password Reset for Habitica",

--- a/website/server/controllers/api-v3/auth.js
+++ b/website/server/controllers/api-v3/auth.js
@@ -98,6 +98,9 @@ api.loginLocal = {
     // load the entire user because we may have to save it to convert the password to bcrypt
     let user = await User.findOne(login).exec();
 
+    // if user is using social login, then user will not have a hashed_password stored
+    if (!user.auth.local.hashed_password) throw new NotAuthorized(res.t('invalidLoginCredentialsLong'));
+
     let isValidPassword;
 
     if (!user) {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: #11062  (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11062
### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
1. Added a check for existence of user password before proceeding to authenticate the user. 
2. Removed unused string constant "invalidLoginCredentials" 
3. Added test case for user with no password (uses social authentication)
4. Added new method inside `ApiObject` to unset fields for testing


[//]: #cf6b1c9e-6257-46d5-8e44-da48fc954282
 (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: cf6b1c9e-6257-46d5-8e44-da48fc954282
