### PR TITLE
fix(challengeItem.vue): guild name hidden caused by the fixed height

### DIFF
--- a/website/client/src/components/challenges/challengeItem.vue
+++ b/website/client/src/components/challenges/challengeItem.vue
@@ -215,7 +215,6 @@
     }
 
     .meta-info {
-      height: 24px;
       margin-bottom: 8px;
     }
 


### PR DESCRIPTION
Fixes #11500

Changes:
remove the fixed height of the `.meta-info` container