### PR TITLE
Permit changing the name of a party without adding a description

### DIFF
--- a/website/client/src/components/groups/groupFormModal.vue
+++ b/website/client/src/components/groups/groupFormModal.vue
@@ -254,7 +254,7 @@ label.custom-control-label(v-once) {{ $t('allowGuildInvitationsFromNonMembers') 
         <button
           v-if="workingGroup.id"
           class="btn btn-primary btn-md"
-          :disabled="!workingGroup.name || !workingGroup.description"
+          :disabled="!workingGroup.name"
         >
           {{ isParty ? $t('updateParty') : $t('updateGuild') }}
         </button>


### PR DESCRIPTION
Fixes #10828

### Changes
Until now a description had to be added when changing the name of a party. Now the party name can be changed without also changing its description.

As the picture below shows, the Button is enabled even though the description was not changed.

![image](https://user-images.githubusercontent.com/17971153/68019008-daf28200-fc9a-11e9-9476-0943e12666d8.png)

UUID: 7c99d188-7c2e-45cc-9da3-130a26b63cf5