### PR TITLE
Add message of cancelled quest in party chat

### DIFF
--- a/test/api/v3/integration/quests/POST-groups_groupid_quests_cancel.test.js
+++ b/test/api/v3/integration/quests/POST-groups_groupid_quests_cancel.test.js
@@ -99,6 +99,10 @@ describe('POST /groups/:groupId/quests/cancel', () => {
   it('cancels a quest', async () => {
     await leader.post(`/groups/${questingGroup._id}/quests/invite/${PET_QUEST}`);
     await partyMembers[0].post(`/groups/${questingGroup._id}/quests/accept`);
+    // partyMembers[1] hasn't accepted the invitation, because if he accepts, invitation phase ends.
+    // The cancel command can be done only in the invitation phase.
+
+    let stub = sandbox.spy(Group.prototype, 'sendChat');
 
     let res = await leader.post(`/groups/${questingGroup._id}/quests/cancel`);
 
@@ -135,5 +139,9 @@ describe('POST /groups/:groupId/quests/cancel', () => {
       },
       members: {},
     });
+    expect(Group.prototype.sendChat).to.be.calledOnce;
+    expect(Group.prototype.sendChat).to.be.calledWithMatch(/cancelled the party quest Wail of the Whale.`/);
+
+    stub.restore();
   });
 });

--- a/test/api/v3/integration/quests/POST-groups_groupid_quests_cancel.test.js
+++ b/test/api/v3/integration/quests/POST-groups_groupid_quests_cancel.test.js
@@ -4,6 +4,7 @@ import {
   generateUser,
 } from '../../../../helpers/api-integration/v3';
 import { v4 as generateUUID } from 'uuid';
+import { model as Group } from '../../../../../website/server/models/group';
 
 describe('POST /groups/:groupId/quests/cancel', () => {
   let questingGroup;

--- a/website/server/controllers/api-v3/quests.js
+++ b/website/server/controllers/api-v3/quests.js
@@ -372,12 +372,12 @@ api.cancelQuest = {
 
     let questName = questScrolls[group.quest.key].text('en');
     const newChatMessage = group.sendChat(`\`${user.profile.name} cancelled the party quest ${questName}.\``);
-    await newChatMessage.save();
 
     group.quest = Group.cleanGroupQuest();
     group.markModified('quest');
 
     let [savedGroup] = await Promise.all([
+      newChatMessage.save(),
       group.save(),
       User.update(
         {'party._id': groupId},

--- a/website/server/controllers/api-v3/quests.js
+++ b/website/server/controllers/api-v3/quests.js
@@ -363,13 +363,13 @@ api.cancelQuest = {
     if (validationErrors) throw validationErrors;
 
     let group = await Group.getGroup({user, groupId, fields: basicGroupFields.concat(' quest')});
-    
+
     if (!group) throw new NotFound(res.t('groupNotFound'));
     if (group.type !== 'party') throw new NotAuthorized(res.t('guildQuestsNotSupported'));
     if (!group.quest.key) throw new NotFound(res.t('questInvitationDoesNotExist'));
     if (user._id !== group.leader && group.quest.leader !== user._id) throw new NotAuthorized(res.t('onlyLeaderCancelQuest'));
     if (group.quest.active) throw new NotAuthorized(res.t('cantCancelActiveQuest'));
-    
+
     let questName = questScrolls[group.quest.key].text('en');
     const newChatMessage = group.sendChat(`\`${user.profile.name} cancelled the party quest ${questName}.\``);
     await newChatMessage.save();

--- a/website/server/controllers/api-v3/quests.js
+++ b/website/server/controllers/api-v3/quests.js
@@ -377,8 +377,8 @@ api.cancelQuest = {
     group.markModified('quest');
 
     let [savedGroup] = await Promise.all([
-      newChatMessage.save(),
       group.save(),
+      newChatMessage.save(),
       User.update(
         {'party._id': groupId},
         Group.cleanQuestParty(),

--- a/website/server/controllers/api-v3/quests.js
+++ b/website/server/controllers/api-v3/quests.js
@@ -363,11 +363,16 @@ api.cancelQuest = {
     if (validationErrors) throw validationErrors;
 
     let group = await Group.getGroup({user, groupId, fields: basicGroupFields.concat(' quest')});
+    
     if (!group) throw new NotFound(res.t('groupNotFound'));
     if (group.type !== 'party') throw new NotAuthorized(res.t('guildQuestsNotSupported'));
     if (!group.quest.key) throw new NotFound(res.t('questInvitationDoesNotExist'));
     if (user._id !== group.leader && group.quest.leader !== user._id) throw new NotAuthorized(res.t('onlyLeaderCancelQuest'));
     if (group.quest.active) throw new NotAuthorized(res.t('cantCancelActiveQuest'));
+    
+    let questName = questScrolls[group.quest.key].text('en');
+    const newChatMessage = group.sendChat(`\`${user.profile.name} cancelled the party quest ${questName}.\``);
+    await newChatMessage.save();
 
     group.quest = Group.cleanGroupQuest();
     group.markModified('quest');
@@ -405,7 +410,7 @@ api.abortQuest = {
   url: '/groups/:groupId/quests/abort',
   middlewares: [authWithHeaders()],
   async handler (req, res) {
-    // Abort a quest AFTER it has begun (see questCancel for BEFORE)
+    // Abort a quest AFTER it has begun
     let user = res.locals.user;
     let groupId = req.params.groupId;
 


### PR DESCRIPTION
Fixes #11093

### Changes
- A message of cancelling a quest that's still in the invitation phase will be displayed in the party chat

![github](https://user-images.githubusercontent.com/46248839/55645335-fa96fa00-57e0-11e9-8296-0feba814c40b.png)

- Change the comment due to function's renaming (`questCancel`->`cancelQuest`)

----
UUID: af1477b6-509a-4611-b851-d7a8e3a9c02a