### PR TITLE
Fix tasks draggable on mobile

### DIFF
--- a/website/client/src/components/tasks/column.vue
+++ b/website/client/src/components/tasks/column.vue
@@ -81,6 +81,8 @@
         ref="tasksList"
         class="sortable-tasks"
         :options="{disabled: activeFilter.label === 'scheduled' || !isUser, scrollSensitivity: 64}"
+        :delay-on-touch-only="true"
+        :delay="100"
         @update="taskSorted"
         @start="isDragging(true)"
         @end="isDragging(false)"
@@ -101,6 +103,8 @@
         <draggable
           ref="rewardsList"
           class="reward-items"
+          :delay-on-touch-only="true"
+          :delay="100"
           @update="rewardSorted"
           @start="rewardDragStart"
           @end="rewardDragEnd"


### PR DESCRIPTION


[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11181 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Add 100ms delay to draggable on touch devices. 
Makes tapping the +/- and checkbox possible and also fixes scrolling on mobile. 

Before:
(trying to scroll the page and tap the + and checkbox) 
![before-draggable-fix](https://user-images.githubusercontent.com/1764167/80313043-591a8600-87f1-11ea-8d33-3dfa57db2b06.gif)

After:
(scrolling works, tapping + and checkbox work, sorting works by keeping short delay before moving) 
![after-draggable-fix](https://user-images.githubusercontent.com/1764167/80313088-9da62180-87f1-11ea-967f-377c55e1c4a4.gif)



[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: fa756acf-9127-4a3c-8dac-8ff627d30073
