### PR TITLE
Fix some tier Display Name colors on hover/active/focus

### DIFF
--- a/website/client/src/assets/scss/tiers.scss
+++ b/website/client/src/assets/scss/tiers.scss
@@ -17,7 +17,7 @@
 .tier3 {
   color: #d70e14;
 
-  :hover, :active, :focus {
+  &:hover, &:active, &:focus {
     color: #d70e14;
   }
 }
@@ -25,7 +25,7 @@
 .tier4 {
   color: #c24d00;
 
-  &:hover, &:active, :focus {
+  &:hover, &:active, &:focus {
     color: #c24d00;
   }
 }
@@ -33,7 +33,7 @@
 .tier5 {
   color: #9e650f;
 
-  :hover, :active, :focus {
+  &:hover, &:active, &:focus {
     color: #9e650f;
   }
 }
@@ -41,7 +41,7 @@
 .tier6 {
   color: #2b8363;
 
-  :hover, :active, &:focus {
+  &:hover, &:active, &:focus {
     color: #2b8363;
   }
 }


### PR DESCRIPTION
On hover/active/focus tier 3 and 5 the username still changes it's color

[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11633

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
I think & character was mistyped from some tier classes.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 07bd9063-362f-40c6-8d0c-1fa8b977243d
