### PR TITLE
Add audio theme demo button

### DIFF
--- a/website/client/components/settings/site.vue
+++ b/website/client/components/settings/site.vue
@@ -25,10 +25,12 @@
       hr
 
       .form-horizontal
-        h5 {{ $t('audioTheme') }}
-        select.form-control(v-model='user.preferences.sound',
-          @change='set("sound")')
-          option(v-for='sound in availableAudioThemes', :value='sound') {{ $t(`audioTheme_${sound}`) }}
+        .form-group
+          h5 {{ $t('audioTheme') }}
+          select.form-control(v-model='user.preferences.sound',
+            @change='changeAudioTheme')
+            option(v-for='sound in availableAudioThemes', :value='sound') {{ $t(`audioTheme_${sound}`) }}
+        button.btn.btn-primary.btn-xs(@click='playAudio', v-once) {{ $t('demo') }}
       hr
 
       .form-horizontal(v-if='hasClass')
@@ -215,6 +217,7 @@ import deleteModal from './deleteModal';
 import { SUPPORTED_SOCIAL_NETWORKS } from '../../../common/script/constants';
 import changeClass from  '../../../common/script/ops/changeClass';
 import notificationsMixin from '../../mixins/notifications';
+import sounds from '../../libs/sounds';
 // @TODO: this needs our window.env fix
 // import { availableLanguages } from '../../../server/libs/i18n';
 
@@ -267,6 +270,7 @@ export default {
     this.temporaryDisplayName = this.user.profile.name;
     this.emailUpdates.newEmail = this.user.auth.local.email || null;
     this.localAuth.username = this.user.auth.local.username || null;
+    this.soundIndex = 0;
     hello.init({
       facebook: process.env.FACEBOOK_KEY, // eslint-disable-line no-process-env
       google: process.env.GOOGLE_CLIENT_ID, // eslint-disable-line no-process-env
@@ -510,6 +514,14 @@ export default {
       if (this.usernameUpdates.username.length < 1) {
         this.usernameUpdates.username = this.user.auth.local.username;
       }
+    },
+    changeAudioTheme () {
+      this.soundIndex = 0;
+      this.set('sound');
+    },
+    playAudio () {
+      this.$root.$emit('playSound', sounds[this.soundIndex]);
+      this.soundIndex = (this.soundIndex + 1) % sounds.length;
     },
   },
 };

--- a/website/client/libs/sounds.js
+++ b/website/client/libs/sounds.js
@@ -1,0 +1,12 @@
+export default [
+  'Achievement_Unlocked',
+  'Chat',
+  'Daily',
+  'Death',
+  'Item_Drop',
+  'Level_Up',
+  'Minus_Habit',
+  'Plus_Habit',
+  'Reward',
+  'Todo',
+];

--- a/website/common/locales/en/generic.json
+++ b/website/common/locales/en/generic.json
@@ -132,6 +132,7 @@
   "noNotificationsText": "The notification fairies give you a raucous round of applause! Well done!",
   "clear": "Clear",
   "endTour": "End Tour",
+  "demo": "Demo",
   "audioTheme": "Audio Theme",
   "audioTheme_off": "Off",
   "audioTheme_danielTheBard": "Daniel The Bard",


### PR DESCRIPTION
Trello feature request: https://trello.com/c/tljx8gKC/18-music-sound-effects

> Gustavo Silveira Jul 28, 2018 at 8:58 AM
> Hey, is there already a way to preview an audio theme? Today I was actually struggling with this, as to check an audio theme I had to change it, them go back to my tasks and tick something, change the audio, tick a task, etc... If theres no way of previewing a theme now, I would like to suggest this feature

I'm not sure if a different UX/UI would be desired for this feature (or if the feature is desired to release at all), but here is a potential solution. I found that exploring the different audio options in the current app is too tedious to bother with, and when I looked through the sound effects Trello card I noticed that I wasn't the only one that wished there was a sound demo feature.

### Changes
* Adds a "Demo" button to the audio theme selection setting. 
  * When the button is clicked a sound sample from that theme will be played. 
  * Each additional click plays the next sound in that theme's list, cycling back to the first sound when the end is reached. 
  * Changing themes resets the sound index to 0.

**Old UI**
![Screen Shot 2019-06-30 at 4 29 25 PM](https://user-images.githubusercontent.com/15791290/60403612-5361fe80-9b54-11e9-86ef-587798d16049.png)

**New UI**
![Screen Shot 2019-06-30 at 3 58 49 PM](https://user-images.githubusercontent.com/15791290/60403613-59f07600-9b54-11e9-8bff-a1f308589441.png)

**Demo with log statements**:
![sound-demo](https://user-images.githubusercontent.com/15791290/60403597-244b8d00-9b54-11e9-85f4-317ef7316181.gif)

----
UUID: f19ed7b1-366c-4999-b77f-9bd48cc88eaf
