### PR TITLE
Updates notifications screen to a more consistent UI

### DIFF
--- a/website/client/src/components/settings/notifications.vue
+++ b/website/client/src/components/settings/notifications.vue
@@ -28,39 +28,38 @@
       <small>{{ $t('unsubscribeAllEmailsText') }}</small>
     </div>
     <div class="col-8">
-      <table class="table"></table>
-      <tr>
-        <td></td>
-        <th>
-          <span>{{ $t('email') }}</span>
-        </th>
-        <th>
-          <span>{{ $t('push') }}</span>
-        </th>
-      </tr>
-      <tr
-        v-for="notification in notificationsIds"
-        :key="notification"
-      >
-        <td>
-          <span>{{ $t(notification) }}</span>
-        </td>
-        <td>
-          <input
-            v-model="user.preferences.emailNotifications[notification]"
-            type="checkbox"
-            @change="set('emailNotifications', notification)"
-          >
-        </td>
-        <td v-if="onlyEmailsIds.indexOf(notification) === -1">
-          <input
-            v-model="user.preferences.pushNotifications[notification]"
-            type="checkbox"
-            @change="set('pushNotifications', notification)"
-          >
-          <hr>
-        </td>
-      </tr>
+      <table class="table">
+        <tr>
+          <td></td>
+          <th>
+            <span>{{ $t('email') }}</span>
+          </th>
+          <th>
+            <span>{{ $t('push') }}</span>
+          </th>
+        </tr>
+        <tr v-for="notification in notificationsIds" :key="notification">
+          <td>
+            <span>{{ $t(notification) }}</span>
+          </td>
+          <td>
+            <input
+              v-model="user.preferences.emailNotifications[notification]"
+              type="checkbox"
+              @change="set('emailNotifications', notification)"
+            >
+          </td>
+          <td v-if="onlyEmailsIds.indexOf(notification) === -1">
+            <input
+              v-model="user.preferences.pushNotifications[notification]"
+              type="checkbox"
+              @change="set('pushNotifications', notification)"
+            >
+          <td v-else>
+            &nbsp;
+          </td>
+        </tr>
+      </table>
     </div>
   </div>
 </template>
@@ -74,6 +73,8 @@ export default {
   data () {
     return {
       notificationsIds: Object.freeze([
+        'majorUpdates',
+        'onboarding',
         'newPM',
         'wonChallenge',
         'giftedGems',
@@ -85,8 +86,6 @@ export default {
         'invitedQuest',
         'importantAnnouncements',
         'weeklyRecaps',
-        'onboarding',
-        'majorUpdates',
         'subscriptionReminders',
       ]),
       // list of email-only notifications

--- a/website/common/locales/en/settings.json
+++ b/website/common/locales/en/settings.json
@@ -120,7 +120,7 @@
     "giftedSubscriptionFull": "Hello <%= username %>, <%= sender %> has sent you <%= monthCount %> months of subscription!",
     "giftedSubscriptionWinterPromo": "Hello <%= username %>, you received <%= monthCount %> months of subscription as part of our holiday gift-giving promotion!",
     "invitedParty": "You were invited to a Party",
-    "invitedGuild": "You were invited to a  Guild",
+    "invitedGuild": "You were invited to a Guild",
     "importantAnnouncements": "Reminders to check in to complete tasks and receive prizes",
     "weeklyRecaps": "Summaries of your account activity in the past week (Note: this is currently disabled due to performance issues, but we hope to have this back up and sending e-mails again soon!)",
     "onboarding": "Guidance with setting up your Habitica account",


### PR DESCRIPTION
### Changes
#### Updates notifications screen to a more consistent UI

The user interface on the notifications page was inconsistent and not very pretty; I've cleaned it up so that it feels better.

I've also slightly adjusted the order of the items in the list (taken after the "after" screenshot) as `Important announcements` feels like it's more important than `Received Private Message`, though I'm not married to that change as much.

Before:
![image](https://user-images.githubusercontent.com/50712/70833760-95ab8f00-1dc6-11ea-916e-47d0e2f43cb0.png)

After:
![image](https://user-images.githubusercontent.com/50712/70833792-a0662400-1dc6-11ea-8236-53b678cace98.png)

----
UUID: 65d86915-6f66-400c-8d58-80ab61bb8ca2
