### PR TITLE
Modified the sort for name to be case-insensitive, fixes #11547

### DIFF
--- a/website/client/src/components/groups/membersModal.vue
+++ b/website/client/src/components/groups/membersModal.vue
@@ -480,6 +480,8 @@ export default {
       if (!isEmpty(this.sortOption)) {
         // Use the memberlist filtered by searchTerm
         if (this.sortOption.value === 'profile.name') {
+          // If members are to be sorted by name, use localeCompare for case-
+          // insensitive sort
           sortedMembers.sort(
             (a, b) => a.profile.name.localeCompare(b.profile.name),
           );

--- a/website/client/src/components/groups/membersModal.vue
+++ b/website/client/src/components/groups/membersModal.vue
@@ -479,11 +479,17 @@ export default {
 
       if (!isEmpty(this.sortOption)) {
         // Use the memberlist filtered by searchTerm
-        sortedMembers = orderBy(
-          sortedMembers,
-          [this.sortOption.value],
-          [this.sortOption.direction],
-        );
+        if (this.sortOption.value === 'profile.name') {
+          sortedMembers.sort(
+            (a, b) => a.profile.name.localeCompare(b.profile.name),
+          );
+        } else {
+          sortedMembers = orderBy(
+            sortedMembers,
+            [this.sortOption.value],
+            [this.sortOption.direction],
+          );
+        }
       }
 
       return sortedMembers;


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: #11547 
Fixes #11547 

### Changes
Before, when sorting members by name, the result would be according to case (A, B, C, a, b, c). This is changed to a technique where the case is not sensitive (a, A, b, B, c, C) as well as maintaining the ability to compare in different languages (using localCompare).



43f0b0bd-c910-4453-bd41-d8f38a7adc59

----
UUID: 
