### PR TITLE
remain on party invites tab after removing invite - fixes #11523

### DIFF
--- a/website/client/src/components/groups/membersModal.vue
+++ b/website/client/src/components/groups/membersModal.vue
@@ -656,7 +656,6 @@ export default {
         groupId: this.groupId,
       });
       if (this.invites.length === 0) this.viewMembers();
-      else this.viewInvites();
     },
     async promoteToLeader (member) {
       const groupData = { ...this.group };

--- a/website/client/src/components/groups/membersModal.vue
+++ b/website/client/src/components/groups/membersModal.vue
@@ -655,7 +655,8 @@ export default {
         memberId: member._id,
         groupId: this.groupId,
       });
-      this.viewMembers();
+      if (this.invites.length === 0) this.viewMembers();
+      else this.viewInvites();
     },
     async promoteToLeader (member) {
       const groupData = { ...this.group };


### PR DESCRIPTION
Fixes #11523 

### Changes
When invite is removed from party:
if there are other invites pending, stays on invites tab.
if no other invites are pending, switch back to members tab (since invites tab disappears).

note: did not write tests for change, but willing to add if necessary!

f8773841-dd31-466e-bce9-e412190f414c

----
UUID: 