### PR TITLE
Updated hatching tooltip language in all English instances.

### DIFF
--- a/website/common/locales/en/pets.json
+++ b/website/common/locales/en/pets.json
@@ -46,7 +46,7 @@
   "hatchingPotion": "hatching potion",
   "noHatchingPotions": "You don't have any hatching potions.",
   "inventoryText": "Click an egg to see usable potions highlighted in green and then click one of the highlighted potions to hatch your pet. If no potions are highlighted, click that egg again to deselect it, and instead click a potion first to have the usable eggs highlighted. You can also sell unwanted drops to Alexander the Merchant.",
-  "haveHatchablePet": "You have a <%= potion %> hatching potion and <%= egg %> egg to hatch this pet! <b>Click</b> the paw print to hatch.",
+  "haveHatchablePet": "You have a <%= potion %> hatching potion and <%= egg %> egg to hatch this pet! <b>Click</b> to hatch!",
   "quickInventory": "Quick Inventory",
   "food": "Pet Food and Saddles",
   "noFoodAvailable": "You don't have any Pet Food.",


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11613 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Modified locale files to remove confusing language from the tool tip when hatching a discovered type in the stable. Changed "Click the paw print to..." to "Click the button to" so that it made sense.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: bdf85c2b-391c-42cd-8d98-2d39a846aebc
