### PR TITLE
[WIP] Move task icons up to the same line as the task name, saving vertical space

### DIFF
--- a/website/client/src/components/tasks/task.vue
+++ b/website/client/src/components/tasks/task.vue
@@ -605,19 +605,15 @@
     font-style: normal;
 
     &-right {
-      flex-grow: 1;
+      margin: 0;
+      padding: 7px 0;
+      padding-right: 8px;
+
+      flex-direction: column;
+      justify-content: space-between;
+      align-items: end;
+      flex-shrink: 0;
     }
-  }
-
-  .icons-right {
-    margin: 0;
-    padding: 7px 0;
-    padding-right: 8px;
-
-    flex-direction: column;
-    justify-content: space-between;
-    align-items: end;
-    flex-shrink: 0;
   }
 
   .icons-right .svg-icon {

--- a/website/client/src/components/tasks/task.vue
+++ b/website/client/src/components/tasks/task.vue
@@ -508,7 +508,6 @@
   }
 
   .task-content {
-    position: relative;
     padding-top: 0px;
     padding-bottom: 7px;
     flex-grow: 1;
@@ -592,10 +591,7 @@
   }
 
   .icons {
-    position: absolute;
-    right: 0;
-    bottom: 7px;
-
+    margin-top: 4px;
     color: $gray-300;
     font-style: normal;
 

--- a/website/client/src/components/tasks/task.vue
+++ b/website/client/src/components/tasks/task.vue
@@ -84,74 +84,6 @@
                 class="task-title"
                 :class="{ 'has-notes': task.notes }"
               ></h3>
-              <menu-dropdown
-                v-if="!isRunningYesterdailies && showOptions"
-                ref="taskDropdown"
-                v-b-tooltip.hover.top="$t('options')"
-                class="task-dropdown"
-                :right="task.type === 'reward'"
-              >
-                <div slot="dropdown-toggle">
-                  <div
-                    class="svg-icon dropdown-icon"
-                    v-html="icons.menu"
-                  ></div>
-                </div>
-                <div slot="dropdown-content">
-                  <div
-                    v-if="showEdit"
-                    ref="editTaskItem"
-                    class="dropdown-item edit-task-item"
-                  >
-                    <span class="dropdown-icon-item">
-                      <span
-                        class="svg-icon inline edit-icon"
-                        v-html="icons.edit"
-                      ></span>
-                      <span class="text">{{ $t('edit') }}</span>
-                    </span>
-                  </div>
-                  <div
-                    v-if="isUser"
-                    class="dropdown-item"
-                    @click="moveToTop"
-                  >
-                    <span class="dropdown-icon-item">
-                      <span
-                        class="svg-icon inline push-to-top"
-                        v-html="icons.top"
-                      ></span>
-                      <span class="text">{{ $t('taskToTop') }}</span>
-                    </span>
-                  </div>
-                  <div
-                    v-if="isUser"
-                    class="dropdown-item"
-                    @click="moveToBottom"
-                  >
-                    <span class="dropdown-icon-item">
-                      <span
-                        class="svg-icon inline push-to-bottom"
-                        v-html="icons.bottom"
-                      ></span>
-                      <span class="text">{{ $t('taskToBottom') }}</span>
-                    </span>
-                  </div>
-                  <div
-                    v-if="showDelete"
-                    class="dropdown-item"
-                    @click="destroy"
-                  >
-                    <span class="dropdown-icon-item delete-task-item">
-                      <span
-                        class="svg-icon inline delete"
-                        v-html="icons.delete"
-                      ></span>
-                      <span class="text">{{ $t('delete') }}</span>
-                    </span>
-                  </div>
-                </div>
-              </menu-dropdown>
             </div>
             <div
               v-markdown="task.notes"
@@ -223,82 +155,152 @@
           </div>
         </div>
         <div class="icons icons-right small-text d-flex">
-          <div
-            v-if="showStreak"
-            class="d-flex align-items-center"
+          <menu-dropdown
+            v-if="!isRunningYesterdailies && showOptions"
+            ref="taskDropdown"
+            v-b-tooltip.hover.top="$t('options')"
+            class="task-dropdown"
+            :right="task.type === 'reward'"
           >
-            <div
-              v-b-tooltip.hover.bottom="$t('streakCounter')"
-              class="svg-icon streak"
-              v-html="icons.streak"
-            ></div>
-            <span v-if="task.type === 'daily'">{{ task.streak }}</span>
-            <span v-if="task.type === 'habit'">
-              <span
-                v-if="task.up"
-                class="m-0"
-              >+{{ task.counterUp }}</span>
-              <span
-                v-if="task.up && task.down"
-                class="m-0"
-              >&nbsp;|&nbsp;</span>
-              <span
-                v-if="task.down"
-                class="m-0"
-              >-{{ task.counterDown }}</span>
-            </span>
-          </div>
-          <div
-            v-if="task.challenge && task.challenge.id"
-            class="d-flex align-items-center"
-          >
-            <div
-              v-if="!task.challenge.broken"
-              v-b-tooltip.hover.bottom="shortName"
-              class="svg-icon challenge"
-              v-html="icons.challenge"
-            ></div>
-            <div
-              v-if="task.challenge.broken"
-              v-b-tooltip.hover.bottom="$t('brokenChaLink')"
-              class="svg-icon challenge broken"
-              @click="handleBrokenTask(task)"
-              v-html="icons.brokenChallengeIcon"
-            ></div>
-          </div>
-          <div
-            v-if="hasTags"
-            :id="`tags-icon-${task._id}`"
-            class="d-flex align-items-center"
-          >
-            <div
-              class="svg-icon tags"
-              v-html="icons.tags"
-            ></div>
-          </div>
-          <b-popover
-            v-if="hasTags"
-            :target="`tags-icon-${task._id}`"
-            triggers="hover"
-            placement="bottom"
-          >
-            <div class="tags-popover">
-              <div class="d-flex align-items-center tags-container">
-                <div
-                  v-once
-                  class="tags-popover-title"
-                >
-                  {{ `${$t('tags')}:` }}
-                </div>
-                <div
-                  v-for="tag in getTagsFor(task)"
-                  :key="tag"
-                  v-markdown="tag"
-                  class="tag-label"
-                ></div>
+            <div slot="dropdown-toggle">
+              <div
+                class="svg-icon dropdown-icon"
+                v-html="icons.menu"
+              ></div>
+            </div>
+            <div slot="dropdown-content">
+              <div
+                v-if="showEdit"
+                ref="editTaskItem"
+                class="dropdown-item edit-task-item"
+              >
+                <span class="dropdown-icon-item">
+                  <span
+                    class="svg-icon inline edit-icon"
+                    v-html="icons.edit"
+                  ></span>
+                  <span class="text">{{ $t('edit') }}</span>
+                </span>
+              </div>
+              <div
+                v-if="isUser"
+                class="dropdown-item"
+                @click="moveToTop"
+              >
+                <span class="dropdown-icon-item">
+                  <span
+                    class="svg-icon inline push-to-top"
+                    v-html="icons.top"
+                  ></span>
+                  <span class="text">{{ $t('taskToTop') }}</span>
+                </span>
+              </div>
+              <div
+                v-if="isUser"
+                class="dropdown-item"
+                @click="moveToBottom"
+              >
+                <span class="dropdown-icon-item">
+                  <span
+                    class="svg-icon inline push-to-bottom"
+                    v-html="icons.bottom"
+                  ></span>
+                  <span class="text">{{ $t('taskToBottom') }}</span>
+                </span>
+              </div>
+              <div
+                v-if="showDelete"
+                class="dropdown-item"
+                @click="destroy"
+              >
+                <span class="dropdown-icon-item delete-task-item">
+                  <span
+                    class="svg-icon inline delete"
+                    v-html="icons.delete"
+                  ></span>
+                  <span class="text">{{ $t('delete') }}</span>
+                </span>
               </div>
             </div>
-          </b-popover>
+          </menu-dropdown>
+          <div class="d-flex">
+            <div
+              v-if="showStreak"
+              class="d-flex align-items-center"
+            >
+              <div
+                v-b-tooltip.hover.bottom="$t('streakCounter')"
+                class="svg-icon streak"
+                v-html="icons.streak"
+              ></div>
+              <span v-if="task.type === 'daily'">{{ task.streak }}</span>
+              <span v-if="task.type === 'habit'">
+                <span
+                  v-if="task.up"
+                  class="m-0"
+                >+{{ task.counterUp }}</span>
+                <span
+                  v-if="task.up && task.down"
+                  class="m-0"
+                >&nbsp;|&nbsp;</span>
+                <span
+                  v-if="task.down"
+                  class="m-0"
+                >-{{ task.counterDown }}</span>
+              </span>
+            </div>
+            <div
+              v-if="task.challenge && task.challenge.id"
+              class="d-flex align-items-center"
+            >
+              <div
+                v-if="!task.challenge.broken"
+                v-b-tooltip.hover.bottom="shortName"
+                class="svg-icon challenge"
+                v-html="icons.challenge"
+              ></div>
+              <div
+                v-if="task.challenge.broken"
+                v-b-tooltip.hover.bottom="$t('brokenChaLink')"
+                class="svg-icon challenge broken"
+                @click="handleBrokenTask(task)"
+                v-html="icons.brokenChallengeIcon"
+              ></div>
+            </div>
+            <div
+              v-if="hasTags"
+              :id="`tags-icon-${task._id}`"
+              class="d-flex align-items-center"
+            >
+              <div
+                class="svg-icon tags"
+                v-html="icons.tags"
+              ></div>
+            </div>
+            <b-popover
+              v-if="hasTags"
+              :target="`tags-icon-${task._id}`"
+              triggers="hover"
+              placement="bottom"
+            >
+              <div class="tags-popover">
+                <div class="d-flex align-items-center tags-container">
+                  <div
+                    v-once
+                    class="tags-popover-title"
+                  >
+                    {{ `${$t('tags')}:` }}
+                  </div>
+                  <div
+                    v-for="tag in getTagsFor(task)"
+                    :key="tag"
+                    v-markdown="tag"
+                    class="tag-label"
+                  ></div>
+                </div>
+              </div>
+            </b-popover>
+          </div>
         </div>
         <!-- Habits right side control-->
         <div
@@ -461,7 +463,7 @@
     opacity: 1;
   }
 
