### PR TITLE
Enable challenges to be closed by "End Challenge" button (fix member dropdown and search)  fix#11339

### DIFF
--- a/website/client/components/members/memberSearchDropdown.vue
+++ b/website/client/components/members/memberSearchDropdown.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 b-dropdown.create-dropdown(:text="text", no-flip)
-  b-dropdown-form(:disabled='true')
+  b-dropdown-form(:disabled='false')
     input.form-control(type='text', v-model='searchTerm')
   b-dropdown-item(v-for="member in memberResults", :key="member._id", @click="selectMember(member)")
     | {{ member.profile.name }}

--- a/website/client/components/members/memberSearchDropdown.vue
+++ b/website/client/components/members/memberSearchDropdown.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 b-dropdown.create-dropdown(:text="text", no-flip)
-  b-dropdown-form(:disabled='false')
+  b-dropdown-form(:disabled='false', v-on:submit.prevent="onSubmit")
     input.form-control(type='text', v-model='searchTerm')
   b-dropdown-item(v-for="member in memberResults", :key="member._id", @click="selectMember(member)")
     | {{ member.profile.name }}

--- a/website/client/mixins/challengeMemberSearch.js
+++ b/website/client/mixins/challengeMemberSearch.js
@@ -6,8 +6,11 @@ export default {
     searchTerm: debounce(function searchTerm (newSearch) {
       this.challengeMemberSearchMixin_searchChallengeMember(newSearch);
     }, 500),
-    members () {
-      this.memberResults = this.members;
+    members: {
+      handler () {
+        this.memberResults = this.members;
+      },
+      immediate: true,
     },
   },
   methods: {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11339

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
#### 1. dropdown list empty problem in close-challenge-modal

In `challengeMemberSearch` mixin, I set the callback(`this.memberResults = this.members;`) of the watcher `members`  to be immediately called after the memberSearchDropdown being opened, so the `memberResults` would not be empty when user opened the `closeChallengeModal`.

#### 2. fix the memberSearchDropdown not accepting input problem

The `b-dropdown-form` does't accept input because it got a default `:disabled='false'` attribute. But this `disabled`  seems not referenced anywhere, so I simply changed it to be `true`.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: c57a0797-60a3-4811-9146-709a3312b823
