### PR TITLE
Fix over-collecting Quest collection items

### DIFF
--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -1112,7 +1112,7 @@ schema.methods._processCollectionQuest = async function processCollectionQuest (
   const itemsFound = {};
 
   const possibleItemKeys = Object.keys(quest.collect)
-    .filter(key => group.quest.progress.collect[key] !== quest.collect[key].count);
+    .filter(key => group.quest.progress.collect[key] < quest.collect[key].count);
 
   const possibleItemsToCollect = possibleItemKeys.reduce((accumulator, current, index) => {
     accumulator[possibleItemKeys[index]] = quest.collect[current];


### PR DESCRIPTION
Hopefully fixes #8248 by replacing `!==` with `<` in group.js