### PR TITLE
Add min-width to PM for wrapping fixes #11060

### DIFF
--- a/website/client/components/chat/chatMessages.vue
+++ b/website/client/components/chat/chatMessages.vue
@@ -93,6 +93,10 @@
     padding: 0rem;
     width: 90%;
   }
+
+  .message-scroll .d-flex {
+    min-width: 1px;
+  }
 </style>
 
 <script>


### PR DESCRIPTION
Fixes #11060

To be honest, I don't really understand why this works... but it does. I got the fix from [a discussion on SO](https://stackoverflow.com/questions/12022288/how-to-keep-a-flex-item-from-overflowing-due-to-its-text) that seems to point to it being a bug in Chrome.

### Changes
1. Add min-width to the `.d-flex` container

<img width="808" alt="Screen Shot 2019-03-23 at 3 19 56 PM" src="https://user-images.githubusercontent.com/392859/54870598-2779f480-4d7f-11e9-88b9-52cb66900e16.png">
<img width="791" alt="Screen Shot 2019-03-23 at 3 19 43 PM" src="https://user-images.githubusercontent.com/392859/54870599-2a74e500-4d7f-11e9-84c2-eae852ef02c0.png">
<img width="795" alt="Screen Shot 2019-03-23 at 3 19 27 PM" src="https://user-images.githubusercontent.com/392859/54870601-2c3ea880-4d7f-11e9-9c55-080cff49da89.png">


----
UUID: 949c048a-c49b-434a-97af-cc7603082dec

Made with ❤️ by sergeanthacker