### PR TITLE
Enchanted Armoire immediately updates XP stat in header (fixes #11827) and does level-up if needed (partial fix #2433)

### DIFF
--- a/website/client/src/store/actions/shops.js
+++ b/website/client/src/store/actions/shops.js
@@ -93,6 +93,10 @@ async function buyArmoire (store, params) {
       timeout: true,
       ...notificationOptions,
     });
+
+    if (isExperience) {
+      await store.dispatch('user:fetch', { forceLoad: true });
+    }
   }
 }
 

--- a/website/client/src/store/actions/shops.js
+++ b/website/client/src/store/actions/shops.js
@@ -78,9 +78,8 @@ async function buyArmoire (store, params) {
     // @TODO: We might need to abstract notifications to library rather than mixin
     const notificationOptions = isExperience
       ? {
-        text: `+ ${item.value}`,
-        type: 'xp',
-        flavorMessage: message,
+        text: message,
+        type: 'success',
       }
       : {
         text: message,

--- a/website/common/script/ops/buy/buyArmoire.js
+++ b/website/common/script/ops/buy/buyArmoire.js
@@ -10,6 +10,7 @@ import {
 import randomVal, * as randomValFns from '../../libs/randomVal';
 import { removeItemByPath } from '../pinnedGearUtils';
 import { AbstractGoldItemOperation } from './abstractBuyOperation';
+import updateStats from '../../fns/updateStats';
 
 // TODO this is only used on the server
 // move out of common?
@@ -156,6 +157,7 @@ export class BuyArmoireOperation extends AbstractGoldItemOperation { // eslint-d
   _experienceResult (user) {
     const armoireExp = Math.floor(randomValFns.trueRandom() * 40 + 10);
     user.stats.exp += armoireExp;
+    updateStats(user, user.stats, this.req);
 
     return {
       message: this.i18n('armoireExp'),


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11827, also partial fix for #2433 as the Armoire will now level you up.

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Currently, if someone gets Experience from the Enchanted Armoire, they have to click the sync button to see their Experience bar update. When they sync, they also see the default XP notification saying "You gained some Experience" which makes it look like they received Experience twice. 

This PR changes three things: 

-  It forces a sync for the user if the Armoire gives Experience. This makes the bar in the header update immediately without the user needing to click the sync button.
-  It calls `updateStats` after the user's Experience is modified. Since there is now a sync, this will level up the user if they have enough Experience to do so. 
-  The sync causes the Armoire XP notification ("You wrestle with the Armoire and gain Experience. Take that!") and the default XP notification ("You gained some Experience") to display at the same time, which again makes it look like the user received Experience twice. It's not possible to get rid of the default notification, so as a workaround, this PR removes the XP amount from the Armoire notification. (The XP amount is still shown by the default notification.)

After the changes, this is what the notifications look like if the Armoire gives Experience: 
<img width="265" alt="testexp" src="https://user-images.githubusercontent.com/10248632/74905226-7d299900-5362-11ea-8c89-8685abf712a5.PNG">

The XP notification problem is discussed in more detail over on the issue thread #11827. (In particular, Alys in the second half of https://github.com/HabitRPG/habitica/issues/11827#issuecomment-587337769 explains the problem/solution probably much better than I can.)


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 9261598f-9f1a-44ef-bcfb-dc8bc4a70d86
