### PR TITLE
Show 0 in the gem prize box if gem prize is null

### DIFF
--- a/website/client/src/components/challenges/challengeDetail.vue
+++ b/website/client/src/components/challenges/challengeDetail.vue
@@ -68,7 +68,7 @@
               class="svg-icon gem-icon"
               v-html="icons.gemIcon"
             ></div>
-            {{ challenge.prize }}
+            {{ challenge.prize || 0}}
             <div
               v-once
               class="details"

--- a/website/client/src/components/challenges/challengeDetail.vue
+++ b/website/client/src/components/challenges/challengeDetail.vue
@@ -68,7 +68,7 @@
               class="svg-icon gem-icon"
               v-html="icons.gemIcon"
             ></div>
-            {{ challenge.prize || 0}}
+            {{ challenge.prize || 0 }}
             <div
               v-once
               class="details"

--- a/website/client/src/components/challenges/challengeItem.vue
+++ b/website/client/src/components/challenges/challengeItem.vue
@@ -6,7 +6,7 @@
           class="svg-icon"
           v-html="icons.gemIcon"
         ></span>
-        <span class="value">{{ challenge.prize || 0}}</span>
+        <span class="value">{{ challenge.prize || 0 }}</span>
       </div>
       <div class="label">
         {{ $t('prize') }}

--- a/website/client/src/components/challenges/challengeItem.vue
+++ b/website/client/src/components/challenges/challengeItem.vue
@@ -6,7 +6,7 @@
           class="svg-icon"
           v-html="icons.gemIcon"
         ></span>
-        <span class="value">{{ challenge.prize }}</span>
+        <span class="value">{{ challenge.prize || 0}}</span>
       </div>
       <div class="label">
         {{ $t('prize') }}


### PR DESCRIPTION
Fixes #11264 

### Changes

Validating if `challenge.prize` is null. If so, show `0` gems instead.

Existing behaviour
![image](https://user-images.githubusercontent.com/35370302/67165872-05cb0500-f382-11e9-934d-b82b9cbd7baa.png)


New behaviour
![image](https://user-images.githubusercontent.com/35370302/67165898-66f2d880-f382-11e9-841e-d15a1fc57b06.png)


----
UUID: 4c0fa3ff-440c-418a-85ee-1ad7ea998a20
