### PR TITLE
Challenge privacy fix

### DIFF
--- a/test/api/v3/integration/challenges/GET-challenges_user.test.js
+++ b/test/api/v3/integration/challenges/GET-challenges_user.test.js
@@ -171,7 +171,7 @@ describe('GET challenges/user', () => {
       });
     });
 
-    it('should return not return challenges in user groups if we send member true param', async () => {
+    it('should not return challenges in user groups if we send member true param', async () => {
       let challenges = await member.get(`/challenges/user?member=${true}`);
 
       let foundChallenge1 = _.find(challenges, { _id: challenge._id });
@@ -210,6 +210,28 @@ describe('GET challenges/user', () => {
       await groupLeader.post(`/challenges/${privateChallenge._id}/join`);
 
       let challenges = await nonMember.get('/challenges/user');
+
+      let foundChallenge = _.find(challenges, { _id: privateChallenge._id });
+      expect(foundChallenge).to.not.exist;
+    });
+
+    it('should not return challenges user doesn\'t have access to, even with query parameters', async () => {
+      let { group, groupLeader } = await createAndPopulateGroup({
+        groupDetails: {
+          name: 'TestPrivateGuild',
+          summary: 'summary for TestPrivateGuild',
+          type: 'guild',
+          privacy: 'private',
+        },
+      });
+
+      let privateChallenge = await generateChallenge(groupLeader, group, {categories: [{
+        name: 'academics',
+        slug: 'academics',
+      }]});
+      await groupLeader.post(`/challenges/${privateChallenge._id}/join`);
+
+      let challenges = await nonMember.get('/challenges/user?categories=academics&owned=not_owned');
 
       let foundChallenge = _.find(challenges, { _id: privateChallenge._id });
       expect(foundChallenge).to.not.exist;

--- a/website/server/controllers/api-v3/challenges.js
+++ b/website/server/controllers/api-v3/challenges.js
@@ -419,6 +419,11 @@ api.getUserChallenges = {
       });
     }));
 
+    // Filter out challenges the user should not have access to, i.e., from private groups they don't belong to
+    resChals = resChals.filter((chal) => {
+      return chal.group.privacy === 'public' || user.getGroups().indexOf(chal.group._id) !== -1;
+    });
+
     res.respond(200, resChals);
   },
 };

--- a/website/server/controllers/api-v3/challenges.js
+++ b/website/server/controllers/api-v3/challenges.js
@@ -366,11 +366,11 @@ api.getUserChallenges = {
 
     if (owned) {
       if (owned === 'not_owned') {
-        query.$and = [{leader: {$ne: user._id}}];
+        query.$and.push({leader: {$ne: user._id}});
       }
 
       if (owned === 'owned') {
-        query.$and = [{leader: user._id}];
+        query.$and.push({leader: user._id});
       }
     }
 
@@ -418,11 +418,6 @@ api.getUserChallenges = {
         resChals[index].group = populatedData[1] ? populatedData[1].toJSON({minimize: true}) : null;
       });
     }));
-
-    // Filter out challenges the user should not have access to, i.e., from private groups they don't belong to
-    resChals = resChals.filter((chal) => {
-      return chal.group.privacy === 'public' || user.getGroups().indexOf(chal.group._id) !== -1;
-    });
 
     res.respond(200, resChals);
   },


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

**Previously**, the `owned` query parameter was overriding the default query options for fetching the Challenge list, causing inappropriate Challenges to appear when the user applied the "Not Owned" option in Challenge discovery.

**Now**, the `owned` parameter refines the query rather than replacing it, allowing the baseline logic to continue filtering out Challenges that should not be visible to the user.