### PR TITLE
Bolding text inside a link in task title/notes. (#12178)

### DIFF
--- a/website/client/src/components/tasks/task.vue
+++ b/website/client/src/components/tasks/task.vue
@@ -976,10 +976,16 @@ export default {
     edit (e, task) {
       if (this.isRunningYesterdailies || !this.showEdit) return;
 
-      // Prevent clicking on a link from opening the edit modal
       const target = e.target || e.srcElement;
 
-      for (let element = target; element.className === undefined || element.className.indexOf('task-clickable-area') === -1; element = element.parentNode) {
+      /*
+       * Prevent clicking on a link from opening the edit modal
+       *
+       * Ascend up the ancestors of the click target, up until the node defining the click handler.
+       * If any of them is an <a> element, don't open the edit task popup.
+       * Needed in case of a link, with a bold and/or italic link description
+       */
+      for (let element = target; !element.classList.contains('task-clickable-area'); element = element.parentNode) {
         if (element.tagName === 'A') return; // clicked on a link
       }
 

--- a/website/client/src/components/tasks/task.vue
+++ b/website/client/src/components/tasks/task.vue
@@ -979,7 +979,9 @@ export default {
       // Prevent clicking on a link from opening the edit modal
       const target = e.target || e.srcElement;
 
-      if (target.tagName === 'A') return; // clicked on a link
+      for (let element = target; element.className === undefined || element.className.indexOf('task-clickable-area') === -1; element = element.parentNode) {
+        if (element.tagName === 'A') return; // clicked on a link
+      }
 
       const isDropdown = this.$refs.taskDropdown && this.$refs.taskDropdown.$el.contains(target);
       const isEditAction = this.$refs.editTaskItem && this.$refs.editTaskItem.contains(target);


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

Fixes #12178

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Ascend up the ancestors of the click target, up until the node defining the click handler.
If any of them is an `<a>` element, don't open the edit task popup.

When clicking on a link, with a bold and/or italic link description: 
Before:
* link target opened in new tab
* task edit popup opened

Now:
* only link target opened in new tab

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: c4d64716-9f93-4356-a436-0df52dbf44d5
