### PR TITLE
User Icon > Edit Avatar option always links to a correct page.

### DIFF
--- a/website/client/components/header/userDropdown.vue
+++ b/website/client/components/header/userDropdown.vue
@@ -5,7 +5,7 @@ menu-dropdown.item-user(:right="true")
       message-count(v-if='user.inbox.newMessages > 0', :count="user.inbox.newMessages", :top="true")
       .top-menu-icon.svg-icon.user(v-html="icons.user")
   .user-dropdown(slot="dropdown-content")
-    a.dropdown-item.edit-avatar.dropdown-separated(@click='showAvatar()')
+    a.dropdown-item.edit-avatar.dropdown-separated(@click='showAvatar("body", "size")')
       h3 {{ user.profile.name }}
       span.small-text {{ $t('editAvatar') }}
     a.nav-link.dropdown-item.dropdown-separated.d-flex.justify-content-between.align-items-center(@click.prevent='showInbox()')


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Partial fix for #11337

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
User Icon > Edit Avatar option now always takes you to the avatar editing modal with the Body section open.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: dd59e7c1-b76a-466e-b301-783b852da699
