### PR TITLE
Don't break up links with user profile link injections

### DIFF
--- a/test/api/unit/libs/highlightMentions.test.js
+++ b/test/api/unit/libs/highlightMentions.test.js
@@ -58,6 +58,12 @@ describe('highlightMentions', () => {
     expect(result[0]).to.equal(text);
   });
 
+  it('doesn\'t highlight user in link between brackets', async () => {
+    const text = '(http://www.medium.com/@user/blog)';
+    const result = await highlightMentions(text);
+    expect(result[0]).to.equal(text);
+  });
+
   it('doesn\'t highlight users in link when followed by same @user mention', async () => {
     const text = 'http://www.medium.com/@user/blog @user';
     const result = await highlightMentions(text);

--- a/test/api/unit/libs/highlightMentions.test.js
+++ b/test/api/unit/libs/highlightMentions.test.js
@@ -52,24 +52,6 @@ describe('highlightMentions', () => {
     expect(result[0]).to.equal('@nouser message');
   });
 
-  it('doesn\'t highlight users in link', async () => {
-    const text = 'http://www.medium.com/@user/blog';
-    const result = await highlightMentions(text);
-    expect(result[0]).to.equal(text);
-  });
-
-  it('doesn\'t highlight user in link between brackets', async () => {
-    const text = '(http://www.medium.com/@user/blog)';
-    const result = await highlightMentions(text);
-    expect(result[0]).to.equal(text);
-  });
-
-  it('doesn\'t highlight users in link when followed by same @user mention', async () => {
-    const text = 'http://www.medium.com/@user/blog @user';
-    const result = await highlightMentions(text);
-    expect(result[0]).to.equal('http://www.medium.com/@user/blog [@user](/profile/111)');
-  });
-
   it('highlights multiple existing users', async () => {
     const text = '@user message (@user2) @user3 @user';
     const result = await highlightMentions(text);
@@ -80,6 +62,44 @@ describe('highlightMentions', () => {
     const text = '@user @user2 @user3 @user4 @user5 @user6';
     const result = await highlightMentions(text);
     expect(result[0]).to.equal(text);
+  });
+
+  describe('link interactions', async () => {
+    it('doesn\'t highlight users in link', async () => {
+      const text = 'http://www.medium.com/@user/blog';
+      const result = await highlightMentions(text);
+      expect(result[0]).to.equal(text);
+    });
+
+    it('doesn\'t highlight user in link between brackets', async () => {
+      const text = '(http://www.medium.com/@user/blog)';
+      const result = await highlightMentions(text);
+      expect(result[0]).to.equal(text);
+    });
+
+    it('doesn\'t highlight user in an autolink', async () => {
+      const text = '<http://www.medium.com/@user/blog>';
+      const result = await highlightMentions(text);
+      expect(result[0]).to.equal(text);
+    });
+
+    it('doesn\'t highlight users in link text', async () => {
+      const text = '[Check awesome blog written by @user](http://www.medium.com/@user/blog)';
+      const result = await highlightMentions(text);
+      expect(result[0]).to.equal(text);
+    });
+
+    it('doesn\'t highlight users in link with newlines and markup', async () => {
+      const text = '[Check `awesome` \nblog **written** by @user](http://www.medium.com/@user/blog)';
+      const result = await highlightMentions(text);
+      expect(result[0]).to.equal(text);
+    });
+
+    it('doesn\'t highlight users in link when followed by same @user mention', async () => {
+      const text = 'http://www.medium.com/@user/blog @user';
+      const result = await highlightMentions(text);
+      expect(result[0]).to.equal('http://www.medium.com/@user/blog [@user](/profile/111)');
+    });
   });
 
   describe('exceptions in code blocks', () => {

--- a/test/api/unit/libs/highlightMentions.test.js
+++ b/test/api/unit/libs/highlightMentions.test.js
@@ -52,6 +52,18 @@ describe('highlightMentions', () => {
     expect(result[0]).to.equal('@nouser message');
   });
 
+  it('doesn\'t highlight users in link', async () => {
+    const text = 'http://www.medium.com/@user/blog';
+    const result = await highlightMentions(text);
+    expect(result[0]).to.equal(text);
+  });
+
+  it('doesn\'t highlight users in link when followed by same @user mention', async () => {
+    const text = 'http://www.medium.com/@user/blog @user';
+    const result = await highlightMentions(text);
+    expect(result[0]).to.equal('http://www.medium.com/@user/blog [@user](/profile/111)');
+  });
+
   it('highlights multiple existing users', async () => {
     const text = '@user message (@user2) @user3 @user';
     const result = await highlightMentions(text);

--- a/website/server/libs/highlightMentions.js
+++ b/website/server/libs/highlightMentions.js
@@ -103,12 +103,16 @@ function findTextAndCodeBlocks (text) {
   return new TextWithCodeBlocks(blocks);
 }
 
+function stripBrackets (text) {
+  return text.slice(text[0] === '(', text.slice(-1) === ')' ? -1 : text.length);
+}
+
 function injectLinkIfNecessary (username, userId) {
-  const regex = new RegExp(`(\\S*)(@${username}(?![\\w-]))(\\S*)`, 'g');
+  const regex = new RegExp(`(\\(?[^(\\s]*)(@${username}(?![\\w-]))([^)\\s]*\\)?)`, 'g');
 
   return text => text.replace(regex, (fullMatch, prefix, mention, suffix) => {
     // Can be done with ternary but then linter goes loopy
-    if (habiticaMarkdown.isLinkOrEmail(fullMatch)) {
+    if (habiticaMarkdown.isLinkOrEmail(stripBrackets(fullMatch))) {
       return fullMatch;
     }
     return `${prefix}[${mention}](/profile/${userId})${suffix}`;

--- a/website/server/libs/highlightMentions.js
+++ b/website/server/libs/highlightMentions.js
@@ -95,10 +95,10 @@ function toSourceMapRegex (token) {
 }
 
 /**
- * Uses habiticaMarkdown to determine what part of the text are code blocks
+ * Uses habiticaMarkdown to determine which text blocks should be ignored (links and code blocks)
  * according to the specification here: https://spec.commonmark.org/0.29/
  */
-function findTextAndIgnoreBlocks (text) {
+function findTextBlocks (text) {
   // For token description see https://markdown-it.github.io/markdown-it/#Token
   // The second parameter is mandatory even if not used, see
   // https://markdown-it.github.io/markdown-it/#MarkdownIt.parse
@@ -112,12 +112,11 @@ function findTextAndIgnoreBlocks (text) {
     const match = targetText.match(regex);
 
     if (match.index) {
-      index += match.index;
       blocks.push({ text: targetText.substr(0, match.index), ignore: false });
     }
 
     blocks.push({ text: match[0], ignore: true });
-    index += match[0].length;
+    index += match.index + match[0].length;
   });
 
   if (index < text.length) {
@@ -135,7 +134,7 @@ function findTextAndIgnoreBlocks (text) {
  * - Skips mentions in links
  */
 export default async function highlightMentions (text) {
-  const textBlocks = findTextAndIgnoreBlocks(text);
+  const textBlocks = findTextBlocks(text);
 
   const mentions = textBlocks.allValidText.match(mentionRegex);
   let members = [];

--- a/website/server/libs/highlightMentions.js
+++ b/website/server/libs/highlightMentions.js
@@ -4,21 +4,21 @@ import habiticaMarkdown from 'habitica-markdown';
 import { model as User } from '../models/user';
 
 const mentionRegex = /\B@[-\w]+/g;
-const codeTokenTypes = ['code_block', 'code_inline', 'fence'];
+const ignoreTokenTypes = ['code_block', 'code_inline', 'fence', 'link_open'];
 
 /**
- * Container class for text blocks and code blocks combined
- * Blocks have the properties `text` and `isCodeBlock`
+ * Container class for valid text blocks and text blocks that should be ignored.
+ * Blocks have the properties `text` and `ignore`
  */
-class TextWithCodeBlocks {
+class TextBlocks {
   constructor (blocks) {
     this.blocks = blocks;
-    this.textBlocks = blocks.filter(block => !block.isCodeBlock);
-    this.allText = this.textBlocks.map(block => block.text).join('\n');
+    this.validBlocks = blocks.filter(block => !block.ignore);
+    this.allValidText = this.validBlocks.map(block => block.text).join('\n');
   }
 
-  transformTextBlocks (transform) {
-    this.textBlocks.forEach(block => {
+  transformValidBlocks (transform) {
+    this.validBlocks.forEach(block => {
       block.text = transform(block.text);
     });
   }
@@ -32,18 +32,31 @@ class TextWithCodeBlocks {
  * Since tokens have both order and can be nested until infinite depth,
  * use a branching recursive algorithm to maintain order and check all tokens.
  */
-function findCodeBlocks (tokens, aggregator) {
-  const result = aggregator || [];
-  const [head, ...tail] = tokens;
-  if (!head) {
-    return result;
+function findIgnoreBlocks (tokens) {
+  // Links span multiple tokens, so keep local state of whether we're in a link
+  let inLink = false;
+
+  function recursor (ts, result) {
+    const [head, ...tail] = ts;
+    if (!head) {
+      return result;
+    }
+
+    if (!inLink && ignoreTokenTypes.includes(head.type)) {
+      result.push(head);
+    }
+
+    if (head.type.includes('link')) {
+      inLink = !inLink;
+    } else if (inLink && head.type === 'text') {
+      const linkBlock = result[result.length - 1];
+      linkBlock.textContents = (linkBlock.textContents || []).concat(head.content);
+    }
+
+    return recursor(tail, head.children ? recursor(head.children, result) : result);
   }
 
-  if (codeTokenTypes.includes(head.type)) {
-    result.push(head);
-  }
-
-  return findCodeBlocks(tail, head.children ? findCodeBlocks(head.children, result) : result);
+  return recursor(tokens, []);
 }
 
 /**
@@ -57,7 +70,10 @@ function withOptionalIndentation (content) {
   return content.split('\n').map(line => `\\s*${line}`).join('\n');
 }
 
-function createCodeBlockRegex ({ content, type, markup }) {
+// This is essentially a workaround around the fact that markdown-it doesn't
+// provide sourcemap functionality and is the most brittle part of this code.
+function toSourceMapRegex (token) {
+  const { type, content, markup } = token;
   const contentRegex = escapeRegExp(content);
   let regexStr = '';
 
@@ -65,58 +81,50 @@ function createCodeBlockRegex ({ content, type, markup }) {
     regexStr = withOptionalIndentation(contentRegex);
   } else if (type === 'fence') {
     regexStr = `\\s*${markup}.*\n${withOptionalIndentation(contentRegex)}\\s*${markup}`;
-  } else { // type === code_inline
+  } else if (type === 'code_inline') {
     regexStr = `${markup} ?${contentRegex} ?${markup}`;
+  } else if (type === 'link_open') {
+    const texts = token.textContents.map(escapeRegExp);
+    regexStr = markup === 'linkify' || markup === 'autolink' ? texts[0]
+      : `\\[.*${texts.join('.*')}.*\\]\\(${escapeRegExp(token.attrs[0][1])}\\)`;
+  } else {
+    throw new Error(`No source mapping regex defined for ignore blocks of type ${type}`);
   }
 
-  return new RegExp(regexStr);
+  return new RegExp(regexStr, 's');
 }
 
 /**
  * Uses habiticaMarkdown to determine what part of the text are code blocks
  * according to the specification here: https://spec.commonmark.org/0.29/
  */
-function findTextAndCodeBlocks (text) {
+function findTextAndIgnoreBlocks (text) {
   // For token description see https://markdown-it.github.io/markdown-it/#Token
   // The second parameter is mandatory even if not used, see
   // https://markdown-it.github.io/markdown-it/#MarkdownIt.parse
   const tokens = habiticaMarkdown.parse(text, {});
-  const codeBlocks = findCodeBlocks(tokens);
+  const ignoreBlockRegexes = findIgnoreBlocks(tokens).map(toSourceMapRegex);
 
   const blocks = [];
-  let remainingText = text;
-  codeBlocks.forEach(codeBlock => {
-    const codeBlockRegex = createCodeBlockRegex(codeBlock);
-    const match = remainingText.match(codeBlockRegex);
+  let index = 0;
+  ignoreBlockRegexes.forEach(regex => {
+    const targetText = text.substr(index);
+    const match = targetText.match(regex);
 
     if (match.index) {
-      blocks.push({ text: remainingText.substr(0, match.index), isCodeBlock: false });
+      index += match.index;
+      blocks.push({ text: targetText.substr(0, match.index), ignore: false });
     }
-    blocks.push({ text: match[0], isCodeBlock: true });
 
-    remainingText = remainingText.substr(match.index + match[0].length);
+    blocks.push({ text: match[0], ignore: true });
+    index += match[0].length;
   });
 
-  if (remainingText) {
-    blocks.push({ text: remainingText, isCodeBlock: false });
+  if (index < text.length) {
+    blocks.push({ text: text.substr(index), ignore: false });
   }
-  return new TextWithCodeBlocks(blocks);
-}
 
-function stripBrackets (text) {
-  return text.slice(text[0] === '(', text.slice(-1) === ')' ? -1 : text.length);
-}
-
-function injectLinkIfNecessary (username, userId) {
-  const regex = new RegExp(`(\\(?[^(\\s]*)(@${username}(?![\\w-]))([^)\\s]*\\)?)`, 'g');
-
-  return text => text.replace(regex, (fullMatch, prefix, mention, suffix) => {
-    // Can be done with ternary but then linter goes loopy
-    if (habiticaMarkdown.isLinkOrEmail(stripBrackets(fullMatch))) {
-      return fullMatch;
-    }
-    return `${prefix}[${mention}](/profile/${userId})${suffix}`;
-  });
+  return new TextBlocks(blocks);
 }
 
 /**
@@ -124,11 +132,12 @@ function injectLinkIfNecessary (username, userId) {
  * a link towards the user's profile page.
  * - Only works if there are no more that 5 user mentions
  * - Skips mentions in code blocks as defined by https://spec.commonmark.org/0.29/
+ * - Skips mentions in links
  */
 export default async function highlightMentions (text) {
-  const textAndCodeBlocks = findTextAndCodeBlocks(text);
+  const textBlocks = findTextAndIgnoreBlocks(text);
 
-  const mentions = textAndCodeBlocks.allText.match(mentionRegex);
+  const mentions = textBlocks.allValidText.match(mentionRegex);
   let members = [];
 
   if (mentions && mentions.length <= 5) {
@@ -140,9 +149,12 @@ export default async function highlightMentions (text) {
       .exec();
     members.forEach(member => {
       const { username } = member.auth.local;
-      textAndCodeBlocks.transformTextBlocks(injectLinkIfNecessary(username, member._id));
+      const regex = new RegExp(`@${username}(?![\\-\\w])`, 'g');
+      const replacement = `[@${username}](/profile/${member._id})`;
+
+      textBlocks.transformValidBlocks(blockText => blockText.replace(regex, replacement));
     });
   }
 
-  return [textAndCodeBlocks.rebuild(), mentions, members];
+  return [textBlocks.rebuild(), mentions, members];
 }


### PR DESCRIPTION
Fixes #10924
Edit: Now also fixes #11520 
(Backend part, frontend part is fixed by #12089 )

### Changes
~Uses the isLinkOrEmail method on habitica-markdown exposed in https://github.com/HabitRPG/habitica-markdown/pull/87 to make sure user profile links are not injected into messages. (As such, this merge request is blocked by that merge request).~ Now uses the same strategy for links as code blocks, and as such no longer depends on habitica-markdown 2.0.0.

### Merge strategy
As @paglias mentioned in #12071 it's a good idea to merge the open backend markdown-related merge requests first and then look at the new habitica-markdown module. ~With that in mind I changed my open branches to be all sequential. (Since this functionality needed the changes from both).~

So my proposed strategy for merging would be:
1. ~Merge #12071 (underscore stopgap by @kareenf fixing #12033 -- I'll take care of resolving conflicts in #12089)~ ✅ 
2. ~Merge #12069 (Don't inject user profile links into code blocks)~ ✅ 
3. ~Merge https://github.com/HabitRPG/habitica-markdown/pull/87 (Generate spans for user mention highlights in a markdown-it plugin)~ ✅
4. ~Merge #12089 (Use the new version of habitica-markdown, fixing #12033 and frontend parts of #11504 and #10924 )~ ❎ (No longer a dependency)
5. Merge this one (Merge at will!)

----
UUID: d71d2c57-a73d-4591-b64d-e688584a9092
