### PR TITLE
Store original quantities, to avoid reordering in Inventory Items screen

### DIFF
--- a/website/client/src/components/inventory/items/index.vue
+++ b/website/client/src/components/inventory/items/index.vue
@@ -466,18 +466,11 @@ export default {
         });
 
         if (this.sortBy === 'quantity') {
-          const quantitySnapshot = this.quantitySnapshot[groupKey];
-          if (quantitySnapshot) {
-            itemsArray.sort((a, b) => quantitySnapshot[b.key] - quantitySnapshot[a.key]);
-          } else {
-            itemsArray.sort((a, b) => b.quantity - a.quantity);
-          }
-
-          if (quantitySnapshot === null) {
-            this.quantitySnapshot[groupKey] = Object.fromEntries(
-              itemsArray.map(item => [item.key, item.quantity]),
-            );
-          }
+          const quantitySnapshot = this.quantitySnapshot[groupKey] || Object.fromEntries(
+            itemsArray.map(item => [item.key, item.quantity]),
+          );
+          itemsArray.sort((a, b) => quantitySnapshot[b.key] - quantitySnapshot[a.key]);
+          this.quantitySnapshot[groupKey] = quantitySnapshot;
         } else {
           itemsArray.sort((a, b) => a.text.localeCompare(b.text));
         }

--- a/website/client/src/components/inventory/items/index.vue
+++ b/website/client/src/components/inventory/items/index.vue
@@ -466,6 +466,7 @@ export default {
         });
 
         if (this.sortBy === 'quantity') {
+          // Store original quantities, to avoid reordering when using items.
           const quantitySnapshot = this.quantitySnapshot[groupKey] || Object.fromEntries(
             itemsArray.map(item => [item.key, item.quantity]),
           );

--- a/website/client/src/components/inventory/items/index.vue
+++ b/website/client/src/components/inventory/items/index.vue
@@ -419,6 +419,11 @@ export default {
         cardType: '',
         messageOptions: 0,
       },
+      quantitySnapshot: {
+        eggs: null,
+        hatchingPotions: null,
+        food: null,
+      },
     };
   },
   computed: {
@@ -443,7 +448,9 @@ export default {
           if (itemQuantity > 0 && isAllowed) {
             const item = contentItems[itemKey];
 
-            const isSearched = !searchText || item.text().toLowerCase().indexOf(searchText) !== -1;
+            const isSearched = !searchText || item.text()
+              .toLowerCase()
+              .indexOf(searchText) !== -1;
             if (isSearched) {
               itemsArray.push({
                 ...item,
@@ -458,12 +465,22 @@ export default {
           }
         });
 
-        itemsArray.sort((a, b) => {
-          if (this.sortBy === 'quantity') {
-            return b.quantity - a.quantity;
-          } // AZ
-          return a.text.localeCompare(b.text);
-        });
+        if (this.sortBy === 'quantity') {
+          const quantitySnapshot = this.quantitySnapshot[groupKey];
+          if (quantitySnapshot) {
+            itemsArray.sort((a, b) => quantitySnapshot[b.key] - quantitySnapshot[a.key]);
+          } else {
+            itemsArray.sort((a, b) => b.quantity - a.quantity);
+          }
+
+          if (quantitySnapshot === null) {
+            this.quantitySnapshot[groupKey] = Object.fromEntries(
+              itemsArray.map(item => [item.key, item.quantity]),
+            );
+          }
+        } else {
+          itemsArray.sort((a, b) => a.text.localeCompare(b.text));
+        }
       });
 
       const specialArray = itemsByType.special;


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes: #12040

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Create a quantity snapshot when loading the screen.
Sort based on the snapshot after updates.

![Items_before](https://user-images.githubusercontent.com/2563216/82123104-d35a7c80-9797-11ea-9f89-4067fac78392.png)

Hatching a Cotton Candy Pink Parrot

![Items_after](https://user-images.githubusercontent.com/2563216/82123111-d9505d80-9797-11ea-9d5f-296b0c2615a7.png)


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: c4d64716-9f93-4356-a436-0df52dbf44d5
