### PR TITLE
Special case for member profile name.

### DIFF
--- a/website/client/src/components/header/index.vue
+++ b/website/client/src/components/header/index.vue
@@ -170,9 +170,30 @@ export default {
       return Math.floor(this.currentWidth / 140) + 1;
     },
     sortedPartyMembers () {
-      const sortBy = this.user.party.order === 'profile.name' ? member => member.profile.name.toLowerCase() : this.user.party.order;
+      let sortedMembers = this.partyMembers;
+      const { order, orderAscending } = this.user.party;
 
-      return orderBy(this.partyMembers, [sortBy], [this.user.party.orderAscending]);
+      if (order === 'profile.name') {
+        // If members are to be sorted by name, use localeCompare for case-
+        // insensitive sort
+        sortedMembers.sort(
+          (a, b) => {
+            if (orderAscending === 'desc') {
+              return b.profile.name.localeCompare(a.profile.name);
+            }
+
+            return a.profile.name.localeCompare(b.profile.name);
+          },
+        );
+      } else {
+        sortedMembers = orderBy(
+          sortedMembers,
+          [order],
+          [orderAscending],
+        );
+      }
+
+      return sortedMembers;
     },
     hideHeader () {
       return ['groupPlan', 'privateMessages'].includes(this.$route.name);

--- a/website/client/src/components/header/index.vue
+++ b/website/client/src/components/header/index.vue
@@ -170,7 +170,9 @@ export default {
       return Math.floor(this.currentWidth / 140) + 1;
     },
     sortedPartyMembers () {
-      return orderBy(this.partyMembers, [this.user.party.order], [this.user.party.orderAscending]);
+      const sortBy = this.user.party.order === 'profile.name' ? member => member.profile.name.toLowerCase() : this.user.party.order;
+
+      return orderBy(this.partyMembers, [sortBy], [this.user.party.orderAscending]);
     },
     hideHeader () {
       return ['groupPlan', 'privateMessages'].includes(this.$route.name);


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11914 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Sorting members by name should be case insensitive. Add special case when comparing profile.name by passing a callback function to lowercase the name.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 07bd9063-362f-40c6-8d0c-1fa8b977243d
