### PR TITLE
Fix Issue #12103: Wacky potions purchase warning

### DIFF
--- a/website/client/src/components/shops/buyModal.vue
+++ b/website/client/src/components/shops/buyModal.vue
@@ -377,6 +377,7 @@
 
 <script>
 import keys from 'lodash/keys';
+import size from 'lodash/size';
 import reduce from 'lodash/reduce';
 import moment from 'moment';
 
@@ -407,8 +408,12 @@ import Avatar from '@/components/avatar';
 
 import seasonalShopConfig from '@/../../common/script/libs/shops-seasonal.config';
 import { drops as dropEggs } from '@/../../common/script/content/eggs';
+import { drops as dropPotions } from '@/../../common/script/content/hatching-potions';
 
 const dropEggKeys = keys(dropEggs);
+
+const amountOfDropEggs = size(dropEggs);
+const amountOfDropPotions = size(dropPotions);
 
 const hideAmountSelectionForPurchaseTypes = [
   'gear', 'backgrounds', 'mystery_set', 'card',
@@ -537,12 +542,13 @@ export default {
         if (this.item.pinType === 'premiumHatchingPotion') { // buying potions
           if (this.item.path.includes('wackyHatchingPotions.')) {
             // wacky potions don't have mounts
-            totalPetsToHatch = 9;
+            totalPetsToHatch = amountOfDropEggs;
           } else {
-            totalPetsToHatch = 18; // Each of the 9 eggs, combine into pet twice
+            // Each of the drop eggs, combine into pet twice
+            totalPetsToHatch = amountOfDropEggs * 2;
           }
-        } else { // buying quest eggs: Each of the 10 potions, combine into pet twice
-          totalPetsToHatch = 20;
+        } else { // buying quest eggs: Each of the drop potions, combine into pet twice
+          totalPetsToHatch = amountOfDropPotions * 2;
         }
 
         /* Amount of items the user already has */

--- a/website/client/src/components/shops/buyModal.vue
+++ b/website/client/src/components/shops/buyModal.vue
@@ -542,6 +542,9 @@ export default {
         }, 0);
         if (this.item.pinType === 'premiumHatchingPotion') {
           petsRemaining -= this.user.items.hatchingPotions[this.item.key] + 2 || 2;
+          if (this.item.path.indexOf('wackyHatchingPotions.') !== -1) {
+            petsRemaining -= 9;
+          }
         } else {
           petsRemaining -= this.user.items.eggs[this.item.key] || 0;
         }

--- a/website/client/src/components/shops/buyModal.vue
+++ b/website/client/src/components/shops/buyModal.vue
@@ -529,7 +529,7 @@ export default {
 
       if (
         this.item.pinType === 'premiumHatchingPotion'
-        || (this.item.pinType === 'eggs' && dropEggKeys.indexOf(this.item.key) === -1)
+        || (this.item.pinType === 'eggs' && !dropEggKeys.includes(this.item.key))
       ) {
         /* Total amount of pets to hatch with item bought */
         let totalPetsToHatch;
@@ -554,12 +554,12 @@ export default {
         }
 
         const ownedPets = reduce(this.user.items.pets, (sum, petValue, petKey) => {
-          if (petKey.indexOf(this.item.key) !== -1 && petValue > 0) return sum + 1;
+          if (petKey.includes(this.item.key) && petValue > 0) return sum + 1;
           return sum;
         }, 0);
 
         const ownedMounts = reduce(this.user.items.mounts, (sum, mountValue, mountKey) => {
-          if (mountKey.indexOf(this.item.key) !== -1 && mountValue === true) return sum + 1;
+          if (mountKey.includes(this.item.key) && mountValue === true) return sum + 1;
           return sum;
         }, 0);
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #12103

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
For wacky potions lower petsRemaining by 9,
to exclude the mounts that don't exist.

### Tests
- [x] manual
- [x] npm test 

Verified that it shows the warning when the total would exceed 9, for Confection Potion.
Verified that it only shows the warning when the total would exceed 18 for Premium potion like Silver.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)
----
UUID: c4d64716-9f93-4356-a436-0df52dbf44d5
