### PR TITLE
Fixes issue where usernames that are sandwiched with underscores are not properly formatted [fixes #12033]

### DIFF
--- a/website/client/src/components/userMenu/profile.vue
+++ b/website/client/src/components/userMenu/profile.vue
@@ -349,16 +349,16 @@
               </div>
             </div>
           </div>
-          <div
-            v-if="achievementsCategories[key].number > 5"
-            class="btn btn-flat btn-show-more"
-            @click="toggleAchievementsCategory(key)"
-          >
-            {{ achievementsCategories[key].open ?
-              $t('hideAchievements', {category: $t(key+'Achievs')}) :
-              $t('showAllAchievements', {category: $t(key+'Achievs')})
-            }}
-          </div>
+            <div
+              v-if="achievementsCategories[key].number > 5"
+              class="btn btn-flat btn-show-more"
+              @click="toggleAchievementsCategory(key)"
+            >
+              {{ achievementsCategories[key].open ?
+                $t('hideAchievements', {category: $t(key+'Achievs')}) :
+                $t('showAllAchievements', {category: $t(key+'Achievs')})
+              }}
+            </div>
         </div>
       </div>
       <hr class="col-12">

--- a/website/client/src/components/userMenu/profile.vue
+++ b/website/client/src/components/userMenu/profile.vue
@@ -349,16 +349,16 @@
               </div>
             </div>
           </div>
-            <div
-              v-if="achievementsCategories[key].number > 5"
-              class="btn btn-flat btn-show-more"
-              @click="toggleAchievementsCategory(key)"
-            >
-              {{ achievementsCategories[key].open ?
-                $t('hideAchievements', {category: $t(key+'Achievs')}) :
-                $t('showAllAchievements', {category: $t(key+'Achievs')})
-              }}
-            </div>
+          <div
+            v-if="achievementsCategories[key].number > 5"
+            class="btn btn-flat btn-show-more"
+            @click="toggleAchievementsCategory(key)"
+          >
+            {{ achievementsCategories[key].open ?
+              $t('hideAchievements', {category: $t(key+'Achievs')}) :
+              $t('showAllAchievements', {category: $t(key+'Achievs')})
+            }}
+          </div>
         </div>
       </div>
       <hr class="col-12">

--- a/website/client/src/libs/highlightUsers.js
+++ b/website/client/src/libs/highlightUsers.js
@@ -17,7 +17,7 @@ export function highlightUsers (text, userName, displayName) { // eslint-disable
     let fixedStr = mentionStr.replace(/<\/?em>/g, '_');
     fixedStr = fixedStr.replace(/<\/?strong>/g, '__');
 
-    const isUserMention = currentUser.includes(mentionStr) ? 'at-highlight' : '';
+    const isUserMention = currentUser.includes(fixedStr) ? 'at-highlight' : '';
 
     return fullMatched.replace(mentionStr, `<span class="at-text ${isUserMention}">${fixedStr}</span>`);
   });

--- a/website/client/src/libs/highlightUsers.js
+++ b/website/client/src/libs/highlightUsers.js
@@ -1,7 +1,7 @@
 import escapeRegExp from 'lodash/escapeRegExp';
 
 const optionalAnchorTagRegExStr = '(<\\w[^>]*)?'; // everything including the anchor tag is recognized
-const mentionRegExStr = '(@[<em>\\w-</em>]+)';
+const mentionRegExStr = '(@(?:<(?:em|strong)>)?[\\w-]+(?:<\\/(?:em|strong)>)?)';
 const optionalPostMentionRegExStr = '(\\.\\w+)?'; // like dot-TLD
 
 const finalMentionRegEx = new RegExp(`${optionalAnchorTagRegExStr}${mentionRegExStr}${optionalPostMentionRegExStr}`, 'gi');
@@ -14,11 +14,9 @@ export function highlightUsers (text, userName, displayName) { // eslint-disable
       return fullMatched;
     }
 
