### PR TITLE
WIP: Private Messages search &API

### DIFF
--- a/website/client/src/components/messages/messageCard.vue
+++ b/website/client/src/components/messages/messageCard.vue
@@ -64,7 +64,7 @@
       </div>
       <div
         v-if="searchMode"
-        class="action d-flex align-items-center"
+        class="action d-flex align-items-center jump-to-context"
         @click="jumpToContext()"
       >
         <div v-once>
@@ -141,6 +141,10 @@
   .reported {
     margin-top: 18px;
     color: $red-50;
+  }
+
+  .jump-to-context {
+    color: $blue-10;
   }
 </style>
 

--- a/website/client/src/components/messages/messageCard.vue
+++ b/website/client/src/components/messages/messageCard.vue
@@ -62,6 +62,15 @@
           {{ $t('delete') }}
         </div>
       </div>
+      <div
+        v-if="searchMode"
+        class="action d-flex align-items-center"
+        @click="jumpToContext()"
+      >
+        <div v-once>
+          {{ $t('jumpToContext') }}
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -158,6 +167,7 @@ export default {
   },
   props: {
     msg: {},
+    searchMode: Boolean,
   },
   data () {
     return {
@@ -210,6 +220,10 @@ export default {
     parseMarkdown (text) {
       if (!text) return null;
       return habiticaMarkdown.render(String(text));
+    },
+    jumpToContext () {
+      const message = this.msg;
+      this.$emit('jump-to-context', message);
     },
   },
 };

--- a/website/client/src/components/messages/messageList.vue
+++ b/website/client/src/components/messages/messageList.vue
@@ -42,8 +42,10 @@
           :hide-class-badge="true"
           @click.native="showMemberModal(msg.uuid)"
         />
-        <div class="card"
-             :class="{'card-right': user._id !== msg.uuid, 'card-left': user._id === msg.uuid}">
+        <div
+          class="card"
+          :class="{'card-right': user._id !== msg.uuid, 'card-left': user._id === msg.uuid}"
+        >
           <message-card
             :msg="msg"
             :search-mode="searchMode"

--- a/website/client/src/pages/private-messages.vue
+++ b/website/client/src/pages/private-messages.vue
@@ -609,6 +609,7 @@ export default {
       selectedConversation: {},
       search: '',
       searchMode: false,
+      jumpContextMode: false,
       newMessage: '',
       showPopover: false,
       messages: [],
@@ -874,7 +875,7 @@ export default {
       this.selectedConversation = convoFound || {};
 
       if (!this.messagesByConversation[this.selectedConversation.key] || forceLoadMessage) {
-        await this.loadMessages('before');
+        await this.loadMessages({ type: 'before' });
       }
 
       this.scrollToBottom();
@@ -947,13 +948,11 @@ export default {
         ? this.selectedConversation.oldestTimestamp
         : this.selectedConversation.newestTimestamp;
 
-      return this.loadMore(type, timestamp);
-    },
-    loadMore (type, timestamp) {
       this.selectedConversation.page += 1;
-      return this.loadMessages(type, timestamp);
+
+      return this.loadMessages({ type, timestamp });
     },
-    async loadMessages (type, timestamp) {
+    async loadMessages ({ type, timestamp }) {
       this.messagesLoading[type] = true;
 
       let { searchMode } = this;
@@ -971,15 +970,15 @@ export default {
       const params = [`conversation=${conversationKey}`];
 
       if (searchMode) {
-        if (this.search) {
+        if (this.search && !this.jumpContextMode) {
           params.push(`searchMessage=${this.search}`);
         }
 
         if (timestamp) {
           if (type === 'before') {
-            params.push(`beforeTimestamp=${timestamp}`);
+            params.push(`beforeTimestamp=${encodeURIComponent(timestamp)}`);
           } else {
-            params.push(`afterTimestamp=${timestamp}`);
+            params.push(`afterTimestamp=${encodeURIComponent(timestamp)}`);
           }
         }
       } else {
@@ -1031,6 +1030,7 @@ export default {
     },
     triggerSearch: debounce(function triggerSearch () {
       this.searchMode = Boolean(this.search);
+      this.jumpContextMode = false;
       this.reload({
         search: this.search,
       });
@@ -1038,28 +1038,23 @@ export default {
     async jumpToContext (msg) {
       const selectedConversationKey = this.selectedConversation.key;
 
-      // reset
-      this.search = '';
-      this.loadedConversations = [];
-
-      // reload the conversations
-      await this.reload();
-
       const convoFound = this.conversations.find(conversation => conversation.key === selectedConversationKey);
 
       // re-select the conversation
       this.selectedConversation = convoFound || {};
 
-      Vue.nextTick(async () => {
-        // select conversation & load messages from selected
-        await this.loadMessages('before', msg.timestamp);
+      this.jumpContextMode = true;
 
-        // re-select the conversation
-        this.selectedConversation = convoFound || {};
-        this.selectedConversation.canLoadMore.after = true; // enable initial load button
-
-        this.scrollToBottom();
+      // select conversation & load messages from selected
+      await this.loadMessages({
+        type: 'before',
+        timestamp: msg.timestamp,
       });
+
+      // re-select the conversation
+      this.selectedConversation.canLoadMore.after = true; // enable initial load button
+
+      this.scrollToBottom();
     },
     scrollToBottom () {
       Vue.nextTick(() => {

--- a/website/client/src/pages/private-messages.vue
+++ b/website/client/src/pages/private-messages.vue
@@ -86,7 +86,7 @@
              && selectedConversation.searchMode">
           <span>
             <span>
-              {{ $t('viewingOlderMessagesOf', {name: selectedConversation.name})}}
+              {{ $t('viewingOlderMessagesOf', {text: search})}}
               </span>
             <span class="divider"></span>
             <span class="jump-to-recent" @click="jumpToRecent()">

--- a/website/client/src/pages/private-messages.vue
+++ b/website/client/src/pages/private-messages.vue
@@ -982,7 +982,6 @@ export default {
       });
 
       this.newMessage = '';
-      this.autoSize();
     },
     removeTags (html) {
       const tmp = document.createElement('DIV');

--- a/website/client/src/pages/private-messages.vue
+++ b/website/client/src/pages/private-messages.vue
@@ -172,10 +172,8 @@
               class="flex-fill"
               :placeholder="$t('needsTextPlaceholder')"
               :maxlength="MAX_MESSAGE_LENGTH"
-              :class="{'has-content': newMessage !== '', 'disabled': newMessageDisabled}"
-              :style="{'--textarea-auto-height': textareaAutoHeight}"
+              :class="{'has-content': newMessage.trim() !== '', 'disabled': newMessageDisabled}"
               @keyup.ctrl.enter="sendPrivateMessage()"
-              @input="autoSize()"
             >
             </textarea>
           </div>
@@ -455,6 +453,10 @@
         background-color: $gray-500;
       }
 
+      &:focus, &.has-content {
+        --textarea-auto-height: 80px
+      }
+
       min-height: var(--textarea-auto-height, 40px);
       max-height: var(--textarea-auto-height, 40px);
     }
@@ -622,8 +624,6 @@ import conversationItem from '@/components/messages/conversationItem';
 import faceAvatar from '@/components/faceAvatar';
 import Avatar from '@/components/avatar';
 import { EVENTS } from '@/libs/events';
-
-const MAX_TEXTAREA_HEIGHT = 80;
 
 export default {
   components: {
@@ -1062,22 +1062,6 @@ export default {
       this.messagesByConversation[conversationKey] = messagesList;
       this.selectedConversation.canLoadMore[type] = loadedMessages.length === 10;
       this.messagesLoading[type] = false;
-    },
-    autoSize () {
-      const { textarea } = this.$refs;
-      // weird issue: browser only removing the scrollHeight / clientHeight per key event - 56-54-52
-      let { scrollHeight } = textarea;
-
-      if (!this.newMessage || this.newMessage.trim() === '') {
-        // reset height when the message was removed again
-        scrollHeight = 40;
-      }
-
-      if (scrollHeight > MAX_TEXTAREA_HEIGHT) {
-        scrollHeight = MAX_TEXTAREA_HEIGHT;
-      }
-
-      this.textareaAutoHeight = `${scrollHeight}px`;
     },
     selectFirstConversation () {
       if (this.loadedConversations.length > 0) {

--- a/website/client/src/pages/private-messages.vue
+++ b/website/client/src/pages/private-messages.vue
@@ -1126,6 +1126,7 @@ export default {
       // re-select the conversation
       this.selectedConversation = convoFound || {};
       this.selectedConversation.searchMode = false;
+      this.messagesByConversation[selectedConversationKey] = [];
 
       // select conversation & load messages from selected
       await this.loadMessages({

--- a/website/client/src/pages/private-messages.vue
+++ b/website/client/src/pages/private-messages.vue
@@ -880,8 +880,15 @@ export default {
 
       this.scrollToBottom();
     },
-    sendPrivateMessage () {
+    async sendPrivateMessage () {
       if (!this.newMessage) return;
+
+      if (this.searchMode) {
+        // reset message list
+        this.selectedConversation.page = 0;
+        // reload current view
+        await this.loadMessages({ type: 'before', disableSearchMode: true });
+      }
 
       const messages = this.messagesByConversation[this.selectedConversation.key];
 
@@ -952,13 +959,17 @@ export default {
 
       return this.loadMessages({ type, timestamp });
     },
-    async loadMessages ({ type, timestamp }) {
+    async loadMessages ({ type, timestamp, disableSearchMode }) {
       this.messagesLoading[type] = true;
 
       let { searchMode } = this;
 
       if (type && timestamp) {
         searchMode = true;
+      }
+
+      if (disableSearchMode) {
+        searchMode = false;
       }
 
       // use local vars if the loading takes longer

--- a/website/client/src/pages/private-messages.vue
+++ b/website/client/src/pages/private-messages.vue
@@ -19,8 +19,10 @@
           <!-- placeholder -->
         </div>
       </div>
-      <div class="d-flex selected-conversion"
-           v-if="selectedConversation && selectedConversation.key">
+      <div
+        v-if="selectedConversation && selectedConversation.key"
+        class="d-flex selected-conversion"
+      >
         <router-link
           :to="{'name': 'userProfile', 'params': {'userId': selectedConversation.key}}"
         >
@@ -616,6 +618,9 @@ export default {
       MAX_MESSAGE_LENGTH: MAX_MESSAGE_LENGTH.toString(),
     };
   },
+  watch: {
+    search: 'triggerSearch',
+  },
   async mounted () {
     // notification click to refresh
     this.$root.$on(EVENTS.PM_REFRESH, async () => {
@@ -658,9 +663,6 @@ export default {
   },
   destroyed () {
     this.$root.$off(EVENTS.RESYNC_COMPLETED);
-  },
-  watch: {
-    search: 'triggerSearch',
   },
   computed: {
     ...mapState({ user: 'user.data' }),

--- a/website/client/src/pages/private-messages.vue
+++ b/website/client/src/pages/private-messages.vue
@@ -1060,7 +1060,7 @@ export default {
 
       // only show the load more Button if the max count was returned
       this.messagesByConversation[conversationKey] = messagesList;
-      this.selectedConversation.canLoadMore[type] = !this.search && loadedMessages.length === 10;
+      this.selectedConversation.canLoadMore[type] = loadedMessages.length === 10;
       this.messagesLoading[type] = false;
     },
     autoSize () {
@@ -1068,7 +1068,7 @@ export default {
       // weird issue: browser only removing the scrollHeight / clientHeight per key event - 56-54-52
       let { scrollHeight } = textarea;
 
-      if (this.newMessage === '') {
+      if (!this.newMessage || this.newMessage.trim() === '') {
         // reset height when the message was removed again
         scrollHeight = 40;
       }

--- a/website/common/locales/en/generic.json
+++ b/website/common/locales/en/generic.json
@@ -304,5 +304,7 @@
   "habiticaHasUpdated": "There is a new Habitica update. Refresh to get the latest version!",
   "contactForm": "Contact the Moderation Team",
   "loadEarlierMessages": "Load earlier Messages",
-  "loadNewerMessages": "Load newer Messages"
+  "loadNewerMessages": "Load newer Messages",
+  "viewingOlderMessagesOf": "Viewing older messages with \"<%= name %>\"",
+  "jumpToRecent": "Jump to recent messages"
 }

--- a/website/common/locales/en/generic.json
+++ b/website/common/locales/en/generic.json
@@ -305,6 +305,6 @@
   "contactForm": "Contact the Moderation Team",
   "loadEarlierMessages": "Load earlier Messages",
   "loadNewerMessages": "Load newer Messages",
-  "viewingOlderMessagesOf": "Viewing older messages with \"<%= name %>\"",
+  "viewingOlderMessagesOf": "Viewing older messages with \"<%= text %>\"",
   "jumpToRecent": "Jump to recent messages"
 }

--- a/website/common/locales/en/generic.json
+++ b/website/common/locales/en/generic.json
@@ -303,5 +303,6 @@
   "howManyToBuy": "How many would you like to buy?",
   "habiticaHasUpdated": "There is a new Habitica update. Refresh to get the latest version!",
   "contactForm": "Contact the Moderation Team",
-  "loadEarlierMessages": "Load Earlier Messages"
+  "loadEarlierMessages": "Load earlier Messages",
+  "loadNewerMessages": "Load newer Messages"
 }

--- a/website/common/locales/en/messages.json
+++ b/website/common/locales/en/messages.json
@@ -74,5 +74,7 @@
   "messageDeletedUser": "Sorry, this user has deleted their account.",
   "messageMissingDisplayName": "Missing display name.",
   "reportedMessage": "You have reported this message to moderators.",
-  "canDeleteNow": "You can now delete the message if you wish."
+  "canDeleteNow": "You can now delete the message if you wish.",
+
+  "jumpToContext": "Jump to context"
 }

--- a/website/server/controllers/api-v4/inbox.js
+++ b/website/server/controllers/api-v4/inbox.js
@@ -81,6 +81,8 @@ api.clearMessages = {
  * This is for API v4 which must not be used in third-party tools.
  * For API v3, use "Get inbox messages for a user".
  *
+ * @apiParam (Query) {String} searchMessage Lists only the conversations that contain this message
+ *
  * @apiSuccess {Array} data An array of inbox conversations
  *
  * @apiSuccessExample {json} Success-Response:
@@ -104,8 +106,9 @@ api.conversations = {
   url: '/inbox/conversations',
   async handler (req, res) {
     const { user } = res.locals;
+    const { searchMessage } = req.query;
 
-    const result = await listConversations(user);
+    const result = await listConversations(user, searchMessage);
 
     res.respond(200, result);
   },
@@ -129,8 +132,7 @@ api.getInboxMessages = {
   middlewares: [authWithHeaders()],
   async handler (req, res) {
     const { user } = res.locals;
-    const { page } = req.query;
-    const { conversation } = req.query;
+    const { page, conversation } = req.query;
 
     const userInbox = await getUserInbox(user, {
       page, conversation, mapProps: true,

--- a/website/server/controllers/api-v4/inbox.js
+++ b/website/server/controllers/api-v4/inbox.js
@@ -4,7 +4,9 @@ import {
   NotFound,
 } from '../../libs/errors';
 import { listConversations } from '../../libs/inbox/conversation.methods';
-import { clearPMs, deleteMessage, getUserInbox, searchUserInbox } from '../../libs/inbox';
+import {
+  clearPMs, deleteMessage, getUserInbox, searchUserInbox,
+} from '../../libs/inbox';
 
 const api = {};
 

--- a/website/server/controllers/api-v4/inbox.js
+++ b/website/server/controllers/api-v4/inbox.js
@@ -144,27 +144,38 @@ api.getInboxMessages = {
 
 
 /**
- * @api {get} /api/v4/inbox/paged-messages Get inbox messages for a user
- * @apiName GetInboxMessages
- * @apiGroup Inbox TODO
- * @apiDescription Get inbox messages for a user.
+ * @api {get} /api/v4/inbox/search-messages Search inbox messages for a user
+ * @apiName SearchInboxMessages
+ * @apiGroup Inbox
+ * @apiDescription Search inbox messages for a user.
  * Entries already populated with the correct `sent` - information
  *
- * @apiParam (Query) {Number} page Load the messages of the selected Page - 10 Messages per Page
+ * @apiParam (Query) {Timestamp} Optional beforeTimestamp
+ * Load the messages before (less then equal) this timestamp
+ * @apiParam (Query) {Timestamp} Optional afterTimestamp
+ * Load the messages after (greater then equal) this timestamp
+ * @apiParam (Query) {String} Optional searchMessage
+ * Load the messages that contain this searchMessage-string
  * @apiParam (Query) {GUID} conversation Loads only the messages of a conversation
  *
  * @apiSuccess {Array} data An array of inbox messages
  */
-api.getInboxMessages = {
+api.searchInboxMessages = {
   method: 'GET',
   url: '/inbox/search-messages',
   middlewares: [authWithHeaders()],
   async handler (req, res) {
     const { user } = res.locals;
-    const { beforeTimestamp, afterTimestamp, conversation } = req.query;
+    const {
+      beforeTimestamp, afterTimestamp, conversation, searchMessage,
+    } = req.query;
 
     const userInbox = await searchUserInbox(user, {
-      beforeTimestamp, afterTimestamp, conversation, mapProps: true,
+      beforeTimestamp,
+      afterTimestamp,
+      searchMessage,
+      conversation,
+      mapProps: true,
     });
 
     res.respond(200, userInbox);

--- a/website/server/controllers/api-v4/inbox.js
+++ b/website/server/controllers/api-v4/inbox.js
@@ -108,9 +108,9 @@ api.conversations = {
   url: '/inbox/conversations',
   async handler (req, res) {
     const { user } = res.locals;
-    const { searchMessage } = req.query;
+    const { searchMessage, page = 0 } = req.query;
 
-    const result = await listConversations(user, searchMessage);
+    const result = await listConversations(user, page, searchMessage);
 
     res.respond(200, result);
   },

--- a/website/server/controllers/api-v4/inbox.js
+++ b/website/server/controllers/api-v4/inbox.js
@@ -4,7 +4,7 @@ import {
   NotFound,
 } from '../../libs/errors';
 import { listConversations } from '../../libs/inbox/conversation.methods';
-import { clearPMs, deleteMessage, getUserInbox } from '../../libs/inbox';
+import { clearPMs, deleteMessage, getUserInbox, searchUserInbox } from '../../libs/inbox';
 
 const api = {};
 
@@ -136,6 +136,35 @@ api.getInboxMessages = {
 
     const userInbox = await getUserInbox(user, {
       page, conversation, mapProps: true,
+    });
+
+    res.respond(200, userInbox);
+  },
+};
+
+
+/**
+ * @api {get} /api/v4/inbox/paged-messages Get inbox messages for a user
+ * @apiName GetInboxMessages
+ * @apiGroup Inbox TODO
+ * @apiDescription Get inbox messages for a user.
+ * Entries already populated with the correct `sent` - information
+ *
+ * @apiParam (Query) {Number} page Load the messages of the selected Page - 10 Messages per Page
+ * @apiParam (Query) {GUID} conversation Loads only the messages of a conversation
+ *
+ * @apiSuccess {Array} data An array of inbox messages
+ */
+api.getInboxMessages = {
+  method: 'GET',
+  url: '/inbox/search-messages',
+  middlewares: [authWithHeaders()],
+  async handler (req, res) {
+    const { user } = res.locals;
+    const { beforeTimestamp, afterTimestamp, conversation } = req.query;
+
+    const userInbox = await searchUserInbox(user, {
+      beforeTimestamp, afterTimestamp, conversation, mapProps: true,
     });
 
     res.respond(200, userInbox);

--- a/website/server/libs/inbox/conversation.methods.js
+++ b/website/server/libs/inbox/conversation.methods.js
@@ -41,14 +41,23 @@ async function usersMapByConversations (users) {
   return usersMap;
 }
 
-export async function listConversations (owner) {
+export async function listConversations (owner, searchMessage = null) {
+  const matchQuery = {
+    ownerId: owner._id,
+  };
+
+  if (searchMessage) {
+    const searchRegex = { $regex: new RegExp(`${searchMessage}`, 'i') };
+
+    matchQuery.text = searchRegex;
+  }
+
+
   // group messages by user owned by logged-in user
   const query = Inbox
     .aggregate([
       {
-        $match: {
-          ownerId: owner._id,
-        },
+        $match: matchQuery,
       },
       {
         $group: {
@@ -57,6 +66,7 @@ export async function listConversations (owner) {
           username: { $last: '$username' },
           timestamp: { $last: '$timestamp' },
           text: { $last: '$text' },
+          messageId: { $last: '$id' },
           count: { $sum: 1 },
         },
       },

--- a/website/server/libs/inbox/conversation.methods.js
+++ b/website/server/libs/inbox/conversation.methods.js
@@ -1,5 +1,6 @@
 import { inboxModel as Inbox, setUserStyles } from '../../models/message';
 import { model as User } from '../../models/user';
+import { createSearchParams } from './shared.methods';
 
 /**
  * Get the current user (avatar/setting etc) for conversations
@@ -42,16 +43,13 @@ async function usersMapByConversations (users) {
 }
 
 export async function listConversations (owner, searchMessage = null) {
-  const matchQuery = {
+  let matchQuery = {
     ownerId: owner._id,
   };
 
   if (searchMessage) {
-    const searchRegex = { $regex: new RegExp(`${searchMessage}`, 'i') };
-
-    matchQuery.text = searchRegex;
+    matchQuery = Object.assign(matchQuery, createSearchParams(searchMessage));
   }
-
 
   // group messages by user owned by logged-in user
   const query = Inbox

--- a/website/server/libs/inbox/index.js
+++ b/website/server/libs/inbox/index.js
@@ -40,7 +40,7 @@ const getUserInboxDefaultOptions = {
 
 export async function getUserInbox (user, optionParams = getUserInboxDefaultOptions) {
   // if not all properties are passed, fill the default values
-  const options = Object.assign(getUserInboxDefaultOptions, optionParams);
+  const options = { ...getUserInboxDefaultOptions, ...optionParams };
 
   const findObj = { ownerId: user._id };
 
@@ -89,7 +89,7 @@ const searchUserInboxDefaultOptions = {
 // WIP remove once ready to merge
 export async function searchUserInbox (user, optionParams = searchUserInboxDefaultOptions) {
   // if not all properties are passed, fill the default values
-  const options = Object.assign(searchUserInboxDefaultOptions, optionParams);
+  const options = { ...searchUserInboxDefaultOptions, ...optionParams };
 
   const findObj = { ownerId: user._id };
 

--- a/website/server/libs/inbox/index.js
+++ b/website/server/libs/inbox/index.js
@@ -83,6 +83,7 @@ const searchUserInboxDefaultOptions = {
   afterTimestamp: null,
   conversation: null,
   mapProps: false,
+  searchMessage: null,
 };
 
 // WIP remove once ready to merge
@@ -97,12 +98,18 @@ export async function searchUserInbox (user, optionParams = searchUserInboxDefau
   }
 
   if (options.beforeTimestamp) {
-    findObj.timestamp = { $lt: options.beforeTimestamp };
+    findObj.timestamp = { $lte: options.beforeTimestamp };
   }
 
   if (options.afterTimestamp) {
     findObj.timestamp = Object.assign(findObj.timestamp || {},
-      { $gt: options.afterTimestamp });
+      { $gte: options.afterTimestamp });
+  }
+
+  if (options.searchMessage) {
+    const searchRegex = { $regex: new RegExp(`${options.searchMessage}`, 'i') };
+
+    findObj.text = searchRegex;
   }
 
   const query = Inbox

--- a/website/server/libs/inbox/index.js
+++ b/website/server/libs/inbox/index.js
@@ -1,6 +1,7 @@
 import { mapInboxMessage, inboxModel as Inbox } from '../../models/message';
 import { getUserInfo, sendTxn as sendTxnEmail } from '../email'; // eslint-disable-line import/no-cycle
 import { sendNotification as sendPushNotification } from '../pushNotifications';
+import { createSearchParams } from './shared.methods';
 
 export async function sentMessage (sender, receiver, message, translate) {
   const messageSent = await sender.sendMessage(receiver, { receiverMsg: message });
@@ -91,7 +92,7 @@ export async function searchUserInbox (user, optionParams = searchUserInboxDefau
   // if not all properties are passed, fill the default values
   const options = { ...searchUserInboxDefaultOptions, ...optionParams };
 
-  const findObj = { ownerId: user._id };
+  let findObj = { ownerId: user._id };
 
   if (options.conversation) {
     findObj.uuid = options.conversation;
@@ -107,9 +108,7 @@ export async function searchUserInbox (user, optionParams = searchUserInboxDefau
   }
 
   if (options.searchMessage) {
-    const searchRegex = { $regex: new RegExp(`${options.searchMessage}`, 'i') };
-
-    findObj.text = searchRegex;
+    findObj = Object.assign(findObj, createSearchParams(options.searchMessage));
   }
 
   const query = Inbox

--- a/website/server/libs/inbox/shared.methods.js
+++ b/website/server/libs/inbox/shared.methods.js
@@ -1,0 +1,17 @@
+export function createSearchParams (searchText) {
+  const searchRegex = { $regex: new RegExp(`${searchText}`, 'i') };
+
+  return {
+    $or: [
+      {
+        text: searchRegex,
+      },
+      {
+        user: searchRegex,
+      },
+      {
+        userName: searchRegex,
+      },
+    ],
+  };
+}


### PR DESCRIPTION
This is a WIP to add the ability:
- [x] to search for a specific message / username / display (#11140) in all conversations
  - [x] reloads the conversations sidebar
  - [x] on the conversation selection it only lists the messages that contain the search string
- [x] ability to jump to the context
  - [x] resets the search mode, reloads the normal conversations
  - [x] reload the messages-lists to 10 messages before (including the selected message)
- [x] load newer messages 
- [x] jump to recent messages (reset to current behavior)
- [x] send a new message in search mode - also resets to the recent messages
- [x] conversations are now loaded in pages (10 per load) to reduce more server load

- fixes #11140