### PR TITLE
Content API Cache improvements

### DIFF
--- a/.nodemonignore
+++ b/.nodemonignore
@@ -1,4 +1,6 @@
 node_modules/**
+content_cache
+content_cache/**
 website/client/**
 test/**
 .git/**

--- a/gulp/gulp-build.js
+++ b/gulp/gulp-build.js
@@ -1,7 +1,7 @@
 import gulp from 'gulp';
 import babel from 'gulp-babel';
 
-gulp.task('build:src', () => gulp.src('website/server/**/*.js')
+gulp.task('build:server', () => gulp.src('website/server/**/*.js')
   .pipe(babel())
   .pipe(gulp.dest('website/transpiled-babel/')));
 
@@ -9,11 +9,11 @@ gulp.task('build:common', () => gulp.src('website/common/script/**/*.js')
   .pipe(babel())
   .pipe(gulp.dest('website/common/transpiled-babel/')));
 
-gulp.task('build:server', gulp.series('build:src', 'build:common', done => done()));
-
-gulp.task('build:prod', gulp.series(
+gulp.task('build:prod', gulp.parallel(
   'build:server',
+  'build:common',
   'apidoc',
+  'content:cache',
   done => done(),
 ));
 

--- a/gulp/gulp-content.js
+++ b/gulp/gulp-content.js
@@ -1,0 +1,35 @@
+import gulp from 'gulp';
+import fs from 'fs';
+import clean from 'rimraf';
+import { CONTENT_CACHE_PATH, getLocalizedContent } from '../website/server/libs/content';
+import { langCodes } from '../website/server/libs/i18n';
+
+gulp.task('content:cache:clean', done => {
+  clean(CONTENT_CACHE_PATH, done);
+});
+
+// TODO parallelize, use gulp file helpers
+gulp.task('content:cache', gulp.series('content:cache:clean', done => {
+  try {
+    // create the cache folder (if it doesn't exist)
+    try {
+      fs.mkdirSync(CONTENT_CACHE_PATH);
+    } catch (err) {
+      if (err.code !== 'EEXIST') throw err;
+    }
+
+    // clone the content for each language and save
+    // localize it
+    // save the result
+    langCodes.forEach(langCode => {
+      fs.writeFileSync(
+        `${CONTENT_CACHE_PATH}${langCode}.json`,
+        getLocalizedContent(langCode),
+        'utf8',
+      );
+    });
+    done();
+  } catch (err) {
+    done(err);
+  }
+}));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,8 +13,16 @@ const gulp = require('gulp');
 
 if (process.env.NODE_ENV === 'production') { // eslint-disable-line no-process-env
   require('./gulp/gulp-apidoc'); // eslint-disable-line global-require
+  require('./gulp/gulp-content'); // eslint-disable-line global-require
   require('./gulp/gulp-build'); // eslint-disable-line global-require
 } else {
-  require('glob').sync('./gulp/gulp-*').forEach(require); // eslint-disable-line global-require
+  require('./gulp/gulp-apidoc'); // eslint-disable-line global-require
+  require('./gulp/gulp-content'); // eslint-disable-line global-require
+  require('./gulp/gulp-build'); // eslint-disable-line global-require
+  require('./gulp/gulp-console'); // eslint-disable-line global-require
+  require('./gulp/gulp-sprites'); // eslint-disable-line global-require
+  require('./gulp/gulp-start'); // eslint-disable-line global-require
+  require('./gulp/gulp-tests'); // eslint-disable-line global-require
+  require('./gulp/gulp-transifex-test'); // eslint-disable-line global-require
   require('gulp').task('default', gulp.series('test')); // eslint-disable-line global-require
 }

--- a/test/api/unit/libs/content.test.js
+++ b/test/api/unit/libs/content.test.js
@@ -1,0 +1,17 @@
+import * as contentLib from '../../../../website/server/libs/content';
+import content from '../../../../website/common/script/content';
+
+describe('contentLib', () => {
+  describe('CONTENT_CACHE_PATH', () => {
+    it('exports CONTENT_CACHE_PATH', () => {
+      expect(contentLib.CONTENT_CACHE_PATH).to.be.a.string;
+    });
+  });
+
+  describe('getLocalizedContent', () => {
+    it('clones, not modify, the original content data', () => {
+      contentLib.getLocalizedContent();
+      expect(typeof content.backgrounds.backgrounds062014.beach.text).to.equal('function');
+    });
+  });
+});

--- a/website/server/libs/content.js
+++ b/website/server/libs/content.js
@@ -1,7 +1,5 @@
 import _ from 'lodash';
-import fs from 'fs';
 import path from 'path';
-import { langCodes } from './i18n';
 import common from '../../common';
 
 export const CONTENT_CACHE_PATH = path.join(__dirname, '/../../../content_cache/');
@@ -20,24 +18,4 @@ export function getLocalizedContent (langCode) {
   const contentClone = _.cloneDeep(common.content);
   walkContent(contentClone, langCode);
   return `{"success": true, "data": ${JSON.stringify(contentClone)}}`;
-}
-
-export async function cacheLocalizedContentToDisk () {
-  // create the cache folder (if it doesn't exist)
-  try {
-    fs.mkdirSync(CONTENT_CACHE_PATH);
-  } catch (err) {
-    if (err.code !== 'EEXIST') throw err;
-  }
-
-  // clone the content for each language and save
-  // localize it
-  // save the result
-  langCodes.forEach(langCode => {
-    fs.writeFileSync(
-      `${CONTENT_CACHE_PATH}${langCode}.json`,
-      getLocalizedContent(langCode),
-      'utf8',
-    );
-  });
 }

--- a/website/server/libs/content.js
+++ b/website/server/libs/content.js
@@ -1,0 +1,43 @@
+import _ from 'lodash';
+import fs from 'fs';
+import path from 'path';
+import { langCodes } from './i18n';
+import common from '../../common';
+
+export const CONTENT_CACHE_PATH = path.join(__dirname, '/../../../content_cache/');
+
+function walkContent (obj, lang) {
+  _.each(obj, (item, key, source) => {
+    if (_.isPlainObject(item) || _.isArray(item)) {
+      walkContent(item, lang);
+    } else if (_.isFunction(item) && item.i18nLangFunc) {
+      source[key] = item(lang);
+    }
+  });
+}
+
+export function getLocalizedContent (langCode) {
+  const contentClone = _.cloneDeep(common.content);
+  walkContent(contentClone, langCode);
+  return `{"success": true, "data": ${JSON.stringify(contentClone)}}`;
+}
+
+export async function cacheLocalizedContentToDisk () {
+  // create the cache folder (if it doesn't exist)
+  try {
+    fs.mkdirSync(CONTENT_CACHE_PATH);
+  } catch (err) {
+    if (err.code !== 'EEXIST') throw err;
+  }
+
+  // clone the content for each language and save
+  // localize it
+  // save the result
+  langCodes.forEach(langCode => {
+    fs.writeFileSync(
+      `${CONTENT_CACHE_PATH}${langCode}.json`,
+      getLocalizedContent(langCode),
+      'utf8',
+    );
+  });
+}


### PR DESCRIPTION
The caching used for the content api is not very efficient, changing it so the cache is pre-filled when the app is built for production.

- [x] create cache during production build
- [x] test lib?
- [x] contentType application/json