### PR TITLE
Force reward value to 0 when empty field

### DIFF
--- a/website/client/src/components/tasks/taskModal.vue
+++ b/website/client/src/components/tasks/taskModal.vue
@@ -1437,6 +1437,10 @@ export default {
         this.task.group.sharedCompletion = this.sharedCompletion;
       }
 
+      if (this.task.type === 'reward' && this.task.value === '') {
+        this.task.value = 0;
+      }
+
       if (this.purpose === 'create') {
         if (this.challengeId) {
           const response = await this.$store.dispatch('tasks:createChallengeTasks', {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11560 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
When a user edits or adds a new reward. Force the value to be equal to 0 if the field is empty.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 07bd9063-362f-40c6-8d0c-1fa8b977243d
