### PR TITLE
Show "no owner" when challenge leader cannot be found and allow tasks to be seen fixes #11768

### DIFF
--- a/website/client/src/components/challenges/challengeDetail.vue
+++ b/website/client/src/components/challenges/challengeDetail.vue
@@ -18,7 +18,10 @@
           <div>
             <span class="mr-1 ml-0 d-block">
               <strong v-once>{{ $t('createdBy') }}:</strong>
-              <user-link
+              <span v-if="challenge.leader === null">
+                {{ $t('noChallengeOwner') }}
+              </span>
+              <user-link v-else
                 class="mx-1"
                 :user="challenge.leader"
               />

--- a/website/client/src/components/challenges/challengeItem.vue
+++ b/website/client/src/components/challenges/challengeItem.vue
@@ -43,7 +43,14 @@
         >
           <div class="owner-item">
             <strong>{{ $t('createdBy') }}:</strong>
+            <span
+              v-if="challenge.leader === null"
+              class="mx-1"
+            >
+              {{ $t('noChallengeOwner') }}
+            </span>
             <user-link
+              v-else
               class="mx-1"
               :user="challenge.leader"
             />

--- a/website/client/src/store/getters/tasks.js
+++ b/website/client/src/store/getters/tasks.js
@@ -44,7 +44,8 @@ export function canDelete (store) {
       && group.leader._id === userId);
     const isUserGroupManager = group && (group.managers
         && Boolean(group.managers[userId]));
-    const isUserChallenge = userId === (challenge && challenge.leader.id);
+    const isUserChallenge = userId === (challenge
+      && challenge.leader !== null && challenge.leader.id);
 
     let isUserCanDeleteTask = onUserDashboard;
 
@@ -81,7 +82,8 @@ export function canEdit (store) {
       && group.leader._id === userId);
     const isUserGroupManager = group && (group.managers
         && Boolean(group.managers[userId]));
-    const isUserChallenge = userId === (challenge && challenge.leader.id);
+    const isUserChallenge = userId === (challenge
+      && challenge.leader !== null && challenge.leader.id);
 
 
     switch (taskCategory) {


### PR DESCRIPTION
Fixes #11768

### Changes
- Check if `challenge.leader` is `null` before trying to display the user's name after "Created By:"
- Check the `challenge.leader` isn't `null` before trying to get its `id` for comparison when determining if the current user `canDelete` or `canEdit`

----
UUID: 76dae72e-04bb-461c-a4eb-22093c4d18c1
