### PR TITLE
Fix task dropdown menu overflow

### DIFF
--- a/website/client/app.vue
+++ b/website/client/app.vue
@@ -57,6 +57,7 @@ div
     display: flex;
     flex-direction: column;
     min-height: 100vh;
+    overflow-x: hidden;
   }
 
   #loading-screen-inapp {
@@ -89,7 +90,6 @@ div
   }
 
   .container-fluid {
-    overflow-x: hidden;
     flex: 1 0 auto;
   }
 

--- a/website/client/components/appFooter.vue
+++ b/website/client/components/appFooter.vue
@@ -113,11 +113,11 @@
   .footer-row {
     margin: 0;
     flex: 0 1 auto;
+    z-index: 17;
   }
 
   footer {
     color: #c3c0c7;
-    z-index: 17;
     padding-bottom: 3em;
 
     a {


### PR DESCRIPTION
Fixes #11227

### Changes
![image](https://user-images.githubusercontent.com/2582617/59569892-31ff0e00-9090-11e9-9738-6d673468d10b.png)

While I am essentially just moving two lines of code, there is a lot of trial-and-error behind them. To make the dropdown menu properly overlap, I had to solve two obstacles:

1. The `container-fluid` class needs to allow overflow, otherwise it will clip the dropdown. This was accomplished by simply removing `overflow-x: hidden;`, reverting it to the default `visible`. What has this to do with the x-axis? No idea. CSS is magic. This breaks the layout, so I moved `overflow-x: hidden;` to `#app` instead.
2. For z-index to render over another div, the DOM elements needs to be in the same stacking context[1], as far as I understand. This is accomplished by explicitly setting the z-index of the footer-row. Here I can just move it from the header.

[1] https://philipwalton.com/articles/what-no-one-told-you-about-z-index/

----
UUID: de91221c-6b7e-4614-8854-c5c6a6d3ffe7
