### PR TITLE
Pet Hatching Item Overbuy Warning

### DIFF
--- a/website/client/components/shops/buyModal.vue
+++ b/website/client/components/shops/buyModal.vue
@@ -418,7 +418,7 @@
             return sum;
           }, 0);
           if (this.item.pinType === 'premiumHatchingPotion') {
-            petsRemaining -= this.user.items.hatchingPotions[this.item.key] + 2;
+            petsRemaining -= this.user.items.hatchingPotions[this.item.key] + 2 || 2;
           } else {
             petsRemaining -= this.user.items.eggs[this.item.key] || 0;
           }

--- a/website/common/locales/en/character.json
+++ b/website/common/locales/en/character.json
@@ -171,6 +171,7 @@
   "purchaseFor": "Purchase for <%= cost %> Gems?",
   "purchaseForGold": "Purchase for <%= cost %> Gold?",
   "purchaseForHourglasses": "Purchase for <%= cost %> Hourglasses?",
+  "purchasePetItemConfirm": "This purchase would exceed the number of items you need to hatch all possible <%= itemText %> pets. Are you sure?",
   "notEnoughMana": "Not enough mana.",
   "invalidTarget": "You can't cast a skill on that.",
   "youCast": "You cast <%= spell %>.",


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Partially addresses #8056 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Adds a warning if the user attempts to purchase a number of quest pet eggs or premium hatching potions beyond the number necessary to hatch and raise all possible combinations. No warning appears for standard pet eggs or droppable hatching potions, as the Key to the Kennels keeps additional items relevant indefinitely.