### PR TITLE
[Fix #11824] Show member Display Name if Username is blank

### DIFF
--- a/website/client/src/components/members/memberSearchDropdown.vue
+++ b/website/client/src/components/members/memberSearchDropdown.vue
@@ -62,7 +62,7 @@ export default {
       this.$emit('member-selected', member);
     },
     memberName (member) {
-      if (member.auth.local.username) {
+      if (member.auth.local && member.auth.local.username) {
         return `@${member.auth.local.username}`;
       }
       return member.profile.name;

--- a/website/client/src/components/members/memberSearchDropdown.vue
+++ b/website/client/src/components/members/memberSearchDropdown.vue
@@ -19,7 +19,7 @@
       :key="member._id"
       @click="selectMember(member)"
     >
-      @{{ member.auth.local.username }}
+      {{ memberName(member) }}
     </b-dropdown-item>
   </b-dropdown>
 </template>
@@ -60,6 +60,12 @@ export default {
   methods: {
     selectMember (member) {
       this.$emit('member-selected', member);
+    },
+    memberName (member) {
+      if (member.auth.local.username) {
+        return `@${member.auth.local.username}`;
+      }
+      return member.profile.name;
     },
   },
 };


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes https://github.com/HabitRPG/habitica/issues/11824

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Added a method `memberName` to `memberSearchDropdown` that checks if `member.auth.username` is blank, it will return `member.profile.name` instead.

I preferred to use a method rather than an `OR` or ternary operator to include the logic that if it's a Username it will append the `@` symbol before, if it's a Display Name it won't.

### Screenshots (reproduced locally)

Scenario: User `@tuttiq` has username. User `kayoreena` (display name) doesn't have username.

#### Before

_Challenge page_
<img width="341" src="https://user-images.githubusercontent.com/1096046/73852984-7899b680-4873-11ea-90d9-2ec82dfd0571.png">

_End challenge modal_
<img width="333" src="https://user-images.githubusercontent.com/1096046/73853057-9535ee80-4873-11ea-8a93-c1dd44904439.png">

#### After

_Challenge page_
<img width="361" src="https://user-images.githubusercontent.com/1096046/73853098-a5e66480-4873-11ea-80bc-a9e681319a75.png">

_End challenge modal_
<img width="339" src="https://user-images.githubusercontent.com/1096046/73853113-ab43af00-4873-11ea-9e9a-9c2dbce9d373.png">

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 7e8107e4-c309-43cc-93c9-50311506e53f
