### PR TITLE
Quest invitation webhook

### DIFF
--- a/test/api/unit/libs/webhooks.test.js
+++ b/test/api/unit/libs/webhooks.test.js
@@ -43,6 +43,7 @@ describe('webhooks', () => {
       options: {
         questStarted: true,
         questFinised: true,
+        questInvited: true,
       },
     }, {
       id: 'userActivity',
@@ -576,7 +577,7 @@ describe('webhooks', () => {
       };
     });
 
-    ['questStarted', 'questFinised'].forEach(type => {
+    ['questStarted', 'questFinised', 'questInvited'].forEach(type => {
       it(`sends ${type} webhooks`, () => {
         data.type = type;
 

--- a/test/api/unit/models/webhook.test.js
+++ b/test/api/unit/models/webhook.test.js
@@ -183,6 +183,7 @@ describe('Webhook Model', () => {
             options: {
               questStarted: true,
               questFinished: true,
+              questInvited: true,
             },
           };
         });
@@ -197,6 +198,7 @@ describe('Webhook Model', () => {
           expect(wh.options).to.eql({
             questStarted: false,
             questFinished: false,
+            questInvited: false,
           });
         });
 
@@ -210,6 +212,7 @@ describe('Webhook Model', () => {
           expect(wh.options).to.eql({
             questStarted: false,
             questFinished: true,
+            questInvited: true,
           });
         });
 
@@ -224,6 +227,7 @@ describe('Webhook Model', () => {
           expect(wh.options).to.eql({
             questStarted: true,
             questFinished: true,
+            questInvited: true,
           });
         });
 

--- a/website/server/controllers/api-v3/quests.js
+++ b/website/server/controllers/api-v3/quests.js
@@ -18,6 +18,7 @@ import {
 import common from '../../../common';
 import { sendNotification as sendPushNotification } from '../../libs/pushNotifications';
 import apiError from '../../libs/apiError';
+import { questActivityWebhook } from '../../libs/webhook';
 
 const questScrolls = common.content.quests;
 
@@ -79,7 +80,7 @@ api.inviteToQuest = {
       'party._id': group._id,
       _id: { $ne: user._id },
     })
-      .select('auth.facebook auth.google auth.local preferences.emailNotifications preferences.pushNotifications preferences.language profile.name pushDevices')
+      .select('auth.facebook auth.google auth.local preferences.emailNotifications preferences.pushNotifications preferences.language profile.name pushDevices webhooks')
       .exec();
 
     group.markModified('quest');
@@ -131,6 +132,13 @@ api.inviteToQuest = {
           },
         );
       }
+
+      // Send webhooks
+      questActivityWebhook.send(member, {
+        type: 'questInvited',
+        group,
+        quest,
+      });
 
       return member.preferences.emailNotifications.invitedQuest !== false;
     });

--- a/website/server/controllers/api-v3/webhook.js
+++ b/website/server/controllers/api-v3/webhook.js
@@ -35,8 +35,8 @@ const api = {};
  * @apiParam (Body) {String} [label] A label to remind you what this webhook does
  * @apiParam (Body) {Boolean} [enabled=true] If the webhook should be enabled
  * @apiParam (Body) {String="taskActivity","groupChatReceived",
-                    "userActivity"} [type="taskActivity"] The webhook's type.
- * @apiParam (Body) {Object} [options] The webhook's options. Wil differ depending on type.
+                    "userActivity","questActivity"} [type="taskActivity"] The webhook's type.
+ * @apiParam (Body) {Object} [options] The webhook's options. Will differ depending on type.
  *                                     Required for `groupChatReceived` type.
  *                                     If a webhook supports options, the default values
  *                                     are displayed in the examples below
@@ -61,6 +61,30 @@ const api = {};
  *     "type": "groupChatReceived",
  *     "options": {
  *       "groupId": "required-uuid-of-group"
+ *     }
+ *   }
+ * @apiParamExample {json} User Activity Example
+ *   {
+ *     "enabled": true,
+ *     "url": "http://some-webhook-url.com",
+ *     "label": "My Activity Webhook",
+ *     "type": "userActivity",
+ *     "options": { // set at least one to true
+ *       "petHatched": false,  // default
+ *       "mountRaised": false, // default
+ *       "leveledUp": false,   // default
+ *     }
+ *   }
+ * @apiParamExample {json} Quest Activity Example
+ *   {
+ *     "enabled": true,
+ *     "url": "http://some-webhook-url.com",
+ *     "label": "My Quest Webhook",
+ *     "type": "questActivity",
+ *     "options": { // set at least one to true
+ *       "questStarted": false,  // default
+ *       "questFinished": false, // default
+ *       "questInvited": false,  // default
  *     }
  *   }
  * @apiParamExample {json} Minimal Example
@@ -131,8 +155,9 @@ api.getWebhook = {
  * @apiParam (Body) {String} [url] The webhook's URL
  * @apiParam (Body) {String} [label] A label to remind you what this webhook does
  * @apiParam (Body) {Boolean} [enabled] If the webhook should be enabled
- * @apiParam (Body) {String="taskActivity","groupChatReceived"} [type] The webhook's type.
- * @apiParam (Body) {Object} [options] The webhook's options. Wil differ depending on type.
+ * @apiParam (Body) {String="taskActivity","groupChatReceived",
+ *                  "userActivity","questActivity"} [type] The webhook's type.
+ * @apiParam (Body) {Object} [options] The webhook's options. Will differ depending on type.
  *                                     The options are enumerated in the
  *                                     [add webhook examples](#api-Webhook-UserAddWebhook).
  * @apiParamExample {json} Update Enabled and Type Properties

--- a/website/server/models/webhook.js
+++ b/website/server/models/webhook.js
@@ -28,6 +28,7 @@ const USER_ACTIVITY_DEFAULT_OPTIONS = Object.freeze({
 const QUEST_ACTIVITY_DEFAULT_OPTIONS = Object.freeze({
   questStarted: false,
   questFinished: false,
+  questInvited: false,
 });
 
 export const schema = new Schema({


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11682 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Sends webhook on quest invitation for members that have it activated.

Added questActivity webhook to API docs with an example + also added an example for userActivity.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: fa756acf-9127-4a3c-8dac-8ff627d30073
