### PR TITLE
Fix: unauthorized sorting of group tasks

### DIFF
--- a/website/client/components/tasks/column.vue
+++ b/website/client/components/tasks/column.vue
@@ -482,7 +482,7 @@ export default {
       const newIndexOnServer = originTasks.findIndex(taskId => taskId === taskIdToReplace);
 
       let newOrder;
-      if (taskToMove.group.id) {
+      if (taskToMove.group.id && !this.isUser) {
         newOrder = await this.$store.dispatch('tasks:moveGroupTask', {
           taskId: taskIdToMove,
           position: newIndexOnServer,


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11331
Fixes #11268

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

As I understand a logic of isUser key in props of column component: it indicates if this column belongs to user dashboard. I checked the endpoints which we use to move tasks in column and understand that we should check not only if it is a group task we should check even more -- if it is a user dashboard. It helps us to pick a correct endpoint which will not response to us with unauthorised error.

I made a minimal change to current logic to not destroy what we already have for now, I'm really sure that reviewer will check if it works as expected on local install

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: d94eca66-c6de-423c-a864-9cb103b9eb77
