### PR TITLE
(Issue #11805) Removing duplicated user.pushDevices in cron task. 

### DIFF
--- a/test/api/unit/libs/cron.test.js
+++ b/test/api/unit/libs/cron.test.js
@@ -1882,6 +1882,33 @@ describe('cron', () => {
       expect(user.notifications[0].type).to.not.equal('CRON');
       common.statsComputed.restore();
     });
+
+    it('should remove duplicates from pushDevices array', () => {
+      // Arrange
+      const device1 = {
+        regId: 'erWWzAqL9Bw:APA91bEkvxR_bo1232148734487103471983479817349287ieROEjvT1cx5',
+        type: 'android',
+        createdAt: '2018-12-18T09:12:51.415Z',
+        updatedAt: '2020-02-02T07:57:28.447Z',
+      };
+      const device2 = {
+        regId: 'fr_5B_ezlkE:APA91bF4Rq1RlTalkdsjfkaksjdflkasdflskajdflskjfj87GyD_9zKNIKB-hcybmte37kw',
+        type: 'android',
+        createdAt: '2019-01-12T23:50:24.531Z',
+        updatedAt: '2020-02-02T07:57:28.447Z',
+      };
+      user.pushDevices = [device1, device1, device2, device2, device2];
+
+      // Act
+      cron({
+        user, tasksByType, daysMissed, analytics,
+      });
+
+      // Assert
+      expect(user.pushDevices).to.be.an('array').that.does.have.lengthOf(2);
+      expect(user.pushDevices[0].regId).to.eql(device1.regId);
+      expect(user.pushDevices[1].regId).to.eql(device2.regId);
+    });
   });
 
   describe('private messages', () => {
@@ -2140,37 +2167,6 @@ describe('cron', () => {
       expect(user.loginIncentives).to.eql(50);
       expect(user.items.food.Saddle).to.eql(1);
       expect(user.notifications[0].type).to.eql('LOGIN_INCENTIVE');
-    });
-
-    it('should remove duplicates from pushDevices array', () => {
-      // Arrange
-      const device1 = {
-        regId: 'erWWzAqL9Bw:APA91bEkvxR_bo1232148734487103471983479817349287ieROEjvT1cx5',
-        type: 'android',
-        createdAt: '2018-12-18T09:12:51.415Z',
-        updatedAt: '2020-02-02T07:57:28.447Z',
-      };
-      const device2 = {
-        regId: 'fr_5B_ezlkE:APA91bF4Rq1RlTalkdsjfkaksjdflkasdflskajdflskjfj87GyD_9zKNIKB-hcybmte37kw',
-        type: 'android',
-        createdAt: '2019-01-12T23:50:24.531Z',
-        updatedAt: '2020-02-02T07:57:28.447Z',
-      };
-      user.pushDevices = [device1, device1, device2, device2, device2];
-
-      // Act
-      cron({
-        user, tasksByType, daysMissed, analytics,
-      });
-
-      // Assert
-      expect(user.pushDevices).to.be.an('array').that.does.have.lengthOf(2);
-      expect(user.pushDevices[0].regId).to.eql(device1.regId);
-      expect(user.pushDevices[1].regId).to.eql(device2.regId);
-    });
-
-    it('cron should remove duplicates from pushDevices array', () => {
-      user.pushDevices = [];
     });
   });
 });

--- a/test/api/unit/libs/cron.test.js
+++ b/test/api/unit/libs/cron.test.js
@@ -2141,6 +2141,37 @@ describe('cron', () => {
       expect(user.items.food.Saddle).to.eql(1);
       expect(user.notifications[0].type).to.eql('LOGIN_INCENTIVE');
     });
+
+    it('should remove duplicates from pushDevices array', () => {
+      // Arrange
+      const device1 = {
+        regId: 'erWWzAqL9Bw:APA91bEkvxR_bo1232148734487103471983479817349287ieROEjvT1cx5',
+        type: 'android',
+        createdAt: '2018-12-18T09:12:51.415Z',
+        updatedAt: '2020-02-02T07:57:28.447Z',
+      };
+      const device2 = {
+        regId: 'fr_5B_ezlkE:APA91bF4Rq1RlTalkdsjfkaksjdflkasdflskajdflskjfj87GyD_9zKNIKB-hcybmte37kw',
+        type: 'android',
+        createdAt: '2019-01-12T23:50:24.531Z',
+        updatedAt: '2020-02-02T07:57:28.447Z',
+      };
+      user.pushDevices = [device1, device1, device2, device2, device2];
+
+      // Act
+      cron({
+        user, tasksByType, daysMissed, analytics,
+      });
+
+      // Assert
+      expect(user.pushDevices).to.be.an('array').that.does.have.lengthOf(2);
+      expect(user.pushDevices[0].regId).to.eql(device1.regId);
+      expect(user.pushDevices[1].regId).to.eql(device2.regId);
+    });
+
+    it('cron should remove duplicates from pushDevices array', () => {
+      user.pushDevices = [];
+    });
   });
 });
 

--- a/website/server/libs/cron.js
+++ b/website/server/libs/cron.js
@@ -479,6 +479,9 @@ export function cron (options = {}) {
 
   user.history.exp.push({ date: now, value: expTally });
 
+  // Remove duplicated user's pushDevices
+  user.pushDevices = _.uniqBy(user.pushDevices, 'regId');
+
   // Remove any remaining completed todos from the list of active todos
   user.tasksOrder.todos = user.tasksOrder.todos
     .filter(taskOrderId => _.some(


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11805

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Cron task was modified to remove duplicated `user.pushDevices`
So, the `pushDevices` array now contains only objects with unique `regId` field.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: a9b92003-4817-4edd-8fa6-65fa995b2b1f
