### PR TITLE
Allow changing name of party without adding description

### DIFF
--- a/website/client/src/components/groups/groupFormModal.vue
+++ b/website/client/src/components/groups/groupFormModal.vue
@@ -115,8 +115,8 @@ label.custom-control-label(v-once) {{ $t('allowGuildInvitationsFromNonMembers') 
       </div>
       <div class="form-group">
         <label>
-          <strong v-if="isParty" v-once>{{ $t('groupDescription') }}</strong>
-          <strong v-if="!isParty" v-once>{{ $t('groupDescription') }} *</strong>
+          <strong v-if="isParty">{{ $t('groupDescription') }}</strong>
+          <strong v-else>{{ $t('groupDescription') }} *</strong>
         </label>
         <a
           v-markdown="$t('markdownFormattingHelp')"
@@ -255,8 +255,7 @@ label.custom-control-label(v-once) {{ $t('allowGuildInvitationsFromNonMembers') 
         <button
           v-if="workingGroup.id"
           class="btn btn-primary btn-md"
-          :disabled="(isParty && !workingGroup.name) ||
-            (!isParty && (!workingGroup.name || !workingGroup.description))"
+          :disabled="!workingGroup.name || (!isParty && !workingGroup.description)"
         >
           {{ isParty ? $t('updateParty') : $t('updateGuild') }}
         </button>

--- a/website/client/src/components/groups/groupFormModal.vue
+++ b/website/client/src/components/groups/groupFormModal.vue
@@ -18,7 +18,7 @@
       </div>
       <div class="form-group">
         <label>
-          <strong v-once>{{ $t('privacySettings') }} *</strong>
+          <strong v-once>{{ $t('privacySettings') }}</strong>
         </label>
         <br>
         <div class="custom-control custom-checkbox">
@@ -115,7 +115,14 @@ label.custom-control-label(v-once) {{ $t('allowGuildInvitationsFromNonMembers') 
       </div>
       <div class="form-group">
         <label>
-          <strong v-once>{{ $t('groupDescription') }} *</strong>
+          <strong
+            v-if="isParty"
+            v-once
+          >{{ $t('groupDescription') }}</strong>
+          <strong
+            v-if="!isParty"
+            v-once
+          >{{ $t('groupDescription') }} *</strong>
         </label>
         <a
           v-markdown="$t('markdownFormattingHelp')"
@@ -254,7 +261,8 @@ label.custom-control-label(v-once) {{ $t('allowGuildInvitationsFromNonMembers') 
         <button
           v-if="workingGroup.id"
           class="btn btn-primary btn-md"
-          :disabled="!workingGroup.name || !workingGroup.description"
+          :disabled="(isParty && !workingGroup.name) ||
+            (!isParty && (!workingGroup.name || !workingGroup.description))"
         >
           {{ isParty ? $t('updateParty') : $t('updateGuild') }}
         </button>
@@ -540,7 +548,7 @@ export default {
       if (!this.workingGroup.name) errors.push(this.$t('nameRequired'));
       if (!this.workingGroup.summary) errors.push(this.$t('summaryRequired'));
       if (this.workingGroup.summary.length > MAX_SUMMARY_SIZE_FOR_GUILDS) errors.push(this.$t('summaryTooLong'));
-      if (!this.workingGroup.description) errors.push(this.$t('descriptionRequired'));
+      if (!this.isParty && !this.workingGroup.description) errors.push(this.$t('descriptionRequired'));
       if (!this.isParty && (!this.workingGroup.categories || this.workingGroup.categories.length === 0)) errors.push(this.$t('categoiresRequired'));
 
       if (errors.length > 0) {

--- a/website/client/src/components/groups/groupFormModal.vue
+++ b/website/client/src/components/groups/groupFormModal.vue
@@ -115,14 +115,8 @@ label.custom-control-label(v-once) {{ $t('allowGuildInvitationsFromNonMembers') 
       </div>
       <div class="form-group">
         <label>
-          <strong
-            v-if="isParty"
-            v-once
-          >{{ $t('groupDescription') }}</strong>
-          <strong
-            v-if="!isParty"
-            v-once
-          >{{ $t('groupDescription') }} *</strong>
+          <strong v-if="isParty" v-once>{{ $t('groupDescription') }}</strong>
+          <strong v-if="!isParty" v-once>{{ $t('groupDescription') }} *</strong>
         </label>
         <a
           v-markdown="$t('markdownFormattingHelp')"


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10828

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Fixes the following issues with editing parties and guilds:
- Users can now click the "Update Party" button in the party edit menu without having to add a description
- Removed asterisk from "Description" label in party edit menu
- Removed asterisk from "Privacy settings" label in both party and guild edit menus

New edit party and edit guild menus:
![Screen Shot 2020-04-15 at 11 20 45 PM](https://user-images.githubusercontent.com/34986736/79412610-e9e09e80-7f73-11ea-8d25-5e6855d675b2.jpg)
![Screen Shot 2020-04-15 at 11 21 48 PM](https://user-images.githubusercontent.com/34986736/79412625-f2d17000-7f73-11ea-99e9-a7487bec49be.jpg)


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: c2079065-97bd-44a5-b45b-4fccf9455ce2
