### PR TITLE
Issue 12138 - Fix chat support for regex chars in code blocks

### DIFF
--- a/test/api/unit/libs/highlightMentions.test.js
+++ b/test/api/unit/libs/highlightMentions.test.js
@@ -119,4 +119,18 @@ describe('highlightMentions', () => {
 
     expect(err).to.be.undefined;
   });
+
+  it('github issue 12138, method crashes when regex chars are used in code block', async () => {
+    const text = '`[test]`';
+
+    let err;
+
+    try {
+      await highlightMentions(text);
+    } catch (e) {
+      err = e;
+    }
+
+    expect(err).to.be.undefined;
+  });
 });

--- a/website/server/libs/highlightMentions.js
+++ b/website/server/libs/highlightMentions.js
@@ -1,3 +1,4 @@
+import escapeRegExp from 'lodash/escapeRegExp';
 import habiticaMarkdown from 'habitica-markdown';
 
 import { model as User } from '../models/user';
@@ -57,14 +58,15 @@ function withOptionalIndentation (content) {
 }
 
 function createCodeBlockRegex ({ content, type, markup }) {
+  const contentRegex = escapeRegExp(content);
   let regexStr = '';
 
   if (type === 'code_block') {
-    regexStr = withOptionalIndentation(content);
+    regexStr = withOptionalIndentation(contentRegex);
   } else if (type === 'fence') {
-    regexStr = `\\s*${markup}.*\n${withOptionalIndentation(content)}\\s*${markup}`;
+    regexStr = `\\s*${markup}.*\n${withOptionalIndentation(contentRegex)}\\s*${markup}`;
   } else { // type === code_inline
-    regexStr = `${markup} ?${content} ?${markup}`;
+    regexStr = `${markup} ?${contentRegex} ?${markup}`;
   }
 
   return new RegExp(regexStr);


### PR DESCRIPTION
Fixes #12138 

### Changes
Escape code block content before matching it

----
UUID: d71d2c57-a73d-4591-b64d-e688584a9092 (Though this one probably shouldn't count towards my contribution count 😕)