### PR TITLE
edit foundNewItemsExplanation string to say Pet Food, not food

### DIFF
--- a/website/common/locales/en/achievements.json
+++ b/website/common/locales/en/achievements.json
@@ -13,7 +13,7 @@
   "showAllAchievements": "Show All <%= category %>",
   "hideAchievements": "Hide <%= category %>",
   "foundNewItems": "You found new items!",
-  "foundNewItemsExplanation": "Completing tasks gives you a chance to find items, like eggs, hatching potions, and food.",
+  "foundNewItemsExplanation": "Completing tasks gives you a chance to find items, like Eggs, Hatching Potions, and Pet Food.",
   "foundNewItemsCTA": "Head to your Inventory and try combining your new hatching potion and egg!",
   "achievementLostMasterclasser": "Quest Completionist: Masterclasser Series",
   "achievementLostMasterclasserText": "Completed all sixteen quests in the Masterclasser Quest Series and solved the mystery of the Lost Masterclasser!",


### PR DESCRIPTION
This changes the `foundNewItemsExplanation` to say "Pet Food" rather than just "food".

It also capitalises terms in that string that are usually capitalised these days.

Note that I haven't run this past any staff member so it might not be desirable but doing a PR was about as fast as mentioning the potential issue somewhere. :)