### PR TITLE
Make hatching modal height adjust automatically to dialog text length (fixes #10232)

### DIFF
--- a/website/client/src/components/inventory/stable/hatchingModal.vue
+++ b/website/client/src/components/inventory/stable/hatchingModal.vue
@@ -70,7 +70,8 @@
     }
 
     .text {
-      height: 60px;
+      height: auto;
+      min-height: 60px;
       font-size: 14px;
       line-height: 1.43;
       text-align: center;


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10232 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Changes modal text area's height to auto to accommodate languages too long for the previous height of 60px. Sets previous 60px height as the minimum height of the modal.

Before:

![hatching modal german before](https://user-images.githubusercontent.com/14182450/68679128-45be7b80-052d-11ea-99c5-9343263267ea.PNG)

After:

![hatching modal german after](https://user-images.githubusercontent.com/14182450/68679414-d1d0a300-052d-11ea-8c91-0e4120e67c51.PNG)

If for any reason the modal is tall enough to go offscreen, it scrolls just fine, just the same as any other modal (i.e. Bailey or quest modals) when they're too tall. (I have a screenshot of this but wasn't sure I needed to share it so I haven't done so here.)



[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 2d6ef231-50b4-4a22-90e7-45eb97147a2c
