### PR TITLE
Ask for confirmation when buying quests

### DIFF
--- a/website/client/components/shops/buyModal.vue
+++ b/website/client/components/shops/buyModal.vue
@@ -402,13 +402,8 @@
           return;
         }
 
-        if (this.item.currency === 'gems' &&
-          !confirm(this.$t('purchaseFor', { cost: this.item.value * this.selectedAmountToBuy }))) {
-          return;
-        }
-
-        if (this.item.currency === 'hourglasses' &&
-          !confirm(this.$t('purchaseForHourglasses', { cost: this.item.value }))) {
+        const shouldConfirmPurchase = this.item.currency === 'gems' || this.item.currency === 'hourglasses';
+        if (shouldConfirmPurchase && !this.confirmPurchase(this.item.currency, this.item.value * this.selectedAmountToBuy)) {
           return;
         }
 

--- a/website/client/components/shops/quests/buyQuestModal.vue
+++ b/website/client/components/shops/quests/buyQuestModal.vue
@@ -265,6 +265,11 @@
         this.$emit('change', $event);
       },
       buyItem () {
+        if (this.item.currency === 'gems') {
+          if (!confirm(this.$t('purchaseFor', { cost: this.item.value * this.selectedAmountToBuy }))) {
+            return;
+          }
+        }
         this.makeGenericPurchase(this.item, 'buyQuestModal', this.selectedAmountToBuy);
         this.purchased(this.item.text);
         this.hideDialog();

--- a/website/client/components/shops/quests/buyQuestModal.vue
+++ b/website/client/components/shops/quests/buyQuestModal.vue
@@ -265,10 +265,8 @@
         this.$emit('change', $event);
       },
       buyItem () {
-        if (this.item.currency === 'gems') {
-          if (!confirm(this.$t('purchaseFor', { cost: this.item.value * this.selectedAmountToBuy }))) {
-            return;
-          }
+        if (!this.confirmPurchase(this.item.currency, this.item.value * this.selectedAmountToBuy)) {
+          return;
         }
         this.makeGenericPurchase(this.item, 'buyQuestModal', this.selectedAmountToBuy);
         this.purchased(this.item.text);

--- a/website/client/mixins/buy.js
+++ b/website/client/mixins/buy.js
@@ -32,5 +32,15 @@ export default {
 
       this.$root.$emit('buyModal::boughtItem', item);
     },
+    confirmPurchase (currency, cost) {
+      const currencyToPurchaseForKey = {
+        gems: 'purchaseFor',
+        gold: 'purchaseForGold',
+        hourglasses: 'purchaseForHourglasses',
+      };
+
+      const purchaseForKey = currencyToPurchaseForKey[currency];
+      return confirm(this.$t(purchaseForKey, { cost }));
+    },
   },
 };

--- a/website/common/locales/en/character.json
+++ b/website/common/locales/en/character.json
@@ -169,6 +169,7 @@
   "dieText": "You've lost a Level, all your Gold, and a random piece of Equipment. Arise, Habiteer, and try again! Curb those negative Habits, be vigilant in completion of Dailies, and hold death at arm's length with a Health Potion if you falter!",
   "sureReset": "Are you sure? This will reset your character's class and allocated Stat Points (you'll get them all back to re-allocate), and costs 3 Gems.",
   "purchaseFor": "Purchase for <%= cost %> Gems?",
+  "purchaseForGold": "Purchase for <%= cost %> Gold?",
   "purchaseForHourglasses": "Purchase for <%= cost %> Hourglasses?",
   "notEnoughMana": "Not enough mana.",
   "invalidTarget": "You can't cast a skill on that.",


### PR DESCRIPTION
Fixes #11244 

When a user clicks "Buy Now" for an item with currency 'gems' or 'hourglasses', a confirmation dialog prompts the user to confirm their purchase. This should also happen for quests.

Some quests cost gold, but the default behavior is to not ask for confirmation for gold purchases. As suggested by @Alys I have made it so that quests that cost gold-purchasable quests trigger a confirmation modal as well.

### Changes
* Create `confirmPurchase` mixin method for the `buy` modals
* Add `purchaseForGold` key to `website/common/locales/en/character.json`
* Use the `confirmPurchase` method in the `buyQuestModal` to prompt user for confirmation on "Buy Now" click
* Refactor `buyModal` to also use `confirmPurchase` method

### Testing Steps

* Confirm quest buy modals trigger confirmation dialogs for:
  * Quest bundles
  * Quests that cost gold
  * Quests that cost gems
![quest-confirmations](https://user-images.githubusercontent.com/15791290/60399665-f565f480-9b1c-11e9-939c-edc6a27722d7.gif)

* Confirm other items trigger confirmation dialogs (with the exception of gold-purchasable items):
  * Items that cost gold (doesn't trigger dialog)
  * Items that cost gems
  * Items that cost hourglasses
![item-confirmations](https://user-images.githubusercontent.com/15791290/60399678-26dec000-9b1d-11e9-95da-631325a33147.gif)

----
UUID: f19ed7b1-366c-4999-b77f-9bd48cc88eaf
