### PR TITLE
Disabled auto notification dismissal for received card on click fix for #11688

### DIFF
--- a/website/client/src/components/header/notifications/cardReceived.vue
+++ b/website/client/src/components/header/notifications/cardReceived.vue
@@ -3,7 +3,7 @@
     :can-remove="canRemove"
     :has-icon="true"
     :notification="notification"
-    :read-after-click="true"
+    :read-after-click="false"
     @click="action"
   >
     <div


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11688

### Changes
[//]: # Disabled the auto dismissal of notification when clicking on a card received notification



----
UUID: 641375c3-346d-4797-adaf-7c0366f9cab4
