### PR TITLE
Prevent server from cancelling still active subs

### DIFF
--- a/test/api/unit/libs/payments/google.test.js
+++ b/test/api/unit/libs/payments/google.test.js
@@ -278,29 +278,6 @@ describe('Google Payments', () => {
         });
     });
 
-    it('should not throw an error if subscription is still valid', async () => {
-      iap.getPurchaseData.restore();
-      expect(iapSetupStub).to.be.calledOnce;
-      expect(iapValidateStub).to.be.calledOnce;
-      expect(iapValidateStub).to.be.calledWith(iap.GOOGLE, {
-        data: receipt,
-        signature,
-      });
-      expect(iapIsValidatedStub).to.be.calledOnce;
-      expect(iapIsValidatedStub).to.be.calledWith({
-        expirationDate,
-      });
-      expect(iapGetPurchaseDataStub).to.be.calledOnce;
-
-      expect(paymentCancelSubscriptionSpy).to.be.calledOnce;
-      expect(paymentCancelSubscriptionSpy).to.be.calledWith({
-        user,
-        paymentMethod: googlePayments.constants.PAYMENT_METHOD_GOOGLE,
-        nextBill: expirationDate.toDate(),
-        headers,
-      });
-    });
-
     it('should throw an error if receipt is invalid', async () => {
       iap.isValidated.restore();
       iapIsValidatedStub = sinon.stub(iap, 'isValidated')

--- a/website/server/libs/payments/google.js
+++ b/website/server/libs/payments/google.js
@@ -234,6 +234,9 @@ api.cancelSubscribe = async function cancelSubscribe (user, headers) {
     const purchases = iap.getPurchaseData(googleRes);
     if (purchases.length === 0) throw new NotAuthorized(this.constants.RESPONSE_INVALID_RECEIPT);
     const subscriptionData = purchases[0];
+    // Check to make sure the sub isn't active anymore.
+    if (subscriptionData.autoRenews) return;
+
     dateTerminated = new Date(Number(subscriptionData.expirationDate));
   } catch (err) {
     // Status:410 means that the subsctiption isn't active anymore and we can safely delete it

--- a/website/server/libs/payments/google.js
+++ b/website/server/libs/payments/google.js
@@ -247,8 +247,6 @@ api.cancelSubscribe = async function cancelSubscribe (user, headers) {
     }
   }
 
-  if (dateTerminated > new Date()) throw new NotAuthorized(this.constants.RESPONSE_STILL_VALID);
-
   await payments.cancelSubscription({
     user,
     nextBill: dateTerminated,


### PR DESCRIPTION
Just a small check for the call that cancels android subs. If the autoRenews field is true, the sub is still active on google play and should not be cancelled. Probably not strictly needed, but a good safety measure.