### PR TITLE
Fix market dropdownmenu default text

### DIFF
--- a/website/client/src/components/ui/filterDropdown.vue
+++ b/website/client/src/components/ui/filterDropdown.vue
@@ -1,7 +1,9 @@
 <template>
   <span>
     <span class="dropdown-label">{{ label }}</span>
-    <b-dropdown right="right">
+    <b-dropdown
+    :text="(selectedItem.id.includes('sortBy')) ? selectedItem.id.substring(6) : selectedItem.id"
+    right="right">
       <span
         slot="text"
         :class="{'dropdown-icon-item': withIcon}"

--- a/website/client/src/components/ui/filterDropdown.vue
+++ b/website/client/src/components/ui/filterDropdown.vue
@@ -1,11 +1,9 @@
 <template>
   <span>
     <span class="dropdown-label">{{ label }}</span>
-    <b-dropdown
-    :text="(selectedItem.id.includes('sortBy')) ? selectedItem.id.substring(6) : selectedItem.id"
-    right="right">
+    <b-dropdown right="right">
       <span
-        slot="text"
+        slot="button-content"
         :class="{'dropdown-icon-item': withIcon}"
       >
         <slot


### PR DESCRIPTION
Add text attribute to b-dropdown in filterDropdown component

[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11423
### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)



[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 
