### PR TITLE
Update user count and write text consistently. fixes #11790

### DIFF
--- a/website/client/src/components/static/home.vue
+++ b/website/client/src/components/static/home.vue
@@ -289,7 +289,7 @@
       <div class="container featured">
         <div class="row text-center">
           <h3 class="col-12">
-            {{ $t('joinMany') }}
+            {{ $t('joinMany', {userCountInMillions}) }}
           </h3>
         </div>
         <div class="row">
@@ -824,7 +824,7 @@ export default {
         makeuseof,
         thenewyorktimes,
       }),
-      userCountInMillions: 3,
+      userCountInMillions: 4,
       username: '',
       password: '',
       passwordConfirm: '',

--- a/website/common/locales/en/front.json
+++ b/website/common/locales/en/front.json
@@ -321,7 +321,7 @@
   "muchmuchMoreDesc": "Our fully customizable task list means that you can shape Habitica to fit your personal goals. Work on creative projects, emphasize self-care, or pursue a different dream -- it's all up to you.",
   "levelUpAnywhere": "Level Up Anywhere",
   "levelUpAnywhereDesc": "Our mobile apps make it simple to keep track of your tasks on-the-go. Accomplish your goals with a single tap, no matter where you are.",
-  "joinMany": "Join over 2,000,000 people having fun while accomplishing their goals!",
+  "joinMany": "Join over <%= userCountInMillions %> million people having fun while accomplishing their goals!",
   "joinToday": "Join Habitica Today",
   "featuredIn": "Featured in",
   "signup": "Sign Up",


### PR DESCRIPTION
The user count is currently 4,671,530 according to Alys. So the million count goes up to 4 and the texts mentioning the number of users is supposed to display this count. There have been two texts and the count is only in one of them with the other hardcoded. Seems like a good thing to not actually calculate the number of users for performance reasons. This fixes #11790

----
UUID: @neepsnikeep
