### PR TITLE
WIP enabling add challenge button after selecting new group

### DIFF
--- a/website/client/src/components/challenges/challengeModal.vue
+++ b/website/client/src/components/challenges/challengeModal.vue
@@ -71,7 +71,7 @@
           <option v-for="group in authorizedCreateChallenge"
             :key="group._id"
             :value="group._id"
-            >
+           >
             {{ group.name }}
           </option>
         </select>
@@ -534,10 +534,8 @@ export default {
       if (!this.workingChallenge.summary) errors.push(this.$t('summaryRequired'));
       if (this.workingChallenge.summary.length > MAX_SUMMARY_SIZE_FOR_CHALLENGES) errors.push(this.$t('summaryTooLong'));
       if (!this.workingChallenge.description) errors.push(this.$t('descriptionRequired'));
-
       if (!this.workingChallenge.group) errors.push(this.$t('locationRequired'));
       if (!this.workingChallenge.categories || this.workingChallenge.categories.length === 0) errors.push(this.$t('categoiresRequired'));
-
       if (errors.length > 0) {
         window.alert(errors.join('\n'));
         this.loading = false;

--- a/website/client/src/components/challenges/challengeModal.vue
+++ b/website/client/src/components/challenges/challengeModal.vue
@@ -68,11 +68,10 @@
           v-model="workingChallenge.group"
           class="form-control"
         >
-          <option
-            v-for="group in groups"
+          <option v-for="group in authorizedCreateChallenge"
             :key="group._id"
             :value="group._id"
-          >
+            >
             {{ group.name }}
           </option>
         </select>
@@ -419,6 +418,9 @@ export default {
     challenge () {
       return this.$store.state.challengeOptions.workingChallenge;
     },
+    authorizedCreateChallenge () {
+      return this.groups.filter(i => !(i.leader !== this.user._id));
+    },
   },
   watch: {
     user () {
@@ -532,12 +534,14 @@ export default {
       if (!this.workingChallenge.summary) errors.push(this.$t('summaryRequired'));
       if (this.workingChallenge.summary.length > MAX_SUMMARY_SIZE_FOR_CHALLENGES) errors.push(this.$t('summaryTooLong'));
       if (!this.workingChallenge.description) errors.push(this.$t('descriptionRequired'));
+
       if (!this.workingChallenge.group) errors.push(this.$t('locationRequired'));
       if (!this.workingChallenge.categories || this.workingChallenge.categories.length === 0) errors.push(this.$t('categoiresRequired'));
 
       if (errors.length > 0) {
         window.alert(errors.join('\n'));
         this.loading = false;
+        this.resetWorkingChallenge();
         return;
       }
 

--- a/website/client/src/components/challenges/challengeModal.vue
+++ b/website/client/src/components/challenges/challengeModal.vue
@@ -536,10 +536,10 @@ export default {
       if (!this.workingChallenge.description) errors.push(this.$t('descriptionRequired'));
       if (!this.workingChallenge.group) errors.push(this.$t('locationRequired'));
       if (!this.workingChallenge.categories || this.workingChallenge.categories.length === 0) errors.push(this.$t('categoiresRequired'));
+      
       if (errors.length > 0) {
         window.alert(errors.join('\n'));
         this.loading = false;
-        this.resetWorkingChallenge();
         return;
       }
 


### PR DESCRIPTION
partial fix #11545 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

The pull request is a WIP for a client side solution to the issue. The conditional should also be checking if the group is not a "only leaders can add challenges" type (but I've encountered some issues getting that field).

The original issue was the button to add a challenge task would not reenable after attempting to add a task to a group which the user is not authorized for (e.g. is not the leader for a group that only allows the leader to create challenges).

I wanted to get some feedback on if this issue might be better resolved if the list of groups that a user could select would already be filtered to those which they have authorization to (hence the client side solution). I noticed the check for this currently occurs on the server side in the API (and throws an error when not authorized), so the existing design makes it difficult to adjust UI changes for a particular error.

Any guidance on this method or if there's a better approach would be appreciated!

[//]: #f8773841-dd31-466e-bce9-e412190f414c

----
UUID: 