-    let fixedStr = mentionStr;
-    if (mentionStr.includes('<em>')) {
-      fixedStr = mentionStr.replace('<em>', '_');
-      fixedStr = fixedStr.replace('</em>', '_');
-    }
+    let fixedStr = mentionStr.replace(/<\/?em>/g, '_');
+    fixedStr = fixedStr.replace(/<\/?strong>/g, '__');
+
     const isUserMention = currentUser.includes(mentionStr) ? 'at-highlight' : '';
 
     return fullMatched.replace(mentionStr, `<span class="at-text ${isUserMention}">${fixedStr}</span>`);

--- a/website/client/src/libs/highlightUsers.js
+++ b/website/client/src/libs/highlightUsers.js
@@ -1,7 +1,7 @@
 import escapeRegExp from 'lodash/escapeRegExp';
 
 const optionalAnchorTagRegExStr = '(<\\w[^>]*)?'; // everything including the anchor tag is recognized
-const mentionRegExStr = '(@[\\w-]+)';
+const mentionRegExStr = '(@[<em>\\w-</em>]+)';
 const optionalPostMentionRegExStr = '(\\.\\w+)?'; // like dot-TLD
 
 const finalMentionRegEx = new RegExp(`${optionalAnchorTagRegExStr}${mentionRegExStr}${optionalPostMentionRegExStr}`, 'gi');
@@ -14,9 +14,14 @@ export function highlightUsers (text, userName, displayName) { // eslint-disable
       return fullMatched;
     }
 
+    let fixedStr = mentionStr;
+    if (mentionStr.includes('<em>')) {
+      fixedStr = mentionStr.replace('<em>', '_');
+      fixedStr = fixedStr.replace('</em>', '_');
+    }
     const isUserMention = currentUser.includes(mentionStr) ? 'at-highlight' : '';
 
-    return fullMatched.replace(mentionStr, `<span class="at-text ${isUserMention}">${mentionStr}</span>`);
+    return fullMatched.replace(mentionStr, `<span class="at-text ${isUserMention}">${fixedStr}</span>`);
   });
 
   return text;

--- a/website/client/tests/unit/libs/highlightUsers.spec.js
+++ b/website/client/tests/unit/libs/highlightUsers.spec.js
@@ -17,6 +17,14 @@ describe('highlightUserAndEmail', () => {
     expect(result).to.contain('<span class="at-text at-highlight">@user</span>');
   });
 