-  .task-clickable-area ::v-deep .habitica-menu-dropdown.open .habitica-menu-dropdown-toggle {
+  .icons-right ::v-deep .habitica-menu-dropdown.open .habitica-menu-dropdown-toggle {
     opacity: 1;
 
     .svg-icon {
@@ -469,7 +471,7 @@
     }
   }
 
-  .task-clickable-area ::v-deep .habitica-menu-dropdown .habitica-menu-dropdown-toggle:hover .svg-icon {
+  .icons-right ::v-deep .habitica-menu-dropdown .habitica-menu-dropdown-toggle:hover .svg-icon {
     color: $purple-400 !important;
   }
 
@@ -608,10 +610,12 @@
   }
 
   .icons-right {
-    padding-left: 0;
-    padding-bottom: 7px;
+    margin: 0;
+    padding: 7px 0;
+    padding-right: 8px;
 
-    justify-content: end;
+    flex-direction: column;
+    justify-content: space-between;
     align-items: end;
     flex-shrink: 0;
   }

--- a/website/client/src/components/tasks/task.vue
+++ b/website/client/src/components/tasks/task.vue
@@ -508,6 +508,7 @@
   }
 
   .task-content {
+    position: relative;
     padding-top: 0px;
     padding-bottom: 7px;
     flex-grow: 1;
@@ -591,7 +592,10 @@
   }
 
   .icons {
-    margin-top: 4px;
+    position: absolute;
+    right: 0;
+    bottom: 7px;
+
     color: $gray-300;
     font-style: normal;
 

--- a/website/client/src/components/tasks/task.vue
+++ b/website/client/src/components/tasks/task.vue
@@ -74,170 +74,90 @@
           :class="contentClass"
         >
           <div
-            class="task-clickable-area d-flex justify-content-between"
+            class="task-clickable-area"
             :class="{'task-clickable-area-user': isUser}"
             @click="edit($event, task)"
           >
-            <div>
-              <div class="d-flex justify-content-between">
-                <h3
-                  v-markdown="task.text"
-                  class="task-title"
-                  :class="{ 'has-notes': task.notes }"
-                ></h3>
-                <menu-dropdown
-                  v-if="!isRunningYesterdailies && showOptions"
-                  ref="taskDropdown"
-                  v-b-tooltip.hover.top="$t('options')"
-                  class="task-dropdown"
-                  :right="task.type === 'reward'"
-                >
-                  <div slot="dropdown-toggle">
-                    <div
-                      class="svg-icon dropdown-icon"
-                      v-html="icons.menu"
-                    ></div>
+            <div class="d-flex justify-content-between">
+              <h3
+                v-markdown="task.text"
+                class="task-title"
+                :class="{ 'has-notes': task.notes }"
+              ></h3>
+              <menu-dropdown
+                v-if="!isRunningYesterdailies && showOptions"
+                ref="taskDropdown"
+                v-b-tooltip.hover.top="$t('options')"
+                class="task-dropdown"
+                :right="task.type === 'reward'"
+              >
+                <div slot="dropdown-toggle">
+                  <div
+                    class="svg-icon dropdown-icon"
+                    v-html="icons.menu"
+                  ></div>
+                </div>
+                <div slot="dropdown-content">
+                  <div
+                    v-if="showEdit"
+                    ref="editTaskItem"
+                    class="dropdown-item edit-task-item"
+                  >
+                    <span class="dropdown-icon-item">
+                      <span
+                        class="svg-icon inline edit-icon"
+                        v-html="icons.edit"
+                      ></span>
+                      <span class="text">{{ $t('edit') }}</span>
+                    </span>
                   </div>
-                  <div slot="dropdown-content">
-                    <div
-                      v-if="showEdit"
-                      ref="editTaskItem"
-                      class="dropdown-item edit-task-item"
-                    >
-                      <span class="dropdown-icon-item">
-                        <span
-                          class="svg-icon inline edit-icon"
-                          v-html="icons.edit"
-                        ></span>
-                        <span class="text">{{ $t('edit') }}</span>
-                      </span>
-                    </div>
-                    <div
-                      v-if="isUser"
-                      class="dropdown-item"
-                      @click="moveToTop"
-                    >
-                      <span class="dropdown-icon-item">
-                        <span
-                          class="svg-icon inline push-to-top"
-                          v-html="icons.top"
-                        ></span>
-                        <span class="text">{{ $t('taskToTop') }}</span>
-                      </span>
-                    </div>
-                    <div
-                      v-if="isUser"
-                      class="dropdown-item"
-                      @click="moveToBottom"
-                    >
-                      <span class="dropdown-icon-item">
-                        <span
-                          class="svg-icon inline push-to-bottom"
-                          v-html="icons.bottom"
-                        ></span>
-                        <span class="text">{{ $t('taskToBottom') }}</span>
-                      </span>
-                    </div>
-                    <div
-                      v-if="showDelete"
-                      class="dropdown-item"
-                      @click="destroy"
-                    >
-                      <span class="dropdown-icon-item delete-task-item">
-                        <span
-                          class="svg-icon inline delete"
-                          v-html="icons.delete"
-                        ></span>
-                        <span class="text">{{ $t('delete') }}</span>
-                      </span>
-                    </div>
+                  <div
+                    v-if="isUser"
+                    class="dropdown-item"
+                    @click="moveToTop"
+                  >
+                    <span class="dropdown-icon-item">
+                      <span
+                        class="svg-icon inline push-to-top"
+                        v-html="icons.top"
+                      ></span>
+                      <span class="text">{{ $t('taskToTop') }}</span>
+                    </span>
                   </div>
-                </menu-dropdown>
-              </div>
-              <div
-                v-markdown="task.notes"
-                class="task-notes small-text"
-                :class="{'has-checklist': task.notes && hasChecklist}"
-              ></div>
-            </div>
-            <div class="icons icons-right small-text d-flex">
-              <div
-                v-if="showStreak"
-                class="d-flex align-items-center"
-              >
-                <div
-                  v-b-tooltip.hover.bottom="$t('streakCounter')"
-                  class="svg-icon streak"
-                  v-html="icons.streak"
-                ></div>
-                <span v-if="task.type === 'daily'">{{ task.streak }}</span>
-                <span v-if="task.type === 'habit'">
-                  <span
-                    v-if="task.up"
-                    class="m-0"
-                  >+{{ task.counterUp }}</span>
-                  <span
-                    v-if="task.up && task.down"
-                    class="m-0"
-                  >&nbsp;|&nbsp;</span>
-                  <span
-                    v-if="task.down"
-                    class="m-0"
-                  >-{{ task.counterDown }}</span>
-                </span>
-              </div>
-              <div
-                v-if="task.challenge && task.challenge.id"
-                class="d-flex align-items-center"
-              >
-                <div
-                  v-if="!task.challenge.broken"
-                  v-b-tooltip.hover.bottom="shortName"
-                  class="svg-icon challenge"
-                  v-html="icons.challenge"
-                ></div>
-                <div
-                  v-if="task.challenge.broken"
-                  v-b-tooltip.hover.bottom="$t('brokenChaLink')"
-                  class="svg-icon challenge broken"
-                  @click="handleBrokenTask(task)"
-                  v-html="icons.brokenChallengeIcon"
-                ></div>
-              </div>
-              <div
-                v-if="hasTags"
-                :id="`tags-icon-${task._id}`"
-                class="d-flex align-items-center"
-              >
-                <div
-                  class="svg-icon tags"
-                  v-html="icons.tags"
-                ></div>
-              </div>
-              <b-popover
-                v-if="hasTags"
-                :target="`tags-icon-${task._id}`"
-                triggers="hover"
-                placement="bottom"
-              >
-                <div class="tags-popover">
-                  <div class="d-flex align-items-center tags-container">
-                    <div
-                      v-once
-                      class="tags-popover-title"
-                    >
-                      {{ `${$t('tags')}:` }}
-                    </div>
-                    <div
-                      v-for="tag in getTagsFor(task)"
-                      :key="tag"
-                      v-markdown="tag"
-                      class="tag-label"
-                    ></div>
+                  <div
+                    v-if="isUser"
+                    class="dropdown-item"
+                    @click="moveToBottom"
+                  >
+                    <span class="dropdown-icon-item">
+                      <span
+                        class="svg-icon inline push-to-bottom"
+                        v-html="icons.bottom"
+                      ></span>
+                      <span class="text">{{ $t('taskToBottom') }}</span>
+                    </span>
+                  </div>
+                  <div
+                    v-if="showDelete"
+                    class="dropdown-item"
+                    @click="destroy"
+                  >
+                    <span class="dropdown-icon-item delete-task-item">
+                      <span
+                        class="svg-icon inline delete"
+                        v-html="icons.delete"
+                      ></span>
+                      <span class="text">{{ $t('delete') }}</span>
+                    </span>
                   </div>
                 </div>
-              </b-popover>
+              </menu-dropdown>
             </div>
+            <div
+              v-markdown="task.notes"
+              class="task-notes small-text"
+              :class="{'has-checklist': task.notes && hasChecklist}"
+            ></div>
           </div>
           <div
             v-if="canViewchecklist"
@@ -301,6 +221,84 @@
               <span>{{ dueIn }}</span>
             </div>
           </div>
+        </div>
+        <div class="icons icons-right small-text d-flex">
+          <div
+            v-if="showStreak"
+            class="d-flex align-items-center"
+          >
+            <div
+              v-b-tooltip.hover.bottom="$t('streakCounter')"
+              class="svg-icon streak"
+              v-html="icons.streak"
+            ></div>
+            <span v-if="task.type === 'daily'">{{ task.streak }}</span>
+            <span v-if="task.type === 'habit'">
+              <span
+                v-if="task.up"
+                class="m-0"
+              >+{{ task.counterUp }}</span>
+              <span
+                v-if="task.up && task.down"
+                class="m-0"
+              >&nbsp;|&nbsp;</span>
+              <span
+                v-if="task.down"
+                class="m-0"
+              >-{{ task.counterDown }}</span>
+            </span>
+          </div>
+          <div
+            v-if="task.challenge && task.challenge.id"
+            class="d-flex align-items-center"
+          >
+            <div
+              v-if="!task.challenge.broken"
+              v-b-tooltip.hover.bottom="shortName"
+              class="svg-icon challenge"
+              v-html="icons.challenge"
+            ></div>
+            <div
+              v-if="task.challenge.broken"
+              v-b-tooltip.hover.bottom="$t('brokenChaLink')"
+              class="svg-icon challenge broken"
+              @click="handleBrokenTask(task)"
+              v-html="icons.brokenChallengeIcon"
+            ></div>
+          </div>
+          <div
+            v-if="hasTags"
+            :id="`tags-icon-${task._id}`"
+            class="d-flex align-items-center"
+          >
+            <div
+              class="svg-icon tags"
+              v-html="icons.tags"
+            ></div>
+          </div>
+          <b-popover
+            v-if="hasTags"
+            :target="`tags-icon-${task._id}`"
+            triggers="hover"
+            placement="bottom"
+          >
+            <div class="tags-popover">
+              <div class="d-flex align-items-center tags-container">
+                <div
+                  v-once
+                  class="tags-popover-title"
+                >
+                  {{ `${$t('tags')}:` }}
+                </div>
+                <div
+                  v-for="tag in getTagsFor(task)"
+                  :key="tag"
+                  v-markdown="tag"
+                  class="tag-label"
+                ></div>
+              </div>
+            </div>
+          </b-popover>
         </div>
         <!-- Habits right side control-->
         <div
@@ -611,6 +609,7 @@
 
   .icons-right {
     padding-left: 0;
+    padding-bottom: 7px;
 
     justify-content: end;
     align-items: end;

--- a/website/client/src/components/tasks/task.vue
+++ b/website/client/src/components/tasks/task.vue
@@ -74,150 +74,93 @@
           :class="contentClass"
         >
           <div
-            class="task-clickable-area"
+            class="task-clickable-area d-flex justify-content-between"
             :class="{'task-clickable-area-user': isUser}"
             @click="edit($event, task)"
           >
-            <div class="d-flex justify-content-between">
-              <h3
-                v-markdown="task.text"
-                class="task-title"
-                :class="{ 'has-notes': task.notes }"
-              ></h3>
-              <menu-dropdown
-                v-if="!isRunningYesterdailies && showOptions"
-                ref="taskDropdown"
-                v-b-tooltip.hover.top="$t('options')"
-                class="task-dropdown"
-                :right="task.type === 'reward'"
-              >
-                <div slot="dropdown-toggle">
-                  <div
-                    class="svg-icon dropdown-icon"
-                    v-html="icons.menu"
-                  ></div>
-                </div>
-                <div slot="dropdown-content">
-                  <div
-                    v-if="showEdit"
-                    ref="editTaskItem"
-                    class="dropdown-item edit-task-item"
-                  >
-                    <span class="dropdown-icon-item">
-                      <span
-                        class="svg-icon inline edit-icon"
-                        v-html="icons.edit"
-                      ></span>
-                      <span class="text">{{ $t('edit') }}</span>
-                    </span>
+            <div>
+              <div class="d-flex justify-content-between">
+                <h3
+                  v-markdown="task.text"
+                  class="task-title"
+                  :class="{ 'has-notes': task.notes }"
+                ></h3>
+                <menu-dropdown
+                  v-if="!isRunningYesterdailies && showOptions"
+                  ref="taskDropdown"
+                  v-b-tooltip.hover.top="$t('options')"
+                  class="task-dropdown"
+                  :right="task.type === 'reward'"
+                >
+                  <div slot="dropdown-toggle">
+                    <div
+                      class="svg-icon dropdown-icon"
+                      v-html="icons.menu"
+                    ></div>
                   </div>
-                  <div
-                    v-if="isUser"
-                    class="dropdown-item"
-                    @click="moveToTop"
-                  >
-                    <span class="dropdown-icon-item">
-                      <span
-                        class="svg-icon inline push-to-top"
-                        v-html="icons.top"
-                      ></span>
-                      <span class="text">{{ $t('taskToTop') }}</span>
-                    </span>
+                  <div slot="dropdown-content">
+                    <div
+                      v-if="showEdit"
+                      ref="editTaskItem"
+                      class="dropdown-item edit-task-item"
+                    >
+                      <span class="dropdown-icon-item">
+                        <span
+                          class="svg-icon inline edit-icon"
+                          v-html="icons.edit"
+                        ></span>
+                        <span class="text">{{ $t('edit') }}</span>
+                      </span>
+                    </div>
+                    <div
+                      v-if="isUser"
+                      class="dropdown-item"
+                      @click="moveToTop"
+                    >
+                      <span class="dropdown-icon-item">
+                        <span
+                          class="svg-icon inline push-to-top"
+                          v-html="icons.top"
+                        ></span>
+                        <span class="text">{{ $t('taskToTop') }}</span>
+                      </span>
+                    </div>
+                    <div
+                      v-if="isUser"
+                      class="dropdown-item"
+                      @click="moveToBottom"
+                    >
+                      <span class="dropdown-icon-item">
+                        <span
+                          class="svg-icon inline push-to-bottom"
+                          v-html="icons.bottom"
+                        ></span>
+                        <span class="text">{{ $t('taskToBottom') }}</span>
+                      </span>
+                    </div>
+                    <div
+                      v-if="showDelete"
+                      class="dropdown-item"
+                      @click="destroy"
+                    >
+                      <span class="dropdown-icon-item delete-task-item">
+                        <span
+                          class="svg-icon inline delete"
+                          v-html="icons.delete"
+                        ></span>
+                        <span class="text">{{ $t('delete') }}</span>
+                      </span>
+                    </div>
                   </div>
-                  <div
-                    v-if="isUser"
-                    class="dropdown-item"
-                    @click="moveToBottom"
-                  >
-                    <span class="dropdown-icon-item">
-                      <span
-                        class="svg-icon inline push-to-bottom"
-                        v-html="icons.bottom"
-                      ></span>
-                      <span class="text">{{ $t('taskToBottom') }}</span>
-                    </span>
-                  </div>
-                  <div
-                    v-if="showDelete"
-                    class="dropdown-item"
-                    @click="destroy"
-                  >
-                    <span class="dropdown-icon-item delete-task-item">
-                      <span
-                        class="svg-icon inline delete"
-                        v-html="icons.delete"
-                      ></span>
-                      <span class="text">{{ $t('delete') }}</span>
-                    </span>
-                  </div>
-                </div>
-              </menu-dropdown>
-            </div>
-            <div
-              v-markdown="task.notes"
-              class="task-notes small-text"
-              :class="{'has-checklist': task.notes && hasChecklist}"
-            ></div>
-          </div>
-          <div
-            v-if="canViewchecklist"
-            class="checklist"
-            :class="{isOpen: !task.collapseChecklist}"
-          >
-            <div class="d-inline-flex">
-              <div
-                v-if="isUser"
-                v-b-tooltip.hover.right="$t(`${task.collapseChecklist
-                  ? 'expand': 'collapse'}Checklist`)"
-                class="collapse-checklist d-flex align-items-center expand-toggle"
-                :class="{open: !task.collapseChecklist}"
-                @click="collapseChecklist(task)"
-              >
-                <div
-                  class="svg-icon"
-                  v-html="icons.checklist"
-                ></div>
-                <span>{{ checklistProgress }}</span>
+                </menu-dropdown>
               </div>
-            </div>
-            <!-- eslint-disable vue/no-use-v-if-with-v-for -->
-            <div
-              v-for="item in task.checklist"
-              v-if="!task.collapseChecklist"
-              :key="item.id"
-              class="custom-control custom-checkbox checklist-item"
-              :class="{'checklist-item-done': item.completed}"
-            >
-              <!-- eslint-enable vue/no-use-v-if-with-v-for -->
-              <input
-                :id="`checklist-${item.id}-${random}`"
-                class="custom-control-input"
-                type="checkbox"
-                :checked="item.completed"
-                :disabled="castingSpell || !isUser"
-                @change="toggleChecklistItem(item)"
-              >
-              <label
-                v-markdown="item.text"
-                class="custom-control-label"
-                :for="`checklist-${item.id}-${random}`"
-              ></label>
-            </div>
-          </div>
-          <div class="icons small-text d-flex align-items-center">
-            <div
-              v-if="task.type === 'todo' && task.date"
-              class="d-flex align-items-center"
-              :class="{'due-overdue': isDueOverdue}"
-            >
               <div
-                v-b-tooltip.hover.bottom="$t('dueDate')"
-                class="svg-icon calendar"
-                v-html="icons.calendar"
+                v-markdown="task.notes"
+                class="task-notes small-text"
+                :class="{'has-checklist': task.notes && hasChecklist}"
               ></div>
-              <span>{{ dueIn }}</span>
             </div>
-            <div class="icons-right d-flex justify-content-end">
+            <div class="icons icons-right small-text d-flex">
               <div
                 v-if="showStreak"
                 class="d-flex align-items-center"
@@ -294,6 +237,68 @@
                   </div>
                 </div>
               </b-popover>
+            </div>
+          </div>
+          <div
+            v-if="canViewchecklist"
+            class="checklist"
+            :class="{isOpen: !task.collapseChecklist}"
+          >
+            <div class="d-inline-flex">
+              <div
+                v-if="isUser"
+                v-b-tooltip.hover.right="$t(`${task.collapseChecklist
+                  ? 'expand': 'collapse'}Checklist`)"
+                class="collapse-checklist d-flex align-items-center expand-toggle"
+                :class="{open: !task.collapseChecklist}"
+                @click="collapseChecklist(task)"
+              >
+                <div
+                  class="svg-icon"
+                  v-html="icons.checklist"
+                ></div>
+                <span>{{ checklistProgress }}</span>
+              </div>
+            </div>
+            <!-- eslint-disable vue/no-use-v-if-with-v-for -->
+            <div
+              v-for="item in task.checklist"
+              v-if="!task.collapseChecklist"
+              :key="item.id"
+              class="custom-control custom-checkbox checklist-item"
+              :class="{'checklist-item-done': item.completed}"
+            >
+              <!-- eslint-enable vue/no-use-v-if-with-v-for -->
+              <input
+                :id="`checklist-${item.id}-${random}`"
+                class="custom-control-input"
+                type="checkbox"
+                :checked="item.completed"
+                :disabled="castingSpell || !isUser"
+                @change="toggleChecklistItem(item)"
+              >
+              <label
+                v-markdown="item.text"
+                class="custom-control-label"
+                :for="`checklist-${item.id}-${random}`"
+              ></label>
+            </div>
+          </div>
+          <div
+            v-if="task.type === 'todo' && task.date"
+            class="icons small-text d-flex align-items-center flex-shrink-0"
+          >
+            <div
+              v-if="task.type === 'todo' && task.date"
+              class="d-flex align-items-center"
+              :class="{'due-overdue': isDueOverdue}"
+            >
+              <div
+                v-b-tooltip.hover.bottom="$t('dueDate')"
+                class="svg-icon calendar"
+                v-html="icons.calendar"
+              ></div>
+              <span>{{ dueIn }}</span>
             </div>
           </div>
         </div>
@@ -505,6 +510,10 @@
     &.has-checklist {
       padding-bottom: 2px;
     }
+
+    p {
+      margin-bottom: 4px;
+    }
   }
 
   .task-content {
@@ -598,6 +607,14 @@
     &-right {
       flex-grow: 1;
     }
+  }
+
+  .icons-right {
+    padding-left: 0;
+
+    justify-content: end;
+    align-items: end;
+    flex-shrink: 0;
   }
 
   .icons-right .svg-icon {


### PR DESCRIPTION
Especially on smaller screens, space is precious. Having the icons on a separate line takes up vertical space, when there's plenty of room for them to sit to the right of the rest of the task content.

I've also created an issue for this in habitica-android, I'm not sure how separated the codebases are: https://github.com/HabitRPG/habitica-android/issues/1270.

### Changes
Set `position: absolute` on `.icons` in `task.vue`.

Before:
![Skjermbilde 2020-03-13 kl  10 54 17](https://user-images.githubusercontent.com/524709/76610339-0de63580-6519-11ea-8517-ba01bec28ba7.png)

After:
![Skjermbilde 2020-03-13 kl  10 54 10](https://user-images.githubusercontent.com/524709/76610347-10e12600-6519-11ea-8e46-88eb710e5761.png)

A small possible issue is a slight overlap of text, this is the most overlap I was able to acheive:

![Skjermbilde 2020-03-13 kl  10 59 53](https://user-images.githubusercontent.com/524709/76610810-c7450b00-6519-11ea-9e8c-667d57efb241.png)

This could be remedied by increasing `padding-right` on `.task-notes`, or `margin-bottom` on `.task-notes.markdown p`.

----
UUID: 7b9c79ad-ad01-4ef0-a250-01d0e4a73bf3