### PR TITLE
fix loading owned messages

### DIFF
--- a/website/server/controllers/api-v3/challenges.js
+++ b/website/server/controllers/api-v3/challenges.js
@@ -364,12 +364,14 @@ api.getUserChallenges = {
       $and: [{$or: orOptions}],
     };
 
-    if (owned && owned === 'not_owned') {
-      query.$and.push({leader: {$ne: user._id}});
-    }
+    if (owned) {
+      if (owned === 'not_owned') {
+        query.$and = [{leader: {$ne: user._id}}];
+      }
 
-    if (owned && owned === 'owned') {
-      query.$and.push({leader: user._id});
+      if (owned === 'owned') {
+        query.$and = [{leader: user._id}];
+      }
     }
 
     if (req.query.search) {
@@ -399,7 +401,6 @@ api.getUserChallenges = {
     // .populate('group', basicGroupFields)
     // .populate('leader', nameFields)
     const challenges = await mongoQuery.exec();
-
 
     let resChals = challenges.map(challenge => challenge.toJSON());
 


### PR DESCRIPTION
fixes #11145 

this was a filter issue having a list of the group-challenges and using $and with `leader` resulted in none, this should be correct now