### PR TITLE
Fix dark-on-dark in quest modal tooltip (fixes #11117)

### DIFF
--- a/website/client/components/shops/quests/questInfo.vue
+++ b/website/client/components/shops/quests/questInfo.vue
@@ -77,6 +77,13 @@ dt {
   }
 }
 
+// popover used in quest selection modal
+.popover-body {
+  dt {
+    color: inherit;
+  }
+}
+
 // making sure the star-colors always correct
 .star {
   fill: #ffb445;


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11117 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

#11317 fixed the light text on white background in the main info area noted in the issue, but the issue also noted a similar issue with dark text on a dark background in the popover displayed when the mouse hovers over a quest in the sidebar of that info modal. This fixes that to match the screenshot @Tressley posted in the issue. Went over my local site with a fine-toothed comb, to test as well as because I'm constantly paranoid of doing things wrong and messing everything up somehow, and everything seems fine.

Before:
![before](https://user-images.githubusercontent.com/14182450/66005793-803af000-e47a-11e9-8db7-2b1fda5c4788.PNG)

After:
![after](https://user-images.githubusercontent.com/14182450/66005792-803af000-e47a-11e9-8fc5-e60efa05a615.PNG)

(The screenshot shows a boss quest but this happens with and is fixed for all quest types.)

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 2d6ef231-50b4-4a22-90e7-45eb97147a2c
