### PR TITLE
Fixes #11119: Added check for wacky pet before feeding

### DIFF
--- a/test/common/ops/feed.js
+++ b/test/common/ops/feed.js
@@ -89,6 +89,18 @@ describe('shared.ops.feed', () => {
       }
     });
 
+    it('does not allow feeding of wacky pets', done => {
+      user.items.pets['Wolf-Veggie'] = 5;
+      user.items.food.Meat = 1;
+      try {
+        feed(user, { params: { pet: 'Wolf-Vegie', food: 'Meat' } });
+      } catch (err) {
+        expect(err).to.be.an.instanceof(NotAuthorized);
+        expect(err.message).to.equal(i18n.t('messageCannotFeedPet'));
+        done();
+      }
+    });
+
     it('does not allow feeding of mounts', done => {
       user.items.pets['Wolf-Base'] = -1;
       user.items.mounts['Wolf-Base'] = true;

--- a/test/common/ops/feed.js
+++ b/test/common/ops/feed.js
@@ -93,7 +93,7 @@ describe('shared.ops.feed', () => {
       user.items.pets['Wolf-Veggie'] = 5;
       user.items.food.Meat = 1;
       try {
-        feed(user, { params: { pet: 'Wolf-Vegie', food: 'Meat' } });
+        feed(user, { params: { pet: 'Wolf-Veggie', food: 'Meat' } });
       } catch (err) {
         expect(err).to.be.an.instanceof(NotAuthorized);
         expect(err.message).to.equal(i18n.t('messageCannotFeedPet'));

--- a/website/common/script/ops/feed.js
+++ b/website/common/script/ops/feed.js
@@ -61,7 +61,7 @@ export default function feed (user, req = {}, analytics) {
     throw new NotFound(i18n.t('messageFoodNotFound', req.language));
   }
 
-  if (pet.type === 'special') {
+  if (pet.type === 'special' || pet.type === 'wacky') {
     throw new NotAuthorized(i18n.t('messageCannotFeedPet', req.language));
   }
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11119

### Changes
[//]: Added a check when on the server API in feed.js to display messageCannotFeedPet if the pet type is a wacky pet.



[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 321dffb4-8124-40e4-832b-d32b5fb997fa
