### PR TITLE
update members list and count when joining or leaving challenge

### DIFF
--- a/website/client/src/components/challenges/challengeDetail.vue
+++ b/website/client/src/components/challenges/challengeDetail.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="row">
     <challenge-modal @updatedChallenge="updatedChallenge" />
-    <leave-challenge-modal :challenge-id="challenge._id" />
+    <leave-challenge-modal :challenge-id="challenge._id" @update-challenge="updateChallenge" />
     <close-challenge-modal
       :members="members"
       :challenge-id="challenge._id"
@@ -491,15 +491,19 @@ export default {
     },
     async joinChallenge () {
       this.user.challenges.push(this.searchId);
-      this.challenge.memberCount += 1;
-      this.members = [this.user, ...this.members];
-      await this.$store.dispatch('challenges:joinChallenge', { challengeId: this.searchId });
+      this.challenge = await this.$store.dispatch('challenges:joinChallenge', { challengeId: this.searchId });
+      this.members = await this
+        .loadMembers({ challengeId: this.searchId, includeAllPublicFields: true });
+
       await this.$store.dispatch('tasks:fetchUserTasks', { forceLoad: true });
     },
     async leaveChallenge () {
-      this.challenge.memberCount -= 1;
-      this.members = this.members.filter(member => member._id !== this.user._id);
       this.$root.$emit('bv::show::modal', 'leave-challenge-modal');
+    },
+    async updateChallenge () {
+      this.challenge = await this.$store.dispatch('challenges:getChallenge', { challengeId: this.searchId });
+      this.members = await this
+        .loadMembers({ challengeId: this.searchId, includeAllPublicFields: true });
     },
     closeChallenge () {
       this.$root.$emit('bv::show::modal', 'close-challenge-modal');

--- a/website/client/src/components/challenges/challengeDetail.vue
+++ b/website/client/src/components/challenges/challengeDetail.vue
@@ -491,10 +491,14 @@ export default {
     },
     async joinChallenge () {
       this.user.challenges.push(this.searchId);
+      this.challenge.memberCount += 1;
+      this.members = [this.user, ...this.members];
       await this.$store.dispatch('challenges:joinChallenge', { challengeId: this.searchId });
       await this.$store.dispatch('tasks:fetchUserTasks', { forceLoad: true });
     },
     async leaveChallenge () {
+      this.challenge.memberCount -= 1;
+      this.members = this.members.filter(member => member._id !== this.user._id);
       this.$root.$emit('bv::show::modal', 'leave-challenge-modal');
     },
     closeChallenge () {

--- a/website/client/src/components/challenges/leaveChallengeModal.vue
+++ b/website/client/src/components/challenges/leaveChallengeModal.vue
@@ -54,6 +54,7 @@ export default {
       this.close();
     },
     close () {
+      this.$emit('update-challenge');
       this.$root.$emit('bv::hide::modal', 'leave-challenge-modal');
     },
   },


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11537 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Update the count and members list when leaving/joining a challenge on the front-end so that it is immediately reflected in the UI without having to reload data.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 2d02f021-be7b-4be4-b20e-3488a00336c8
