### PR TITLE
hides item count in quest sidebar section for non-participants - Fixes #11168

### DIFF
--- a/website/client/components/groups/questSidebarSection.vue
+++ b/website/client/components/groups/questSidebarSection.vue
@@ -35,7 +35,7 @@ sidebar-section(:title="$t('questDetailsTitle')")
               .grey-progress-bar
                 .collect-progress-bar(:style="{width: (group.quest.progress.collect[key] / value.count) * 100 + '%'}")
               strong {{group.quest.progress.collect[key]}} / {{value.count}}
-          div.text-right {{parseFloat(user.party.quest.progress.collectedItems) || 0}} items found
+          div.text-right(v-if='userIsOnQuest') {{parseFloat(user.party.quest.progress.collectedItems) || 0}} items found
         .boss-info(v-if='questData.boss')
           .row
             .col-6


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11168 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
![image](https://user-images.githubusercontent.com/7713603/58008979-77451580-7abb-11e9-9421-196a320ec04b.png)



[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: e85452ec-b96d-474d-a222-8d4ba9c1497d

