### PR TITLE
Fix issues with local Docker development.

### DIFF
--- a/Dockerfile-Dev
+++ b/Dockerfile-Dev
@@ -3,9 +3,12 @@ FROM node:12
 # Install global packages
 RUN npm install -g gulp-cli mocha
 
-# Copy Habitica code into container and install dependencies
+# Copy package.json and package-lock.json into image, then install
+# dependencies.
 WORKDIR /usr/src/habitica
-COPY . /usr/src/habitica
-
+COPY ["package.json", "package-lock.json", "./"]
 RUN npm install
+
+# Copy the remaining source files in.
+COPY . /usr/src/habitica
 RUN npm run postinstall

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,8 +15,9 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - .:/code
-      - /code/node_modules
+      - .:/usr/src/habitica
+      - /usr/src/habitica/node_modules
+      - /usr/src/habitica/website/client/node_modules
   server:
     build:
       context: .
@@ -32,8 +33,8 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - .:/code
-      - /code/node_modules
+      - .:/usr/src/habitica
+      - /usr/src/habitica/node_modules
   mongo:
     image: mongo:3.6
     networks:

--- a/website/client/vue.config.js
+++ b/website/client/vue.config.js
@@ -116,6 +116,7 @@ module.exports = {
   },
 
   devServer: {
+    disableHostCheck: true,
     proxy: {
       // proxy all requests to the server at IP:PORT as specified in the top-level config
       '^/api/v3': {


### PR DESCRIPTION
### Changes
When trying to follow the [instructions](https://habitica.fandom.com/wiki/Setting_up_Habitica_Locally_on_Docker) to get Habitica working locally with Docker, I ran into a few issues:

a) It looks like at some point, the code mount within the Dockerfile was changed from `/code/` to `/usr/src/`, but the compose files weren't updated. For the sake of this PR, I've _only_ changed the development compose file, as I'm not 100% sure how y'all run in production and didn't want to screw anything up there. I made a few tweaks to Dockerfile-dev for caching benefits as well.
b) I run all my development stuff within a VM and use modifications to my hosts file to access it at a custom domain. This presents problems with the standard webpack-dev-server setup, as it prevents anything but `localhost` from being run by returning an "Invalid Host header" error to the browser. In webpack-dev-server 2.4.4, they added a `disableHostCheck` parameter to allow for any header to be used locally. I've added that here, as it seems like it'd be valuable for other folks.

Wanted to land these before I start plugging away at help needed issues. Thanks!

----
UUID: 2626073c-9617-4ca2-951d-3d7ff2510512
