### PR TITLE
Add close button to profile modal

### DIFF
--- a/website/client/src/components/userMenu/profile.vue
+++ b/website/client/src/components/userMenu/profile.vue
@@ -4,6 +4,11 @@
     class="profile"
   >
     <div class="header">
+      <span
+        class="close-icon svg-icon inline icon-10"
+        @click="close()"
+        v-html="icons.close"
+      ></span>
       <div class="profile-actions">
         <router-link
           :to="{ path: '/private-messages', query: { uuid: user._id } }"
@@ -718,6 +723,7 @@ import lock from '@/assets/svg/lock.svg';
 import challenge from '@/assets/svg/challenge.svg';
 import member from '@/assets/svg/member-icon.svg';
 import staff from '@/assets/svg/tier-staff.svg';
+import svgClose from '@/assets/svg/close.svg';
 // @TODO: EMAILS.COMMUNITY_MANAGER_EMAIL
 const COMMUNITY_MANAGER_EMAIL = 'admin@habitica.com';
 
@@ -743,6 +749,7 @@ export default {
         lock,
         member,
         staff,
+        close: svgClose,
       }),
       adminToolsLoaded: false,
       userIdToMessage: '',
@@ -987,6 +994,9 @@ export default {
     toggleAchievementsCategory (categoryKey) {
       const status = this.achievementsCategories[categoryKey].open;
       this.achievementsCategories[categoryKey].open = !status;
+    },
+    close () {
+      this.$root.$emit('bv::hide::modal', 'profile');
     },
   },
 };


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #12182

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Add same close button to profile modal that is used in e.g.  User Profile > Backgrounds (avatar modal).

![Screenshot from 2020-05-13 23-41-43](https://user-images.githubusercontent.com/1764167/81863146-66ff3380-9573-11ea-844d-872283a42857.png)



[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: fa756acf-9127-4a3c-8dac-8ff627d30073
