### PR TITLE
Allow update webhook label with an empty string

### DIFF
--- a/test/api/v3/integration/webhook/PUT-user_update_webhook.test.js
+++ b/test/api/v3/integration/webhook/PUT-user_update_webhook.test.js
@@ -63,6 +63,26 @@ describe('PUT /user/webhook/:id', () => {
     expect(webhook.options).to.eql(options);
   });
 
+  it('updates a webhook with empty label', async () => {
+    const url = 'http://a-new-url.com';
+    const type = 'groupChatReceived';
+    const label = '';
+    const options = { groupId: generateUUID() };
+
+    await user.put(`/user/webhook/${webhookToUpdate.id}`, {
+      url, type, options, label,
+    });
+
+    await user.sync();
+
+    const webhook = user.webhooks.find(hook => webhookToUpdate.id === hook.id);
+
+    expect(webhook.url).to.equal(url);
+    expect(webhook.label).to.equal(label);
+    expect(webhook.type).to.equal(type);
+    expect(webhook.options).to.eql(options);
+  });
+
   it('returns the updated webhook', async () => {
     const url = 'http://a-new-url.com';
     const type = 'groupChatReceived';

--- a/website/server/controllers/api-v3/webhook.js
+++ b/website/server/controllers/api-v3/webhook.js
@@ -179,7 +179,7 @@ api.updateWebhook = {
       webhook.url = url;
     }
 
-    if (label) {
+    if (label !== null && label !== undefined) {
       webhook.label = label;
     }
 

--- a/website/server/controllers/api-v3/webhook.js
+++ b/website/server/controllers/api-v3/webhook.js
@@ -179,6 +179,7 @@ api.updateWebhook = {
       webhook.url = url;
     }
 
+    // using this check to allow the setting of empty labels
     if (label !== null && label !== undefined) {
       webhook.label = label;
     }


### PR DESCRIPTION
Fixes #11477 

### Changes
Checking if `label` is `null` or `undefined` instead of checking if it's also an empty string + tests

![image](https://user-images.githubusercontent.com/35370302/67633812-96d33c00-f8ac-11e9-8a5b-f8582a457d8b.png)

![image](https://user-images.githubusercontent.com/35370302/67633814-9e92e080-f8ac-11e9-84fb-710c3e59092b.png)

----
UUID: 4c0fa3ff-440c-418a-85ee-1ad7ea998a20