### PR TITLE
APIDoc update for Tasks: fixes #10943

### DIFF
--- a/website/server/controllers/api-v3/tasks.js
+++ b/website/server/controllers/api-v3/tasks.js
@@ -76,7 +76,7 @@ const requiredGroupFields = '_id leader tasksOrder name';
  *                                         include: a UUID, startDate and time.
  *                                         For example {"id":"ed427623-9a69-4aac-9852-13deb9c190c3",
  *                                         "startDate":"1/16/17","time":"1/16/17" }
- * @apiParam (Body) {String="weekly","daily"} [frequency=weekly] Value "weekly" enables
+ * @apiParam (Body) {String="daily","weekly","monthly","yearly"} [frequency=weekly] Values "weekly" and
  *                                                               "On days of the week", value
  *                                                               "daily" enables "EveryX Days".
  *                                                               Only valid for type "daily".
@@ -240,7 +240,7 @@ api.createUserTasks = {
  *                                         include: a UUID, startDate and time.
  *                                         For example {"id":"ed427623-9a69-4aac-9852-13deb9c190c3",
  *                                         "startDate":"1/16/17","time":"1/16/17" }
- * @apiParam (Body) {String="weekly","daily"} [frequency=weekly] Value "weekly" enables
+ * @apiParam (Body) {String="daily","weekly","monthly","yearly"} [frequency=weekly] Values "weekly" and
  *                                                               "On days of the week", value
  *                                                               "daily" enables "EveryX Days".
  *                                                               Only valid for type "daily".
@@ -544,7 +544,7 @@ api.getTask = {
  *                                                            Easy, Medium, Hard.
  * @apiParam (Body) {String[]} [reminders] Array of reminders, each an object that must include:
  *                                         a UUID, startDate and time.
- * @apiParam (Body) {String="weekly","daily"} [frequency=weekly] Value "weekly" enables "On days
+ * @apiParam (Body) {String="daily","weekly","monthly","yearly"} [frequency=weekly] Values "weekly" and
  *                                                               of the week", value "daily"
  *                                                               enables "EveryX Days".
  *                                                               Only valid for type "daily".

--- a/website/server/controllers/api-v3/tasks.js
+++ b/website/server/controllers/api-v3/tasks.js
@@ -77,9 +77,11 @@ const requiredGroupFields = '_id leader tasksOrder name';
  *                                         For example {"id":"ed427623-9a69-4aac-9852-13deb9c190c3",
  *                                         "startDate":"1/16/17","time":"1/16/17" }
  * @apiParam (Body) {String="daily","weekly","monthly","yearly"} [frequency=weekly] Values "weekly" and
- *                                                               "On days of the week", value
- *                                                               "daily" enables "EveryX Days".
- *                                                               Only valid for type "daily".
+ *                                                               "monthly" enable use of the "repeat" field.
+ *                                                               All frequency values enable use of the "everyX" field.
+ *                                                               Value "monthly" enables use of the
+ *                                                               "weeksOfMonth" and "daysOfMonth" fields.
+ *                                                               Frequency is only valid for type "daily".
  * @apiParam (Body) {String} [repeat=true] List of objects for days of the week,
  *                                         Days that are true will be repeated upon.
  *                                         Only valid for type "daily". Any days not specified
@@ -241,9 +243,11 @@ api.createUserTasks = {
  *                                         For example {"id":"ed427623-9a69-4aac-9852-13deb9c190c3",
  *                                         "startDate":"1/16/17","time":"1/16/17" }
  * @apiParam (Body) {String="daily","weekly","monthly","yearly"} [frequency=weekly] Values "weekly" and
- *                                                               "On days of the week", value
- *                                                               "daily" enables "EveryX Days".
- *                                                               Only valid for type "daily".
+ *                                                               "monthly" enable use of the "repeat" field.
+ *                                                               All frequency values enable use of the "everyX" field.
+ *                                                               Value "monthly" enables use of the
+ *                                                               "weeksOfMonth" and "daysOfMonth" fields.
+ *                                                               Frequency is only valid for type "daily".
  * @apiParam (Body) {String} [repeat=true] List of objects for days of the week,
  *                                         Days that are true will be repeated upon.
  *                                         Only valid for type "daily". Any days not
@@ -545,9 +549,11 @@ api.getTask = {
  * @apiParam (Body) {String[]} [reminders] Array of reminders, each an object that must include:
  *                                         a UUID, startDate and time.
  * @apiParam (Body) {String="daily","weekly","monthly","yearly"} [frequency=weekly] Values "weekly" and
- *                                                               of the week", value "daily"
- *                                                               enables "EveryX Days".
- *                                                               Only valid for type "daily".
+ *                                                               "monthly" enable use of the "repeat" field.
+ *                                                               All frequency values enable use of the "everyX" field.
+ *                                                               Value "monthly" enables use of the
+ *                                                               "weeksOfMonth" and "daysOfMonth" fields.
+ *                                                               Frequency is only valid for type "daily".
  * @apiParam (Body) {String} [repeat=true] List of objects for days of the week,  Days that
  *                                         are true will be repeated upon. Only valid for type
  *                                         "daily". Any days not specified will be marked as true.

--- a/website/server/controllers/api-v3/tasks.js
+++ b/website/server/controllers/api-v3/tasks.js
@@ -76,12 +76,12 @@ const requiredGroupFields = '_id leader tasksOrder name';
  *                                         include: a UUID, startDate and time.
  *                                         For example {"id":"ed427623-9a69-4aac-9852-13deb9c190c3",
  *                                         "startDate":"1/16/17","time":"1/16/17" }
- * @apiParam (Body) {String="daily","weekly","monthly","yearly"} [frequency=weekly] Values "weekly" and
- *                                                               "monthly" enable use of the "repeat" field.
- *                                                               All frequency values enable use of the "everyX" field.
- *                                                               Value "monthly" enables use of the
- *                                                               "weeksOfMonth" and "daysOfMonth" fields.
- *                                                               Frequency is only valid for type "daily".
+ * @apiParam (Body) {String="daily","weekly","monthly","yearly"} [frequency=weekly] Values "weekly"
+ *                                           and "monthly" enable use of the "repeat" field.
+ *                                           All frequency values enable use of the "everyX" field.
+ *                                           Value "monthly" enables use of the "weeksOfMonth" and
+ *                                           "daysOfMonth" fields.
+ *                                           Frequency is only valid for type "daily".
  * @apiParam (Body) {String} [repeat=true] List of objects for days of the week,
  *                                         Days that are true will be repeated upon.
  *                                         Only valid for type "daily". Any days not specified
@@ -246,12 +246,12 @@ api.createUserTasks = {
  *                                         include: a UUID, startDate and time.
  *                                         For example {"id":"ed427623-9a69-4aac-9852-13deb9c190c3",
  *                                         "startDate":"1/16/17","time":"1/16/17" }
- * @apiParam (Body) {String="daily","weekly","monthly","yearly"} [frequency=weekly] Values "weekly" and
- *                                                               "monthly" enable use of the "repeat" field.
- *                                                               All frequency values enable use of the "everyX" field.
- *                                                               Value "monthly" enables use of the
- *                                                               "weeksOfMonth" and "daysOfMonth" fields.
- *                                                               Frequency is only valid for type "daily".
+ * @apiParam (Body) {String="daily","weekly","monthly","yearly"} [frequency=weekly] Values "weekly"
+ *                                           and "monthly" enable use of the "repeat" field.
+ *                                           All frequency values enable use of the "everyX" field.
+ *                                           Value "monthly" enables use of the "weeksOfMonth" and
+ *                                           "daysOfMonth" fields.
+ *                                           Frequency is only valid for type "daily".
  * @apiParam (Body) {String} [repeat=true] List of objects for days of the week,
  *                                         Days that are true will be repeated upon.
  *                                         Only valid for type "daily". Any days not
@@ -556,12 +556,12 @@ api.getTask = {
  *                                                            Easy, Medium, Hard.
  * @apiParam (Body) {String[]} [reminders] Array of reminders, each an object that must include:
  *                                         a UUID, startDate and time.
- * @apiParam (Body) {String="daily","weekly","monthly","yearly"} [frequency=weekly] Values "weekly" and
- *                                                               "monthly" enable use of the "repeat" field.
- *                                                               All frequency values enable use of the "everyX" field.
- *                                                               Value "monthly" enables use of the
- *                                                               "weeksOfMonth" and "daysOfMonth" fields.
- *                                                               Frequency is only valid for type "daily".
+ * @apiParam (Body) {String="daily","weekly","monthly","yearly"} [frequency=weekly] Values "weekly"
+ *                                           and "monthly" enable use of the "repeat" field.
+ *                                           All frequency values enable use of the "everyX" field.
+ *                                           Value "monthly" enables use of the "weeksOfMonth" and
+ *                                           "daysOfMonth" fields.
+ *                                           Frequency is only valid for type "daily".
  * @apiParam (Body) {String} [repeat=true] List of objects for days of the week,  Days that
  *                                         are true will be repeated upon. Only valid for type
  *                                         "daily". Any days not specified will be marked as true.

--- a/website/server/controllers/api-v3/tasks.js
+++ b/website/server/controllers/api-v3/tasks.js
@@ -94,6 +94,10 @@ const requiredGroupFields = '_id leader tasksOrder name';
  *                                      task is available again.
  * @apiParam (Body) {Number} [streak=0] Number of days that the task has consecutively
  *                                      been checked off. Only valid for type "daily"
+ * @apiParam (Body) {Integer[]} daysOfMonth Array of integers.
+ *                                      Only valid for type "daily"
+ * @apiParam (Body) {Integer[]} weeksOfMonth Array of integers.
+ *                                      Only valid for type "daily"
  * @apiParam (Body) {Date} [startDate] Date when the task will first become available.
  *                                     Only valid for type "daily"
  * @apiParam (Body) {Boolean} [up=true] Only valid for type "habit"
@@ -259,6 +263,10 @@ api.createUserTasks = {
  *                                      of days until this daily task is available again.
  * @apiParam (Body) {Number} [streak=0] Number of days that the task has consecutively
  *                                      been checked off. Only valid for type "daily"
+ * @apiParam (Body) {Integer[]} daysOfMonth Array of integers.
+ *                                      Only valid for type "daily"
+ * @apiParam (Body) {Integer[]} weeksOfMonth Array of integers.
+ *                                      Only valid for type "daily"
  * @apiParam (Body) {Date} [startDate] Date when the task will first become available.
  *                                     Only valid for type "daily"
  * @apiParam (Body) {Boolean} [up=true] Only valid for type "habit" If true,
@@ -564,6 +572,10 @@ api.getTask = {
  *                                      of days until this daily task is available again.
  * @apiParam (Body) {Number} [streak=0] Number of days that the task has consecutively
  *                                      been checked off. Only valid for type "daily",
+ * @apiParam (Body) {Integer[]} daysOfMonth Array of integers.
+ *                                      Only valid for type "daily"
+ * @apiParam (Body) {Integer[]} weeksOfMonth Array of integers.
+ *                                      Only valid for type "daily"
  * @apiParam (Body) {Date} [startDate] Date when the task will first become available.
  *                                     Only valid for type "daily".
  * @apiParam (Body) {Boolean} [up=true] Only valid for type "habit" If true, enables


### PR DESCRIPTION
As posted in issue 10943, there were some fields relating to adding/updating tasks that had not yet been updated.

Fixes #10943

### Changes
Adding `monthly` and `yearly` to the `frequency` parameter.
Adjusting `frequency` description to include `daysOfMonth` and `weeksOfMonth`, and to clarify that  `everyX` can be used by every value.
Adding entries for the missing fields: `daysOfMonth` and `weeksOfMonth`.

----
UUID: 639ec312-3ddb-4c11-a903-4914b72efeb9
