### PR TITLE
Update rebirth purchase modal text to reference group plans (fixes #8834)

### DIFF
--- a/website/common/locales/en/rebirth.json
+++ b/website/common/locales/en/rebirth.json
@@ -21,7 +21,7 @@
     "rebirthOrb": "Used an Orb of Rebirth to start over after attaining Level <%= level %>.",
     "rebirthOrb100": "Used an Orb of Rebirth to start over after attaining Level 100 or higher.",
     "rebirthOrbNoLevel": "Used an Orb of Rebirth to start over.",
-    "rebirthPop": "Instantly restart your character as a Level 1 Warrior while retaining achievements, collectibles, and equipment. Your tasks and their history will remain but they will be reset to yellow. Your streaks will be removed except from challenge tasks. Your Gold, Experience, Mana, and the effects of all Skills will be removed. All of this will take effect immediately. For more information, see the wiki's <a href='http://habitica.fandom.com/wiki/Orb_of_Rebirth' target='_blank'>Orb of Rebirth</a> page.",
+    "rebirthPop": "Instantly restart your character as a Level 1 Warrior while retaining achievements, collectibles, and equipment. Your tasks and their history will remain but they will be reset to yellow. Your streaks will be removed except from tasks belonging to active Challenges and Group Plans. Your Gold, Experience, Mana, and the effects of all Skills will be removed. All of this will take effect immediately. For more information, see the wiki's <a href='http://habitica.fandom.com/wiki/Orb_of_Rebirth' target='_blank'>Orb of Rebirth</a> page.",
     "rebirthName": "Orb of Rebirth",
     "reborn": "Reborn, max level <%= reLevel %>",
     "confirmReborn": "Are you sure?",


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #8834 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
The behavior the issue asks for (habit counters resetting to zero except for challenge and group plan tasks) appears to already happen when rebirth happens, so this just makes the requested change to the related string (rebirthPop) using the wording used in the issue's first post (that is "challenge tasks" was changed to "tasks belonging to active Challenges and Group Plans".)


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 2d6ef231-50b4-4a22-90e7-45eb97147a2c
