### PR TITLE
Upgrade Stripe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24701,14 +24701,11 @@
       "integrity": "sha1-IrD6OkE4WzO+PzMVUbu4N/oM164="
     },
     "stripe": {
-      "version": "6.36.0",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-6.36.0.tgz",
-      "integrity": "sha512-7vjyVO4NCWvX38CH1AuSQH16uRxcQN+UhUTBPs4UHsIl5+SJXLBvCsHrMgd+bY9k1YDliT0fQB1fH9OI3GrEhw==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-7.9.0.tgz",
+      "integrity": "sha512-nftVEpqjYhRaRlIJgmEX5+NjTNyUBsBRGJiMTfS+eHpbuf6Nh6t5YylmcBN+Oh6BiAsAN9NfRncBe9xoeGxlcw==",
       "requires": {
-        "lodash.isplainobject": "^4.0.6",
-        "qs": "^6.6.0",
-        "safe-buffer": "^5.1.1",
-        "uuid": "^3.3.2"
+        "qs": "^6.6.0"
       },
       "dependencies": {
         "qs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24701,19 +24701,20 @@
       "integrity": "sha1-IrD6OkE4WzO+PzMVUbu4N/oM164="
     },
     "stripe": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-5.10.0.tgz",
-      "integrity": "sha512-AUDmXfNAAY/oOfW87HPO4bDzNWJp8iQd0blVWwwEgPxO1DmEC//foI0C9rhr2ZNsuF6kLypPfNtGB9Uf+RCQzQ==",
+      "version": "6.36.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-6.36.0.tgz",
+      "integrity": "sha512-7vjyVO4NCWvX38CH1AuSQH16uRxcQN+UhUTBPs4UHsIl5+SJXLBvCsHrMgd+bY9k1YDliT0fQB1fH9OI3GrEhw==",
       "requires": {
         "lodash.isplainobject": "^4.0.6",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1"
+        "qs": "^6.6.0",
+        "safe-buffer": "^5.1.1",
+        "uuid": "^3.3.2"
       },
       "dependencies": {
         "qs": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+          "version": "6.8.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.8.0.tgz",
+          "integrity": "sha512-tPSkj8y92PfZVbinY1n84i1Qdx75lZjMQYx9WZhnkofyxzw2r7Ho39G3/aEvSUdebxpnnM4LZJCtvE/Aq3+s9w=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "shelljs": "^0.8.2",
     "short-uuid": "^3.0.0",
     "smartbanner.js": "^1.11.0",
-    "stripe": "^5.9.0",
+    "stripe": "^6.36.0",
     "superagent": "^5.0.2",
     "svg-inline-loader": "^0.8.0",
     "svg-url-loader": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "shelljs": "^0.8.2",
     "short-uuid": "^3.0.0",
     "smartbanner.js": "^1.11.0",
-    "stripe": "^6.36.0",
+    "stripe": "^7.9.0",
     "superagent": "^5.0.2",
     "svg-inline-loader": "^0.8.0",
     "svg-url-loader": "^3.0.0",

--- a/test/api/unit/libs/payments/stripe/edit-subscription.test.js
+++ b/test/api/unit/libs/payments/stripe/edit-subscription.test.js
@@ -97,17 +97,17 @@ describe('edit subscription', () => {
 
     beforeEach(() => {
       subscriptionId = 'subId';
-      stripeListSubscriptionStub = sinon.stub(stripe.customers, 'listSubscriptions')
+      stripeListSubscriptionStub = sinon.stub(stripe.subscriptions, 'list')
         .resolves({
           data: [{id: subscriptionId}],
         });
 
-      stripeUpdateSubscriptionStub = sinon.stub(stripe.customers, 'updateSubscription').resolves({});
+      stripeUpdateSubscriptionStub = sinon.stub(stripe.subscriptions, 'update').resolves({});
     });
 
     afterEach(() => {
-      stripe.customers.listSubscriptions.restore();
-      stripe.customers.updateSubscription.restore();
+      stripe.subscriptions.list.restore();
+      stripe.subscriptions.update.restore();
     });
 
     it('edits a user subscription', async () => {
@@ -118,10 +118,9 @@ describe('edit subscription', () => {
       }, stripe);
 
       expect(stripeListSubscriptionStub).to.be.calledOnce;
-      expect(stripeListSubscriptionStub).to.be.calledWith(user.purchased.plan.customerId);
+      expect(stripeListSubscriptionStub).to.be.calledWith({customer: user.purchased.plan.customerId});
       expect(stripeUpdateSubscriptionStub).to.be.calledOnce;
       expect(stripeUpdateSubscriptionStub).to.be.calledWith(
-        user.purchased.plan.customerId,
         subscriptionId,
         { card: token }
       );
@@ -135,10 +134,9 @@ describe('edit subscription', () => {
       }, stripe);
 
       expect(stripeListSubscriptionStub).to.be.calledOnce;
-      expect(stripeListSubscriptionStub).to.be.calledWith(group.purchased.plan.customerId);
+      expect(stripeListSubscriptionStub).to.be.calledWith({customer: group.purchased.plan.customerId});
       expect(stripeUpdateSubscriptionStub).to.be.calledOnce;
       expect(stripeUpdateSubscriptionStub).to.be.calledWith(
-        group.purchased.plan.customerId,
         subscriptionId,
         { card: token }
       );

--- a/website/server/libs/payments/stripe.js
+++ b/website/server/libs/payments/stripe.js
@@ -79,9 +79,9 @@ api.editSubscription = async function editSubscription (options, stripeInc) {
   if (!customerId) throw new NotAuthorized(i18n.t('missingSubscription'));
   if (!token) throw new BadRequest('Missing req.body.id');
 
-  let subscriptions = await stripeApi.customers.listSubscriptions(customerId); // @TODO: Handle Stripe Error response
+  let subscriptions = await stripeApi.subscriptions.list({customer: customerId}); // @TODO: Handle Stripe Error response
   let subscriptionId = subscriptions.data[0].id;
-  await stripeApi.customers.updateSubscription(customerId, subscriptionId, { card: token });
+  await stripeApi.subscriptions.update(subscriptionId, { card: token });
 };
 
 /**


### PR DESCRIPTION
Closes #10897
We're on 5.x currentrly and the latest is 7.x so I'm going to do this in steps:

### 6
- [x] only one minor breaking change https://github.com/stripe/stripe-node/pull/453/files that affects the `usageRecords`  api that we don't use

### 7 

Migration guide at https://github.com/stripe/stripe-node/wiki/Migration-guide-for-v7

#### Removed methods (that we use)
- [x] customers.listSubscriptions()
- [x] customers.updateSubscription()