### PR TITLE
Fixed disappearing email form bug by forcing a refresh after submission, Fixes #11565 

### DIFF
--- a/website/client/src/components/settings/site.vue
+++ b/website/client/src/components/settings/site.vue
@@ -870,7 +870,7 @@ export default {
       this.soundIndex = (this.soundIndex + 1) % sounds.length;
     },
     reloadPage () {
-    window.location.reload();
+      window.location.reload();
     },
   },
 };

--- a/website/client/src/components/settings/site.vue
+++ b/website/client/src/components/settings/site.vue
@@ -812,8 +812,8 @@ export default {
         this.localAuth.username = this.user.auth.local.username;
         this.user.flags.verifiedUsername = true;
       } else if (attribute === 'email') {
-        this.user.auth.local.email = updates[attribute];
-        window.location.reload();
+        this.user.auth.local.email = updates.newEmail;
+        window.alert(this.$t('emailSuccess'));
       }
     },
     async changeDisplayName (newName) {

--- a/website/client/src/components/settings/site.vue
+++ b/website/client/src/components/settings/site.vue
@@ -443,7 +443,7 @@
             <button
               class="btn btn-primary"
               type="submit"
-              @click="changeUser('email', emailUpdates); reloadPage();"
+              @click="changeUser('email', emailUpdates)"
             >
               {{ $t('submit') }}
             </button>
@@ -813,6 +813,7 @@ export default {
         this.user.flags.verifiedUsername = true;
       } else if (attribute === 'email') {
         this.user.auth.local.email = updates[attribute];
+        reloadPage();
       }
     },
     async changeDisplayName (newName) {

--- a/website/client/src/components/settings/site.vue
+++ b/website/client/src/components/settings/site.vue
@@ -443,7 +443,7 @@
             <button
               class="btn btn-primary"
               type="submit"
-              @click="changeUser('email', emailUpdates)"
+              @click="changeUser('email', emailUpdates); reloadPage();"
             >
               {{ $t('submit') }}
             </button>

--- a/website/client/src/components/settings/site.vue
+++ b/website/client/src/components/settings/site.vue
@@ -869,6 +869,9 @@ export default {
       this.$root.$emit('playSound', sounds[this.soundIndex]);
       this.soundIndex = (this.soundIndex + 1) % sounds.length;
     },
+    reloadPage () {
+    window.location.reload();
+    },
   },
 };
 </script>

--- a/website/client/src/components/settings/site.vue
+++ b/website/client/src/components/settings/site.vue
@@ -813,7 +813,7 @@ export default {
         this.user.flags.verifiedUsername = true;
       } else if (attribute === 'email') {
         this.user.auth.local.email = updates[attribute];
-        reloadPage();
+        window.location.reload();
       }
     },
     async changeDisplayName (newName) {
@@ -869,9 +869,6 @@ export default {
     playAudio () {
       this.$root.$emit('playSound', sounds[this.soundIndex]);
       this.soundIndex = (this.soundIndex + 1) % sounds.length;
-    },
-    reloadPage () {
-      window.location.reload();
     },
   },
 };


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11565 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
This pull request resolves the issue involving the user changing the email address for their account. When the user filled out the form and clicked submit to change their email address, it originally updated the email for the account but also removed the "Change Email Address" and "Change Password" forms from the settings (acting as if the account didn't have an email). This caused confusion for users since they didn't know if the email for their account was actually updated until they refreshed the page.

The solution I created was to force the page to refresh after the user fills out the form and clicks submit. This will avoid causing confusion for the user


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 7d427213-9991-49fb-8513-77e1456da77e
