### PR TITLE
Fix incorrect error when sending private messages to a player you have blocked (fixes #11612)

### DIFF
--- a/test/api/v3/integration/members/POST-send_private_message.test.js
+++ b/test/api/v3/integration/members/POST-send_private_message.test.js
@@ -66,7 +66,7 @@ describe('POST /members/send-private-message', () => {
     })).to.eventually.be.rejected.and.eql({
       code: 401,
       error: 'NotAuthorized',
-      message: t('notAuthorizedToSendMessageToThisUser'),
+      message: t('blockedToSendToThisUser'),
     });
   });
 

--- a/test/api/v3/integration/members/POST-transfer_gems.test.js
+++ b/test/api/v3/integration/members/POST-transfer_gems.test.js
@@ -89,7 +89,7 @@ describe('POST /members/transfer-gems', () => {
     })).to.eventually.be.rejected.and.eql({
       code: 401,
       error: 'NotAuthorized',
-      message: t('notAuthorizedToSendMessageToThisUser'),
+      message: t('blockedToSendToThisUser'),
     });
   });
 

--- a/website/common/locales/en/groups.json
+++ b/website/common/locales/en/groups.json
@@ -151,6 +151,7 @@
   "toUserIDRequired": "A User ID is required",
   "gemAmountRequired": "A number of gems is required",
   "notAuthorizedToSendMessageToThisUser": "You can't send a message to this player because they have chosen to block messages.",
+  "blockedToSendToThisUser": "You can't send to this player because you have blocked this player.",
   "privateMessageGiftGemsMessage": "Hello <%= receiverName %>, <%= senderName %> has sent you <%= gemAmount %> gems!",
   "privateMessageGiftSubscriptionMessage": "<%= numberOfMonths %> months of subscription! ",
   "cannotSendGemsToYourself": "Cannot send gems to yourself. Try a subscription instead.",

--- a/website/server/models/user/methods.js
+++ b/website/server/models/user/methods.js
@@ -61,7 +61,7 @@ const INTERACTION_CHECKS = Object.freeze({
 
     // Direct user blocks prevent all interactions
     (sndr, rcvr) => rcvr.inbox.blocks.includes(sndr._id) && 'notAuthorizedToSendMessageToThisUser',
-    (sndr, rcvr) => sndr.inbox.blocks.includes(rcvr._id) && 'notAuthorizedToSendMessageToThisUser',
+    (sndr, rcvr) => sndr.inbox.blocks.includes(rcvr._id) && 'blockedToSendToThisUser',
   ],
 
   'send-private-message': [


### PR DESCRIPTION
Fixes #11612 

Introduce a new error type blockedToSendToThisUser for the cases where you have blocked a player from sending private messages to you, if you try to message them or if you try to transfer gems to them, you will see the error "You can't send to this player because you have block this player."