### PR TITLE
Make usernames clickable in Hall of Heroes Fixes #11014

### DIFF
--- a/website/client/components/hall/heroes.vue
+++ b/website/client/components/hall/heroes.vue
@@ -115,9 +115,13 @@ import { mountInfo, petInfo } from 'common/script/content/stable';
 import { food, hatchingPotions, special } from 'common/script/content';
 import gear from 'common/script/content/gear';
 import notifications from 'client/mixins/notifications';
+import userLink from '../userLink';
 
 export default {
   mixins: [notifications, styleHelper],
+  components: {
+    userLink,
+  },
   data () {
     return {
       heroes: [],

--- a/website/client/components/hall/heroes.vue
+++ b/website/client/components/hall/heroes.vue
@@ -85,12 +85,8 @@
         tbody
           tr(v-for='(hero, index) in heroes')
             td
-              span(v-if='hero.contributor && hero.contributor.admin', :popover="$t('gamemaster')", popover-trigger='mouseenter', popover-placement='right')
-                .label.label-default(:class='userLevelStyle(hero)')
-                  | {{hero.profile.name}}&nbsp;
-                  //- span(v-class='userAdminGlyphiconStyle(hero)')
-              span(v-if='!hero.contributor || !hero.contributor.admin')
-                .label.label-default(v-if='hero.profile', v-class='userLevelStyle(hero)') {{hero.profile.name}}
+              user-link(v-if='hero.contributor && hero.contributor.admin', :user='hero', :popover="$t('gamemaster')", popover-trigger='mouseenter', popover-placement='right')
+              user-link(v-if='!hero.contributor || !hero.contributor.admin', :user='hero')
             td(v-if='user.contributor.admin', @click='populateContributorInput(hero._id, index)').btn-link {{hero._id}}
             td {{hero.contributor.level}}
             td {{hero.contributor.text}}


### PR DESCRIPTION
Fixes #11014

### Changes

This uses the userLink component to make usernames clickable in the hall of heroes.

----
UUID: af8a4775-6fbd-4390-a82e-e90342d82c73
and
UUID: cd0b1178-b75f-4769-ada4-0b03c29c6a9d

I worked with @margsliu on this change.
