### PR TITLE
Display descriptive error when mongod isn't running

### DIFF
--- a/gulp/gulp-tests.js
+++ b/gulp/gulp-tests.js
@@ -160,7 +160,7 @@ gulp.task('test:content:safe', gulp.series('test:prepare:build', cb => {
   pipe(runner);
 }));
 
-gulp.task('test:api:unit', done => {
+gulp.task('test:api:unit:run', done => {
   const runner = exec(
     testBin('istanbul cover --dir coverage/api-unit node_modules/mocha/bin/_mocha -- test/api/unit --recursive --require ./test/helpers/start-server'),
     err => {
@@ -174,7 +174,7 @@ gulp.task('test:api:unit', done => {
   pipe(runner);
 });
 
-gulp.task('test:api:unit:watch', () => gulp.watch(['website/server/libs/*', 'test/api/unit/**/*', 'website/server/controllers/**/*'], gulp.series('test:api:unit', done => done())));
+gulp.task('test:api:unit:watch', () => gulp.watch(['website/server/libs/*', 'test/api/unit/**/*', 'website/server/controllers/**/*'], gulp.series('test:api:unit:run', done => done())));
 
 gulp.task('test:api-v3:integration', done => {
   const runner = exec(
@@ -235,14 +235,22 @@ gulp.task('test', gulp.series(
   'test:sanity',
   'test:content',
   'test:common',
-  'test:api:unit',
+  'test:prepare:mongo',
+  'test:api:unit:run',
   'test:api-v3:integration',
   'test:api-v4:integration',
   done => done(),
 ));
 
 gulp.task('test:api-v3', gulp.series(
-  'test:api:unit',
+  'test:prepare:mongo',
+  'test:api:unit:run',
   'test:api-v3:integration',
+  done => done(),
+));
+
+gulp.task('test:api:unit', gulp.series(
+  'test:prepare:mongo',
+  'test:api:unit:run',
   done => done(),
 ));


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes: #12101

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Add test:prepare:mongo task to check is mongod is running.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: c4d64716-9f93-4356-a436-0df52dbf44d5
