### PR TITLE
Set the default year for the background meny to 2020 Fix for  #11703

### DIFF
--- a/website/client/src/components/header/userDropdown.vue
+++ b/website/client/src/components/header/userDropdown.vue
@@ -43,7 +43,7 @@
       </a>
       <a
         class="dropdown-item"
-        @click="showAvatar('backgrounds', '2019')"
+        @click="showAvatar('backgrounds', '2020')"
       >{{ $t('backgrounds') }}</a>
       <a
         class="dropdown-item"


### PR DESCRIPTION
Set the default year for the background menu to 2020.

Fixes  #11703
----
UUID: 641375c3-346d-4797-adaf-7c0366f9cab4
