### PR TITLE
Add translated gear name to open-mystery-item call

### DIFF
--- a/test/api/v3/integration/user/POST-user_open_mystery_item.test.js
+++ b/test/api/v3/integration/user/POST-user_open_mystery_item.test.js
@@ -9,6 +9,7 @@ describe('POST /user/open-mystery-item', () => {
   let mysteryItemKey = 'eyewear_special_summerRogue';
   let mysteryItemIndex = content.gear.flat[mysteryItemKey].index;
   let mysteryItemType = content.gear.flat[mysteryItemKey].type;
+  let mysteryItemText = content.gear.flat[mysteryItemKey].text();
 
   beforeEach(async () => {
     user = await generateUser({
@@ -32,5 +33,6 @@ describe('POST /user/open-mystery-item', () => {
     expect(response.data.key).to.eql(mysteryItemKey);
     expect(response.data.index).to.eql(mysteryItemIndex);
     expect(response.data.type).to.eql(mysteryItemType);
+    expect(response.data.text).to.eql(mysteryItemText);
   });
 });

--- a/test/common/ops/openMysteryItem.js
+++ b/test/common/ops/openMysteryItem.js
@@ -36,7 +36,9 @@ describe('shared.ops.openMysteryItem', () => {
 
     expect(user.items.gear.owned[mysteryItemKey]).to.be.true;
     expect(message).to.equal(i18n.t('mysteryItemOpened'));
-    expect(data).to.eql(content.gear.flat[mysteryItemKey]);
+    let item = content.gear.flat[mysteryItemKey];
+    item.text = content.gear.flat[mysteryItemKey].text();
+    expect(data).to.eql(item);
     expect(user.notifications.length).to.equal(0);
   });
 });

--- a/test/common/ops/openMysteryItem.js
+++ b/test/common/ops/openMysteryItem.js
@@ -36,7 +36,7 @@ describe('shared.ops.openMysteryItem', () => {
 
     expect(user.items.gear.owned[mysteryItemKey]).to.be.true;
     expect(message).to.equal(i18n.t('mysteryItemOpened'));
-    let item = content.gear.flat[mysteryItemKey];
+    let item = _.cloneDeep(content.gear.flat[mysteryItemKey]);
     item.text = content.gear.flat[mysteryItemKey].text();
     expect(data).to.eql(item);
     expect(user.notifications.length).to.equal(0);

--- a/website/common/script/ops/openMysteryItem.js
+++ b/website/common/script/ops/openMysteryItem.js
@@ -24,6 +24,7 @@ module.exports = function openMysteryItem (user, req = {}, analytics) {
   if (mysteryItems.length === 0) markNotificationAsRead(user);
 
   item = cloneDeep(content.gear.flat[item]);
+  item.text = content.gear.flat[item.key].text();
   user.items.gear.owned[item.key] = true;
 
   if (user.markModified) {

--- a/website/common/script/ops/openMysteryItem.js
+++ b/website/common/script/ops/openMysteryItem.js
@@ -24,7 +24,7 @@ module.exports = function openMysteryItem (user, req = {}, analytics) {
   if (mysteryItems.length === 0) markNotificationAsRead(user);
 
   item = cloneDeep(content.gear.flat[item]);
-  item.text = content.gear.flat[item.key].text();
+  item.text = content.gear.flat[item.key].text(user.preferences.language);
   user.items.gear.owned[item.key] = true;
 
   if (user.markModified) {


### PR DESCRIPTION
To make it easier for the clients to display the mystery item you received (and also to prevent issues if the data wasn't yet refreshed), this adds the translated name for the gear you receive.