### PR TITLE
Only includes backticks if they haven't been already included. Fixes …

### DIFF
--- a/website/server/libs/chat/group-chat.js
+++ b/website/server/libs/chat/group-chat.js
@@ -35,23 +35,23 @@ export function translateMessage (lang, info) {
 
   switch (info.type) {
     case 'quest_start':
-      msg = `\`${shared.i18n.t('chatQuestStarted', {questName: questScrolls[info.quest].text(lang)}, lang)}\``;
+      msg = `${shared.i18n.t('chatQuestStarted', {questName: questScrolls[info.quest].text(lang)}, lang)}`;
       break;
 
     case 'boss_damage':
-      msg = `\`${shared.i18n.t('chatBossDamage', {username: info.user, bossName: questScrolls[info.quest].boss.name(lang), userDamage: info.userDamage, bossDamage: info.bossDamage}, lang)}\``;
+      msg = `${shared.i18n.t('chatBossDamage', {username: info.user, bossName: questScrolls[info.quest].boss.name(lang), userDamage: info.userDamage, bossDamage: info.bossDamage}, lang)}`;
       break;
 
     case 'boss_dont_attack':
-      msg = `\`${shared.i18n.t('chatBossDontAttack', {username: info.user, bossName: questScrolls[info.quest].boss.name(lang), userDamage: info.userDamage}, lang)}\``;
+      msg = `${shared.i18n.t('chatBossDontAttack', {username: info.user, bossName: questScrolls[info.quest].boss.name(lang), userDamage: info.userDamage}, lang)}`;
       break;
 
     case 'boss_rage':
-      msg = `\`${questScrolls[info.quest].boss.rage.effect(lang)}\``;
+      msg = `${questScrolls[info.quest].boss.rage.effect(lang)}`;
       break;
 
     case 'boss_defeated':
-      msg = `\`${shared.i18n.t('chatBossDefeated', {bossName: questScrolls[info.quest].boss.name(lang)}, lang)}\``;
+      msg = `${shared.i18n.t('chatBossDefeated', {bossName: questScrolls[info.quest].boss.name(lang)}, lang)}`;
       break;
 
     case 'user_found_items':
@@ -59,43 +59,43 @@ export function translateMessage (lang, info) {
         m.push(`${v} ${questScrolls[info.quest].collect[k].text(lang)}`);
         return m;
       }, []).join(', ');
-      msg = `\`${shared.i18n.t('chatFindItems', {username: info.user, items: foundText}, lang)}\``;
+      msg = `${shared.i18n.t('chatFindItems', {username: info.user, items: foundText}, lang)}`;
       break;
 
     case 'all_items_found':
-      msg = `\`${shared.i18n.t('chatItemQuestFinish', lang)}\``;
+      msg = `${shared.i18n.t('chatItemQuestFinish', lang)}`;
       break;
 
     case 'spell_cast_party':
-      msg = `\`${shared.i18n.t('chatCastSpellParty', {username: info.user, spell: spells[info.class][info.spell].text(lang)}, lang)}\``;
+      msg = `${shared.i18n.t('chatCastSpellParty', {username: info.user, spell: spells[info.class][info.spell].text(lang)}, lang)}`;
       break;
 
     case 'spell_cast_user':
-      msg = `\`${shared.i18n.t('chatCastSpellUser', {username: info.user, spell: spells[info.class][info.spell].text(lang), target: info.target}, lang)}\``;
+      msg = `${shared.i18n.t('chatCastSpellUser', {username: info.user, spell: spells[info.class][info.spell].text(lang), target: info.target}, lang)}`;
       break;
 
     case 'quest_cancel':
-      msg = `\`${shared.i18n.t('chatQuestCancelled', {username: info.user, questName: questScrolls[info.quest].text(lang)}, lang)}\``;
+      msg = `${shared.i18n.t('chatQuestCancelled', {username: info.user, questName: questScrolls[info.quest].text(lang)}, lang)}`;
       break;
 
     case 'quest_abort':
-      msg = `\`${shared.i18n.t('chatQuestAborted', {username: info.user, questName: questScrolls[info.quest].text(lang)}, lang)}\``;
+      msg = `${shared.i18n.t('chatQuestAborted', {username: info.user, questName: questScrolls[info.quest].text(lang)}, lang)}`;
       break;
 
     case 'tavern_quest_completed':
-      msg = `\`${quests[info.quest].completionChat(lang)}\``;
+      msg = `${quests[info.quest].completionChat(lang)}`;
       break;
 
     case 'tavern_boss_rage_tired':
-      msg = `\`${shared.i18n.t('tavernBossTired', {rageName: quests[info.quest].boss.rage.title(lang), bossName: quests[info.quest].boss.name(lang)}, lang)}\``;
+      msg = `${shared.i18n.t('tavernBossTired', {rageName: quests[info.quest].boss.rage.title(lang), bossName: quests[info.quest].boss.name(lang)}, lang)}`;
       break;
 
     case 'tavern_boss_rage':
-      msg = `\`${quests[info.quest].boss.rage[info.scene](lang)}\``;
+      msg = `${quests[info.quest].boss.rage[info.scene](lang)}`;
       break;
 
     case 'tavern_boss_desperation':
-      msg = `\`${quests[info.quest].boss.desperation.text(lang)}\``;
+      msg = `${quests[info.quest].boss.desperation.text(lang)}`;
       break;
 
     case 'claim_task':
@@ -103,5 +103,8 @@ export function translateMessage (lang, info) {
       break;
   }
 
+  if (!msg.includes('\`')) {
+    msg = `\`${msg}\``;
+  }
   return msg;
 }

