### PR TITLE
Fixed removing tasks from challenges

### DIFF
--- a/test/client/unit/specs/components/challenges/challengeDetail.js
+++ b/test/client/unit/specs/components/challenges/challengeDetail.js
@@ -17,9 +17,8 @@ describe('Challenge Detail', () => {
             contributor: {
               admin: false,
             },
-            challenges: ['1'],
+            challenges: [],
             stats: {
-              lvl: 0,
             },
             flags: {},
             preferences: {},

--- a/test/client/unit/specs/components/challenges/challengeDetail.js
+++ b/test/client/unit/specs/components/challenges/challengeDetail.js
@@ -1,0 +1,62 @@
+import { shallowMount, createLocalVue } from '@vue/test-utils';
+import ChallengeDetailComponent from 'client/components/challenges/challengeDetail.vue';
+import Store from 'client/libs/store';
+
+const localVue = createLocalVue();
+localVue.use(Store);
+
+describe('Challenge Detail', () => {
+  let store;
+  let wrapper;
+
+  beforeEach(() => {
+    store = new Store({
+      state: {
+        user: {
+          data: {
+            contributor: {
+              admin: false,
+            },
+            challenges: ['1'],
+            stats: {
+              lvl: 0,
+            },
+            flags: {},
+            preferences: {},
+            party: {
+              quest: {
+              },
+            },
+          },
+        },
+      },
+      actions: {
+        'members:getChallengeMembers': () => {},
+        'challenges:getChallenge': () => [
+          {_id: '1', group: { name: '', type: ''}, memberCount: 1, name: '', summary: '', description: '', leader: '', price: 1},
+        ],
+        'tasks:getChallengeTasks': () => [
+          {_id: '1', type: 'habit'},
+          {_id: '2', type: 'daily'},
+          {_id: '3', type: 'reward'},
+          {_id: '4', type: 'todo'},
+        ],
+      },
+      getters: {
+      },
+    });
+    wrapper = shallowMount(ChallengeDetailComponent, {
+      store,
+      localVue,
+      mocks: {
+        $t: (string) => string,
+      },
+    });
+  });
+
+  it('removes destroyed tasks from task list', () => {
+    let taskToRemove = {_id: '1', type: 'habit'};
+    wrapper.vm.taskDestroyed(taskToRemove);
+    expect(wrapper.vm.tasksByType[taskToRemove.type].length).to.eq(0);
+  });
+});

--- a/test/client/unit/specs/components/challenges/challengeDetail.js
+++ b/test/client/unit/specs/components/challenges/challengeDetail.js
@@ -54,7 +54,7 @@ describe('Challenge Detail', () => {
     });
   });
 
-  it('removes destroyed tasks from task list', () => {
+  it('removes a destroyed task from task list', () => {
     let taskToRemove = {_id: '1', type: 'habit'};
     wrapper.vm.taskDestroyed(taskToRemove);
     expect(wrapper.vm.tasksByType[taskToRemove.type].length).to.eq(0);

--- a/website/client/components/challenges/challengeDetail.vue
+++ b/website/client/components/challenges/challengeDetail.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 .row
-  challenge-modal(v-on:updatedChallenge='updatedChallenge')
+  challenge-modal(@updatedChallenge='updatedChallenge')
   leave-challenge-modal(:challengeId='challenge._id')
   close-challenge-modal(:members='members', :challengeId='challenge._id', :prize='challenge.prize')
   challenge-member-progress-modal(:challengeId='challenge._id')
@@ -47,8 +47,8 @@
             @cancel="cancelTaskModal()",
             ref="taskModal",
             :challengeId="challengeId",
-            v-on:taskCreated='taskCreated',
-            v-on:taskEdited='taskEdited',
+            @taskCreated='taskCreated',
+            @taskEdited='taskEdited',
             @taskDestroyed='taskDestroyed'
           )
     .row
@@ -57,7 +57,8 @@
         :type="column",
         :key="column",
         :taskListOverride='tasksByType[column]',
-        v-on:editTask="editTask",
+        @editTask="editTask",
+        @taskDestroyed="taskDestroyed",
         v-if='tasksByType[column].length > 0')
   .col-12.col-md-4.sidebar.standard-page
     .button-container(v-if='canJoin')


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11245

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

With this fix deleted tasks immediately get removed from the challenge task list.
I've also added a test for the taskDestroyed function in the ChallengeDetail component.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 120bed2d-e59f-4adc-820b-9de529d24dc4
