### PR TITLE
Post-outage groups cleanup migration

### DIFF
--- a/migrations/archive/2019/20190731_outage_repair_groups.js
+++ b/migrations/archive/2019/20190731_outage_repair_groups.js
@@ -1,0 +1,74 @@
+/* eslint-disable no-console */
+const MIGRATION_NAME = '20190731_outage_repair_groups';
+import { model as Group } from '../../website/server/models/group';
+import { model as User } from '../../website/server/models/user';
+import forEach from 'lodash/forEach';
+
+const progressCount = 1000;
+let count = 0;
+
+async function updateGroup (group) {
+  count++;
+
+  const set = {};
+
+  if (group.type === 'guild') {
+    set.memberCount = await User.countDocuments({guilds: group._id});
+  } else {
+    set.memberCount = await User.countDocuments({party._id: group._id});
+  }
+
+  if (group.quest && group.quest.key && group.quest.members) {
+    forEach(group.quest.members, async (status, memberId) => {
+      if (status === null) await User.update({_id: memberId, {$set: {
+        'party.quest.RSVPNeeded': true,
+        'party.quest.key': group.quest.key,
+      }}});
+      if (status === true) await User.update({_id: memberId, {$set: {
+        'party.quest.key': group.quest.key,
+      }}})
+    });
+  }
+
+  if (group.leader) {
+    const leaderTrouble = await User.find({_id: group.leader, $or:[{'party._id': group._id}, {guilds: group._id}]});
+
+    if (leaderTrouble === null) console.log(`Group leadership problem: user ${group.leader} not in group ${group._id}`);
+  }
+
+  if (count % progressCount === 0) console.warn(`${count} ${group._id}`);
+
+  return await Group.update({_id: group._id}, {$set: set}).exec();
+}
+
+module.exports = async function processGroups () {
+  let query = {};
+
+  const fields = {
+    _id: 1,
+    type: 1,
+    quest: 1,
+  };
+
+  while (true) { // eslint-disable-line no-constant-condition
+    const groups = await Group // eslint-disable-line no-await-in-loop
+      .find(query)
+      .limit(250)
+      .sort({_id: 1})
+      .select(fields)
+      .lean()
+      .exec();
+
+    if (groups.length === 0) {
+      console.warn('All appropriate groups found and modified.');
+      console.warn(`\n${count} groups processed\n`);
+      break;
+    } else {
+      query._id = {
+        $gt: groups[groups.length - 1]._id,
+      };
+    }
+
+    await Promise.all(groups.map(updateGroup)); // eslint-disable-line no-await-in-loop
+  }
+};

--- a/migrations/archive/2019/20190731_outage_repair_groups.js
+++ b/migrations/archive/2019/20190731_outage_repair_groups.js
@@ -20,13 +20,21 @@ async function updateGroup (group) {
 
   if (group.quest && group.quest.key && group.quest.members) {
     forEach(group.quest.members, async (status, memberId) => {
-      if (status === null) await User.update({_id: memberId, {$set: {
-        'party.quest.RSVPNeeded': true,
-        'party.quest.key': group.quest.key,
-      }}});
-      if (status === true) await User.update({_id: memberId, {$set: {
-        'party.quest.key': group.quest.key,
-      }}})
+      if (status === null) {
+        await User.update({_id: memberId, {$set: {
+          'party.quest.key': group.quest.key,
+          'party.quest.RSVPNeeded': true,
+        }}});
+      } else if (status === true) {
+        await User.update({_id: memberId, {$set: {
+          'party.quest.key': group.quest.key,
+          'party.quest.RSVPNeeded': false,
+        }}});
+      } else {
+        await User.update({_id: memberId, {$set: {
+          'party.quest.RSVPNeeded': false,
+        }}});
+      }
     });
   }
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Adds a migration to patch up a few lingering data discrepancies from the Guilds/Parties outage of a couple weeks back:

* Recalculates `memberCount` for all groups
* Realigns party members' individual `party.quest` data with their statuses in `group.quest.members`
* Outputs (without making any changes) an alert if a group has an assigned leader that's not actually a member of that group