### PR TITLE
fix bug in which editing challenge will not allow editing categories (fixes #11662)

### DIFF
--- a/website/client/src/components/challenges/challengeModal.vue
+++ b/website/client/src/components/challenges/challengeModal.vue
@@ -101,7 +101,7 @@
           </div>
         </div>
         <div
-          v-if="showCategorySelect && creating"
+          v-if="showCategorySelect"
           class="category-box"
         >
           <!-- eslint-disable vue/no-use-v-if-with-v-for -->


### PR DESCRIPTION
fixes #11662 

The bug that I am fixing is that after you've created a Challenge, if you then edit it, you can't change the categories - you should be able to change categories from the Challenge's edit screen for cases where you select the wrong categories by accident.

### Changes
In ChallengeModal, there was an additional condition that would allow the categories to be selected only if the user was creating a challenge. Removing this condition fixed the issue. I used the groupFormModal as a reference.

Note: If there is a way I can test this somewhere please let me know! I am new to front end changes.

