### PR TITLE
Adjust experience required for first levels

### DIFF
--- a/website/common/script/statHelpers.js
+++ b/website/common/script/statHelpers.js
@@ -23,6 +23,11 @@ export function capByLevel (lvl) {
  */
 
 export function toNextLevel (lvl) {
+  if (lvl < 5) {
+    return 25 * lvl;
+  } else if (lvl === 5) {
+    return 150;
+  }
   return Math.round((Math.pow(lvl, 2) * 0.25 + 10 * lvl + 139.75) / 10) * 10;
 }
 


### PR DESCRIPTION
This adjusts the experience required for the first levels to be the following:

Level 1: 25 XP
Lvl 2: 50 XP
Lvl 3: 75 XP
Lvl 4: 100 XP
Lvl 5: 150 XP
Lvl 6: 210 XP (First one that's normal. After that follow regular progresion)

We have gotten feedback that new users take a long time to even reach level 2. And a lot of users drop out before reaching that.