### PR TITLE
Enable keyboard shortcuts for autocomplete @username selection in chat

### DIFF
--- a/website/client/components/chat/autoComplete.vue
+++ b/website/client/components/chat/autoComplete.vue
@@ -27,6 +27,7 @@
 
   .hover-background {
     background-color: rgba(213, 200, 255, 0.32);
+    cursor: pointer;
   }
 
   .hover-foreground {

--- a/website/client/components/chat/autoComplete.vue
+++ b/website/client/components/chat/autoComplete.vue
@@ -3,8 +3,8 @@
   .autocomplete-results.d-flex.align-items-center(
     v-for='result in searchResults',
     @click='select(result)',
-    @mouseenter='result.hover = true',
-    @mouseleave='result.hover = false',
+    @mouseenter='setHover(result)',
+    @mouseleave='resetSelection()',
     :class='{"hover-background": result.hover}',
   )
     span
@@ -87,6 +87,7 @@ export default {
         tier9,
         tierNPC,
       }),
+      selected: null,
     };
   },
   computed: {
@@ -121,12 +122,6 @@ export default {
   mounted () {
     this.grabUserNames();
   },
-  created () {
-    document.addEventListener('keyup', this.handleEsc);
-  },
-  destroyed () {
-    document.removeEventListener('keyup', this.handleEsc);
-  },
   watch: {
     text (newText) {
       if (!newText[newText.length - 1] || newText[newText.length - 1] === ' ') {
@@ -155,6 +150,7 @@ export default {
       this.searchActive = false;
       this.searchEscaped = false;
       this.tmpSelections = [];
+      this.resetSelection();
     },
     grabUserNames () {
       let usersThatMessage = groupBy(this.chat, 'user');
@@ -190,12 +186,49 @@ export default {
       const targetName = `${result.username || result.displayName} `;
       newText = newText.replace(new RegExp(`${this.currentSearch}$`), targetName);
       this.$emit('select', newText);
+      this.resetSelection();
     },
-    handleEsc (e) {
-      if (e.keyCode === 27) {
-        this.searchActive = false;
-        this.searchEscaped = true;
+    setHover (result) {
+      this.resetSelection();
+      result.hover = true;
+    },
+    clearHover () {
+      for (const selection of this.searchResults) {
+        selection.hover = false;
       }
+    },
+    resetSelection () {
+      this.clearHover();
+      this.selected = null;
+    },
+    selectNext () {
+      if (this.searchResults.length > 0) {
+        this.clearHover();
+        this.selected = this.selected === null ?
+          0 :
+          (this.selected + 1) % this.searchResults.length;
+        this.searchResults[this.selected].hover = true;
+      }
+    },
+    selectPrevious () {
+      if (this.searchResults.length > 0) {
+        this.clearHover();
+        this.selected = this.selected === null ?
+          this.searchResults.length - 1 :
+          (this.selected - 1 + this.searchResults.length) % this.searchResults.length;
+        this.searchResults[this.selected].hover = true;
+      }
+    },
+    makeSelection () {
+      if (this.searchResults.length > 0 && this.selected !== null) {
+        const result = this.searchResults[this.selected];
+        this.select(result);
+      }
+    },
+    cancel () {
+      this.searchActive = false;
+      this.searchEscaped = true;
+      this.resetSelection();
     },
   },
   mixins: [styleHelper],

--- a/website/client/components/groups/chat.vue
+++ b/website/client/components/groups/chat.vue
@@ -11,11 +11,17 @@
                   :class='{"user-entry": newMessage}',
                   @keydown='updateCarretPosition',
                   @keyup.ctrl.enter='sendMessageShortcut()',
+                  @keydown.tab='handleTab($event)',
+                  @keydown.up='selectPreviousAutocomplete($event)',
+                  @keydown.down='selectNextAutocomplete($event)',
+                  @keydown.enter='selectAutocomplete($event)',
+                  @keydown.esc='handleEscape($event)',
                   @paste='disableMessageSendShortcut()',
                   maxlength='3000'
                 )
         span {{ currentLength }} / 3000
         autocomplete(
+                ref='autocomplete',
                 :text='newMessage',
                 v-on:select="selectedAutocomplete",
                 :textbox='textbox',
@@ -163,6 +169,45 @@
           this.chat.submitTimeout = null;
           this.chat.submitDisable = false;
         }, 500);
+      },
+
+      handleTab (e) {
+        if (this.$refs.autocomplete.searchActive) {
+          e.preventDefault();
+          if (e.shiftKey) {
+            this.$refs.autocomplete.selectPrevious();
+          } else {
+            this.$refs.autocomplete.selectNext();
+          }
+        }
+      },
+
+      handleEscape (e) {
+        if (this.$refs.autocomplete.searchActive) {
+          e.preventDefault();
+          this.$refs.autocomplete.cancel();
+        }
+      },
+
+      selectNextAutocomplete (e) {
+        if (this.$refs.autocomplete.searchActive) {
+          e.preventDefault();
+          this.$refs.autocomplete.selectNext();
+        }
+      },
+
+      selectPreviousAutocomplete (e) {
+        if (this.$refs.autocomplete.searchActive) {
+          e.preventDefault();
+          this.$refs.autocomplete.selectPrevious();
+        }
+      },
+
+      selectAutocomplete (e) {
+        if (this.$refs.autocomplete.searchActive) {
+          e.preventDefault();
+          this.$refs.autocomplete.makeSelection();
+        }
       },
 
       selectedAutocomplete (newText) {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #9291 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

- Enable keyboard shortcuts for chat autocomplete
  - Tab/down to select next
  - Shift-tab/up to select previous
  - Enter to make selection
  - Escape to cancel
- Chat autocomplete mouse hover styling: use cursor pointer to feel more clickable.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 5ffee717-5618-4429-b161-981d79842f8a

