### PR TITLE
show Reset Flag Count button to moderators regardless of post's report status

### DIFF
--- a/website/client/src/components/chat/reportFlagModal.vue
+++ b/website/client/src/components/chat/reportFlagModal.vue
@@ -23,7 +23,7 @@
     </div>
     <div class="footer text-center">
       <button
-        v-if="user.contributor.admin && abuseObject.flagCount > 0"
+        v-if="user.contributor.admin"
         class="pull-left btn btn-danger"
         @click="clearFlagCount()"
       >


### PR DESCRIPTION
This PR affects only moderators/staff.

It makes a minor change to the report modal (screenshot below).

Before this PR, if a moderator wants to flag a post and then immediately unflag it, they have to flag it, then re-fetch the group's messages, then find the post again, then reopen the modal and unflag it. This is because the "Reset Flag Count" button only shows up after a post has been flagged.

This PR causes the "Reset Flag Count" button to appear all the time, so flagging then unflagging is much simpler (flag the post then immediately reopen the modal to unflag it). 
 
![image](https://user-images.githubusercontent.com/1495809/71539597-38990700-298a-11ea-971b-01bb5a1618b1.png)
