### PR TITLE
Vue component unit test isolation

### DIFF
--- a/website/client/src/components/shops/quests/buyQuestModal.vue
+++ b/website/client/src/components/shops/quests/buyQuestModal.vue
@@ -28,8 +28,8 @@
       <div class="inner-content">
         <questDialogContent :item="item" />
         <div
-          class="purchase-amount"
           v-if="!item.locked"
+          class="purchase-amount"
         >
           <div class="how-many-to-buy">
             <strong>{{ $t('howManyToBuy') }}</strong>

--- a/website/client/src/components/static/home.vue
+++ b/website/client/src/components/static/home.vue
@@ -913,6 +913,7 @@ export default {
       if (username.length < 1) {
         return;
       }
+
       this.$store.dispatch('auth:verifyUsername', {
         username: this.username,
       }).then(res => {
@@ -960,7 +961,7 @@ export default {
       } else {
         try {
           await hello(network).logout();
-          } catch (e) {} // eslint-disable-line
+        } catch (e) {} // eslint-disable-line
 
         const redirectUrl = `${window.location.protocol}//${window.location.host}`;
         const auth = await hello(network).login({

--- a/website/client/src/components/static/home.vue
+++ b/website/client/src/components/static/home.vue
@@ -942,15 +942,7 @@ export default {
         groupInvite,
       });
 
-      let redirectTo;
-
-      if (this.$route.query.redirectTo) {
-        redirectTo = this.$route.query.redirectTo;
-      } else {
-        redirectTo = '/';
-      }
-
-      window.location.href = redirectTo;
+      window.location.href = this.$route.query.redirectTo || '/';
     },
     playButtonClick () {
       Analytics.track({

--- a/website/client/src/components/ui/pinBadge.vue
+++ b/website/client/src/components/ui/pinBadge.vue
@@ -5,7 +5,8 @@
   >
     <div
       class="svg-icon color"
-      v-html="icons.pin">
+      v-html="icons.pin"
+    >
     </div>
   </div>
 </template>

--- a/website/client/src/libs/store/helpers/public.js
+++ b/website/client/src/libs/store/helpers/public.js
@@ -60,7 +60,7 @@ export function mapActions (actions) {
   const res = {};
 
   normalizeMap(actions).forEach(({ key, val }) => {
-    res[key] = function mappedAction (...args) {
+    res[key] = async function mappedAction (...args) {
       return this.$store.dispatch.apply(this.$store, [val].concat(args)); // eslint-disable-line prefer-spread, max-len
     };
   });

--- a/website/client/src/libs/store/index.js
+++ b/website/client/src/libs/store/index.js
@@ -41,7 +41,7 @@ export default class Store {
 
   // Actions should be called using store.dispatch(ACTION_NAME, ...ARGS)
   // They get passed the store instance and any additional argument passed to dispatch()
-  dispatch (type, ...args) {
+  async dispatch (type, ...args) {
     const action = this._actions[type];
 
     if (!action) throw new Error(`Action "${type}" not found.`);

--- a/website/client/src/store/index.js
+++ b/website/client/src/store/index.js
@@ -18,7 +18,7 @@ const IS_TEST = process.env.NODE_ENV === 'test'; // eslint-disable-line no-proce
 let isUserLoggedIn = false;
 
 // eg, 240 - this will be converted on server as -(offset/60)
-const browserTimezoneOffset = -moment().utcOffset();
+const browserTimezoneOffset = moment().zone();
 
 axios.defaults.headers.common['x-client'] = 'habitica-web';
 

--- a/website/client/src/store/index.js
+++ b/website/client/src/store/index.js
@@ -18,7 +18,7 @@ const IS_TEST = process.env.NODE_ENV === 'test'; // eslint-disable-line no-proce
 let isUserLoggedIn = false;
 
 // eg, 240 - this will be converted on server as -(offset/60)
-const browserTimezoneOffset = moment().zone();
+const browserTimezoneOffset = -moment().utcOffset();
 
 axios.defaults.headers.common['x-client'] = 'habitica-web';
 

--- a/website/client/tests/unit/components/home.spec.js
+++ b/website/client/tests/unit/components/home.spec.js
@@ -8,40 +8,102 @@ import * as Analytics from '@/libs/analytics';
 const localVue = createLocalVue();
 localVue.use(Store);
 
-describe('Home', () => { // eslint-disable-line mocha/no-exclusive-tests
-  let actionLog;
+describe('Home', () => {
+  let registerStub;
+  let socialAuthStub;
+  let store;
   let wrapper;
 
-  beforeEach(() => {
-    sinon.stub(Analytics, 'track');
-    actionLog = {};
-
-    const actions = {};
-    ['auth:register', 'auth:socialAuth'].forEach(name => {
-      actions[name] = (_, params) => {
-        actionLog[name] = actionLog[name] || { count: 0, paramses: [] };
-        actionLog[name].count += 1;
-        actionLog[name].invocationParams.push(params);
-      };
-    });
-
-    wrapper = shallowMount(Home, {
-      store: new Store({
-        state: {},
-        getters: {},
-        actions,
-      }),
+  function mountWrapper (query) {
+    return shallowMount(Home, {
+      store,
       localVue,
       mocks: {
         $t: string => string,
-        ga: () => {},
+        $route: { query: query || {} },
       },
     });
+  }
+
+  function fillOutUserForm (username, email, password) {
+    wrapper.find('#usernameInput').setValue(username);
+    wrapper.find('input[type=email]').setValue(email);
+    wrapper.findAll('input[type=password]').setValue(password);
+  }
+
+  beforeEach(() => {
+    registerStub = sinon.stub();
+    socialAuthStub = sinon.stub();
+    store = new Store({
+      state: {},
+      getters: {},
+      actions: {
+        'auth:register': registerStub,
+        'auth:socialAuth': socialAuthStub,
+      },
+    });
+
+    sinon.stub(Analytics, 'track');
+
+    wrapper = mountWrapper();
   });
 
   afterEach(sinon.restore);
 
-  it('Title is visible', () => {
+  it('has a visible title', () => {
     expect(wrapper.find('h1').text()).to.equal('motivateYourself');
+  });
+
+  describe('signup form', () => {
+    it('registers a user from the form', async () => {
+      const username = 'newUser';
+      const email = 'rookie@habitica.com';
+      const password = 'ImmaG3tProductive!';
+      fillOutUserForm(username, email, password);
+
+      await wrapper.find('form').trigger('submit');
+
+      expect(registerStub.calledOnce).to.be.true;
+      expect(registerStub.getCall(0).args[1]).to.deep.equal({
+        username,
+        email,
+        password,
+        passwordConfirm: password,
+        groupInvite: '',
+      });
+    });
+
+    it('registers a user with group invite if groupInvite in the query', async () => {
+      const groupInvite = 'TheBestGroup';
+      wrapper = mountWrapper({ groupInvite });
+      fillOutUserForm('invitedUser', 'invited@habitica.com', '1veGotFri3ndsHooray!');
+
+      await wrapper.find('form').trigger('submit');
+
+      expect(registerStub.calledOnce).to.be.true;
+      expect(registerStub.getCall(0).args[1].groupInvite).to.equal(groupInvite);
+    });
+
+    it('registers a user with group invite if p in the query', async () => {
+      const p = 'ThePiGroup';
+      wrapper = mountWrapper({ p });
+      fillOutUserForm('alsoInvitedUser', 'invited2@habitica.com', '1veGotFri3nds2!');
+
+      await wrapper.find('form').trigger('submit');
+
+      expect(registerStub.calledOnce).to.be.true;
+      expect(registerStub.getCall(0).args[1].groupInvite).to.equal(p);
+    });
+
+    it('registers a user with group invite invite if both p and groupInvite are in the query', async () => {
+      const groupInvite = 'StillTheBestGroup';
+      wrapper = mountWrapper({ p: 'LesserGroup', groupInvite });
+      fillOutUserForm('doublyInvitedUser', 'invited3@habitica.com', '1veGotSm4rtFri3nds!');
+
+      await wrapper.find('form').trigger('submit');
+
+      expect(registerStub.calledOnce).to.be.true;
+      expect(registerStub.getCall(0).args[1].groupInvite).to.equal(groupInvite);
+    });
   });
 });

--- a/website/client/tests/unit/components/home.spec.js
+++ b/website/client/tests/unit/components/home.spec.js
@@ -1,5 +1,4 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
-import sinon from 'sinon';
 
 import Home from '@/components/static/home.vue';
 import Store from '@/libs/store';
@@ -25,10 +24,10 @@ describe('Home', () => {
     });
   }
 
-  function fillOutUserForm (username, email, password) {
-    wrapper.find('#usernameInput').setValue(username);
-    wrapper.find('input[type=email]').setValue(email);
-    wrapper.findAll('input[type=password]').setValue(password);
+  async function fillOutUserForm (username, email, password) {
+    await wrapper.find('#usernameInput').setValue(username);
+    await wrapper.find('input[type=email]').setValue(email);
+    await wrapper.findAll('input[type=password]').setValue(password);
   }
 
   beforeEach(() => {
@@ -59,7 +58,7 @@ describe('Home', () => {
       const username = 'newUser';
       const email = 'rookie@habitica.com';
       const password = 'ImmaG3tProductive!';
-      fillOutUserForm(username, email, password);
+      await fillOutUserForm(username, email, password);
 
       await wrapper.find('form').trigger('submit');
 
@@ -76,7 +75,7 @@ describe('Home', () => {
     it('registers a user with group invite if groupInvite in the query', async () => {
       const groupInvite = 'TheBestGroup';
       wrapper = mountWrapper({ groupInvite });
-      fillOutUserForm('invitedUser', 'invited@habitica.com', '1veGotFri3ndsHooray!');
+      await fillOutUserForm('invitedUser', 'invited@habitica.com', '1veGotFri3ndsHooray!');
 
       await wrapper.find('form').trigger('submit');
 
@@ -87,7 +86,7 @@ describe('Home', () => {
     it('registers a user with group invite if p in the query', async () => {
       const p = 'ThePiGroup';
       wrapper = mountWrapper({ p });
-      fillOutUserForm('alsoInvitedUser', 'invited2@habitica.com', '1veGotFri3nds2!');
+      await fillOutUserForm('alsoInvitedUser', 'invited2@habitica.com', '1veGotFri3nds2!');
 
       await wrapper.find('form').trigger('submit');
 
@@ -98,7 +97,7 @@ describe('Home', () => {
     it('registers a user with group invite invite if both p and groupInvite are in the query', async () => {
       const groupInvite = 'StillTheBestGroup';
       wrapper = mountWrapper({ p: 'LesserGroup', groupInvite });
-      fillOutUserForm('doublyInvitedUser', 'invited3@habitica.com', '1veGotSm4rtFri3nds!');
+      await fillOutUserForm('doublyInvitedUser', 'invited3@habitica.com', '1veGotSm4rtFri3nds!');
 
       await wrapper.find('form').trigger('submit');
 

--- a/website/client/tests/unit/components/home.spec.js
+++ b/website/client/tests/unit/components/home.spec.js
@@ -1,0 +1,47 @@
+import { shallowMount, createLocalVue } from '@vue/test-utils';
+import sinon from 'sinon';
+
+import Home from '@/components/static/home.vue';
+import Store from '@/libs/store';
+import * as Analytics from '@/libs/analytics';
+
+const localVue = createLocalVue();
+localVue.use(Store);
+
+describe('Home', () => { // eslint-disable-line mocha/no-exclusive-tests
+  let actionLog;
+  let wrapper;
+
+  beforeEach(() => {
+    sinon.stub(Analytics, 'track');
+    actionLog = {};
+
+    const actions = {};
+    ['auth:register', 'auth:socialAuth'].forEach(name => {
+      actions[name] = (_, params) => {
+        actionLog[name] = actionLog[name] || { count: 0, paramses: [] };
+        actionLog[name].count += 1;
+        actionLog[name].invocationParams.push(params);
+      };
+    });
+
+    wrapper = shallowMount(Home, {
+      store: new Store({
+        state: {},
+        getters: {},
+        actions,
+      }),
+      localVue,
+      mocks: {
+        $t: string => string,
+        ga: () => {},
+      },
+    });
+  });
+
+  afterEach(sinon.restore);
+
+  it('Title is visible', () => {
+    expect(wrapper.find('h1').text()).to.equal('motivateYourself');
+  });
+});

--- a/website/client/tests/unit/libs/store.spec.js
+++ b/website/client/tests/unit/libs/store.spec.js
@@ -84,8 +84,8 @@ describe('Store', () => {
       expect(await store.dispatch('nested:getName', 1, 2, 3)).to.deep.equal(['test', 1, 2, 3]);
     });
 
-    it('throws an error is the action doesn\'t exists', async () => {
-      expect(async () => store.dispatched('wrong')).to.throw;
+    it('throws an error if the action doesn\'t exists', () => {
+      expect(() => store.dispatched('wrong')).to.throw;
     });
   });
 

--- a/website/client/tests/unit/libs/store.spec.js
+++ b/website/client/tests/unit/libs/store.spec.js
@@ -76,16 +76,16 @@ describe('Store', () => {
   });
 
   describe('actions', () => {
-    it('can dispatch an action', () => {
-      expect(store.dispatch('getName', 1, 2, 3)).to.deep.equal(['test', 1, 2, 3]);
+    it('can dispatch an action', async () => {
+      expect(await store.dispatch('getName', 1, 2, 3)).to.deep.equal(['test', 1, 2, 3]);
     });
 
-    it('can dispatch a nested action', () => {
-      expect(store.dispatch('nested:getName', 1, 2, 3)).to.deep.equal(['test', 1, 2, 3]);
+    it('can dispatch a nested action', async () => {
+      expect(await store.dispatch('nested:getName', 1, 2, 3)).to.deep.equal(['test', 1, 2, 3]);
     });
 
-    it('throws an error is the action doesn\'t exists', () => {
-      expect(() => store.dispatched('wrong')).to.throw;
+    it('throws an error is the action doesn\'t exists', async () => {
+      expect(async () => store.dispatched('wrong')).to.throw;
     });
   });
 
@@ -140,9 +140,9 @@ describe('Store', () => {
         data: {
           title: 'internal',
         },
-        created () {
-          expect(this.getName('123')).to.deep.equal(['test', '123']);
-          expect(this.getNameRenamed('123')).to.deep.equal(['test', '123']);
+        async created () {
+          expect(await this.getName('123')).to.deep.equal(['test', '123']);
+          expect(await this.getNameRenamed('123')).to.deep.equal(['test', '123']);
           done();
         },
         methods: {

--- a/website/client/tests/unit/mixins/groupsUtilities.spec.js
+++ b/website/client/tests/unit/mixins/groupsUtilities.spec.js
@@ -2,10 +2,13 @@ import Vue from 'vue';
 import groupsUtilities from '@/mixins/groupsUtilities';
 import { TAVERN_ID } from '@/../../common/script/constants';
 import generateStore from '@/store';
+import Store from '@/libs/store';
+
+Vue.use(Store);
 
 describe('Groups Utilities Mixin', () => {
-  let instance; let
-    user;
+  let instance;
+  let user;
 
   before(() => {
     instance = new Vue({

--- a/website/client/tests/unit/mixins/groupsUtilities.spec.js
+++ b/website/client/tests/unit/mixins/groupsUtilities.spec.js
@@ -1,17 +1,18 @@
-import Vue from 'vue';
+import { createLocalVue } from '@vue/test-utils';
 import groupsUtilities from '@/mixins/groupsUtilities';
 import { TAVERN_ID } from '@/../../common/script/constants';
 import generateStore from '@/store';
 import Store from '@/libs/store';
 
-Vue.use(Store);
+const LocalVue = createLocalVue();
+LocalVue.use(Store);
 
 describe('Groups Utilities Mixin', () => {
   let instance;
   let user;
 
   before(() => {
-    instance = new Vue({
+    instance = new LocalVue({
       store: generateStore(),
       mixins: [groupsUtilities],
     });

--- a/website/server/libs/email.js
+++ b/website/server/libs/email.js
@@ -69,13 +69,13 @@ export function getGroupUrl (group) {
 export async function sendTxn (mailingInfoArray, emailType, variables, personalVariables) {
   mailingInfoArray = Array.isArray(mailingInfoArray) ? mailingInfoArray : [mailingInfoArray]; // eslint-disable-line no-param-reassign, max-len
 
-  variables = [ // eslint-disable-line no-param-reassign, max-len
+  variables = [ // eslint-disable-line no-param-reassign
     { name: 'BASE_URL', content: BASE_URL },
   ].concat(variables || []);
 
   // It's important to pass at least a user with its `preferences`
   // as we need to check if he unsubscribed
-  mailingInfoArray = mailingInfoArray // eslint-disable-line no-param-reassign, max-len
+  mailingInfoArray = mailingInfoArray // eslint-disable-line no-param-reassign
     .map(mailingInfo => (mailingInfo._id ? getUserInfo(mailingInfo, ['_id', 'email', 'name', 'canSend']) : mailingInfo))
     // Always send reset-password emails
     // Don't check canSend for non registered users as already checked before

--- a/website/server/libs/invites/index.js
+++ b/website/server/libs/invites/index.js
@@ -166,9 +166,7 @@ async function inviteByEmail (invite, group, inviter, req, res) {
   } else {
     userReturnInfo = invite.email;
 
-    let cancelledPlan = false;
-    if (group.hasActiveGroupPlan() && !group.hasNotCancelled()) cancelledPlan = true;
-
+    const cancelledPlan = group.hasActiveGroupPlan() && !group.hasNotCancelled();
     const groupQueryString = JSON.stringify({
       id: group._id,
       inviter: inviter._id,


### PR DESCRIPTION
Fixes unit test isolation for Vue.js component unit tests

While working on a solution for #10786 I started to write a unit test for the `home.vue` component. That went fairly smoothly but after I had added it I noticed that stray events from the home.vue localVue I created ended up failing random other tests. Clearly test isolation was failing. I still haven't figured out exactly why. My standing theory is that the await on the `setValue(value)` somehow doesn't completely wait on the events that are being fired by dispatch because it's not marked as an asynchronous function itself. I think this lack of a-synchronicity somehow breaks the Promise chain. In any case adding the async keyword to the dispatch function seems to fix the test isolation issues.

I'm also tracking down the different stacktraces that are being thrown by Vue.js component unit tests, because they unnecessarily confuse investigations into what is happening. Shall I add those to this merge request or shall I create a new merge request for that?

### Changes
Most significant change is the addition of the `async` keyword to the `dispatch` function in `/src/libs/store/index.js`

Beyond that:
- Added unit test for `home.vue` component
- Small cleanup in `home.vue`
- Replaced use of `zone` by `utcOffset` in `/src/store/index.js`
- Couple other touchups.

----
UUID: d71d2c57-a73d-4591-b64d-e688584a9092
