### PR TITLE
Show specific number of pets/mounts in button "Show More"

### DIFF
--- a/website/client/src/components/inventory/stable/index.vue
+++ b/website/client/src/components/inventory/stable/index.vue
@@ -187,7 +187,7 @@
           class="btn btn-flat btn-show-more"
           @click="setShowMore(petGroup.key)"
         >
-          {{ $_openedItemRows_isToggled(petGroup.key) ? $t('showLess') : $t('showMore') }}
+          {{ $_openedItemRows_isToggled(petGroup.key) ? $t('showLess') : $t('showMore') + getTextOwnedAnimals(petGroup, $t('pets')) }}
         </div>
       </div>
       <h2>
@@ -246,7 +246,7 @@
           class="btn btn-flat btn-show-more"
           @click="setShowMore(mountGroup.key)"
         >
-          {{ $_openedItemRows_isToggled(mountGroup.key) ? $t('showLess') : $t('showMore') }}
+          {{ $_openedItemRows_isToggled(mountGroup.key) ? $t('showLess') : $t('showMore') + getTextOwnedAnimals(mountGroup, $t('mounts')) }}
         </div>
       </div>
       <inventoryDrawer>
@@ -778,14 +778,21 @@ export default {
 
       return animals;
     },
-    countOwnedAnimals (animalGroup, type) {
+    getTextOwnedAnimals (petGroup, pets) {
+      return ` (${this.getCountOwnedAnimals(petGroup, 'pet')} ${petGroup.label} ${pets})`;
+    },
+    getCountOwnedAnimals (animalGroup, type) {
       const animals = this.getAnimalList(animalGroup, type);
 
-      const countAll = animals.length;
       // when counting pets, include those that have been raised into mounts
       const countOwned = _filter(animals, a => a.isOwned() || a.mountOwned());
+      return countOwned.length;
+    },
+    countOwnedAnimals (animalGroup, type) {
+      const animals = this.getAnimalList(animalGroup, type);
+      const count = animals.length;
 
-      return `${countOwned.length}/${countAll}`;
+      return `${this.getCountOwnedAnimals(animalGroup, type)}/${count}`;
     },
     pets (animalGroup, hideMissing, sortBy, searchText) {
       const pets = this.listAnimals(animalGroup, 'pet', hideMissing, sortBy, searchText);


### PR DESCRIPTION
Fixes #9786

### Changes
This fix displays the number of already owned pets (mounts) in the button "Show more". Therefore, this button would contain the text "Show more (2 Standard Pets)" in case this user already owns 2 pets.

![image](https://user-images.githubusercontent.com/17971153/67725930-5d9de780-f9e4-11e9-8fc1-577a34e2d733.png)

To test this fix pets (mounts) should be added to the users collection. This can be done by means of
`> db.users.update({'auth.local.username': 'testusername'}, { $set: {'items.pets.Wolf-Base': 1} })`

----
UUID: 7c99d188-7c2e-45cc-9da3-130a26b63cf5
