### PR TITLE
This change prevents checklists from being toggled when casting skills or spells.

### DIFF
--- a/website/client/components/tasks/task.vue
+++ b/website/client/components/tasks/task.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 .task-wrapper
-  .task
+  .task(@click='castEnd($event, task)')
     approval-header(:task='task', v-if='this.task.group.id', :group='group')
     .d-flex(:class="{'task-not-scoreable': isUser !== true}")
       // Habits left side control
@@ -690,8 +690,6 @@ export default {
 
       if (!this.$store.state.spellOptions.castingSpell) {
         this.$emit('editTask', task);
-      } else {
-        this.$root.$emit('castEnd', task, 'task', e);
       }
     },
     moveToTop () {
@@ -704,6 +702,9 @@ export default {
       if (!confirm(this.$t('sureDelete'))) return;
       this.destroyTask(this.task);
       this.$emit('taskDestroyed', this.task);
+    },
+    castEnd (e, task) {
+      setTimeout(() => this.$root.$emit('castEnd', task, 'task', e), 0);
     },
     async score (direction) {
       if (this.castingSpell) return;

--- a/website/client/components/tasks/task.vue
+++ b/website/client/components/tasks/task.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 .task-wrapper
-  .task(@click='castEnd($event, task)')
+  .task
     approval-header(:task='task', v-if='this.task.group.id', :group='group')
     .d-flex(:class="{'task-not-scoreable': isUser !== true}")
       // Habits left side control
@@ -690,6 +690,8 @@ export default {
 
       if (!this.$store.state.spellOptions.castingSpell) {
         this.$emit('editTask', task);
+      } else {
+        this.$root.$emit('castEnd', task, 'task', e);
       }
     },
     moveToTop () {
@@ -702,9 +704,6 @@ export default {
       if (!confirm(this.$t('sureDelete'))) return;
       this.destroyTask(this.task);
       this.$emit('taskDestroyed', this.task);
-    },
-    castEnd (e, task) {
-      this.$root.$emit('castEnd', task, 'task', e);
     },
     async score (direction) {
       if (this.castingSpell) return;


### PR DESCRIPTION
Fixes #11028

### Changes
The top level event handler `castEnd` was being called before the `toggleChecklistItem` event and thus all checks for `if (this.castingSpell) return;` do not get triggered.

All in all a very challenging issue as I have not worked with vue before (only react/redux) but very satisfying nonetheless.

Thanks for the opportunity @Alys .

----
UUID: 3c8f6348-db5f-4162-82af-590260c05f89

