### PR TITLE
Dockerfile: Modified git clone to only clone with depth 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN npm install -g gulp-cli mocha
 # Clone Habitica repo and install dependencies
 RUN mkdir -p /usr/src/habitrpg
 WORKDIR /usr/src/habitrpg
-RUN git clone --branch release https://github.com/HabitRPG/habitica.git /usr/src/habitrpg
+RUN git clone --branch release --depth 1 https://github.com/HabitRPG/habitica.git /usr/src/habitrpg
 RUN npm install
 RUN gulp build:prod --force
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)

### Changes
Before this change docker downloads the whole repository with all commits for building the project. However the git history is not used inside the docker image, only the current version named `release`. So I added the option `--depth 1` to the git clone command so only the required version without the history will be downloaded inside the docker container. This saves disk space and speeds up the process of building the docker image.

See [this page of the git manual](https://www.git-scm.com/docs/git-clone#Documentation/git-clone.txt---depthltdepthgt) to read about the option `--depth`.

----
UUID: f43b87aa-e434-4564-8932-76b76784edf0
