### PR TITLE
Fixes Japanese conversion bugs on Safari and Chrome

### DIFF
--- a/website/client/src/components/tasks/taskModal.vue
+++ b/website/client/src/components/tasks/taskModal.vue
@@ -138,7 +138,8 @@
             class="inline-edit-input checklist-item form-control"
             type="text"
             :placeholder="$t('newChecklistItem')"
-            @keydown.enter="addChecklistItem($event)"
+            @keypress.enter="setHasPossibilityOfIMEConversion(false)"
+            @keyup.enter="addChecklistItem($event)"
           >
         </div>
         <div
@@ -1222,6 +1223,7 @@ export default {
         per: 'perception',
       },
       calendarHighlights: { dates: [new Date()] },
+      hasPossibilityOfIMEConversion: true,
     };
   },
   computed: {
@@ -1384,7 +1386,12 @@ export default {
       sorting.splice(data.newIndex, 0, movingItem);
       this.task.checklist = sorting;
     },
+    setHasPossibilityOfIMEConversion (bool) {
+      this.hasPossibilityOfIMEConversion = bool;
+    },
     addChecklistItem (e) {
+      if (e) e.preventDefault();
+      if (this.hasPossibilityOfIMEConversion) return;
       const checkListItem = {
         id: uuid.v4(),
         text: this.newChecklistItem,
@@ -1394,7 +1401,7 @@ export default {
       // @TODO: managing checklist separately to help with sorting on the UI
       this.checklist.push(checkListItem);
       this.newChecklistItem = null;
-      if (e) e.preventDefault();
+      this.setHasPossibilityOfIMEConversion(true);
     },
     removeChecklistItem (i) {
       this.task.checklist.splice(i, 1);


### PR DESCRIPTION
Fixes #8326

### Changes
Fixed reported Japanese conversion bugs for some browsers (Safari and Chrome).

I added a flag for conversion status. It is only changed by `@keypress` because `@keypress` is triggered only when it is not a conversion. Only this behavior showed the same behavior in all browsers about conversion.

This is a difficult decision for me.
If we could use `KeyboardEvent.isComposing`, could write cleaner code. But, since `KeyboardEvent.isComposing` behaves differently depending on the browser now, I decided to fix this problem using the flag.

Any feedback is welcome, thank you.

▼ Before (Chrome)
![chrome_before](https://user-images.githubusercontent.com/1789422/75628800-be9e2c00-5c1f-11ea-8c42-d9797136bc22.gif)

▼ After (Chrome)
![chrome_after](https://user-images.githubusercontent.com/1789422/75628808-cbbb1b00-5c1f-11ea-91c2-9936536075fc.gif)

▼ Before (Safari)
![safari_before](https://user-images.githubusercontent.com/1789422/75628816-d4135600-5c1f-11ea-9265-cf4e665ee705.gif)

▼ After (Safari)
![safari_after](https://user-images.githubusercontent.com/1789422/75628821-df668180-5c1f-11ea-96c5-39f005cf9d93.gif)

----
UUID: 1c980e87-ef12-471b-a812-4a020cc226c1
