### PR TITLE
Front-end change for the null gem option.

### DIFF
--- a/website/client/components/challenges/challengeDetail.vue
+++ b/website/client/components/challenges/challengeDetail.vue
@@ -30,7 +30,7 @@
           .details(v-once) {{$t('participantsTitle')}}
         .box
           .svg-icon.gem-icon(v-html="icons.gemIcon")
-          | {{challenge.prize}}
+          challenge.prize(v-if=null) {{challenge.prize = 0}}
           .details(v-once) {{$t('prize')}}
     .row.challenge-actions
       .col-12.col-md-6


### PR DESCRIPTION
Changes it to be a 0 when null in the challenge page only. Still working on the other pages.

[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: #11264 Front-end fix for null gem prize
### Changes
[//]: # Changed lines 33 and 34 to be challenge.prize(v-if=null) {{challenge.prize = 0}}
          .details(v-once) {{$t('prize')}}



[//]: # 0fb3db86-7009-46d6-9eea-485a8f7e6734

----
UUID: 
