### PR TITLE
Prevent duplicate challenge tasks

### DIFF
--- a/migrations/challenges/sync-all-challenges.js
+++ b/migrations/challenges/sync-all-challenges.js
@@ -10,7 +10,7 @@ async function syncChallengeToMembers (challenges) {
 
     const promises = [];
     users.forEach(user => {
-      promises.push(challenge.syncToUser(user));
+      promises.push(challenge.syncTasksToUser(user));
       promises.push(challenge.save());
       promises.push(user.save());
     });

--- a/test/api/unit/models/challenge.test.js
+++ b/test/api/unit/models/challenge.test.js
@@ -120,7 +120,7 @@ describe('Challenge Model', () => {
         expect(updatedNewMember.challenges.length).to.eql(1);
       });
 
-      it('syncs a challenge to a user', async () => {
+      it('syncs challenge tasks to a user', async () => {
         await challenge.addTasks([task]);
 
         const newMember = new User({
@@ -128,7 +128,7 @@ describe('Challenge Model', () => {
         });
         await newMember.save();
 
-        await challenge.syncToUser(newMember);
+        await challenge.syncTasksToUser(newMember);
 
         const updatedNewMember = await User.findById(newMember._id);
         const updatedNewMemberTasks = await Tasks.Task.find({ _id: { $in: updatedNewMember.tasksOrder[`${taskType}s`] } });
@@ -146,7 +146,7 @@ describe('Challenge Model', () => {
         expect(syncedTask.attribute).to.eql('str');
       });
 
-      it('syncs a challenge to a user with the existing task', async () => {
+      it('syncs challenge tasks to a user with the existing task', async () => {
         await challenge.addTasks([task]);
 
         let updatedLeader = await User.findOne({ _id: leader._id });
@@ -163,7 +163,7 @@ describe('Challenge Model', () => {
         task.text = newTitle;
         task.attribute = 'int';
         await task.save();
-        await challenge.syncToUser(leader);
+        await challenge.syncTasksToUser(leader);
 
         updatedLeader = await User.findOne({ _id: leader._id });
         updatedLeadersTasks = await Tasks.Task.find({ _id: { $in: updatedLeader.tasksOrder[`${taskType}s`] } });

--- a/test/api/unit/models/challenge.test.js
+++ b/test/api/unit/models/challenge.test.js
@@ -90,6 +90,36 @@ describe('Challenge Model', () => {
         expect(syncedTask.tags[0]).to.eql(challenge._id);
       });
 
+      it('adds a challenge to a user', async () => {
+        const newMember = new User({
+          guilds: [guild._id],
+        });
+        await newMember.save();
+
+        const addedSuccessfully = await challenge.addToUser(newMember);
+
+        const updatedNewMember = await User.findById(newMember._id);
+
+        expect(addedSuccessfully).to.eql(true);
+        expect(updatedNewMember.challenges).to.contain(challenge._id);
+      });
+
+      it('does not add a challenge to a user that already in the challenge', async () => {
+        const newMember = new User({
+          guilds: [guild._id],
+          challenges: [challenge._id],
+        });
+        await newMember.save();
+
+        const addedSuccessfully = await challenge.addToUser(newMember);
+
+        const updatedNewMember = await User.findById(newMember._id);
+
+        expect(addedSuccessfully).to.eql(false);
+        expect(updatedNewMember.challenges).to.contain(challenge._id);
+        expect(updatedNewMember.challenges.length).to.eql(1);
+      });
+
       it('syncs a challenge to a user', async () => {
         await challenge.addTasks([task]);
 
@@ -110,7 +140,6 @@ describe('Challenge Model', () => {
           ),
         );
 
-        expect(updatedNewMember.challenges).to.contain(challenge._id);
         expect(updatedNewMember.tags[7].id).to.equal(challenge._id);
         expect(updatedNewMember.tags[7].name).to.equal(challenge.shortName);
         expect(syncedTask).to.exist;

--- a/website/server/controllers/api-v3/challenges.js
+++ b/website/server/controllers/api-v3/challenges.js
@@ -270,7 +270,7 @@ api.joinChallenge = {
     addUserJoinChallengeNotification(user);
 
     // Add all challenge's tasks to user's tasks and save the challenge
-    const results = await Promise.all([challenge.syncToUser(user), challenge.save()]);
+    const results = await Promise.all([challenge.syncTasksToUser(user), challenge.save()]);
 
     const response = results[1].toJSON();
     response.group = getChallengeGroupResponse(group);

--- a/website/server/controllers/api-v3/challenges.js
+++ b/website/server/controllers/api-v3/challenges.js
@@ -260,19 +260,8 @@ api.joinChallenge = {
     });
     if (!group || !challenge.canJoin(user, group)) throw new NotFound(res.t('challengeNotFound'));
 
-    // Add challenge to users challenges atomically (with condition that checks that it is not there already)
-    // to prevent multiple concurrent requests from passing through
-    // see https://github.com/HabitRPG/habitica/issues/11295
-    const result = await User.update(
-      {
-        _id: user._id,
-        challenges: { $nin: [ challenge._id ] }
-      },
-      { $push: { challenges: challenge._id } }
-    ).exec();
-
-    // if query did not modify, it means user already in the challenge
-    if (!result.nModified) {
+    const addedSuccessfully = await challenge.addToUser(user);
+    if (!addedSuccessfully) {
       throw new NotAuthorized(res.t('userAlreadyInChallenge'));
     }
 

--- a/website/server/models/challenge.js
+++ b/website/server/models/challenge.js
@@ -119,9 +119,9 @@ schema.methods.canView = function canViewChallenge (user, group) {
   return this.canJoin(user, group);
 };
 
-// Sync challenge to user, including tasks and tags.
+// Sync challenge tasks to user, including tags.
 // Used when user joins the challenge or to force sync.
-schema.methods.syncToUser = async function syncChallengeToUser (user) {
+schema.methods.syncTasksToUser = async function syncChallengeTasksToUser (user) {
   const challenge = this;
   challenge.shortName = challenge.shortName || challenge.name;
 

--- a/website/server/models/challenge.js
+++ b/website/server/models/challenge.js
@@ -103,9 +103,9 @@ schema.methods.addToUser = async function addChallengeToUser (user) {
   const result = await User.update(
     {
       _id: user._id,
-      challenges: { $nin: [ this._id ] }
+      challenges: { $nin: [this._id] },
     },
-    { $push: { challenges: this._id } }
+    { $push: { challenges: this._id } },
   ).exec();
 
   return !!result.nModified;


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11295

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Created a separate method `addToUser` in challenge model that handles adding the challenge to users challenges atomically (with a condition that checks that it is not there already) to prevent multiple concurrent requests from passing through. See issue for more details (#11295).

Also renamed `syncToUser` method to `syncTasksToUser` since now that adding the challenge to user is not there anymore, it's main purpose is to sync the tasks.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: fa756acf-9127-4a3c-8dac-8ff627d30073
