### PR TITLE
Fixed the null gem prize option for challenges fixes #9745

### DIFF
--- a/website/server/models/challenge.js
+++ b/website/server/models/challenge.js
@@ -34,7 +34,7 @@ let schema = new Schema({
   leader: {$type: String, ref: 'User', validate: [v => validator.isUUID(v), 'Invalid uuid.'], required: true},
   group: {$type: String, ref: 'Group', validate: [v => validator.isUUID(v), 'Invalid uuid.'], required: true},
   memberCount: {$type: Number, default: 0},
-  prize: {$type: Number, default: 0, min: 0},
+  prize: {$type: Number, default: 0, min: 0, required: true},
   categories: [{
     slug: {$type: String},
     name: {$type: String},


### PR DESCRIPTION
Will need a mod to fix all the currently null challenges - my code doesn't fix that, just prevents new challenges from being null prize.

[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (https://github.com/HabitRPG/habitica/issues/11264)
fixes #9745

### Changes
[//]: # The reason you could put a null value in as a gem prize is because null is technically all data types. To prevent null gem prizes, I put required: true in the prize line.



[//]: # 0fb3db86-7009-46d6-9eea-485a8f7e6734

----
Habitica Username: @kiramac
