### PR TITLE
Remove strange disjointed :hover effect on .task

### DIFF
--- a/website/client/src/components/tasks/task.vue
+++ b/website/client/src/components/tasks/task.vue
@@ -371,22 +371,6 @@
     position: relative;
 
     &:hover {
-      box-shadow: 0 1px 8px 0 rgba($black, 0.12), 0 4px 4px 0 rgba($black, 0.16);
-      z-index: 11;
-    }
-  }
-
-  .task:not(.groupTask) {
-    &:hover {
-      .left-control, .right-control, .task-content {
-        border-color: $purple-400;
-      }
-    }
-  }
-
-  .task.groupTask {
-
-    &:hover {
       border: $purple-400 solid 1px;
       border-radius: 3px;
       margin: -1px; // to counter the border width
@@ -512,14 +496,8 @@
     padding-bottom: 7px;
     flex-grow: 1;
     cursor: pointer;
-    background: $white;
-    border: 1px solid transparent;
     transition-duration: 0.15;
     min-width: 0px;
-
-    &.no-right-border {
-      border-right: none !important;
-    }
 
     &.reward-content {
       border-top-left-radius: 2px;
@@ -688,12 +666,6 @@
     border-top-left-radius: 2px;
     border-bottom-left-radius: 2px;
     min-height: 60px;
-    border: 1px solid transparent;
-    border-right: none;
-
-    & + .task-content {
-      border-left: none;
-    }
   }
   .task:not(.type_habit) {
     .left-control {
@@ -708,8 +680,6 @@
     border-top-right-radius: 2px;
     border-bottom-right-radius: 2px;
     min-height: 56px;
-    border: 1px solid transparent;
-    border-left: none;
   }
 
   .task-control:not(.task-disabled-habit-control-inner), .reward-control {
@@ -894,20 +864,7 @@ export default {
       return this.getTaskClasses(this.task, 'control', this.dueDate);
     },
     contentClass () {
-      const { type } = this.task;
-
-      const classes = [];
-      classes.push(this.getTaskClasses(this.task, 'control', this.dueDate).content);
-
-      if (type === 'reward' || type === 'habit') {
-        classes.push('no-right-border');
-      }
-
-      if (type === 'reward') {
-        classes.push('reward-content');
-      }
-
-      return classes;
+      return this.getTaskClasses(this.task, 'control', this.dueDate).content;
     },
     showStreak () {
       if (this.task.streak !== undefined) return true;


### PR DESCRIPTION
This reverts part of #8926, specifically ["tasks hover state"](https://github.com/HabitRPG/habitica/pull/8926/commits/5f4fb6264141655a6ffa31324e6ea0dd5ebebece).

This commit is from almost three years ago, so I'm not sure why the border was added in such a strange way.  Regardless, this method is no longer needed as simply setting a border on .task works perfectly fine.

This has the advantage of allowing children to be added to .task without requiring more .no-right-border code. Something I need for #11967.

I believe this commit removes all CSS that references .groupTask, which leads me to believe that 'groupTask': task.group.id is unused. But I am not 100% sure, so I left it in.

## Changes
Replaces the border set on :hover on `.task-content`, `.left-control`, and `.right-control` with a border set on `.task`.

### Before
![screenshot before](https://user-images.githubusercontent.com/524709/76650736-7fe36c80-6563-11ea-8760-54a2db6aa557.png)

### After
![screenshot after](https://user-images.githubusercontent.com/524709/76650743-840f8a00-6563-11ea-8361-522cd3e02639.png)

----
UUID: 7b9c79ad-ad01-4ef0-a250-01d0e4a73bf3
