### PR TITLE
FIX: scroll/loading guilds

### DIFF
--- a/website/client/src/components/groups/discovery.vue
+++ b/website/client/src/components/groups/discovery.vue
@@ -55,7 +55,6 @@ b-dropdown(:text="$t('sort')", right=true)
             :handler="triggerFetchGuilds"
             :should-handle="!loading && !hasLoadedAllGuilds"
             :handle-on-mount="true"
-            :threshold="20"
           >
             <span v-once>{{ $t('loading') }}</span>
           </mugen-scroll>

--- a/website/client/src/components/groups/discovery.vue
+++ b/website/client/src/components/groups/discovery.vue
@@ -52,9 +52,10 @@ b-dropdown(:text="$t('sort')", right=true)
           />
           <mugen-scroll
             v-show="loading"
-            :handler="fetchGuilds"
+            :handler="triggerFetchGuilds"
             :should-handle="!loading && !hasLoadedAllGuilds"
             :handle-on-mount="true"
+            :threshold="20"
           >
             <span v-once>{{ $t('loading') }}</span>
           </mugen-scroll>
@@ -90,6 +91,7 @@ b-dropdown(:text="$t('sort')", right=true)
 
 <script>
 import MugenScroll from 'vue-mugen-scroll';
+import debounce from 'lodash/debounce';
 import PublicGuildItem from './publicGuildItem';
 import Sidebar from './sidebar';
 import groupUtilities from '@/mixins/groupsUtilities';
@@ -217,13 +219,19 @@ export default {
       _mapCategories(guilds);
       this.guilds = guilds;
     },
+    triggerFetchGuilds () {
+      this.loading = true;
+      this.debounceFetchGuilds();
+    },
+    debounceFetchGuilds: debounce(function debounceFetchGuilds () {
+      this.fetchGuilds();
+    }, 1000),
     async fetchGuilds () {
       // We have the data cached
       if (this.lastPageLoaded === 0 && this.guilds.length > 0) {
         this.lastPageLoaded += 1;
       }
 
-      this.loading = true;
       this.queryFilters.page = this.lastPageLoaded;
       const guilds = await this.$store.dispatch('guilds:getPublicGuilds', this.queryFilters);
       if (guilds.length === 0) this.hasLoadedAllGuilds = true;


### PR DESCRIPTION
Using the same debounce time as challenges of 1s that way it won't trigger to load on every single pixel-scroll