### PR TITLE
Fix analytics problems [Adventure Guide Prep]

### DIFF
--- a/website/common/script/libs/onboarding.js
+++ b/website/common/script/libs/onboarding.js
@@ -23,7 +23,7 @@ export function onOnboardingComplete (user) {
 }
 
 // Add notification and awards (server)
-export function checkOnboardingStatus (user, analytics) {
+export function checkOnboardingStatus (user, req, analytics) {
   if (hasActiveOnboarding(user) && hasCompletedOnboarding(user) && user.addNotification) {
     user.addNotification('ONBOARDING_COMPLETE');
     if (analytics) {
@@ -31,6 +31,7 @@ export function checkOnboardingStatus (user, analytics) {
         uuid: user._id,
         hitType: 'event',
         category: 'behavior',
+        headers: req.headers,
       });
     }
     onOnboardingComplete(user);

--- a/website/common/script/ops/buy/buyMarketGear.js
+++ b/website/common/script/ops/buy/buyMarketGear.js
@@ -70,7 +70,7 @@ export class BuyMarketGearOperation extends AbstractGoldItemOperation { // eslin
 
     if (!user.achievements.purchasedEquipment && user.addAchievement) {
       user.addAchievement('purchasedEquipment');
-      checkOnboardingStatus(user, analytics);
+      checkOnboardingStatus(user, req, analytics);
     }
 
     removePinnedGearAddPossibleNewOnes(user, `gear.flat.${item.key}`, item.key);

--- a/website/common/script/ops/feed.js
+++ b/website/common/script/ops/feed.js
@@ -95,7 +95,7 @@ export default function feed (user, req = {}, analytics) {
 
     if (!user.achievements.fedPet && user.addAchievement) {
       user.addAchievement('fedPet');
-      checkOnboardingStatus(user, analytics);
+      checkOnboardingStatus(user, req, analytics);
     }
   }
 

--- a/website/common/script/ops/hatch.js
+++ b/website/common/script/ops/hatch.js
@@ -56,7 +56,7 @@ export default function hatch (user, req = {}, analytics) {
 
   if (!user.achievements.hatchedPet && user.addAchievement) {
     user.addAchievement('hatchedPet');
-    checkOnboardingStatus(user, analytics);
+    checkOnboardingStatus(user, req, analytics);
   }
 
   forEach(content.animalColorAchievements, achievement => {

--- a/website/common/script/ops/scoreTask.js
+++ b/website/common/script/ops/scoreTask.js
@@ -349,7 +349,7 @@ export default function scoreTask (options = {}, req = {}, analytics) {
 
   if (!user.achievements.completedTask && cron === false && direction === 'up' && user.addAchievement) {
     user.addAchievement('completedTask');
-    checkOnboardingStatus(user, analytics);
+    checkOnboardingStatus(user, req, analytics);
   }
 
   return [delta];

--- a/website/server/controllers/api-v3/tasks.js
+++ b/website/server/controllers/api-v3/tasks.js
@@ -205,7 +205,7 @@ api.createUserTasks = {
 
     tasks.forEach(task => {
       // Track when new users (first 7 days) create tasks
-      if (moment().diff(user.auth.timestamps.created, 'days') < 7) {
+      if (moment().diff(user.auth.timestamps.created, 'days') < 7 && user.flags.welcomed) {
         res.analytics.track('task create', {
           uuid: user._id,
           hitType: 'event',
@@ -888,7 +888,7 @@ api.scoreTask = {
     }
 
     // Track when new users (first 7 days) score tasks
-    if (moment().diff(user.auth.timestamps.created, 'days') < 7 && user.flags.welcomed) {
+    if (moment().diff(user.auth.timestamps.created, 'days') < 7) {
       res.analytics.track('task score', {
         uuid: user._id,
         hitType: 'event',

--- a/website/server/controllers/api-v3/user.js
+++ b/website/server/controllers/api-v3/user.js
@@ -790,7 +790,7 @@ api.hatch = {
   url: '/user/hatch/:egg/:hatchingPotion',
   async handler (req, res) {
     const { user } = res.locals;
-    const hatchRes = common.ops.hatch(user, req);
+    const hatchRes = common.ops.hatch(user, req, res.analytics);
 
     await user.save();
 
@@ -881,7 +881,7 @@ api.feed = {
   url: '/user/feed/:pet/:food',
   async handler (req, res) {
     const { user } = res.locals;
-    const feedRes = common.ops.feed(user, req);
+    const feedRes = common.ops.feed(user, req, res.analytics);
 
     await user.save();
 

--- a/website/server/libs/taskManager.js
+++ b/website/server/libs/taskManager.js
@@ -108,7 +108,7 @@ export async function createTasks (req, res, options = {}) {
       // are the onboarding ones
       if (!user.achievements.createdTask && user.flags.welcomed) {
         user.addAchievement('createdTask');
-        shared.onboarding.checkOnboardingStatus(user, res.analytics);
+        shared.onboarding.checkOnboardingStatus(user, req, res.analytics);
       }
     }
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes several issues with https://github.com/HabitRPG/habitica/pull/11883

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

* Passes request headers to `checkOnboardingStatus` so the user's platform can be recorded with the analytics event.
* Moves the `user.flags.welcomed` check to the correct event to _actually_ fix the issue with onboarding tasks firing multiple `task create` analytics actions.
* Passes the analytics object from the API controller to the common ops for pet hatching and feeding so the track action is correctly available.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)