### PR TITLE
Make contributor achievement notification "sticky"

### DIFF
--- a/website/client/src/components/notifications.vue
+++ b/website/client/src/components/notifications.vue
@@ -170,6 +170,7 @@ const NOTIFICATIONS = {
     achievement: true,
     label: $t => $t('modalContribAchievement'),
     modalId: 'contributor',
+    sticky: true,
   },
   ACHIEVEMENT_ALL_YOUR_BASE: {
     achievement: true,
@@ -552,7 +553,7 @@ export default {
         this.text(config.label(this.$t), () => {
           this.notificationData = data;
           this.$root.$emit('bv::show::modal', config.modalId);
-        }, true, 10000);
+        }, !config.sticky, 10000);
       }
     },
     debounceCheckUserAchievements: debounce(function debounceCheck () {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #12122

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Add ability to define any notification to be "sticky", so that it will not timeout and stays on screen until clicked.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: fa756acf-9127-4a3c-8dac-8ff627d30073