+  it('highlights username sandwiched with underscores', () => {
+    const text = 'hello @_user_';
+
+    const result = highlightUsers(text, 'user', 'displayedUser');
+    expect(result).to.contain('<span class="at-text at-highlight">@user</span>');
+    expect(result).to.not.contain('<em>');
+  });
+
   it('not highlights any email', () => {
     const text = habiticaMarkdown.render('hello@example.com');
 

--- a/website/client/tests/unit/libs/highlightUsers.spec.js
+++ b/website/client/tests/unit/libs/highlightUsers.spec.js
@@ -30,7 +30,7 @@ describe('highlightUserAndEmail', () => {
     const text = 'hello @<strong>user</strong>';
 
     const result = highlightUsers(text, 'diffUser', 'displayDiffUser');
-    expect(result).to.contain('<span class="at-text at-highlight">@__user__</span>');
+    expect(result).to.contain('<span class="at-text ">@__user__</span>');
     expect(result).to.not.contain('<strong>');
     expect(result).to.not.contain('</strong>');
   });

--- a/website/client/tests/unit/libs/highlightUsers.spec.js
+++ b/website/client/tests/unit/libs/highlightUsers.spec.js
@@ -18,7 +18,7 @@ describe('highlightUserAndEmail', () => {
   });
 
   it('highlights username sandwiched with underscores', () => {
-    const text = 'hello @_user_';
+    const text = 'hello @<em>user</em>';
 
     const result = highlightUsers(text, '_user_', 'displayedUser');
     expect(result).to.contain('<span class="at-text at-highlight">@_user_</span>');
@@ -27,9 +27,9 @@ describe('highlightUserAndEmail', () => {
   });
 
   it('highlights username sandwiched with double underscores', () => {
-    const text = 'hello @__user__';
+    const text = 'hello @<strong>user</strong>';
 
-    const result = highlightUsers(text, '__user__', 'displayedUser');
+    const result = highlightUsers(text, 'diffUser', 'displayDiffUser');
     expect(result).to.contain('<span class="at-text at-highlight">@__user__</span>');
     expect(result).to.not.contain('<strong>');
     expect(result).to.not.contain('</strong>');

--- a/website/client/tests/unit/libs/highlightUsers.spec.js
+++ b/website/client/tests/unit/libs/highlightUsers.spec.js
@@ -1,7 +1,7 @@
 import habiticaMarkdown from 'habitica-markdown';
 import { highlightUsers } from '@/libs/highlightUsers';
 
-describe('highlightUserAndEmail', () => {
+describe.only('highlightUserAndEmail', () => {
   it('highlights displayname', () => {
     const text = 'hello @displayedUser with text after';
 
@@ -20,7 +20,7 @@ describe('highlightUserAndEmail', () => {
   it('highlights username sandwiched with underscores', () => {
     const text = 'hello @_user_';
 
-    const result = highlightUsers(text, 'user', 'displayedUser');
+    const result = highlightUsers(text, '_user_', 'displayedUser');
     expect(result).to.contain('<span class="at-text at-highlight">@_user_</span>');
     expect(result).to.not.contain('<em>');
   });

--- a/website/client/tests/unit/libs/highlightUsers.spec.js
+++ b/website/client/tests/unit/libs/highlightUsers.spec.js
@@ -1,7 +1,7 @@
 import habiticaMarkdown from 'habitica-markdown';
 import { highlightUsers } from '@/libs/highlightUsers';
 
-describe.only('highlightUserAndEmail', () => {
+describe('highlightUserAndEmail', () => {
   it('highlights displayname', () => {
     const text = 'hello @displayedUser with text after';
 

--- a/website/client/tests/unit/libs/highlightUsers.spec.js
+++ b/website/client/tests/unit/libs/highlightUsers.spec.js
@@ -21,7 +21,7 @@ describe('highlightUserAndEmail', () => {
     const text = 'hello @_user_';
 
     const result = highlightUsers(text, 'user', 'displayedUser');
-    expect(result).to.contain('<span class="at-text at-highlight">@user</span>');
+    expect(result).to.contain('<span class="at-text at-highlight">@_user_</span>');
     expect(result).to.not.contain('<em>');
   });
 

--- a/website/client/tests/unit/libs/highlightUsers.spec.js
+++ b/website/client/tests/unit/libs/highlightUsers.spec.js
@@ -23,6 +23,16 @@ describe('highlightUserAndEmail', () => {
     const result = highlightUsers(text, '_user_', 'displayedUser');
     expect(result).to.contain('<span class="at-text at-highlight">@_user_</span>');
     expect(result).to.not.contain('<em>');
+    expect(result).to.not.contain('</em>');
+  });
+
+  it('highlights username sandwiched with double underscores', () => {
+    const text = 'hello @__user__';
+
+    const result = highlightUsers(text, '__user__', 'displayedUser');
+    expect(result).to.contain('<span class="at-text at-highlight">@__user__</span>');
+    expect(result).to.not.contain('<strong>');
+    expect(result).to.not.contain('</strong>');
   });
 
   it('not highlights any email', () => {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #12033

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Markdown uses underscores on both sides of a word to indicate that this word must be italicized. Therefore usernames such as `@_spider_` became @_spider_ and the color was not the usual purple when mentioning this user in a chat. This is not the proper formatting of usernames in Habitica. The usernames become italicized, they lose the underscores and the color is not correct. To fix this, I added in the em tag to the mention regex such that it would catch any time Markdown accidentally turned a username into italicized. Then in the body of the text.replace function, I added in logic to find em tags and replace them with the proper underscores such that the username would now be displayed correctly. I also added a component test to check for this specific issue.   

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 5ba76e0c-ed09-4a9b-87f7-b28a8971377d
