### PR TITLE
Redirect user to 'Discover Challenges' page on loading an inaccessible challenge. Fixes #11420

### DIFF
--- a/website/client/src/components/challenges/challengeDetail.vue
+++ b/website/client/src/components/challenges/challengeDetail.vue
@@ -417,7 +417,12 @@ export default {
       return cleansedTask;
     },
     async loadChallenge () {
-      this.challenge = await this.$store.dispatch('challenges:getChallenge', { challengeId: this.searchId });
+      try {
+        this.challenge = await this.$store.dispatch('challenges:getChallenge', { challengeId: this.searchId });
+      } catch (e) {
+        this.$router.push('/challenges/findChallenges');
+        return;
+      }
       this.members = await this
         .loadMembers({ challengeId: this.searchId, includeAllPublicFields: true });
       const tasks = await this.$store.dispatch('tasks:getChallengeTasks', { challengeId: this.searchId });


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11420
 
Description:
This PR is related to issue#11420 where the user is able to see challenge detail page with its regular but unresponsive UI elements, when a challenge (e.g. from My Challenges) that is no longer accessible to user is opened. As part of proposed solution, the fix aims to take user to 'Discover Challenges' page in that case and show the error message accordingly.

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
The changes are made in loadChallenge() method of challengeDetail.vue component to intercept the loading of challenge info on the page. In case the challenge attempted to load is not accessible to the current user, the already existing logic throws an exception. This is now caught(per my changes) in a catch block to update the router view to 'findChallenges'. This will take user to '_Discover Challenges_' page and error message from thrown exception is automatically rendered on this page.

Current Status:
The fix has been developed and tested locally. However **I could not run all the tests(npm run test) successfully in my machine due to timeout error**. Upon running tests for each subset, I received same timeout error while running 'unit' tests(npm run test:api:unit) but existing unit test file (GET-challenges_challengeId.test.js) related to my changes successfully ran when I executed npm run test:api-v3:integration.

As such, **I'm hoping to receive the full test results of test suite as part of this PR creation before submitting it for actual review**. **I will update once its ready for review** or if I need more info on further activities.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 984e9826-a483-4036-beed-d94d2fbc9446
