### PR TITLE
Fixed styling bug on stats profile page.

### DIFF
--- a/website/client/assets/scss/popover.scss
+++ b/website/client/assets/scss/popover.scss
@@ -15,7 +15,7 @@
 
 .popover-title-only {
   color: $white;
-  margin-bottom: 20px;
+  margin-bottom: 24px;
 }
 .popover-body {
   padding: 12px 16px;

--- a/website/client/assets/scss/popover.scss
+++ b/website/client/assets/scss/popover.scss
@@ -12,6 +12,11 @@
   }
 }
 
+
+.popover-title-only {
+  color: $white;
+  margin-bottom: 20px;
+}
 .popover-body {
   padding: 12px 16px;
   text-align: center;

--- a/website/client/components/userMenu/profile.vue
+++ b/website/client/components/userMenu/profile.vue
@@ -152,11 +152,6 @@
       background: #f9f9f9;
     }
 
-    .gearTitle {
-      color: white;
-      margin-bottom: 20px;
-    }
-
     .progress-container > .progress {
       background-color: $gray-500 !important;
       height: 16px !important;
@@ -327,11 +322,6 @@
         border-radius: 1px;
         background-color: $gray-500;
       }
-    }
-
-    .gearTitle {
-      color: white;
-      margin-bottom: 20px;
     }
 
   .profile-section {

--- a/website/client/components/userMenu/profileStats.vue
+++ b/website/client/components/userMenu/profileStats.vue
@@ -18,7 +18,7 @@
               :placement="'bottom'",
               :preventOverflow="false",
             )
-              h4.gearTitle {{ getGearTitle(equippedItems[key]) }}
+              h4.popover-title-only {{ getGearTitle(equippedItems[key]) }}
               attributesGrid.attributesGrid(
                 :item="content.gear.flat[equippedItems[key]]",
                 :user="user"
@@ -49,7 +49,7 @@
               :placement="'bottom'",
               :preventOverflow="false",
             )
-              h4.gearTitle {{ getGearTitle(costumeItems[key]) }}
+              h4.popover-title-only {{ getGearTitle(costumeItems[key]) }}
               attributesGrid.attributesGrid(
                :item="content.gear.flat[costumeItems[key]]",
                :user="user"


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

Fixes #10992

### Changes
`gearTitle` wasn't defined in the class that was using it. In order to prevent this in the future, I moved the `gearTitle` class to the `popover.scss` and renamed it `popover-title-only`. All that remained was to use this style in `profileStats.vue`. Also removed `gearTitle` from `profile.vue`. 



User ID: e2961727-f1de-46f5-9b7a-3e4a9bd66cc8

----
UUID: 
