### PR TITLE
Don't link user in markdown code blocks - Fixes #[11504]

### DIFF
--- a/test/api/unit/libs/highlightMentions.js
+++ b/test/api/unit/libs/highlightMentions.js
@@ -13,9 +13,12 @@ describe('highlightMentions', () => {
         return this;
       },
       exec () {
-        return Promise.resolve([{
-          auth: { local: { username: 'user' } }, _id: '111',
-        }, { auth: { local: { username: 'user2' } }, _id: '222' }, { auth: { local: { username: 'user3' } }, _id: '333' }, { auth: { local: { username: 'user-dash' } }, _id: '444' }, { auth: { local: { username: 'user_underscore' } }, _id: '555' },
+        return Promise.resolve([
+          { auth: { local: { username: 'user' } }, _id: '111' },
+          { auth: { local: { username: 'user2' } }, _id: '222' },
+          { auth: { local: { username: 'user3' } }, _id: '333' },
+          { auth: { local: { username: 'user-dash' } }, _id: '444' },
+          { auth: { local: { username: 'user_underscore' } }, _id: '555' },
         ]);
       },
     };
@@ -32,26 +35,31 @@ describe('highlightMentions', () => {
     const result = await highlightMentions(text);
     expect(result[0]).to.equal(text);
   });
+
   it('highlights existing users', async () => {
     const text = '@user: message';
     const result = await highlightMentions(text);
     expect(result[0]).to.equal('[@user](/profile/111): message');
   });
+
   it('highlights special characters', async () => {
     const text = '@user-dash: message @user_underscore';
     const result = await highlightMentions(text);
     expect(result[0]).to.equal('[@user-dash](/profile/444): message [@user_underscore](/profile/555)');
   });
+
   it('doesn\'t highlight nonexisting users', async () => {
     const text = '@nouser message';
     const result = await highlightMentions(text);
     expect(result[0]).to.equal('@nouser message');
   });
+
   it('highlights multiple existing users', async () => {
     const text = '@user message (@user2) @user3 @user';
     const result = await highlightMentions(text);
     expect(result[0]).to.equal('[@user](/profile/111) message ([@user2](/profile/222)) [@user3](/profile/333) [@user](/profile/111)');
   });
+
   it('doesn\'t highlight more than 5 users', async () => {
     const text = '@user @user2 @user3 @user4 @user5 @user6';
     const result = await highlightMentions(text);

--- a/test/api/unit/libs/highlightMentions.test.js
+++ b/test/api/unit/libs/highlightMentions.test.js
@@ -66,43 +66,43 @@ describe('highlightMentions', () => {
 
   describe('exceptions in code blocks', () => {
     it('doesn\'t highlight user in inline code block', async () => {
-      const text = '\`@user\`';
+      const text = '`@user`';
 
-      const [result,,] = await highlightMentions(text);
+      const result = await highlightMentions(text);
 
-      expect(result).to.equal(text);
+      expect(result[0]).to.equal(text);
     });
 
     it('doesn\'t highlight user in fenced code block', async () => {
-      const text = `Text\n\n\`\`\`\n// code referencing @user\n\`\`\`\n\nText`;
+      const text = 'Text\n\n```\n// code referencing @user\n```\n\nText';
 
-      const [result,,] = await highlightMentions(text);
+      const result = await highlightMentions(text);
 
-      expect(result).to.equal(text);
+      expect(result[0]).to.equal(text);
     });
 
     it('doesn\'t highlight user in indented code block', async () => {
-      const text = `      @user`;
+      const text = '      @user';
 
-      const [result,,] = await highlightMentions(text);
+      const result = await highlightMentions(text);
 
-      expect(result).to.equal(text);
+      expect(result[0]).to.equal(text);
     });
 
     it('does highlight user that\'s after in-line code block', async () => {
-      const text = '\`<code />\` for @user';
+      const text = '`<code />` for @user';
 
-      const [result,,] = await highlightMentions(text);
+      const result = await highlightMentions(text);
 
-      expect(result).to.equal('\`<code />\` for [@user](/profile/111)');
+      expect(result[0]).to.equal('`<code />` for [@user](/profile/111)');
     });
 
     it('does highlight same content properly', async () => {
-      const text = '@user `@user`'
+      const text = '@user `@user`';
 
-      const [result,,] = await highlightMentions(text);
+      const result = await highlightMentions(text);
 
-      expect(result).to.equal('[@user](/profile/111) `@user`');
+      expect(result[0]).to.equal('[@user](/profile/111) `@user`');
     });
   });
 });

--- a/website/server/controllers/api-v3/chat.js
+++ b/website/server/controllers/api-v3/chat.js
@@ -22,7 +22,7 @@ import guildsAllowingBannedWords from '../../libs/guildsAllowingBannedWords';
 import { getMatchesByWordArray } from '../../libs/stringUtils';
 import bannedSlurs from '../../libs/bannedSlurs';
 import apiError from '../../libs/apiError';
-import { highlightMentions } from '../../libs/highlightMentions';
+import highlightMentions from '../../libs/highlightMentions';
 
 const FLAG_REPORT_EMAILS = nconf.get('FLAG_REPORT_EMAIL').split(',').map(email => ({ email, canSend: true }));
 

--- a/website/server/controllers/api-v3/members.js
+++ b/website/server/controllers/api-v3/members.js
@@ -24,7 +24,7 @@ import { sentMessage } from '../../libs/inbox';
 import {
   sanitizeText as sanitizeMessageText,
 } from '../../models/message';
-import { highlightMentions } from '../../libs/highlightMentions';
+import highlightMentions from '../../libs/highlightMentions';
 
 const { achievements } = common;
 

--- a/website/server/libs/highlightMentions.js
+++ b/website/server/libs/highlightMentions.js
@@ -1,12 +1,16 @@
+import habiticaMarkdown from 'habitica-markdown';
+
 import { model as User } from '../models/user';
 
-const mentionRegex = new RegExp('\\B@[-\\w]+', 'g');
+const mentionRegex = /\B@[-\w]+/g;
 
-export async function highlightMentions (text) { // eslint-disable-line import/prefer-default-export
-  const mentions = text.match(mentionRegex);
+export default async function highlightMentions (text) {
+  const textAndCodeBlocks = findTextAndCodeBlocks(text);
+
+  const mentions = textAndCodeBlocks.allText.match(mentionRegex);
   let members = [];
 
-  if (mentions !== null && mentions.length <= 5) {
+  if (mentions && mentions.length <= 5) {
     const usernames = mentions.map(mention => mention.substr(1));
     members = await User
       .find({ 'auth.local.username': { $in: usernames }, 'flags.verifiedUsername': true })
@@ -15,9 +19,95 @@ export async function highlightMentions (text) { // eslint-disable-line import/p
       .exec();
     members.forEach(member => {
       const { username } = member.auth.local;
-      // eslint-disable-next-line no-param-reassign
-      text = text.replace(new RegExp(`@${username}(?![\\-\\w])`, 'g'), `[@${username}](/profile/${member._id})`);
+      const regex = new RegExp(`@${username}(?![\\-\\w])`, 'g');
+      const replacement = `[@${username}](/profile/${member._id})`;
+
+      textAndCodeBlocks.transformTextBlocks(text => text.replace(regex, replacement));
     });
   }
-  return [text, mentions, members];
+
+  return [textAndCodeBlocks.rebuild(), mentions, members];
+}
+
+function findTextAndCodeBlocks(text) {
+  // For token description see https://markdown-it.github.io/markdown-it/#Token
+  const tokens = habiticaMarkdown.parse(text);
+  const codeBlocks = findCodeBlocks(tokens);
+
+  const blocks = [];
+  let remainingText = text;
+  codeBlocks.forEach(codeBlock => {
+    const regex = createRegex(codeBlock);
+    const match = remainingText.match(regex);
+
+    if (match.index) {
+      blocks.push({ text: remainingText.substr(0, match.index), isCodeBlock: false });
+    }
+    blocks.push({ text: match[0], isCodeBlock: true });
+
+    remainingText = remainingText.substr(match.index + match[0].length);
+  });
+
+  if (remainingText) {
+    blocks.push({ text: remainingText, isCodeBlock: false });
+  }
+  return new TextWithCodeBlocks(blocks);
+}
+
+function findCodeBlocks(tokens) {
+  function recurse(ts, result) {
+    const [head, ...tail] = ts;
+
+    if (!head) {
+      return result;
+    }
+
+    if (head.type == 'code_block' ||
+        head.type == 'code_inline' ||
+        head.type == 'fence'
+      ) {
+      result.push(head);
+    }
+
+    return recurse(tail, head.children ? recurse(head.children, result) : result);
+  }
+
+  return recurse(tokens, []);
+}
+
+function createRegex({ content, type, markup }) {
+  let regexStr = '';
+
+  if (type == 'code_block') {
+    regexStr = withOptionalIndentation(content);
+  } else if (type == 'fence') {
+    regexStr = (withOptionalIndentation(markup) + '.*\n' +
+        withOptionalIndentation(content + markup));
+  } else { //  type == code_inline
+    regexStr = markup + ' ?' + content + ' ?' + markup;
+  }
+
+  return new RegExp(regexStr);
+}
+
+function withOptionalIndentation(content) {
+  return content.split('\n').map(line => '\\s*' + line).join('\n');
+}
+
+class TextWithCodeBlocks {
+  constructor(blocks) {
+    this.blocks = blocks;
+    this.textBlocks = blocks.filter(block => !block.isCodeBlock);
+    this.allText = this.textBlocks.map(block => block.text).join('\n');
+  }
+
+  transformTextBlocks(transform) {
+    this.textBlocks.forEach(block => {
+      block.text = transform(block.text);
+    });
+  }
+
+  rebuild() {
+    return this.blocks.map(block => block.text).join('');
+  }
 }

--- a/website/server/libs/highlightMentions.js
+++ b/website/server/libs/highlightMentions.js
@@ -4,32 +4,69 @@ import { model as User } from '../models/user';
 
 const mentionRegex = /\B@[-\w]+/g;
 
-export default async function highlightMentions (text) {
-  const textAndCodeBlocks = findTextAndCodeBlocks(text);
+class TextWithCodeBlocks {
+  constructor (blocks) {
+    this.blocks = blocks;
+    this.textBlocks = blocks.filter(block => !block.isCodeBlock);
+    this.allText = this.textBlocks.map(block => block.text).join('\n');
+  }
 
-  const mentions = textAndCodeBlocks.allText.match(mentionRegex);
-  let members = [];
-
-  if (mentions && mentions.length <= 5) {
-    const usernames = mentions.map(mention => mention.substr(1));
-    members = await User
-      .find({ 'auth.local.username': { $in: usernames }, 'flags.verifiedUsername': true })
-      .select(['auth.local.username', '_id', 'preferences.pushNotifications', 'pushDevices', 'party', 'guilds'])
-      .lean()
-      .exec();
-    members.forEach(member => {
-      const { username } = member.auth.local;
-      const regex = new RegExp(`@${username}(?![\\-\\w])`, 'g');
-      const replacement = `[@${username}](/profile/${member._id})`;
-
-      textAndCodeBlocks.transformTextBlocks(text => text.replace(regex, replacement));
+  transformTextBlocks (transform) {
+    this.textBlocks.forEach(block => {
+      block.text = transform(block.text);
     });
   }
 
-  return [textAndCodeBlocks.rebuild(), mentions, members];
+  rebuild () {
+    return this.blocks.map(block => block.text).join('');
+  }
 }
 
-function findTextAndCodeBlocks(text) {
+/**
+ * Since tokens have both order and can be nested until infinite depth,
+ * use a branching recursive algorithm to maintain order and check all tokens.
+ */
+function findCodeBlocks (tokens) {
+  function recurse (ts, result) {
+    const [head, ...tail] = ts;
+
+    if (!head) {
+      return result;
+    }
+
+    if (head.type === 'code_block'
+        || head.type === 'code_inline'
+        || head.type === 'fence'
+    ) {
+      result.push(head);
+    }
+
+    return recurse(tail, head.children ? recurse(head.children, result) : result);
+  }
+
+  return recurse(tokens, []);
+}
+
+function withOptionalIndentation (content) {
+  return content.split('\n').map(line => `\\s*${line}`).join('\n');
+}
+
+function createRegex ({ content, type, markup }) {
+  let regexStr = '';
+
+  if (type === 'code_block') {
+    regexStr = withOptionalIndentation(content);
+  } else if (type === 'fence') {
+    regexStr = (`${withOptionalIndentation(markup)}.*\n${
+      withOptionalIndentation(content + markup)}`);
+  } else { //  type == code_inline
+    regexStr = `${markup} ?${content} ?${markup}`;
+  }
+
+  return new RegExp(regexStr);
+}
+
+function findTextAndCodeBlocks (text) {
   // For token description see https://markdown-it.github.io/markdown-it/#Token
   const tokens = habiticaMarkdown.parse(text);
   const codeBlocks = findCodeBlocks(tokens);
@@ -54,60 +91,27 @@ function findTextAndCodeBlocks(text) {
   return new TextWithCodeBlocks(blocks);
 }
 
-function findCodeBlocks(tokens) {
-  function recurse(ts, result) {
-    const [head, ...tail] = ts;
+export default async function highlightMentions (text) {
+  const textAndCodeBlocks = findTextAndCodeBlocks(text);
 
-    if (!head) {
-      return result;
-    }
+  const mentions = textAndCodeBlocks.allText.match(mentionRegex);
+  let members = [];
 
-    if (head.type == 'code_block' ||
-        head.type == 'code_inline' ||
-        head.type == 'fence'
-      ) {
-      result.push(head);
-    }
+  if (mentions && mentions.length <= 5) {
+    const usernames = mentions.map(mention => mention.substr(1));
+    members = await User
+      .find({ 'auth.local.username': { $in: usernames }, 'flags.verifiedUsername': true })
+      .select(['auth.local.username', '_id', 'preferences.pushNotifications', 'pushDevices', 'party', 'guilds'])
+      .lean()
+      .exec();
+    members.forEach(member => {
+      const { username } = member.auth.local;
+      const regex = new RegExp(`@${username}(?![\\-\\w])`, 'g');
+      const replacement = `[@${username}](/profile/${member._id})`;
 
-    return recurse(tail, head.children ? recurse(head.children, result) : result);
-  }
-
-  return recurse(tokens, []);
-}
-
-function createRegex({ content, type, markup }) {
-  let regexStr = '';
-
-  if (type == 'code_block') {
-    regexStr = withOptionalIndentation(content);
-  } else if (type == 'fence') {
-    regexStr = (withOptionalIndentation(markup) + '.*\n' +
-        withOptionalIndentation(content + markup));
-  } else { //  type == code_inline
-    regexStr = markup + ' ?' + content + ' ?' + markup;
-  }
-
-  return new RegExp(regexStr);
-}
-
-function withOptionalIndentation(content) {
-  return content.split('\n').map(line => '\\s*' + line).join('\n');
-}
-
-class TextWithCodeBlocks {
-  constructor(blocks) {
-    this.blocks = blocks;
-    this.textBlocks = blocks.filter(block => !block.isCodeBlock);
-    this.allText = this.textBlocks.map(block => block.text).join('\n');
-  }
-
-  transformTextBlocks(transform) {
-    this.textBlocks.forEach(block => {
-      block.text = transform(block.text);
+      textAndCodeBlocks.transformTextBlocks(blockText => blockText.replace(regex, replacement));
     });
   }
 
-  rebuild() {
-    return this.blocks.map(block => block.text).join('');
-  }
+  return [textAndCodeBlocks.rebuild(), mentions, members];
 }


### PR DESCRIPTION
Fixes #11504 

### Changes
Adjusts the highlightMentions functions to not create links inside code blocks. Uses the markdown-it markdown parser from habitica-markdown in an attempt to guarantee functional parity between the code block rendering and the code block determination for link generation.

However, there's still quite some work required to reason back from the code block tokens to parts of the text strings, so perhaps the test set should be expanded further.

### highlightUsers
I've stayed away from the display rendering in `highlightUsers` for now, since I think that should be done in habitica-markdown instead. See the issue for a more in-depth discussion.

----
UUID: d71d2c57-a73d-4591-b64d-e688584a9092
