### PR TITLE
Don't bill (subtract gems) multiple times for multiple unlock item set calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "client:build": "cd website/client && npm run build",
     "client:unit": "cd website/client && npm run test:unit",
     "start": "gulp nodemon",
+    "debug": "gulp nodemon --inspect",
     "postinstall": "gulp build && cd website/client && npm install",
     "apidoc": "gulp apidoc"
   },

--- a/test/api/v3/integration/user/POST-user_unlock.js
+++ b/test/api/v3/integration/user/POST-user_unlock.js
@@ -5,7 +5,7 @@ import {
 
 describe('POST /user/unlock', () => {
   let user;
-  const unlockPath = 'shirt.convict,shirt.cross,shirt.fire,shirt.horizon,shirt.ocean,shirt.purple,shirt.rainbow,shirt.redblue,shirt.thunder,shirt.tropical,shirt.zombie';
+  const unlockPath = 'items.gear.owned.headAccessory_special_bearEars,items.gear.owned.headAccessory_special_cactusEars,items.gear.owned.headAccessory_special_foxEars,items.gear.owned.headAccessory_special_lionEars,items.gear.owned.headAccessory_special_pandaEars,items.gear.owned.headAccessory_special_pigEars,items.gear.owned.headAccessory_special_tigerEars,items.gear.owned.headAccessory_special_wolfEars';
   const unlockCost = 1.25;
   const usersStartingGems = 5;
 
@@ -32,6 +32,27 @@ describe('POST /user/unlock', () => {
     await user.sync();
 
     expect(response.message).to.equal(t('unlocked'));
+    expect(user.balance).to.equal(usersStartingGems - unlockCost);
+  });
+
+  it('does not reduce a user\'s balance twice', async () => {
+    await user.update({
+      balance: usersStartingGems,
+    });
+    let response = await user.post(`/user/unlock?path=${unlockPath}`);
+    await user.sync();
+
+    expect(response.message).to.equal(t('unlocked'));
+    expect(user.balance).to.equal(usersStartingGems - unlockCost);
+
+    expect(user.post(`/user/unlock?path=${unlockPath}`))
+      .to.eventually.be.rejected.and.to.eql({
+        code: 401,
+        error: 'NotAuthorized',
+        message: t('alreadyUnlocked'),
+      });
+    await user.sync();
+
     expect(user.balance).to.equal(usersStartingGems - unlockCost);
   });
 });

--- a/test/api/v3/integration/user/POST-user_unlock.js
+++ b/test/api/v3/integration/user/POST-user_unlock.js
@@ -39,7 +39,7 @@ describe('POST /user/unlock', () => {
     await user.update({
       balance: usersStartingGems,
     });
-    let response = await user.post(`/user/unlock?path=${unlockPath}`);
+    const response = await user.post(`/user/unlock?path=${unlockPath}`);
     await user.sync();
 
     expect(response.message).to.equal(t('unlocked'));

--- a/test/api/v3/integration/user/POST-user_unlock.js
+++ b/test/api/v3/integration/user/POST-user_unlock.js
@@ -5,7 +5,8 @@ import {
 
 describe('POST /user/unlock', () => {
   let user;
-  const unlockPath = 'items.gear.owned.headAccessory_special_bearEars,items.gear.owned.headAccessory_special_cactusEars,items.gear.owned.headAccessory_special_foxEars,items.gear.owned.headAccessory_special_lionEars,items.gear.owned.headAccessory_special_pandaEars,items.gear.owned.headAccessory_special_pigEars,items.gear.owned.headAccessory_special_tigerEars,items.gear.owned.headAccessory_special_wolfEars';
+  const unlockPath = 'shirt.convict,shirt.cross,shirt.fire,shirt.horizon,shirt.ocean,shirt.purple,shirt.rainbow,shirt.redblue,shirt.thunder,shirt.tropical,shirt.zombie';
+  const unlockGearSetPath = 'items.gear.owned.headAccessory_special_bearEars,items.gear.owned.headAccessory_special_cactusEars,items.gear.owned.headAccessory_special_foxEars,items.gear.owned.headAccessory_special_lionEars,items.gear.owned.headAccessory_special_pandaEars,items.gear.owned.headAccessory_special_pigEars,items.gear.owned.headAccessory_special_tigerEars,items.gear.owned.headAccessory_special_wolfEars';
   const unlockCost = 1.25;
   const usersStartingGems = 5;
 
@@ -39,13 +40,13 @@ describe('POST /user/unlock', () => {
     await user.update({
       balance: usersStartingGems,
     });
-    const response = await user.post(`/user/unlock?path=${unlockPath}`);
+    const response = await user.post(`/user/unlock?path=${unlockGearSetPath}`);
     await user.sync();
 
     expect(response.message).to.equal(t('unlocked'));
     expect(user.balance).to.equal(usersStartingGems - unlockCost);
 
-    expect(user.post(`/user/unlock?path=${unlockPath}`))
+    expect(user.post(`/user/unlock?path=${unlockGearSetPath}`))
       .to.eventually.be.rejected.and.to.eql({
         code: 401,
         error: 'NotAuthorized',

--- a/test/common/ops/unlock.js
+++ b/test/common/ops/unlock.js
@@ -8,7 +8,7 @@ import {
   BadRequest,
 } from '../../../website/common/script/libs/errors';
 
-describe.only('shared.ops.unlock', () => {
+describe('shared.ops.unlock', () => {
   let user;
   const unlockPath = 'shirt.convict,shirt.cross,shirt.fire,shirt.horizon,shirt.ocean,shirt.purple,shirt.rainbow,shirt.redblue,shirt.thunder,shirt.tropical,shirt.zombie';
   const unlockGearSetPath = 'items.gear.owned.headAccessory_special_bearEars,items.gear.owned.headAccessory_special_cactusEars,items.gear.owned.headAccessory_special_foxEars,items.gear.owned.headAccessory_special_lionEars,items.gear.owned.headAccessory_special_pandaEars,items.gear.owned.headAccessory_special_pigEars,items.gear.owned.headAccessory_special_tigerEars,items.gear.owned.headAccessory_special_wolfEars';

--- a/test/common/ops/unlock.js
+++ b/test/common/ops/unlock.js
@@ -1,12 +1,7 @@
 import unlock from '../../../website/common/script/ops/unlock';
 import i18n from '../../../website/common/script/i18n';
-import {
-  generateUser,
-} from '../../helpers/common.helper';
-import {
-  NotAuthorized,
-  BadRequest,
-} from '../../../website/common/script/libs/errors';
+import { generateUser } from '../../helpers/common.helper';
+import { NotAuthorized, BadRequest } from '../../../website/common/script/libs/errors';
 
 describe('shared.ops.unlock', () => {
   let user;
@@ -29,6 +24,15 @@ describe('shared.ops.unlock', () => {
       expect(err.message).to.equal(i18n.t('pathRequired'));
       done();
     }
+  });
+
+  it('does not unlock lost gear', done => {
+    user.items.gear.owned.headAccessory_special_bearEars = false;
+
+    unlock(user, { query: { path: 'items.gear.owned.headAccessory_special_bearEars' } });
+
+    expect(user.balance).to.equal(usersStartingGems);
+    done();
   });
 
   it('returns an error when user balance is too low', done => {

--- a/test/common/ops/unlock.js
+++ b/test/common/ops/unlock.js
@@ -90,7 +90,7 @@ describe('shared.ops.unlock', () => {
     expect(user.preferences.background).to.equal('giant_florals');
   });
 
-  it('un-equips an item already equipped', () => {
+  it('un-equips a background already equipped', () => {
     expect(user.purchased.background.giant_florals).to.not.exist;
 
     unlock(user, { query: { path: backgroundUnlockPath } }); // unlock

--- a/test/common/ops/unlock.js
+++ b/test/common/ops/unlock.js
@@ -45,16 +45,17 @@ describe('shared.ops.unlock', () => {
 
   it('returns an error when user already owns a full set', done => {
     try {
-      unlock(user, { query: { path: unlockPath } });
-      unlock(user, { query: { path: unlockPath } });
+      unlock(user, { query: { path: unlockGearSetPath } });
+      unlock(user, { query: { path: unlockGearSetPath } });
     } catch (err) {
       expect(err).to.be.an.instanceof(NotAuthorized);
       expect(err.message).to.equal(i18n.t('alreadyUnlocked'));
+      expect(user.balance).to.equal(3.75);
       done();
     }
   });
 
-  // disabled until fully implemente
+  // disabled until fully implemented
   xit('returns an error when user already owns items in a full set', done => {
     try {
       unlock(user, { query: { path: unlockPath } });
@@ -105,7 +106,7 @@ describe('shared.ops.unlock', () => {
     expect(user.items.gear.owned.headAccessory_special_wolfEars).to.be.true;
   });
 
-  it('unlocks a an item', () => {
+  it('unlocks an item', () => {
     const [, message] = unlock(user, { query: { path: backgroundUnlockPath } });
 
     expect(message).to.equal(i18n.t('unlocked'));

--- a/test/common/ops/unlock.js
+++ b/test/common/ops/unlock.js
@@ -55,7 +55,7 @@ describe('shared.ops.unlock', () => {
     }
   });
 
-  it('returns an error when user already owns items in a full set', done => {
+  xit('returns an error when user already owns items in a full set', done => {
     try {
       unlock(user, { query: { path: unlockPath.split(',').splice(2).join(',') } });
       unlock(user, { query: { path: unlockPath } });

--- a/test/common/ops/unlock.js
+++ b/test/common/ops/unlock.js
@@ -8,7 +8,7 @@ import {
   BadRequest,
 } from '../../../website/common/script/libs/errors';
 
-describe('shared.ops.unlock', () => {
+describe.only('shared.ops.unlock', () => {
   let user;
   const unlockPath = 'shirt.convict,shirt.cross,shirt.fire,shirt.horizon,shirt.ocean,shirt.purple,shirt.rainbow,shirt.redblue,shirt.thunder,shirt.tropical,shirt.zombie';
   const unlockGearSetPath = 'items.gear.owned.headAccessory_special_bearEars,items.gear.owned.headAccessory_special_cactusEars,items.gear.owned.headAccessory_special_foxEars,items.gear.owned.headAccessory_special_lionEars,items.gear.owned.headAccessory_special_pandaEars,items.gear.owned.headAccessory_special_pigEars,items.gear.owned.headAccessory_special_tigerEars,items.gear.owned.headAccessory_special_wolfEars';
@@ -55,14 +55,13 @@ describe('shared.ops.unlock', () => {
     }
   });
 
-  // disabled until fully implemented
-  xit('returns an error when user already owns items in a full set', done => {
+  it('returns an error when user already owns items in a full set', done => {
     try {
-      unlock(user, { query: { path: unlockPath } });
+      unlock(user, { query: { path: unlockPath.split(',').splice(2).join(',') } });
       unlock(user, { query: { path: unlockPath } });
     } catch (err) {
       expect(err).to.be.an.instanceof(NotAuthorized);
-      expect(err.message).to.equal(i18n.t('alreadyUnlocked'));
+      expect(err.message).to.equal(i18n.t('alreadyUnlockedPart'));
       done();
     }
   });

--- a/test/common/ops/unlock.js
+++ b/test/common/ops/unlock.js
@@ -45,6 +45,18 @@ describe('shared.ops.unlock', () => {
 
   it('returns an error when user already owns a full set', done => {
     try {
+      unlock(user, { query: { path: unlockPath } });
+      unlock(user, { query: { path: unlockPath } });
+    } catch (err) {
+      expect(err).to.be.an.instanceof(NotAuthorized);
+      expect(err.message).to.equal(i18n.t('alreadyUnlocked'));
+      expect(user.balance).to.equal(3.75);
+      done();
+    }
+  });
+
+  it('returns an error when user already owns a full set of gear', done => {
+    try {
       unlock(user, { query: { path: unlockGearSetPath } });
       unlock(user, { query: { path: unlockGearSetPath } });
     } catch (err) {

--- a/website/client/package-lock.json
+++ b/website/client/package-lock.json
@@ -15158,11 +15158,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "perfect-scrollbar": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/perfect-scrollbar/-/perfect-scrollbar-1.5.0.tgz",
-      "integrity": "sha512-NrNHJn5mUGupSiheBTy6x+6SXCFbLlm8fVZh9moIzw/LgqElN5q4ncR4pbCBCYuCJ8Kcl9mYM0NgDxvW+b4LxA=="
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -15431,17 +15426,6 @@
             "has-flag": "^3.0.0"
           }
         }
-      }
-    },
-    "postcss-import": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-12.0.1.tgz",
-      "integrity": "sha512-3Gti33dmCjyKBgimqGxL3vcV8w9+bsHwO5UrBawp796+jdardbcFl4RP5w/76BwNL7aGzpKstIfF9I+kdE8pTw==",
-      "requires": {
-        "postcss": "^7.0.1",
-        "postcss-value-parser": "^3.2.3",
-        "read-cache": "^1.0.0",
-        "resolve": "^1.1.7"
       }
     },
     "postcss-load-config": {
@@ -16631,21 +16615,6 @@
       "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
       "requires": {
         "lodash": "^4.0.1"
-      }
-    },
-    "read-cache": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-      "integrity": "sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=",
-      "requires": {
-        "pify": "^2.3.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        }
       }
     },
     "read-pkg": {
@@ -19721,16 +19690,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw=="
-    },
-    "vue2-perfect-scrollbar": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/vue2-perfect-scrollbar/-/vue2-perfect-scrollbar-1.4.0.tgz",
-      "integrity": "sha512-kluthjiZOOhAZ/18RTZJr2Y9lpjgkuOuxkH8MMMq1dYrSUdvlEv8V1UPtW7UDVcTAUo048AUE/W4hSPTfluejw==",
-      "requires": {
-        "cssnano": "^4.1.3",
-        "perfect-scrollbar": "^1.4.0",
-        "postcss-import": "^12.0.0"
-      }
     },
     "vuedraggable": {
       "version": "2.23.2",

--- a/website/client/src/components/messages/messageList.vue
+++ b/website/client/src/components/messages/messageList.vue
@@ -6,7 +6,7 @@
     <div class="row loadmore">
       <div v-if="canLoadMore && !isLoading">
         <div class="loadmore-divider-holder">
-        <div class="loadmore-divider"></div>
+          <div class="loadmore-divider"></div>
         </div>
         <button
           class="btn btn-secondary"
@@ -14,9 +14,9 @@
         >
           {{ $t('loadEarlierMessages') }}
         </button>
-      <div class="loadmore-divider-holder">
-        <div class="loadmore-divider"></div>
-      </div>
+        <div class="loadmore-divider-holder">
+          <div class="loadmore-divider"></div>
+        </div>
       </div>
       <h2
         v-show="isLoading"

--- a/website/client/src/pages/private-messages.vue
+++ b/website/client/src/pages/private-messages.vue
@@ -72,8 +72,8 @@
           />
         </div>
         <button
-          class="btn btn-secondary"
           v-if="canLoadMoreConversations"
+          class="btn btn-secondary"
           @click="loadConversations()"
         >
           {{ $t('loadMore') }}

--- a/website/common/script/ops/unlock.js
+++ b/website/common/script/ops/unlock.js
@@ -74,7 +74,7 @@ export default function unlock (user, req = {}, analytics) {
   }
 
   const isFullSet = path.includes(',');
-  const isBackground = path.includes('background.');
+  const isBackground = path.startsWith('background.');
   const cost = determineCost(isBackground, isFullSet);
 
   const setPaths = path.split(',');

--- a/website/server/models/user/schema.js
+++ b/website/server/models/user/schema.js
@@ -187,6 +187,10 @@ export default new Schema({
       $type: Schema.Types.Mixed,
       default: () => ({}),
     },
+    items: {
+      $type: Schema.Types.Mixed,
+      default: () => ({}),
+    },
     txnCount: { $type: Number, default: 0 },
     mobileChat: Boolean,
     plan: {

--- a/website/server/models/user/schema.js
+++ b/website/server/models/user/schema.js
@@ -187,10 +187,6 @@ export default new Schema({
       $type: Schema.Types.Mixed,
       default: () => ({}),
     },
-    items: {
-      $type: Schema.Types.Mixed,
-      default: () => ({}),
-    },
     txnCount: { $type: Number, default: 0 },
     mobileChat: Boolean,
     plan: {


### PR DESCRIPTION
Fixes #11050 

### Changes
- Added `Mixed` items field declaration to user schema
- Added some tests for unlock.js
- Cleaned up some code in unlock.js
- Added a debug run target to allow attaching a debugger to the server

### Possible additional work I can pick up
- Create a migration to fix it for existing purchases of existing users
- Investigate why the tests didn't catch this
- Fix the TODOs (test coverage and partial unlocks)
- Refactor significantly (All the if checks are a clear smell that the abstraction here is totally wrong)

Let me know what you'd like to see included in this merge request

----
UUID: d71d2c57-a73d-4591-b64d-e688584a9092