### PR TITLE
Fix can not remove Group Plan tag

### DIFF
--- a/test/api/unit/models/group.test.js
+++ b/test/api/unit/models/group.test.js
@@ -1164,6 +1164,23 @@ describe('Group Model', () => {
         });
       });
 
+      it('unlink group tag', async () => {
+        participatingMember.tags.push({
+          name: party.name,
+          id: party._id,
+          group: party._id,
+        });
+
+        await participatingMember.save();
+        await party.leave(participatingMember);
+
+        participatingMember = await User.findOne({ _id: participatingMember._id });
+        const groupTag = participatingMember.tags.find(tag => tag.id === party._id);
+
+        expect(groupTag).to.not.be.undefined;
+        expect(groupTag.group).to.be.undefined;
+      });
+
       it('deletes a private party when the last member leaves', async () => {
         await party.leave(participatingMember);
         await party.leave(sleepingParticipatingMember);

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -1345,6 +1345,8 @@ schema.methods.leave = async function leaveGroup (user, keep = 'keep-all', keepC
     .map(task => this.unlinkTask(task, user, keep, false));
   await Promise.all(assignedTasksToRemoveUserFrom);
 
+  this.unlinkTags(user);
+
   // the user could be modified by calls to `unlinkTask` for challenge and group tasks
   // it has not been saved before to avoid multiple saves in parallel
   const promises = user.isModified() ? [user.save()] : [];
@@ -1405,6 +1407,15 @@ schema.methods.leave = async function leaveGroup (user, keep = 'keep-all', keepC
   promises.push(group.update(update).exec());
 
   return Promise.all(promises);
+};
+
+schema.methods.unlinkTags = function unlinkTags (user) {
+  const group = this;
+  user.tags.forEach(tag => {
+    if (tag.group && tag.group === group._id) {
+      tag.group = undefined;
+    }
+  });
 };
 
 /**


### PR DESCRIPTION
- Allow to change name and remove a group tag
- Add a rule to check if the group tag is an active one to hide the
trash icon

[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11522

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
![image](https://user-images.githubusercontent.com/45662151/69009221-aeee2680-0953-11ea-95e2-6c3670a06119.png)

Client : 
- Allow to edit names of all tags
- Allow to remove all tags except if the user belongs to it. (guild or party group plan subscription)

Server :
- api/v4/user update tags. Change rules of tags that will be kept. Do not by default keep all group tags but check if it belongs to an active user guild or party instead.
- When a group leader assigns a new task to a member, do not reset the tag name of this member.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 07bd9063-362f-40c6-8d0c-1fa8b977243d
