### PR TITLE
Allow group links on challenge details to be opened in a new tab

### DIFF
--- a/website/client/src/components/groupLink.vue
+++ b/website/client/src/components/groupLink.vue
@@ -1,5 +1,6 @@
 <template>
   <router-link
+    v-if="group"
     :to="toPath"
   >
     {{ group.name }}

--- a/website/client/src/components/groupLink.vue
+++ b/website/client/src/components/groupLink.vue
@@ -1,10 +1,9 @@
 <template>
-  <b-link
-    v-if="group"
-    @click.prevent="goToGroup"
+  <router-link
+    :to="toPath"
   >
     {{ group.name }}
-  </b-link>
+  </router-link>
 </template>
 
 <script>
@@ -12,15 +11,26 @@ import { TAVERN_ID } from '@/../../common/script/constants';
 
 export default {
   props: ['group'],
-  methods: {
-    goToGroup () {
-      if (this.group.type === 'party') {
-        this.$router.push({ name: 'party' });
-      } else if (this.group._id === TAVERN_ID) {
-        this.$router.push({ name: 'tavern' });
-      } else {
-        this.$router.push({ name: 'guild', params: { groupId: this.group._id } });
+  computed: {
+    toPath () {
+      if (this.group._id === TAVERN_ID) {
+        return {
+          name: 'tavern',
+        };
       }
+
+      if (this.group.type === 'party') {
+        return {
+          name: 'party',
+        };
+      }
+
+      return {
+        name: 'guild',
+        params: {
+          groupId: this.group._id,
+        },
+      };
     },
   },
 };


### PR DESCRIPTION
Fixes #11461

### Changes

- Replace `b-link` with `router-link` and set the `:to` based on the type of `group` that is related to the challenge

----
UUID: 76dae72e-04bb-461c-a4eb-22093c4d18c1
