### PR TITLE
load user info per conversation.id - 2nd try

### DIFF
--- a/test/api/v4/inbox/GET-inbox-conversations.test.js
+++ b/test/api/v4/inbox/GET-inbox-conversations.test.js
@@ -35,9 +35,14 @@ describe('GET /inbox/conversations', () => {
   });
 
   it('returns the conversations', async () => {
+    await user.post('/members/send-private-message', {
+      toUserId: user.id,
+      message: 'some notes to myself',
+    });
+
     const result = await user.get('/inbox/conversations');
 
-    expect(result.length).to.be.equal(3);
+    expect(result.length).to.be.equal(4);
     expect(result[0].user).to.be.equal(user.profile.name);
     expect(result[0].username).to.be.equal(user.auth.local.username);
     expect(result[0].text).to.be.not.empty;

--- a/test/api/v4/inbox/GET-inbox-conversations.test.js
+++ b/test/api/v4/inbox/GET-inbox-conversations.test.js
@@ -35,14 +35,9 @@ describe('GET /inbox/conversations', () => {
   });
 
   it('returns the conversations', async () => {
-    await user.post('/members/send-private-message', {
-      toUserId: user.id,
-      message: 'some notes to myself',
-    });
-
     const result = await user.get('/inbox/conversations');
 
-    expect(result.length).to.be.equal(4);
+    expect(result.length).to.be.equal(3);
     expect(result[0].user).to.be.equal(user.profile.name);
     expect(result[0].username).to.be.equal(user.auth.local.username);
     expect(result[0].text).to.be.not.empty;

--- a/website/server/libs/inbox/index.js
+++ b/website/server/libs/inbox/index.js
@@ -86,12 +86,8 @@ async function usersMapByConversations (owner, users) {
       {
         $group: {
           _id: '$uuid',
-          user: {$last: '$user' },
-          username: {$last: '$username' },
           userStyles: {$last: '$userStyles'},
           contributor: {$last: '$contributor'},
-
-          count: {$sum: 1},
         },
       },
     ]);

--- a/website/server/libs/inbox/index.js
+++ b/website/server/libs/inbox/index.js
@@ -1,6 +1,7 @@
 import {mapInboxMessage, inboxModel as Inbox} from '../../models/message';
 import {getUserInfo, sendTxn as sendTxnEmail} from '../email';
 import {sendNotification as sendPushNotification} from '../pushNotifications';
+import { model as User } from '../../models/user';
 
 const PM_PER_PAGE = 10;
 
@@ -89,8 +90,6 @@ export async function listConversations (owner) {
           username: {$last: '$username' },
           timestamp: {$last: '$timestamp'},
           text: {$last: '$text'},
-          userStyles: {$last: '$userStyles'},
-          contributor: {$last: '$contributor'},
           count: {$sum: 1},
         },
       },
@@ -99,9 +98,32 @@ export async function listConversations (owner) {
 
   const conversationsList = await query.exec();
 
+  const usersQuery = {
+    _id: {$in: conversationsList.map(c => c._id) },
+  };
+
+  const usersAr = await User.find(usersQuery,  {
+    _id: 1,
+    contributor: 2,
+    items: 3,
+    preferences: 4,
+    stats: 5,
+  }).exec();
+  const usersMap = {};
+
+  for (const usr of usersAr) {
+    usersMap[usr._id] = usr;
+  }
+
   const conversations = conversationsList.map((res) => ({
     uuid: res._id,
     ...res,
+    userStyles: {
+      items: usersMap[res._id].items,
+      preferences: usersMap[res._id].preferences,
+      stats: usersMap[res._id].stats,
+    },
+    contributor: usersMap[res._id].contributor,
   }));
 
   return conversations;

--- a/website/server/libs/inbox/index.js
+++ b/website/server/libs/inbox/index.js
@@ -1,7 +1,6 @@
 import {mapInboxMessage, inboxModel as Inbox} from '../../models/message';
 import {getUserInfo, sendTxn as sendTxnEmail} from '../email';
 import {sendNotification as sendPushNotification} from '../pushNotifications';
-import { model as User } from '../../models/user';
 
 const PM_PER_PAGE = 10;
 

--- a/website/server/libs/inbox/index.js
+++ b/website/server/libs/inbox/index.js
@@ -104,10 +104,10 @@ export async function listConversations (owner) {
 
   const usersAr = await User.find(usersQuery,  {
     _id: 1,
-    contributor: 2,
-    items: 3,
-    preferences: 4,
-    stats: 5,
+    contributor: 1,
+    items: 1,
+    preferences: 1,
+    stats: 1,
   }).exec();
   const usersMap = {};
 


### PR DESCRIPTION
In #11368 I didn't counted in deleted users.

Now I load the user-infos of the conversations itself (2nd query)

~Todo / check~
- [x] get the "latest" user data (for avatar)  (always latest due to **$last**)