### PR TITLE
 fixes #11457 - remove z-index for three-dots menu on tasks

### DIFF
--- a/website/client/src/components/tasks/task.vue
+++ b/website/client/src/components/tasks/task.vue
@@ -371,6 +371,7 @@
 
     &:hover {
       box-shadow: 0 1px 8px 0 rgba($black, 0.12), 0 4px 4px 0 rgba($black, 0.16);
+      z-index: 11;
     }
   }
 

--- a/website/client/src/components/tasks/task.vue
+++ b/website/client/src/components/tasks/task.vue
@@ -371,7 +371,6 @@
 
     &:hover {
       box-shadow: 0 1px 8px 0 rgba($black, 0.12), 0 4px 4px 0 rgba($black, 0.16);
-      z-index: 10;
     }
   }
 


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #11457 
- [x] bugfix
- [ ] Includes tests
- [ ] Documentation update

#### Overview of change:
Remove `z-index` from `hover` from class `task`

#### Before Fix:
<img width="291" alt="Screenshot 2019-10-23 at 2 18 36 PM" src="https://user-images.githubusercontent.com/25791025/67375326-11941280-f5a0-11e9-9737-ad77337a19d8.png">


#### After Fix:
<img width="266" alt="Screenshot 2019-10-23 at 2 13 39 PM" src="https://user-images.githubusercontent.com/25791025/67374938-8581eb00-f59f-11e9-91d1-671525d16e52.png">

