### PR TITLE
#11828: Show a boss damage notification for skills

### DIFF
--- a/website/client/src/components/tasks/spells.vue
+++ b/website/client/src/components/tasks/spells.vue
@@ -300,7 +300,7 @@ export default {
       const { user } = this;
       if (!user.party.quest) return 0;
 
-      const userQuest = this.quests[user.party.quest.key];
+      const userQuest = this.quests.quests[user.party.quest.key];
 
       if (!userQuest) {
         return 0;

--- a/website/client/src/mixins/spells.js
+++ b/website/client/src/mixins/spells.js
@@ -77,8 +77,7 @@ export default {
     },
     async castEnd (target, type) {
       if (!this.$store.state.spellOptions.castingSpell) return null;
-      let beforeQuestProgress;
-      if (this.spell.target === 'task') beforeQuestProgress = this.questProgress();
+      const beforeQuestProgress = this.questProgress();
 
       if (!this.applyingAction) return 'No applying action';
 
@@ -153,7 +152,7 @@ export default {
 
 
       this.markdown(msg); // @TODO: mardown directive?
-      if (beforeQuestProgress === undefined) return null;
+
       const questProgress = this.questProgress() - beforeQuestProgress;
       if (questProgress > 0) {
         const userQuest = this.quests.quests[this.user.party.quest.key];

--- a/website/client/src/mixins/spells.js
+++ b/website/client/src/mixins/spells.js
@@ -78,7 +78,7 @@ export default {
     async castEnd (target, type) {
       if (!this.$store.state.spellOptions.castingSpell) return null;
       let beforeQuestProgress;
-      if (this.spell.target === 'party') beforeQuestProgress = this.questProgress();
+      if (this.spell.target === 'task') beforeQuestProgress = this.questProgress();
 
       if (!this.applyingAction) return 'No applying action';
 
@@ -153,10 +153,10 @@ export default {
 
 
       this.markdown(msg); // @TODO: mardown directive?
-      if (!beforeQuestProgress) return null;
+      if (beforeQuestProgress === undefined) return null;
       const questProgress = this.questProgress() - beforeQuestProgress;
       if (questProgress > 0) {
-        const userQuest = this.quests[this.user.party.quest.key];
+        const userQuest = this.quests.quests[this.user.party.quest.key];
         if (userQuest.boss) {
           this.quest('questDamage', questProgress.toFixed(1));
         } else if (userQuest.collection && userQuest.collect) {


### PR DESCRIPTION
Brutal Smash and Burst of Flames skills should show a boss damage notification

[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11828

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Check for damage done was done for spells targeting party instead of spells targeting tasks.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: c4d64716-9f93-4356-a436-0df52dbf44d5
