### PR TITLE
Better promise handling for bulk emailing

### DIFF
--- a/migrations/users/bulk-email.js
+++ b/migrations/users/bulk-email.js
@@ -16,11 +16,11 @@ async function updateUser (user) {
 
   if (count % progressCount === 0) console.warn(`${count} ${user._id}`);
 
-  sendTxn(
+  await sendTxn(
     user,
     EMAIL_SLUG,
     [{ name: 'BASE_URL', content: BASE_URL }], // Add variables from template
-  );
+  ).catch(err => console.error(err));
 
   return User.update({ _id: user._id }, { $set: { migration: MIGRATION_NAME } }).exec();
 }

--- a/migrations/users/bulk-email.js
+++ b/migrations/users/bulk-email.js
@@ -20,7 +20,7 @@ async function updateUser (user) {
     user,
     EMAIL_SLUG,
     [{ name: 'BASE_URL', content: BASE_URL }], // Add variables from template
-  ).catch(err => console.error(err));
+  );
 
   return User.update({ _id: user._id }, { $set: { migration: MIGRATION_NAME } }).exec();
 }

--- a/website/server/libs/email.js
+++ b/website/server/libs/email.js
@@ -149,4 +149,6 @@ export async function sendTxn (mailingInfoArray, emailType, variables, personalV
       },
     }).catch(err => logger.error(err));
   }
+
+  return null;
 }

--- a/website/server/libs/email.js
+++ b/website/server/libs/email.js
@@ -66,7 +66,7 @@ export function getGroupUrl (group) {
 }
 
 // Send a transactional email using Mandrill through the external email server
-export function sendTxn (mailingInfoArray, emailType, variables, personalVariables) {
+export async function sendTxn (mailingInfoArray, emailType, variables, personalVariables) {
   mailingInfoArray = Array.isArray(mailingInfoArray) ? mailingInfoArray : [mailingInfoArray]; // eslint-disable-line no-param-reassign, max-len
 
   variables = [ // eslint-disable-line no-param-reassign, max-len
@@ -130,7 +130,7 @@ export function sendTxn (mailingInfoArray, emailType, variables, personalVariabl
   }
 
   if (IS_PROD && mailingInfoArray.length > 0) {
-    got.post(`${EMAIL_SERVER.url}/job`, {
+    return got.post(`${EMAIL_SERVER.url}/job`, {
       auth: `${EMAIL_SERVER.auth.user}:${EMAIL_SERVER.auth.password}`,
       json: true,
       body: {


### PR DESCRIPTION
### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Corrects the sync/async logic used in the bulk email script, and the server email library function it uses, so we don't blow through and update users in the database even if the email itself fails. Instead we catch the errors like we ought to!

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)