### PR TITLE
Correct some modal repops

### DIFF
--- a/website/client/src/app.vue
+++ b/website/client/src/app.vue
@@ -612,10 +612,18 @@ export default {
 
       this.$root.$on('habitica::dismiss-modal', oldModal => {
         if (!oldModal) return;
-        const removeIndex = this.$store.state.modalStack
+        let removeIndex = this.$store.state.modalStack
           .map(modal => modal.modalId)
           .indexOf(oldModal);
-        if (removeIndex >= 0) this.$store.state.modalStack.splice(removeIndex, 1);
+        if (removeIndex >= 0) {
+          this.$store.state.modalStack.splice(removeIndex, 1);
+        }
+        removeIndex = this.$store.state.modalStack
+          .map(modal => modal.prev)
+          .indexOf(oldModal);
+        if (removeIndex >= 0) {
+          delete this.$store.state.modalStack[removeIndex].prev;
+        }
       });
     },
     validStack (modalStack) {

--- a/website/client/src/app.vue
+++ b/website/client/src/app.vue
@@ -610,8 +610,11 @@ export default {
         if (modalBefore) this.$root.$emit('bv::show::modal', modalBefore, { fromRoot: true });
       });
 
+      // Dismiss modal aggressively. Pass a modal ID to remove a modal instance from the stack
+      // (both the stack entry itself and its "prev" reference) so we don't reopen it
       this.$root.$on('habitica::dismiss-modal', oldModal => {
         if (!oldModal) return;
+        this.$root.$emit('bv::hide::modal', oldModal);
         let removeIndex = this.$store.state.modalStack
           .map(modal => modal.modalId)
           .indexOf(oldModal);

--- a/website/client/src/app.vue
+++ b/website/client/src/app.vue
@@ -609,6 +609,14 @@ export default {
 
         if (modalBefore) this.$root.$emit('bv::show::modal', modalBefore, { fromRoot: true });
       });
+
+      this.$root.$on('habitica::dismiss-modal', oldModal => {
+        if (!oldModal) return;
+        const removeIndex = this.$store.state.modalStack
+          .map(modal => modal.modalId)
+          .indexOf(oldModal);
+        if (removeIndex >= 0) this.$store.state.modalStack.splice(removeIndex, 1);
+      });
     },
     validStack (modalStack) {
       const modalsThatCanShowTwice = ['profile'];

--- a/website/client/src/components/challenges/challengeModal.vue
+++ b/website/client/src/components/challenges/challengeModal.vue
@@ -592,7 +592,7 @@ export default {
       this.$emit('createChallenge', challenge);
       this.resetWorkingChallenge();
 
-      this.$root.$emit('bv::hide::modal', 'challenge-modal');
+      this.$root.$emit('habitica::dismiss-modal', 'challenge-modal');
       this.$router.push(`/challenges/${challenge._id}`);
     },
     async updateChallenge () {
@@ -613,6 +613,7 @@ export default {
       const challenge = await this.$store.dispatch('challenges:updateChallenge', { challenge: challengeDetails });
       this.$emit('updatedChallenge', { challenge });
       this.resetWorkingChallenge();
+      this.$root.$emit('habitica::dismiss-modal', 'challenge-modal');
       this.$root.$emit('bv::hide::modal', 'challenge-modal');
     },
     toggleCategorySelect () {

--- a/website/client/src/components/challenges/challengeModal.vue
+++ b/website/client/src/components/challenges/challengeModal.vue
@@ -614,7 +614,6 @@ export default {
       this.$emit('updatedChallenge', { challenge });
       this.resetWorkingChallenge();
       this.$root.$emit('habitica::dismiss-modal', 'challenge-modal');
-      this.$root.$emit('bv::hide::modal', 'challenge-modal');
     },
     toggleCategorySelect () {
       this.showCategorySelect = !this.showCategorySelect;

--- a/website/client/src/components/challenges/closeChallengeModal.vue
+++ b/website/client/src/components/challenges/closeChallengeModal.vue
@@ -144,14 +144,16 @@ export default {
         challengeId: this.challengeId,
         winnerId: this.winner._id,
       });
+      this.$root.$emit('habitica::dismiss-modal', 'close-challenge-modal');
       this.$router.push('/challenges/myChallenges');
     },
     async deleteChallenge () {
-      if (!window.confirm('Are you sure you want to delete this challenge?')) return;
+      if (!window.confirm(this.$t('sureDelCha'))) return;
       this.challenge = await this.$store.dispatch('challenges:deleteChallenge', {
         challengeId: this.challengeId,
         prize: this.prize,
       });
+      this.$root.$emit('habitica::dismiss-modal', 'close-challenge-modal');
       this.$router.push('/challenges/myChallenges');
     },
   },

--- a/website/client/src/components/payments/sendGemsModal.vue
+++ b/website/client/src/components/payments/sendGemsModal.vue
@@ -294,6 +294,7 @@ export default {
       this.sendingInProgress = false;
     },
     close () {
+      this.$root.$emit('habitica::dismiss-modal', 'send-gems');
       this.$root.$emit('bv::hide::modal', 'send-gems');
     },
   },

--- a/website/client/src/components/payments/sendGemsModal.vue
+++ b/website/client/src/components/payments/sendGemsModal.vue
@@ -295,7 +295,6 @@ export default {
     },
     close () {
       this.$root.$emit('habitica::dismiss-modal', 'send-gems');
-      this.$root.$emit('bv::hide::modal', 'send-gems');
     },
   },
 };


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Partial fix for #11083 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Allows `app.vue` to receive a new event `habitica::dismiss-modal`. When emitted, this event deletes the passed modal ID from the modal stack, ensuring that the modal stack handler won't attempt to re-show it after a later modal is closed. ~~Note that the Bootstrap-Vue hide modal event still needs to be emitted, or a router push initiated to change the view, to actually close the modal.~~

I found two places where I could reproduce the original issue and where emitting the new event resolved it:

- Creating/updating/awarding/deleting Challenges
- Sending a gift to another user

I wasn't able to reproduce the specific scenario described in the issue ticket, with pet hatching / user profiles, so I'm not counting this as a complete fix.

Also corrects one place in the Challenge flow where we unnecessarily used a hardcoded English string instead of a localized string.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)