### PR TITLE
Making Hall of Heroes username link to profile Fixes #11014

### DIFF
--- a/website/client/components/hall/heroes.vue
+++ b/website/client/components/hall/heroes.vue
@@ -86,11 +86,11 @@
           tr(v-for='(hero, index) in heroes')
             td
               span(v-if='hero.contributor && hero.contributor.admin', :popover="$t('gamemaster')", popover-trigger='mouseenter', popover-placement='right')
-                .label.label-default(:class='userLevelStyle(hero)')
+                router-link.label.label-default(:class='userLevelStyle(hero)', :to="{'name': 'userProfile', 'params': {'userId': hero._id}}")
                   | {{hero.profile.name}}&nbsp;
                   //- span(v-class='userAdminGlyphiconStyle(hero)')
               span(v-if='!hero.contributor || !hero.contributor.admin')
-                .label.label-default(v-if='hero.profile', v-class='userLevelStyle(hero)') {{hero.profile.name}}
+                router-link.label.label-default(v-if='hero.profile', v-class='userLevelStyle(hero)', :to="{'name': 'userProfile', 'params': {'userId': hero._id}}") {{hero.profile.name}}
             td(v-if='user.contributor.admin', @click='populateContributorInput(hero._id, index)').btn-link {{hero._id}}
             td {{hero.contributor.level}}
             td {{hero.contributor.text}}


### PR DESCRIPTION
Wanted to tackle a small fun one tonight. I made the HoH username a clickable link to the user profile.

Fixes #11014

### Changes
1. Made the divs surrounding the username a link.

----
UUID: 949c048a-c49b-434a-97af-cc7603082dec

Made with ❤️ by sergeanthacker
