### PR TITLE
Fix collapse checklist tooltip placement

### DIFF
--- a/website/client/src/components/tasks/task.vue
+++ b/website/client/src/components/tasks/task.vue
@@ -167,7 +167,7 @@
             <div class="d-inline-flex">
               <div
                 v-if="isUser"
-                v-b-tooltip.hover.bottom="$t(`${task.collapseChecklist
+                v-b-tooltip.hover.right="$t(`${task.collapseChecklist
                   ? 'expand': 'collapse'}Checklist`)"
                 class="collapse-checklist d-flex align-items-center expand-toggle"
                 :class="{open: !task.collapseChecklist}"


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11888

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
As suggested in #11888, first tried placing the tooltip to `top`, but then it goes over the issue title which didn't look very nice:
![Screenshot from 2020-03-08 23-08-35](https://user-images.githubusercontent.com/1764167/76171364-0af2ea00-6193-11ea-9546-c30ffda0ebff.png)

Placing it to `right` looks nicer as there's more room there with plain white background:
![Screenshot from 2020-03-08 23-08-58](https://user-images.githubusercontent.com/1764167/76171374-252cc800-6193-11ea-8093-4f1cb480299c.png)




[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: fa756acf-9127-4a3c-8dac-8ff627d30073
