### PR TITLE
Handle simultaneous quest accept/reject

### DIFF
--- a/test/api/v3/integration/quests/POST-groups_groupId_quests_accept.test.js
+++ b/test/api/v3/integration/quests/POST-groups_groupId_quests_accept.test.js
@@ -112,7 +112,7 @@ describe('POST /groups/:groupId/quests/accept', () => {
 
       await Promise.all([partyMembers[0].sync(), questingGroup.sync()]);
       expect(leader.party.quest.RSVPNeeded).to.equal(false);
-      expect(questingGroup.quest.members[partyMembers[0]._id]);
+      expect(questingGroup.quest.members[partyMembers[0]._id]).to.equal(true);
     });
 
     it('does not begin the quest if pending invitations remain', async () => {

--- a/website/server/controllers/api-v3/quests.js
+++ b/website/server/controllers/api-v3/quests.js
@@ -193,11 +193,13 @@ api.acceptQuest = {
     if (group.quest.active) throw new NotAuthorized(res.t('questAlreadyStartedFriendly'));
     if (group.quest.members[user._id]) throw new BadRequest(res.t('questAlreadyAccepted'));
 
+    const acceptedSuccessfully = await group.handleQuestInvitation(user, true);
+    if (!acceptedSuccessfully) {
+      throw new NotAuthorized(res.t('questAlreadyAccepted'));
+    }
+
     user.party.quest.RSVPNeeded = false;
     await user.save();
-
-    group.markModified('quest');
-    group.quest.members[user._id] = true;
 
     if (canStartQuestAutomatically(group)) {
       await group.startQuest(user);
@@ -252,12 +254,14 @@ api.rejectQuest = {
     if (group.quest.members[user._id]) throw new BadRequest(res.t('questAlreadyAccepted'));
     if (group.quest.members[user._id] === false) throw new BadRequest(res.t('questAlreadyRejected'));
 
+    const rejectedSuccessfully = await group.handleQuestInvitation(user, false);
+    if (!rejectedSuccessfully) {
+      throw new NotAuthorized(res.t('questAlreadyRejected'));
+    }
+
     user.party.quest = Group.cleanQuestUser(user.party.quest.progress);
     user.markModified('party.quest');
     await user.save();
-
-    group.quest.members[user._id] = false;
-    group.markModified('quest.members');
 
     if (canStartQuestAutomatically(group)) {
       await group.startQuest(user);

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -662,7 +662,7 @@ schema.methods.handleQuestInvitation = async function handleQuestInvitation (use
   ).exec();
 
   if (result.nModified) {
-    // update also current instance so future operations wil work correctly
+    // update also current instance so future operations will work correctly
     this.quest.members[user._id] = !!accept;
   }
 
@@ -698,6 +698,11 @@ schema.methods.startQuest = async function startQuest (user) {
 
   // Changes quest.members to only include participating members
   this.quest.members = _.pickBy(this.quest.members, _.identity);
+
+  // Persist quest.members early to avoid simultaneous handling of accept/reject
+  // while processing the rest of this script
+  this.update({ $set: { 'quest.members': this.quest.members } }).exec();
+
   const nonUserQuestMembers = _.keys(this.quest.members);
   removeFromArray(nonUserQuestMembers, user._id);
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11398

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Handle quest accept/reject atomically so that only the single users true/false status is changed, so that two simultaneous accept/reject request will not override changes from each other. 

Also try to reduce the possibility of force-start conflicting with simultaneous accept/reject by saving the `quest.members` array first (so that incoming accept/reject requests will not do anything while processing the rest of `startQuest` method). 


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: fa756acf-9127-4a3c-8dac-8ff627d30073
