### PR TITLE
Fixes "Hide Basic Achievements" button formatting in Achievements Modal when section is expanded  |  fixes #12012

### DIFF
--- a/website/client/src/components/userMenu/profile.vue
+++ b/website/client/src/components/userMenu/profile.vue
@@ -348,6 +348,7 @@
                 ></div>
               </div>
             </div>
+          </div>
             <div
               v-if="achievementsCategories[key].number > 5"
               class="btn btn-flat btn-show-more"
@@ -358,7 +359,6 @@
                 $t('showAllAchievements', {category: $t(key+'Achievs')})
               }}
             </div>
-          </div>
         </div>
       </div>
       <hr class="col-12">


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #12012

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
"Hide Basic Achievements" button used to be inside the achievements icons flex container, so whenever the last row of achievements had only 1 or 2 of them, the button would be added to the row and expanded to fill the gap.

The solution was basically to remove to button div from inside the flex container and put it right below it on the same level (as a sibling element).

#### Before
![68747470733a2f2f736e6970626f6172642e696f2f374a306f6a6d2e6a7067](https://user-images.githubusercontent.com/26047592/77510729-33930900-6e4e-11ea-9fd2-372acbbc3aa7.png)

#### After
<img width="1680" alt="Screen Shot 2020-03-25 at 04 01 04" src="https://user-images.githubusercontent.com/26047592/77510567-db5c0700-6e4d-11ea-9b0a-6c96557c0324.png">


User ID: 2ed72c40-43fc-4136-9855-69db98fa5041