### PR TITLE
Ensure first-time purchases are synced

### DIFF
--- a/website/common/script/ops/buy/purchase.js
+++ b/website/common/script/ops/buy/purchase.js
@@ -67,7 +67,7 @@ function purchaseItem (user, item, price, type, key) {
     user.items[type] = {
       ...user.items[type],
       [key]: user.items[type][key] + 1,
-    };
+    }; 
     if (user.markModified) user.markModified(`items.${type}`);
   }
 }

--- a/website/common/script/ops/buy/purchase.js
+++ b/website/common/script/ops/buy/purchase.js
@@ -67,7 +67,7 @@ function purchaseItem (user, item, price, type, key) {
     user.items[type] = {
       ...user.items[type],
       [key]: user.items[type][key] + 1,
-    }; 
+    };
     if (user.markModified) user.markModified(`items.${type}`);
   }
 }

--- a/website/common/script/ops/buy/purchase.js
+++ b/website/common/script/ops/buy/purchase.js
@@ -64,7 +64,7 @@ function purchaseItem (user, item, price, type, key) {
     if (!user.items[type][key] || user.items[type][key] < 0) {
       user.items[type][key] = 0;
     }
-    user.items[type] = { 
+    user.items[type] = {
       ...user.items[type],
       [key]: user.items[type][key] + 1,
     };

--- a/website/common/script/ops/buy/purchase.js
+++ b/website/common/script/ops/buy/purchase.js
@@ -64,7 +64,7 @@ function purchaseItem (user, item, price, type, key) {
     if (!user.items[type][key] || user.items[type][key] < 0) {
       user.items[type][key] = 0;
     }
-    user.items[type] = {
+    user.items[type] = { 
       ...user.items[type],
       [key]: user.items[type][key] + 1,
     };

--- a/website/common/script/ops/buy/purchase.js
+++ b/website/common/script/ops/buy/purchase.js
@@ -64,7 +64,10 @@ function purchaseItem (user, item, price, type, key) {
     if (!user.items[type][key] || user.items[type][key] < 0) {
       user.items[type][key] = 0;
     }
-    user.items[type][key] += 1;
+    user.items[type] = {
+      ...user.items[type],
+      [key]: user.items[type][key] + 1,
+    };
     if (user.markModified) user.markModified(`items.${type}`);
   }
 }


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11907. 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
The issue we were having was that when a user bought an item for the first time, they wouldn't see the item counts update. This was due to the fact that Vue isn't reactive when we add a key to an object.

One workaround to adding a new key is replacing the object containing the key. Instead of incrementing the count of the item we buy in `purchase.js`, we replace the `users.items[type]` object entirely.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 3c2b1d99-c6f0-4e6e-a67a-bd8e023cfc7e
