### PR TITLE
buyMysterySet records every item in Amplitude.

### DIFF
--- a/test/common/ops/buy/buyMysterySet.js
+++ b/test/common/ops/buy/buyMysterySet.js
@@ -88,7 +88,14 @@ describe('shared.ops.buyMysterySet', () => {
         expect(user.items.gear.owned).to.have.property('armor_mystery_301404', true);
         expect(user.items.gear.owned).to.have.property('head_mystery_301404', true);
         expect(user.items.gear.owned).to.have.property('eyewear_mystery_301404', true);
-        expect(analytics.track).to.be.called;
+        expect(analytics.track).to.be.calledOnce;
+        expect(analytics.track).to.be.calledWithMatch('acquire item', {
+          uuid: user._id,
+          itemKey: '301404',
+          itemType: 'Subscriber Gear',
+          acquireMethod: 'Hourglass',
+          category: 'behavior',
+        });
       });
     });
   });

--- a/website/common/script/ops/buy/buyMysterySet.js
+++ b/website/common/script/ops/buy/buyMysterySet.js
@@ -26,17 +26,18 @@ export default function buyMysterySet (user, req = {}, analytics) {
 
   each(mysterySet.items, item => {
     user.items.gear.owned[item.key] = true;
-    if (analytics) {
-      analytics.track('acquire item', {
-        uuid: user._id,
-        itemKey: item.key,
-        itemType: 'Subscriber Gear',
-        acquireMethod: 'Hourglass',
-        category: 'behavior',
-        headers: req.headers,
-      });
-    }
   });
+
+  if (analytics) {
+    analytics.track('acquire item', {
+      uuid: user._id,
+      itemKey: mysterySet.key,
+      itemType: 'Subscriber Gear',
+      acquireMethod: 'Hourglass',
+      category: 'behavior',
+      headers: req.headers,
+    });
+  }
 
   // Here we need to trigger vue reactivity through reassign object
   user.items.gear.owned = {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes: #11705

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Track only the mysterySet in Amplitude, instead of each Mystery Set item

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: c4d64716-9f93-4356-a436-0df52dbf44d5
