### PR TITLE
gear: Fix stats for the "Brilliant Bloom" weapon

### DIFF
--- a/migrations/archive/2019/20190816_brilliant_bloom_fix.js
+++ b/migrations/archive/2019/20190816_brilliant_bloom_fix.js
@@ -1,0 +1,52 @@
+/* eslint-disable no-console */
+const MIGRATION_NAME = '20190816_brilliant_bloom_fix';
+import { v4 as uuid } from 'uuid';
+
+import { model as User } from '../../../website/server/models/user';
+
+const progressCount = 1000;
+let count = 0;
+
+async function updateUser (user) {
+  count++;
+  if (count % progressCount === 0) console.warn(`${count} ${user._id}`);
+  return await User.update(
+    { _id: user._id },
+    { $unset: {'items.gear.equipped.shield': 1} }
+  ).exec();
+}
+
+module.exports = async function processUsers () {
+  let query = {
+    migration: { $ne: MIGRATION_NAME },
+    'items.gear.equipped.weapon': 'weapon_special_summer2019Mage',
+    'items.gear.equipped.shield': { $exists: true },
+  };
+
+  const fields = {
+    _id: 1,
+    items: 1,
+  };
+
+  while (true) { // eslint-disable-line no-constant-condition
+    const users = await User // eslint-disable-line no-await-in-loop
+      .find(query)
+      .limit(250)
+      .sort({_id: 1})
+      .select(fields)
+      .lean()
+      .exec();
+
+    if (users.length === 0) {
+      console.warn('All appropriate users found and modified.');
+      console.warn(`\n${count} users processed\n`);
+      break;
+    } else {
+      query._id = {
+        $gt: users[users.length - 1]._id,
+      };
+    }
+
+    await Promise.all(users.map(updateUser)); // eslint-disable-line no-await-in-loop
+  }
+};

--- a/website/common/script/content/gear/sets/special/index.js
+++ b/website/common/script/content/gear/sets/special/index.js
@@ -5119,11 +5119,13 @@ let weapon = {
   summer2019Mage: {
     event: EVENTS.summer2019,
     specialClass: 'wizard',
+    twoHanded: true,
     set: 'summer2019WaterLilyMageSet',
     text: t('weaponSpecialSummer2019MageText'),
-    notes: t('weaponSpecialSummer2019MageNotes', { int: 15 }),
-    value: 90,
+    notes: t('weaponSpecialSummer2019MageNotes', { int: 15, per: 7 }),
+    value: 160,
     int: 15,
+    per: 7,
   },
   summer2019Healer: {
     event: EVENTS.summer2019,


### PR DESCRIPTION
This weapon has been introduced in the Summer Splash of 2019.

With an INT bonus of 15 and also being a one-handed weapon, I think it is way too powerful given that it has a low price and also should be relatively easy to get.

I've set the stats to match the mage gear for other events and appropriately made it a two-handed weapon.

Also included small migration script which unequips the shield if a player happens to have the Brilliant Bloom and a shield.