--- a/website/server/libs/chat/group-chat.js
+++ b/website/server/libs/chat/group-chat.js
@@ -35,23 +35,23 @@ export function translateMessage (lang, info) {
 
   switch (info.type) {
     case 'quest_start':
-      msg = `${shared.i18n.t('chatQuestStarted', {questName: questScrolls[info.quest].text(lang)}, lang)}`;
+      msg = shared.i18n.t('chatQuestStarted', {questName: questScrolls[info.quest].text(lang)}, lang);
       break;
 
     case 'boss_damage':
-      msg = `${shared.i18n.t('chatBossDamage', {username: info.user, bossName: questScrolls[info.quest].boss.name(lang), userDamage: info.userDamage, bossDamage: info.bossDamage}, lang)}`;
+      msg = shared.i18n.t('chatBossDamage', {username: info.user, bossName: questScrolls[info.quest].boss.name(lang), userDamage: info.userDamage, bossDamage: info.bossDamage}, lang);
       break;
 
     case 'boss_dont_attack':
-      msg = `${shared.i18n.t('chatBossDontAttack', {username: info.user, bossName: questScrolls[info.quest].boss.name(lang), userDamage: info.userDamage}, lang)}`;
+      msg = shared.i18n.t('chatBossDontAttack', {username: info.user, bossName: questScrolls[info.quest].boss.name(lang), userDamage: info.userDamage}, lang);
       break;
 
     case 'boss_rage':
-      msg = `${questScrolls[info.quest].boss.rage.effect(lang)}`;
+      msg = questScrolls[info.quest].boss.rage.effect(lang);
       break;
 
     case 'boss_defeated':
-      msg = `${shared.i18n.t('chatBossDefeated', {bossName: questScrolls[info.quest].boss.name(lang)}, lang)}`;
+      msg = shared.i18n.t('chatBossDefeated', {bossName: questScrolls[info.quest].boss.name(lang)}, lang);
       break;
 
     case 'user_found_items':
@@ -59,51 +59,51 @@ export function translateMessage (lang, info) {
         m.push(`${v} ${questScrolls[info.quest].collect[k].text(lang)}`);
         return m;
       }, []).join(', ');
-      msg = `${shared.i18n.t('chatFindItems', {username: info.user, items: foundText}, lang)}`;
+      msg = shared.i18n.t('chatFindItems', {username: info.user, items: foundText}, lang);
       break;
 
     case 'all_items_found':
-      msg = `${shared.i18n.t('chatItemQuestFinish', lang)}`;
+      msg = shared.i18n.t('chatItemQuestFinish', lang);
       break;
 
     case 'spell_cast_party':
-      msg = `${shared.i18n.t('chatCastSpellParty', {username: info.user, spell: spells[info.class][info.spell].text(lang)}, lang)}`;
+      msg = shared.i18n.t('chatCastSpellParty', {username: info.user, spell: spells[info.class][info.spell].text(lang)}, lang);
       break;
 
     case 'spell_cast_user':
-      msg = `${shared.i18n.t('chatCastSpellUser', {username: info.user, spell: spells[info.class][info.spell].text(lang), target: info.target}, lang)}`;
+      msg = shared.i18n.t('chatCastSpellUser', {username: info.user, spell: spells[info.class][info.spell].text(lang), target: info.target}, lang);
       break;
 
     case 'quest_cancel':
-      msg = `${shared.i18n.t('chatQuestCancelled', {username: info.user, questName: questScrolls[info.quest].text(lang)}, lang)}`;
+      msg = shared.i18n.t('chatQuestCancelled', {username: info.user, questName: questScrolls[info.quest].text(lang)}, lang);
       break;
 
     case 'quest_abort':
-      msg = `${shared.i18n.t('chatQuestAborted', {username: info.user, questName: questScrolls[info.quest].text(lang)}, lang)}`;
+      msg = shared.i18n.t('chatQuestAborted', {username: info.user, questName: questScrolls[info.quest].text(lang)}, lang);
       break;
 
     case 'tavern_quest_completed':
-      msg = `${quests[info.quest].completionChat(lang)}`;
+      msg = quests[info.quest].completionChat(lang);
       break;
 
     case 'tavern_boss_rage_tired':
-      msg = `${shared.i18n.t('tavernBossTired', {rageName: quests[info.quest].boss.rage.title(lang), bossName: quests[info.quest].boss.name(lang)}, lang)}`;
+      msg = shared.i18n.t('tavernBossTired', {rageName: quests[info.quest].boss.rage.title(lang), bossName: quests[info.quest].boss.name(lang)}, lang);
       break;
 
     case 'tavern_boss_rage':
-      msg = `${quests[info.quest].boss.rage[info.scene](lang)}`;
+      msg = quests[info.quest].boss.rage[info.scene](lang);
       break;
 
     case 'tavern_boss_desperation':
-      msg = `${quests[info.quest].boss.desperation.text(lang)}`;
+      msg = quests[info.quest].boss.desperation.text(lang);
       break;
 
     case 'claim_task':
-      msg = `${shared.i18n.t('userIsClamingTask', {username: info.user, task: info.task}, lang)}`;
+      msg = shared.i18n.t('userIsClamingTask', {username: info.user, task: info.task}, lang);
       break;
   }
 
-  if (!msg.includes('\`')) {
+  if (!msg.includes('`')) {
     msg = `\`${msg}\``;
   }
   return msg;


### PR DESCRIPTION
…the problem.

[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11202 
<img width="855" alt="Screenshot 2019-06-29 at 19 04 38" src="https://user-images.githubusercontent.com/15756047/60396144-f0656d00-9b3d-11e9-9bf3-2628c6fb0777.png">


### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Affects only messages created by translateMessage function in /website/server/libs/chat/group-chat.js. There doesn't seem to be any other case of displaying double backticks.

Code only includes backticks if they haven't been already included (because they might have been hardcoded in questContent.json).



[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: dd59e7c1-b76a-466e-b301-783b852da699