### PR TITLE
Push Notifications Fixes - Part 2

### DIFF
--- a/website/client/src/components/shops/quests/index.vue
+++ b/website/client/src/components/shops/quests/index.vue
@@ -301,7 +301,7 @@
                 <h4 class="popover-content-title">{{ item.text }}</h4>
                 <questInfo
                   :quest="item"
-                  :popoverVersion="true"
+                  :popover-version="true"
                 />
               </div>
             </span>

--- a/website/server/libs/chat.js
+++ b/website/server/libs/chat.js
@@ -1,6 +1,6 @@
 import { model as User } from '../models/user'; // eslint-disable-line import/no-cycle
 import { getUserInfo } from './email'; // eslint-disable-line import/no-cycle
-import { sendNotification as sendPushNotification } from './pushNotifications';
+import { sendNotification as sendPushNotification } from './pushNotifications'; // eslint-disable-line import/no-cycle
 
 export async function getAuthorEmailFromMessage (message) {
   const authorId = message.uuid;

--- a/website/server/libs/chat.js
+++ b/website/server/libs/chat.js
@@ -30,6 +30,9 @@ export async function sendChatPushNotifications (user, group, message, mentions,
       if (mentions && mentions.includes(`@${member.auth.local.username}`) && member.preferences.pushNotifications.mentionParty !== false) {
         return;
       }
+
+      if (!message.unformattedText) return;
+
       sendPushNotification(
         member,
         {

--- a/website/server/libs/inbox/index.js
+++ b/website/server/libs/inbox/index.js
@@ -14,7 +14,7 @@ export async function sentMessage (sender, receiver, message, translate) {
     ]);
   }
 
-  if (receiver.preferences.pushNotifications.newPM !== false) {
+  if (receiver.preferences.pushNotifications.newPM !== false && messageSent.unformattedText) {
     sendPushNotification(
       receiver,
       {

--- a/website/server/libs/inbox/index.js
+++ b/website/server/libs/inbox/index.js
@@ -1,6 +1,6 @@
 import { mapInboxMessage, inboxModel as Inbox } from '../../models/message';
 import { getUserInfo, sendTxn as sendTxnEmail } from '../email'; // eslint-disable-line import/no-cycle
-import { sendNotification as sendPushNotification } from '../pushNotifications';
+import { sendNotification as sendPushNotification } from '../pushNotifications'; // eslint-disable-line import/no-cycle
 
 const PM_PER_PAGE = 10;
 

--- a/website/server/libs/payments/gems.js
+++ b/website/server/libs/payments/gems.js
@@ -3,7 +3,7 @@ import { // eslint-disable-line import/no-cycle
   getUserInfo,
   sendTxn as txnEmail,
 } from '../email';
-import { sendNotification as sendPushNotification } from '../pushNotifications';
+import { sendNotification as sendPushNotification } from '../pushNotifications'; // eslint-disable-line import/no-cycle
 import shared from '../../../common';
 
 function getGiftMessage (data, byUsername, gemAmount, language) {

--- a/website/server/libs/payments/subscriptions.js
+++ b/website/server/libs/payments/subscriptions.js
@@ -16,7 +16,7 @@ import {
   NotFound,
 } from '../errors';
 import shared from '../../../common';
-import { sendNotification as sendPushNotification } from '../pushNotifications';
+import { sendNotification as sendPushNotification } from '../pushNotifications'; // eslint-disable-line import/no-cycle
 
 // @TODO: Abstract to shared/constant
 const JOINED_GROUP_PLAN = 'joined group plan';

--- a/website/server/models/challenge.js
+++ b/website/server/models/challenge.js
@@ -11,7 +11,7 @@ import { // eslint-disable-line import/no-cycle
 import { removeFromArray } from '../libs/collectionManipulators';
 import shared from '../../common';
 import { sendTxn as txnEmail } from '../libs/email'; // eslint-disable-line import/no-cycle
-import { sendNotification as sendPushNotification } from '../libs/pushNotifications';
+import { sendNotification as sendPushNotification } from '../libs/pushNotifications'; // eslint-disable-line import/no-cycle
 import { syncableAttrs, setNextDue } from '../libs/taskManager';
 
 const { Schema } = mongoose;

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -28,7 +28,7 @@ import {
 } from '../libs/errors';
 import baseModel from '../libs/baseModel';
 import { sendTxn as sendTxnEmail } from '../libs/email'; // eslint-disable-line import/no-cycle
-import { sendNotification as sendPushNotification } from '../libs/pushNotifications';
+import { sendNotification as sendPushNotification } from '../libs/pushNotifications'; // eslint-disable-line import/no-cycle
 import {
   syncableAttrs,
 } from '../libs/taskManager';

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -637,12 +637,15 @@ schema.methods.sendChat = function sendChat (options = {}) {
           return;
         }
       }
-      sendPushNotification(member, {
-        identifier: 'chatMention',
-        title: `${user.profile.name} mentioned you in ${this.name}`,
-        message: newChatMessage.unformattedText,
-        payload: { type: this.type },
-      });
+
+      if (newChatMessage.unformattedText) {
+        sendPushNotification(member, {
+          identifier: 'chatMention',
+          title: `${user.profile.name} mentioned you in ${this.name}`,
+          message: newChatMessage.unformattedText,
+          payload: { type: this.type },
+        });
+      }
     });
   }
   return newChatMessage;


### PR DESCRIPTION
This addresses a few edge cases that came up after the previous fixes went live:

- Removes registered devices if they were registered with an invalid token due to an old bug
- Simplifies logging for known errors
- Handles case where the user was loaded using `lean()` making it impossible to use `user.update`

Still to do:
- [x] details.message is empty in some cases, probably due to the message not containing any text (for example an emoji only message) 