### PR TITLE
Fix edit challenge twice bug

### DIFF
--- a/website/client/src/components/challenges/challengeModal.vue
+++ b/website/client/src/components/challenges/challengeModal.vue
@@ -595,7 +595,7 @@ export default {
       this.$root.$emit('bv::hide::modal', 'challenge-modal');
       this.$router.push(`/challenges/${challenge._id}`);
     },
-    updateChallenge () {
+    async updateChallenge () {
       const categoryKeys = this.workingChallenge.categories;
       const serverCategories = [];
       categoryKeys.forEach(key => {
@@ -610,10 +610,8 @@ export default {
       const challengeDetails = clone(this.workingChallenge);
       challengeDetails.categories = serverCategories;
 
-      this.$emit('updatedChallenge', {
-        challenge: challengeDetails,
-      });
-      this.$store.dispatch('challenges:updateChallenge', { challenge: challengeDetails });
+      const challenge = await this.$store.dispatch('challenges:updateChallenge', { challenge: challengeDetails });
+      this.$emit('updatedChallenge', { challenge });
       this.resetWorkingChallenge();
       this.$root.$emit('bv::hide::modal', 'challenge-modal');
     },


### PR DESCRIPTION
Description: Use of a same object property group for differents types between a
challenge and workingChallenge
workingChallenge use group as an id but this.challenge have a group
object

Fix: Wait for server response for challenge edit. Set this.challenge
from response and not directly from form data workingChallenge

[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11561

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
After clicking on "Update Challenge" button wait for server response to set this response as this.challenge. WorkingChallenge is just an image of form data. Should not be used as is.

PS : Like this comment says it is error prone
![image](https://user-images.githubusercontent.com/45662151/69698542-da0c0f00-10e5-11ea-90e8-87f2f48be04e.png)

Maybe group should be groupID instead.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 07bd9063-362f-40c6-8d0c-1fa8b977243d
