### PR TITLE
Fix: Edit/deleting tasks in a challenge appears possible for people who are not admin/the creator

### DIFF
--- a/website/client/components/challenges/challengeDetail.vue
+++ b/website/client/components/challenges/challengeDetail.vue
@@ -57,6 +57,7 @@
         :type="column",
         :key="column",
         :taskListOverride='tasksByType[column]',
+        :showOptions="showOptions",
         @editTask="editTask",
         @taskDestroyed="taskDestroyed",
         v-if='tasksByType[column].length > 0')
@@ -250,6 +251,9 @@ export default {
     },
     canJoin () {
       return !this.isMember;
+    },
+    showOptions () {
+      return this.isLeader;
     },
   },
   mounted () {

--- a/website/client/components/group-plans/taskInformation.vue
+++ b/website/client/components/group-plans/taskInformation.vue
@@ -41,6 +41,7 @@
       :type="column",
       :key="column",
       :taskListOverride='tasksByType[column]',
+      :showOptions="showOptions"
       v-on:editTask="editTask",
       v-on:loadGroupCompletedTodos="loadGroupCompletedTodos",
       v-on:taskDestroyed="taskDestroyed",
@@ -175,6 +176,9 @@ export default {
     canCreateTasks () {
       if (!this.group) return false;
       return this.group.leader && this.group.leader._id === this.user._id || this.group.managers && Boolean(this.group.managers[this.user._id]);
+    },
+    showOptions () {
+      return this.canCreateTasks;
     },
   },
   methods: {

--- a/website/client/components/tasks/column.vue
+++ b/website/client/components/tasks/column.vue
@@ -45,6 +45,7 @@
         v-for="task in taskList",
         :key="task.id", :task="task",
         :isUser="isUser",
+        :showOptions="showOptions"
         @editTask="editTask",
         @moveTo="moveTo",
         :group='group',
@@ -311,6 +312,10 @@ export default {
     selectedTags: {},
     taskListOverride: {},
     group: {},
+    showOptions: {
+      type: Boolean,
+      default: true,
+    },
   }, // @TODO: maybe we should store the group on state?
   data () {
     const icons = Object.freeze({

--- a/website/client/components/tasks/task.vue
+++ b/website/client/components/tasks/task.vue
@@ -19,7 +19,7 @@
           .d-flex.justify-content-between
             h3.task-title(:class="{ 'has-notes': task.notes }", v-markdown="task.text")
             menu-dropdown.task-dropdown(
-              v-if="!isRunningYesterdailies",
+              v-if="!isRunningYesterdailies && showOptions",
               :right="task.type === 'reward'",
               ref="taskDropdown",
               v-b-tooltip.hover.top="$t('options')"
@@ -555,7 +555,7 @@ export default {
   directives: {
     markdown: markdownDirective,
   },
-  props: ['task', 'isUser', 'group', 'dueDate'], // @TODO: maybe we should store the group on state?
+  props: ['task', 'isUser', 'group', 'dueDate', 'showOptions'], // @TODO: maybe we should store the group on state?
   data () {
     return {
       random: uuid.v4(), // used to avoid conflicts between checkboxes ids


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes https://github.com/HabitRPG/habitica/issues/11137

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Introduce showOptions propr for column and task and pull it from challenge container to task itself to restrict editing for non leader of challenge users. By default this prop is true, so it will not hide options in place where we not pass such prop. 


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: d94eca66-c6de-423c-a864-9cb103b9eb77
