### PR TITLE
change "Load Tools" profile icon that mods and staff use from pencil to crown

### DIFF
--- a/website/client/components/userMenu/profile.vue
+++ b/website/client/components/userMenu/profile.vue
@@ -14,7 +14,7 @@
         .svg-icon.positive-icon(v-html="icons.positive")
       button.btn.btn-secondary.positive-icon(v-if='this.userLoggedIn.contributor.admin && !adminToolsLoaded',
         @click="loadAdminTools()", v-b-tooltip.hover.right="'Admin - Load Tools'")
-        .svg-icon.positive-icon(v-html="icons.edit")
+        .svg-icon.positive-icon(v-html="icons.staff")
       span(v-if='this.userLoggedIn.contributor.admin && adminToolsLoaded')
         button.btn.btn-secondary.positive-icon(v-if='!hero.flags || (hero.flags && !hero.flags.chatRevoked)',
           @click="adminRevokeChat()", v-b-tooltip.hover.bottom="'Admin - Revoke Chat Privileges'")
@@ -407,7 +407,7 @@ import megaphone from 'assets/svg/broken-megaphone.svg';
 import lock from 'assets/svg/lock.svg';
 import challenge from 'assets/svg/challenge.svg';
 import member from 'assets/svg/member-icon.svg';
-import edit from 'assets/svg/edit.svg';
+import staff from 'assets/svg/tier-staff.svg';
 
 export default {
   props: ['userId', 'startingPage'],
@@ -430,7 +430,7 @@ export default {
         challenge,
         lock,
         member,
-        edit,
+        staff,
       }),
       adminToolsLoaded: false,
       userIdToMessage: '',


### PR DESCRIPTION
When mods and staff view a player's profile, they see a "Load Tools" icon for special mod actions (e.g., banning the player from the site). Currently it's a pencil icon:
![image](https://user-images.githubusercontent.com/1495809/57692157-6d6d7d80-7689-11e9-84c7-a9ef20d262ed.png)

This PR changes it to a crown icon:
![image](https://user-images.githubusercontent.com/1495809/57692273-b9b8bd80-7689-11e9-8cad-626d1b73e0c2.png)

Note that mods and staff are the only people who can see that crown icon so normal design considerations don't apply here.

The crown icon makes it clearer to us that it's for the special mod/staff tools. The pencil icon is too similar to normal edit/compose icons and we were sometimes clicking it by mistake (with an accidental double-click once resulting in a user being briefly banned by mistake since the ban icon is directly "under" the Load Tools icon).

I've checked with the other mods and they feel that the crown will avoid that problem.
