### PR TITLE
Less hacky (but still hacky) fix for equip modal shenanigans

### DIFF
--- a/website/client/components/inventory/equipment/equipGearModal.vue
+++ b/website/client/components/inventory/equipment/equipGearModal.vue
@@ -4,7 +4,6 @@
     v-if="item != null",
     :hide-header="true",
     @change="onChange($event)"
-    @hide="fixDocBody()"
   )
     div.close
       span.svg-icon.inline.icon-10(aria-hidden="true", v-html="icons.close", @click="hideDialog()")
@@ -187,17 +186,9 @@
         this.hideDialog();
       },
       hideDialog () {
-        this.$root.$emit('bv::hide::modal', 'equipgear-modal');
-      },
-      fixDocBody () {
-        document.body.classList.remove('modal-open');
-        if (document.body.getAttribute('data-modal-open-count') <= 1) {
-          document.body.removeAttribute('data-modal-open-count');
-        } else {
-          document.body.setAttribute('data-modal-open-count', document.body.getAttribute('data-modal-open-count') - 1);
-        }
-        document.body.removeAttribute('data-padding-right');
-        document.body.style.removeProperty('padding-right');
+        this.visible = false;
+        this.onChange(false);
+        // this.$root.$emit('bv::hide::modal', 'equipgear-modal');
       },
       memberOverrideAvatarGear (gear) {
         return {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Continuing partial fixage for #11015 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

While researching to provide more information to the Bootstrap-Vue folks on https://github.com/bootstrap-vue/bootstrap-vue/issues/2809, I discovered that if we toggle the `visible` property of the modal component rather than emit `bv::hide::modal`, the modal closes cleanly without needing to hack the document body ourselves.

I haven't been able to reproduce the other situations where modal scrollbars get stuck, unfortunately. :\

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)