### PR TITLE
Dont throw away extra paypal months

### DIFF
--- a/test/api/unit/libs/payments/stripe/calculateSubscriptionTerminationDate.test.js
+++ b/test/api/unit/libs/payments/stripe/calculateSubscriptionTerminationDate.test.js
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import { calculateSubscriptionTerminationDate } from '../../../../../../website/server/libs/payments/util';
+import calculateSubscriptionTerminationDate from '../../../../../../website/server/libs/payments/calculateSubscriptionTerminationDate';
 import api from '../../../../../../website/server/libs/payments/payments';
 
 describe('#calculateSubscriptionTerminationDate', () => {
@@ -13,6 +13,7 @@ describe('#calculateSubscriptionTerminationDate', () => {
     };
     nextBill = moment();
   });
+
   it('should extend date to the exact amount of days left before the next bill will occur', () => {
     nextBill = moment()
       .add(5, 'days');
@@ -22,6 +23,7 @@ describe('#calculateSubscriptionTerminationDate', () => {
     const terminationDate = calculateSubscriptionTerminationDate(nextBill, plan, api.constants);
     expect(expectedTerminationDate.diff(terminationDate, 'days')).to.eql(0);
   });
+
   it('if nextBill is null, add 30 days to termination date', () => {
     nextBill = null;
     const expectedTerminationDate = moment()
@@ -30,6 +32,7 @@ describe('#calculateSubscriptionTerminationDate', () => {
 
     expect(expectedTerminationDate.diff(terminationDate, 'days')).to.eql(0);
   });
+
   it('if nextBill is null and it\'s a group plan, add 2 days instead of 30', () => {
     nextBill = null;
     plan.customerId = api.constants.GROUP_PLAN_CUSTOMER_ID;
@@ -39,6 +42,7 @@ describe('#calculateSubscriptionTerminationDate', () => {
     const terminationDate = calculateSubscriptionTerminationDate(nextBill, plan, api.constants);
     expect(expectedTerminationDate.diff(terminationDate, 'days')).to.eql(0);
   });
+
   it('should add 30.5 days for each extraMonth', () => {
     plan.extraMonths = 4;
     const expectedTerminationDate = moment()
@@ -47,6 +51,7 @@ describe('#calculateSubscriptionTerminationDate', () => {
     const terminationDate = calculateSubscriptionTerminationDate(nextBill, plan, api.constants);
     expect(expectedTerminationDate.diff(terminationDate, 'days')).to.eql(0);
   });
+
   it('should round up if total days gained by extraMonth is a decimal number', () => {
     plan.extraMonths = 5;
     const expectedTerminationDate = moment()
@@ -55,6 +60,7 @@ describe('#calculateSubscriptionTerminationDate', () => {
     const terminationDate = calculateSubscriptionTerminationDate(nextBill, plan, api.constants);
     expect(expectedTerminationDate.diff(terminationDate, 'days')).to.eql(0);
   });
+
   it('behaves like extraMonths is 0 if it\'s set to a negative number', () => {
     plan.extraMonths = -5;
     const expectedTerminationDate = moment();

--- a/test/api/unit/libs/payments/stripe/calculateSubscriptionTerminationDate.test.js
+++ b/test/api/unit/libs/payments/stripe/calculateSubscriptionTerminationDate.test.js
@@ -2,6 +2,8 @@ import moment from 'moment';
 import calculateSubscriptionTerminationDate from '../../../../../../website/server/libs/payments/calculateSubscriptionTerminationDate';
 import api from '../../../../../../website/server/libs/payments/payments';
 
+const groupPlanId = api.constants.GROUP_PLAN_CUSTOMER_ID;
+
 describe('#calculateSubscriptionTerminationDate', () => {
   let plan;
   let nextBill;
@@ -20,7 +22,7 @@ describe('#calculateSubscriptionTerminationDate', () => {
     const expectedTerminationDate = moment()
       .add(5, 'days');
 
-    const terminationDate = calculateSubscriptionTerminationDate(nextBill, plan, api.constants);
+    const terminationDate = calculateSubscriptionTerminationDate(nextBill, plan, groupPlanId);
     expect(expectedTerminationDate.diff(terminationDate, 'days')).to.eql(0);
   });
 
@@ -28,7 +30,7 @@ describe('#calculateSubscriptionTerminationDate', () => {
     nextBill = null;
     const expectedTerminationDate = moment()
       .add(30, 'days');
-    const terminationDate = calculateSubscriptionTerminationDate(nextBill, plan, api.constants);
+    const terminationDate = calculateSubscriptionTerminationDate(nextBill, plan, groupPlanId);
 
     expect(expectedTerminationDate.diff(terminationDate, 'days')).to.eql(0);
   });
@@ -39,7 +41,7 @@ describe('#calculateSubscriptionTerminationDate', () => {
     const expectedTerminationDate = moment()
       .add(2, 'days');
 
-    const terminationDate = calculateSubscriptionTerminationDate(nextBill, plan, api.constants);
+    const terminationDate = calculateSubscriptionTerminationDate(nextBill, plan, groupPlanId);
     expect(expectedTerminationDate.diff(terminationDate, 'days')).to.eql(0);
   });
 
@@ -48,7 +50,7 @@ describe('#calculateSubscriptionTerminationDate', () => {
     const expectedTerminationDate = moment()
       .add(30.5 * 4, 'days');
 
-    const terminationDate = calculateSubscriptionTerminationDate(nextBill, plan, api.constants);
+    const terminationDate = calculateSubscriptionTerminationDate(nextBill, plan, groupPlanId);
     expect(expectedTerminationDate.diff(terminationDate, 'days')).to.eql(0);
   });
 
@@ -57,14 +59,23 @@ describe('#calculateSubscriptionTerminationDate', () => {
     const expectedTerminationDate = moment()
       .add(Math.ceil(30.5 * 5), 'days');
 
-    const terminationDate = calculateSubscriptionTerminationDate(nextBill, plan, api.constants);
+    const terminationDate = calculateSubscriptionTerminationDate(nextBill, plan, groupPlanId);
     expect(expectedTerminationDate.diff(terminationDate, 'days')).to.eql(0);
   });
 
   it('behaves like extraMonths is 0 if it\'s set to a negative number', () => {
     plan.extraMonths = -5;
     const expectedTerminationDate = moment();
-    const terminationDate = calculateSubscriptionTerminationDate(nextBill, plan, api.constants);
+    const terminationDate = calculateSubscriptionTerminationDate(nextBill, plan, groupPlanId);
     expect(expectedTerminationDate.diff(terminationDate, 'days')).to.eql(0);
+  });
+
+  it('returns current terminated date if it exists and is later than newly calculated date', () => {
+    const expectedTerminationDate = moment().add({ months: 5 }).toDate();
+    plan.terminationDate = expectedTerminationDate;
+
+    const terminationDate = calculateSubscriptionTerminationDate(nextBill, plan, groupPlanId);
+
+    expect(terminationDate).to.equal(expectedTerminationDate);
   });
 });

--- a/test/api/v3/integration/groups/POST-groups_groupId_leave.test.js
+++ b/test/api/v3/integration/groups/POST-groups_groupId_leave.test.js
@@ -13,7 +13,7 @@ import {
 } from '../../../../helpers/api-integration/v3';
 import { model as User } from '../../../../../website/server/models/user';
 import payments from '../../../../../website/server/libs/payments/payments';
-import { calculateSubscriptionTerminationDate } from '../../../../../website/server/libs/payments/util';
+import calculateSubscriptionTerminationDate from '../../../../../website/server/libs/payments/calculateSubscriptionTerminationDate';
 
 describe('POST /groups/:groupId/leave', () => {
   const typesOfGroups = {
@@ -359,6 +359,7 @@ describe('POST /groups/:groupId/leave', () => {
           'purchased.plan.extraMonths': extraMonths,
         });
       });
+
       it('calculates dateTerminated and sets extraMonths to zero after user leaves the group', async () => {
         const userBeforeLeave = await User.findById(member._id).exec();
 

--- a/test/api/v3/integration/groups/POST-groups_groupId_leave.test.js
+++ b/test/api/v3/integration/groups/POST-groups_groupId_leave.test.js
@@ -1,7 +1,5 @@
 import { v4 as generateUUID } from 'uuid';
-import {
-  each,
-} from 'lodash';
+import each from 'lodash/each';
 import moment from 'moment';
 import {
   generateChallenge,
@@ -374,7 +372,7 @@ describe('POST /groups/:groupId/leave', () => {
         const expectedTerminationDate = calculateSubscriptionTerminationDate(null, {
           customerId: payments.constants.GROUP_PLAN_CUSTOMER_ID,
           extraMonths,
-        }, payments.constants);
+        }, payments.constants.GROUP_PLAN_CUSTOMER_ID);
 
         expect(extraMonthsBefore).to.gte(12);
         expect(extraMonthsAfter).to.equal(0);

--- a/website/server/libs/payments/calculateSubscriptionTerminationDate.js
+++ b/website/server/libs/payments/calculateSubscriptionTerminationDate.js
@@ -7,14 +7,13 @@ const DEFAULT_REMAINING_DAYS_FOR_GROUP_PLAN = 2;
  * paymentsApiConstants is provided as parameter because of a dependency cycle
  * with subscriptions api which will occur if api.constants would be used directly
  */
-export function calculateSubscriptionTerminationDate (
+export default function calculateSubscriptionTerminationDate (
   nextBill, purchasedPlan, paymentsApiConstants,
 ) {
   const defaultRemainingDays = (
     purchasedPlan.customerId === paymentsApiConstants.GROUP_PLAN_CUSTOMER_ID
   ) ? DEFAULT_REMAINING_DAYS_FOR_GROUP_PLAN
     : DEFAULT_REMAINING_DAYS;
-  const now = moment();
 
   const remaining = nextBill
     ? moment(nextBill).diff(new Date(), 'days', true)
@@ -22,10 +21,8 @@ export function calculateSubscriptionTerminationDate (
 
   const extraMonths = Math.max(purchasedPlan.extraMonths, 0);
   const extraDays = Math.ceil(30.5 * extraMonths);
-  const nowStr = `${now.format('MM')}/${now.format('DD')}/${now.format('YYYY')}`;
-  const nowStrFormat = 'MM/DD/YYYY';
 
-  return moment(nowStr, nowStrFormat)
+  return moment().startOf('day')
     .add({ days: remaining })
     .add({ days: extraDays })
     .toDate();

--- a/website/server/libs/payments/calculateSubscriptionTerminationDate.js
+++ b/website/server/libs/payments/calculateSubscriptionTerminationDate.js
@@ -3,17 +3,11 @@ import moment from 'moment';
 const DEFAULT_REMAINING_DAYS = 30;
 const DEFAULT_REMAINING_DAYS_FOR_GROUP_PLAN = 2;
 
-/**
- * paymentsApiConstants is provided as parameter because of a dependency cycle
- * with subscriptions api which will occur if api.constants would be used directly
- */
 export default function calculateSubscriptionTerminationDate (
-  nextBill, purchasedPlan, paymentsApiConstants,
+  nextBill, purchasedPlan, groupPlanCustomerId,
 ) {
-  const defaultRemainingDays = (
-    purchasedPlan.customerId === paymentsApiConstants.GROUP_PLAN_CUSTOMER_ID
-  ) ? DEFAULT_REMAINING_DAYS_FOR_GROUP_PLAN
-    : DEFAULT_REMAINING_DAYS;
+  const defaultRemainingDays = purchasedPlan.customerId === groupPlanCustomerId
+    ? DEFAULT_REMAINING_DAYS_FOR_GROUP_PLAN : DEFAULT_REMAINING_DAYS;
 
   const remaining = nextBill
     ? moment(nextBill).diff(new Date(), 'days', true)
@@ -22,8 +16,8 @@ export default function calculateSubscriptionTerminationDate (
   const extraMonths = Math.max(purchasedPlan.extraMonths, 0);
   const extraDays = Math.ceil(30.5 * extraMonths);
 
-  return moment().startOf('day')
-    .add({ days: remaining })
-    .add({ days: extraDays })
-    .toDate();
+  const calculatedTerminationDate = moment().startOf('day').add({ days: remaining + extraDays });
+
+  return calculatedTerminationDate.isBefore(purchasedPlan.terminationDate)
+    ? purchasedPlan.terminationDate : calculatedTerminationDate.toDate();
 }

--- a/website/server/libs/payments/subscriptions.js
+++ b/website/server/libs/payments/subscriptions.js
@@ -314,7 +314,9 @@ async function cancelSubscription (data) {
     sendEmail = false; // because group-member-cancel email has already been sent
   }
 
-  plan.dateTerminated = calculateSubscriptionTerminationDate(data.nextBill, plan, this.constants);
+  plan.dateTerminated = calculateSubscriptionTerminationDate(
+    data.nextBill, plan, this.constants.GROUP_PLAN_CUSTOMER_ID,
+  );
 
   // clear extra time. If they subscribe again, it'll be recalculated from p.dateTerminated
   plan.extraMonths = 0;

--- a/website/server/libs/payments/subscriptions.js
+++ b/website/server/libs/payments/subscriptions.js
@@ -17,7 +17,7 @@ import {
 } from '../errors';
 import shared from '../../../common';
 import { sendNotification as sendPushNotification } from '../pushNotifications'; // eslint-disable-line import/no-cycle
-import { calculateSubscriptionTerminationDate } from './util';
+import calculateSubscriptionTerminationDate from './calculateSubscriptionTerminationDate';
 
 // @TODO: Abstract to shared/constant
 const JOINED_GROUP_PLAN = 'joined group plan';


### PR DESCRIPTION
Partially fixes #10605

### Changes
- Renamed `libs/payments/util.js` to `libs/payments/calculateSubscriptionTerminationDate.js` to be more in line with other util functions
- Changed `calculateSubscriptionTerminationDate` to return `max(newlyCalculatedDate, oldTerminationDate` to make it defensive against weird behaviour.
- Small touchups in the function

----
UUID: d71d2c57-a73d-4591-b64d-e688584a9092