### PR TITLE
FIX:moment().zone is deprecated

### DIFF
--- a/website/common/script/cron.js
+++ b/website/common/script/cron.js
@@ -32,7 +32,7 @@ function sanitizeOptions (o) {
   let dayStart = !Number.isNaN(ref) && ref >= 0 && ref <= 24 ? ref : 0;
 
   let timezoneOffset;
-  let timezoneOffsetDefault = Number(moment().zone());
+  let timezoneOffsetDefault = Number(moment().utcOffset());
 
   if (isFinite(o.timezoneOffsetOverride)) {
     timezoneOffset = Number(o.timezoneOffsetOverride);
@@ -46,7 +46,7 @@ function sanitizeOptions (o) {
     timezoneOffset = timezoneOffsetDefault;
   }
 
-  let now = o.now ? moment(o.now).zone(timezoneOffset) : moment().zone(timezoneOffset);
+  let now = o.now ? moment(o.now).utcOffset(timezoneOffset) : moment().utcOffset(timezoneOffset);
   // return a new object, we don't want to add "now" to user object
   return {
     dayStart,
@@ -106,7 +106,7 @@ export function shouldDo (day, dailyTask, options = {}) {
   // Therefore, we must also ignore the time portion of the user's day start (startOfDayWithCDSTime), otherwise the date comparison will be wrong for some times.
   // NB: The user's day start date has already been converted to the PREVIOUS day's date if the time portion was before CDS.
 
-  let startDate = moment(dailyTask.startDate).zone(o.timezoneOffset).startOf('day');
+  let startDate = moment(dailyTask.startDate).utcOffset(o.timezoneOffset).startOf('day');
 
   if (startDate > startOfDayWithCDSTime.startOf('day') && !options.nextDue) {
     return false; // Daily starts in the future

--- a/website/server/libs/cron.js
+++ b/website/server/libs/cron.js
@@ -145,7 +145,7 @@ function resetHabitCounters (user, tasksByType, now, daysMissed) {
     if (resetWeekly === true && resetMonthly === true) {
       break;
     }
-    let thatDay = moment(now).zone(user.preferences.timezoneOffset + user.preferences.dayStart * 60).subtract({days: i});
+    let thatDay = moment(now).utcOffset(user.preferences.timezoneOffset + user.preferences.dayStart * 60).subtract({days: i});
     if (thatDay.day() === 1) {
       resetWeekly = true;
     }


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes put_#_and_issue_numer_here- Custom Day Start time is not used for displaying To-Do due dates #11139

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
moment.zone() is deprecated so it is changed to moment.utcOffset() 


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 
