### PR TITLE
Fix 500 server error when trying to log in with wrong username

### DIFF
--- a/website/server/controllers/api-v3/auth.js
+++ b/website/server/controllers/api-v3/auth.js
@@ -99,7 +99,7 @@ api.loginLocal = {
     let user = await User.findOne(login).exec();
 
     // if user is using social login, then user will not have a hashed_password stored
-    if (!user.auth.local.hashed_password) throw new NotAuthorized(res.t('invalidLoginCredentialsLong'));
+    if (!user || !user.auth.local.hashed_password) throw new NotAuthorized(res.t('invalidLoginCredentialsLong'));
 
     let isValidPassword;
 


### PR DESCRIPTION
Adds a check to see if the user even exists before checking if a hashed password exists. Otherwise there is a 500 server error, because user is null and then you can't access the auth property on that.