### PR TITLE
Remove max-height for app-header

### DIFF
--- a/website/client/src/components/header/index.vue
+++ b/website/client/src/components/header/index.vue
@@ -83,7 +83,6 @@
     color: $header-color;
     flex-wrap: nowrap;
     position: relative;
-    max-height: 10.25rem;
   }
 
   .hide-header {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

Tossed the REM changes I'd made before for a light-touch fix: removing the max-height. Want to flag that the commit that made the change (53555a0f161a883a9a9bb3c801cf63e36153b8ed) seemed to have applied the CSS with good reason - I just can't figure out what that was.

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11822 
Fixes #11071

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Allows sprites to expand the `app-header` container to whatever size they need, rather than being restricted by the root node's font size.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 69f621bd-7d92-4516-aadb-c1764c930c5d
