### PR TITLE
Bugfix for Incorrect avatar for your own account in private messages

### DIFF
--- a/website/client/src/components/messages/messageList.vue
+++ b/website/client/src/components/messages/messageList.vue
@@ -34,9 +34,9 @@
         class="d-flex flex-grow-1"
       >
         <avatar
-          v-if="conversationOpponentUser"
+          v-if="msg.userStyles"
           class="avatar-left"
-          :member="conversationOpponentUser"
+          :member="msg.userStyles"
           :avatar-only="true"
           :override-top-padding="'14px'"
           :hide-class-badge="true"
@@ -64,13 +64,22 @@
           />
         </div>
         <avatar
-          v-if="user"
+          v-if="msg.userStyles"
           class="avatar-right"
-          :member="user"
+          :member="msg.userStyles"
           :avatar-only="true"
           :hide-class-badge="true"
           :override-top-padding="'14px'"
           @click.native="showMemberModal(msg.uuid)"
+        />
+        <avatar
+         v-else-if="user"
+         class="avatar-right"
+         :member="user"
+         :avatar-only="true"
+         :hide-class-badge="true"
+         :override-top-padding="'14px'"
+         @click.native="showMemberModal(msg.uuid)"
         />
       </div>
     </div>

--- a/website/client/src/components/messages/messageList.vue
+++ b/website/client/src/components/messages/messageList.vue
@@ -73,13 +73,13 @@
           @click.native="showMemberModal(msg.uuid)"
         />
         <avatar
-         v-else-if="user"
-         class="avatar-right"
-         :member="user"
-         :avatar-only="true"
-         :hide-class-badge="true"
-         :override-top-padding="'14px'"
-         @click.native="showMemberModal(msg.uuid)"
+          v-else-if="user"
+          class="avatar-right"
+          :member="user"
+          :avatar-only="true"
+          :hide-class-badge="true"
+          :override-top-padding="'14px'"
+          @click.native="showMemberModal(msg.uuid)"
         />
       </div>
     </div>

--- a/website/client/src/components/userMenu/profile.vue
+++ b/website/client/src/components/userMenu/profile.vue
@@ -349,16 +349,16 @@
               </div>
             </div>
           </div>
-            <div
-              v-if="achievementsCategories[key].number > 5"
-              class="btn btn-flat btn-show-more"
-              @click="toggleAchievementsCategory(key)"
-            >
-              {{ achievementsCategories[key].open ?
-                $t('hideAchievements', {category: $t(key+'Achievs')}) :
-                $t('showAllAchievements', {category: $t(key+'Achievs')})
-              }}
-            </div>
+          <div
+            v-if="achievementsCategories[key].number > 5"
+            class="btn btn-flat btn-show-more"
+            @click="toggleAchievementsCategory(key)"
+          >
+            {{ achievementsCategories[key].open ?
+              $t('hideAchievements', {category: $t(key+'Achievs')}) :
+              $t('showAllAchievements', {category: $t(key+'Achievs')})
+            }}
+          </div>
         </div>
       </div>
       <hr class="col-12">


### PR DESCRIPTION
Fixes #12014

Fixed bug so that the code display the following expected behaviour:

Let's say I am logged in as player A having a conversation on PM page with player B. So the expected behaviour on my PM page (player A's PM page) are:
(1) To show my (player A) avatar at the time that the message was sent by me (player A).
(2) To show player B's avatar at the time that the message was sent by player B.