### PR TITLE
Fix Purchase Background Modal on "Edit Avatar"

### DIFF
--- a/website/client/components/creatorIntro.vue
+++ b/website/client/components/creatorIntro.vue
@@ -196,10 +196,6 @@ b-modal#avatar-modal(title="", :size='editing ? "lg" : "md"', :hide-header='true
   /* @TODO do not rely on avatar-modal___BV_modal_body_,
      it already changed once when bootstrap-vue reached version 1 */
 
-  #avatar-modal___BV_modal_outer_ {
-    z-index: 1045 !important; // on production the toolbar has a higher z-index
-  }
-
   #avatar-modal___BV_modal_body_, #avatar-modal___BV_modal_body_ {
     padding: 0;
   }

--- a/website/client/components/header/menu.vue
+++ b/website/client/components/header/menu.vue
@@ -250,7 +250,6 @@ div
 
     &-modal {
       z-index: 1035;
-    z-index: 1042; // To stay above snakbar notifications and modals
     }
   }
 


### PR DESCRIPTION
This PR removes an older, now obsolete, z-index override.  (Navbars should not stay above modals, and notifications are positioned under the navbar)

Also removes my previous override (that was added because of the previous mentioned one^^)
