### PR TITLE
fix(chat): change class name because of active route

### DIFF
--- a/website/client/components/chat/chatCard.vue
+++ b/website/client/components/chat/chatCard.vue
@@ -26,10 +26,10 @@ div
         .svg-icon(v-html="icons.delete", v-once)
         div(v-once) {{$t('delete')}}
       .ml-auto.d-flex(v-b-tooltip="{title: likeTooltip(msg.likes[user._id])}", v-if='!inbox')
-        .action.d-flex.align-items-center.mr-0(@click='like()', v-if='likeCount > 0', :class='{active: msg.likes[user._id]}')
+        .action.d-flex.align-items-center.mr-0(@click='like()', v-if='likeCount > 0', :class='{activeLike: msg.likes[user._id]}')
           .svg-icon(v-html="icons.liked", :title='$t("liked")')
           | +{{ likeCount }}
-        .action.d-flex.align-items-center.mr-0(@click='like()', v-if='likeCount === 0', :class='{active: msg.likes[user._id]}')
+        .action.d-flex.align-items-center.mr-0(@click='like()', v-if='likeCount === 0', :class='{activeLike: msg.likes[user._id]}')
           .svg-icon(v-html="icons.like", :title='$t("like")')
       span(v-if='!msg.likes[user._id] && !inbox') {{ $t('like') }}
 </template>
@@ -106,7 +106,7 @@ div
     }
   }
 
-  .active {
+  .activeLike {
     color: $purple-300;
 
     .svg-icon {


### PR DESCRIPTION
[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11404

### Changes
Renamed like `active` class name to `activeLike`, so it is not get confused with current active route class.

The bug in the issue was occurring because [Vue Router applies a class name](https://router.vuejs.org/api/#active-class) to links that are active routes. This class name is not applied when the route is activated by a link - which are 90% of the cases -, but it is when accessed from a new tab or url.
Also, by default, this active route class name is `router-link-active`, but in the Habitica's project it is replaced via the `linkActiveClass` router constructor option in `router/index.js`.

![linkActiveClass](https://i.imgur.com/FWTW0Z0.png)

The `active` class name was being applied to the like button ![likebutton](http://i.imgur.com/ekGWwpC.png) when the user has liked someone's post **and also when displaying a user's chat message while visiting its profile directly (new tab/direct url)**.

![activeLike](https://i.imgur.com/zXEVbJT.png)

The fix is changing this `active` like class name to `activeLike`, so it doens't get "triggered" by active route class name.

----
UUID: 40387571-91ee-489e-960f-278bf8fd503a
