### PR TITLE
Unify behaviour for shops (make earnable quests purchasable with gems/gold)

### DIFF
--- a/website/client/src/components/shops/quests/index.vue
+++ b/website/client/src/components/shops/quests/index.vue
@@ -209,7 +209,6 @@
           <!-- eslint-disable vue/no-use-v-if-with-v-for, max-len -->
           <div
             v-for="(items, key) in getGrouped(questItems(category, selectedSortItemsBy,searchTextThrottled, hideLocked, hidePinned))"
-            v-if="key !== 'questGroupEarnable'"
             :key="key"
             class="group"
           >

--- a/website/common/script/content/quests.js
+++ b/website/common/script/content/quests.js
@@ -2262,7 +2262,7 @@ const quests = {
     value: 4,
     category: 'unlockable',
     unlockCondition: {
-      condition: 'party invite',
+      condition: 'login reward',
       incentiveThreshold: 7,
       text: t('loginReward', { count: 7 }),
     },
@@ -2293,7 +2293,7 @@ const quests = {
     value: 4,
     category: 'unlockable',
     unlockCondition: {
-      condition: 'party invite',
+      condition: 'login reward',
       incentiveThreshold: 22,
       text: t('loginReward', { count: 22 }),
     },
@@ -2323,7 +2323,7 @@ const quests = {
     value: 4,
     category: 'unlockable',
     unlockCondition: {
-      condition: 'party invite',
+      condition: 'login reward',
       incentiveThreshold: 40,
       text: t('loginReward', { count: 40 }),
     },

--- a/website/common/script/content/quests.js
+++ b/website/common/script/content/quests.js
@@ -1067,7 +1067,7 @@ const quests = {
     notes: t('questBasilistNotes'),
     group: 'questGroupEarnable',
     completion: t('questBasilistCompletion'),
-    value: 4,
+    goldValue: 100,
     category: 'unlockable',
     unlockCondition: {
       condition: 'party invite',
@@ -2238,7 +2238,7 @@ const quests = {
     notes: t('questDustBunniesNotes'),
     group: 'questGroupEarnable',
     completion: t('questDustBunniesCompletion'),
-    value: 4,
+    value: 1,
     category: 'unlockable',
     unlockCondition: {
       condition: 'party invite',

--- a/website/common/script/ops/buy/buyQuestGold.js
+++ b/website/common/script/ops/buy/buyQuestGold.js
@@ -42,7 +42,7 @@ export class BuyQuestWithGoldOperation extends AbstractGoldItemOperation { // es
 
     if (!item) throw new NotFound(errorMessage('questNotFound', { key }));
 
-    if (!(item.category === 'gold' && item.goldValue)) {
+    if (!(item.goldValue)) {
       throw new NotAuthorized(this.i18n('questNotGoldPurchasable', { key }));
     }
 


### PR DESCRIPTION
Fixes #9501 

This PR changes the following:

1. Change the price for basilist to 100 gold and for dustbunnies to 1 gem.
2. Make both purchasable on the website (was already available in the shop API and thus purchasable on mobile
3. Fix unlockCondition for the 3 moon quests to be `login reward` instead of `party invite`.