### PR TITLE
hide "clear completed todos" while no entries are listed

### DIFF
--- a/website/client/components/tasks/column.vue
+++ b/website/client/components/tasks/column.vue
@@ -207,6 +207,7 @@
     position: absolute;
     width: 100%;
     bottom: 32px;
+    margin-left: -8px;
 
     &.initial-description {
       top: 30%;

--- a/website/client/components/tasks/column.vue
+++ b/website/client/components/tasks/column.vue
@@ -25,7 +25,7 @@
     )
     transition(name="quick-add-tip-slide")
       .quick-add-tip.small-text(v-show="quickAddFocused", v-html="$t('addMultipleTip', {taskType: $t(typeLabel)})")
-    clear-completed-todos(v-if="activeFilter.label === 'complete2' && isUser === true")
+    clear-completed-todos(v-if="activeFilter.label === 'complete2' && isUser === true && taskList.length > 0")
     .column-background(
       v-if="isUser === true",
       :class="{'initial-description': initialColumnDescription}",


### PR DESCRIPTION
This hides the "delete completed" button if there aren't any completed entries listed.