### PR TITLE
Conversation-API: Add last message 

### DIFF
--- a/test/api/v4/inbox/GET-inbox-conversations.test.js
+++ b/test/api/v4/inbox/GET-inbox-conversations.test.js
@@ -40,6 +40,7 @@ describe('GET /inbox/conversations', () => {
     expect(result.length).to.be.equal(3);
     expect(result[0].user).to.be.equal(user.profile.name);
     expect(result[0].username).to.be.equal(user.auth.local.username);
+    expect(result[0].text).to.be.not.empty;
   });
 
   it('returns the user inbox messages as an array of ordered messages (from most to least recent)', async () => {

--- a/website/server/controllers/api-v4/inbox.js
+++ b/website/server/controllers/api-v4/inbox.js
@@ -79,6 +79,20 @@ api.clearMessages = {
  * @apiDescription Get the conversations for a user
  *
  * @apiSuccess {Array} data An array of inbox conversations
+ *
+ * @apiSuccessExample {json} Success-Response:
+ * {"success":true,"data":[
+ *    {
+ *       "_id":"8a9d461b-f5eb-4a16-97d3-c03380c422a3",
+ *       "user":"user display name",
+ *       "username":"some_user_name",
+ *       "timestamp":"12315123123",
+ *       "text":"last message of conversation",
+ *       "userStyles": {},
+ *       "contributor": {},
+ *       "count":1
+ *    }
+ * }
  */
 api.conversations = {
   method: 'GET',

--- a/website/server/libs/inbox/index.js
+++ b/website/server/libs/inbox/index.js
@@ -1,5 +1,4 @@
 import {mapInboxMessage, inboxModel as Inbox} from '../../models/message';
-import orderBy from 'lodash/orderBy';
 import {getUserInfo, sendTxn as sendTxnEmail} from '../email';
 import {sendNotification as sendPushNotification} from '../pushNotifications';
 

--- a/website/server/libs/inbox/index.js
+++ b/website/server/libs/inbox/index.js
@@ -86,20 +86,23 @@ export async function listConversations (owner) {
       {
         $group: {
           _id: '$uuid',
-          user: {$first: '$user' },
-          username: {$first: '$username' },
-          timestamp: {$max: '$timestamp'}, // sort before group doesn't work - use the max value to sort it again after
+          user: {$last: '$user' },
+          username: {$last: '$username' },
+          timestamp: {$last: '$timestamp'},
+          text: {$last: '$text'},
+          userStyles: {$last: '$userStyles'},
+          contributor: {$last: '$contributor'},
+          count: {$sum: 1},
         },
       },
+      { $sort: {timestamp: -1}}, // sort by latest message
     ]);
 
-  const conversationsList = orderBy(await query.exec(), ['timestamp'], ['desc']);
+  const conversationsList = await query.exec();
 
-  const conversations = conversationsList.map(({_id, user, username, timestamp}) => ({
-    uuid: _id,
-    user,
-    username,
-    timestamp,
+  const conversations = conversationsList.map((res) => ({
+    uuid: res._id,
+    ...res,
   }));
 
   return conversations;


### PR DESCRIPTION
Refactored the conversation query (thx to @phillipthelen).

The Website UI already used the same properties, so those are now `auto-filled` (instead of filled on selecting a conversation) 