### PR TITLE
Only show attainable and owned special pets/mounts

### DIFF
--- a/test/content/stable.test.js
+++ b/test/content/stable.test.js
@@ -62,7 +62,7 @@ describe('stable', () => {
   describe('specialPets', () => {
     it('each value is a valid translation string', () => {
       each(stable.specialPets, pet => {
-        const string = t(pet);
+        const string = t(pet.translationString);
         expectValidTranslationString(string);
       });
     });
@@ -107,7 +107,7 @@ describe('stable', () => {
   describe('specialMounts', () => {
     it('each value is a valid translation string', () => {
       each(stable.specialMounts, mount => {
-        const string = t(mount);
+        const string = t(mount.translationString);
         expectValidTranslationString(string);
       });
     });

--- a/test/content/stable.test.js
+++ b/test/content/stable.test.js
@@ -62,7 +62,7 @@ describe('stable', () => {
   describe('specialPets', () => {
     it('each value is a valid translation string', () => {
       each(stable.specialPets, pet => {
-        const string = t(pet.translationString);
+        const string = t(pet);
         expectValidTranslationString(string);
       });
     });
@@ -107,7 +107,7 @@ describe('stable', () => {
   describe('specialMounts', () => {
     it('each value is a valid translation string', () => {
       each(stable.specialMounts, mount => {
-        const string = t(mount.translationString);
+        const string = t(mount);
         expectValidTranslationString(string);
       });
     });

--- a/website/client/src/components/inventory/stable/index.vue
+++ b/website/client/src/components/inventory/stable/index.vue
@@ -154,7 +154,7 @@
           <!-- eslint-enable vue/no-use-v-if-with-v-for -->
           <div
             v-for="item in group"
-            v-show="item.canFind === undefined || item.canFind()"
+            v-show="show('pet', item)"
             :key="item.key"
             v-drag.drop.food="item.key"
             class="pet-group"
@@ -217,7 +217,7 @@
           <!-- eslint-enable vue/no-use-v-if-with-v-for -->
           <div
             v-for="item in group"
-            v-show="item.canFind === undefined || item.canFind()"
+            v-show="show('mount', item)"
             :key="item.key"
             class="pet-group"
           >
@@ -691,6 +691,11 @@ export default {
     setShowMore (key) {
       this.$_openedItemRows_toggleByType(key, !this.$_openedItemRows_isToggled(key));
     },
+    show (type, item) {
+      return item.canFind === undefined
+        || isOwned(type, item, this.userItems)
+        || item.canFind;
+    },
     getAnimalList (animalGroup, type) {
       const { key } = animalGroup;
 
@@ -716,11 +721,9 @@ export default {
               eggKey,
               potionKey,
               name: text(),
+              canFind,
               isOwned () {
                 return isOwned(type, this, userItems);
-              },
-              canFind () {
-                return canFind || this.isOwned();
               },
               mountOwned () {
                 return isOwned('mount', this, userItems);

--- a/website/client/src/components/inventory/stable/index.vue
+++ b/website/client/src/components/inventory/stable/index.vue
@@ -154,6 +154,7 @@
           <!-- eslint-enable vue/no-use-v-if-with-v-for -->
           <div
             v-for="item in group"
+            v-show="item.canFind === undefined || item.canFind()"
             :key="item.key"
             v-drag.drop.food="item.key"
             class="pet-group"
@@ -216,6 +217,7 @@
           <!-- eslint-enable vue/no-use-v-if-with-v-for -->
           <div
             v-for="item in group"
+            v-show="item.canFind === undefined || item.canFind()"
             :key="item.key"
             class="pet-group"
           >
@@ -225,6 +227,7 @@
               :popover-position="'top'"
               :show-popover="true"
               @click="selectMount(item)"
+
             >
               <span slot="popoverContent">
                 <h4 class="popover-content-title">{{ item.name }}</h4>
@@ -706,26 +709,29 @@ export default {
             const eggKey = specialKey.split('-')[0];
             const potionKey = specialKey.split('-')[1];
 
-            if (this.content[`${type}Info`][specialKey].canFind || isOwned('mount', this, userItems)) {
-              animals.push({
-                key: specialKey,
-                eggKey,
-                potionKey,
-                name: this.content[`${type}Info`][specialKey].text(),
-                isOwned () {
-                  return isOwned(type, this, userItems);
-                },
-                mountOwned () {
-                  return isOwned('mount', this, userItems);
-                },
-                isAllowedToFeed () {
-                  return type === 'pet' && this.isOwned() && !this.mountOwned();
-                },
-                isHatchable () {
-                  return false;
-                },
-              });
-            }
+            const { canFind, text } = this.content[`${type}Info`][specialKey];
+
+            animals.push({
+              key: specialKey,
+              eggKey,
+              potionKey,
+              name: text(),
+              isOwned () {
+                return isOwned(type, this, userItems);
+              },
+              canFind () {
+                return canFind || this.isOwned();
+              },
+              mountOwned () {
+                return isOwned('mount', this, userItems);
+              },
+              isAllowedToFeed () {
+                return type === 'pet' && this.isOwned() && !this.mountOwned();
+              },
+              isHatchable () {
+                return false;
+              },
+            });
           });
           break;
         }

--- a/website/client/src/components/inventory/stable/index.vue
+++ b/website/client/src/components/inventory/stable/index.vue
@@ -706,24 +706,26 @@ export default {
             const eggKey = specialKey.split('-')[0];
             const potionKey = specialKey.split('-')[1];
 
-            animals.push({
-              key: specialKey,
-              eggKey,
-              potionKey,
-              name: this.content[`${type}Info`][specialKey].text(),
-              isOwned () {
-                return isOwned(type, this, userItems);
-              },
-              mountOwned () {
-                return isOwned('mount', this, userItems);
-              },
-              isAllowedToFeed () {
-                return type === 'pet' && this.isOwned() && !this.mountOwned();
-              },
-              isHatchable () {
-                return false;
-              },
-            });
+            if (value.canFind || isOwned('mount', this, userItems)) {
+              animals.push({
+                key: specialKey,
+                eggKey,
+                potionKey,
+                name: this.content[`${type}Info`][specialKey].text(),
+                isOwned () {
+                  return isOwned(type, this, userItems);
+                },
+                mountOwned () {
+                  return isOwned('mount', this, userItems);
+                },
+                isAllowedToFeed () {
+                  return type === 'pet' && this.isOwned() && !this.mountOwned();
+                },
+                isHatchable () {
+                  return false;
+                },
+              });
+            }
           });
           break;
         }

--- a/website/client/src/components/inventory/stable/index.vue
+++ b/website/client/src/components/inventory/stable/index.vue
@@ -706,7 +706,7 @@ export default {
             const eggKey = specialKey.split('-')[0];
             const potionKey = specialKey.split('-')[1];
 
-            if (value.canFind || isOwned('mount', this, userItems)) {
+            if (this.content[`${type}Info`][specialKey].canFind || isOwned('mount', this, userItems)) {
               animals.push({
                 key: specialKey,
                 eggKey,

--- a/website/common/script/content/stable.js
+++ b/website/common/script/content/stable.js
@@ -82,63 +82,180 @@ const [questPets, questMounts] = constructSet('quest', questEggs, dropPotions);
 const wackyPets = constructPetOnlySet('wacky', dropEggs, wackyPotions);
 
 const specialPets = {
-  'Wolf-Veteran': 'veteranWolf',
-  'Wolf-Cerberus': 'cerberusPup',
-  'Dragon-Hydra': 'hydra',
-  'Turkey-Base': 'turkey',
-  'BearCub-Polar': 'polarBearPup',
-  'MantisShrimp-Base': 'mantisShrimp',
-  'JackOLantern-Base': 'jackolantern',
-  'Mammoth-Base': 'mammoth',
-  'Tiger-Veteran': 'veteranTiger',
-  'Phoenix-Base': 'phoenix',
-  'Turkey-Gilded': 'gildedTurkey',
-  'MagicalBee-Base': 'magicalBee',
-  'Lion-Veteran': 'veteranLion',
-  'Gryphon-RoyalPurple': 'royalPurpleGryphon',
-  'JackOLantern-Ghost': 'ghostJackolantern',
-  'Jackalope-RoyalPurple': 'royalPurpleJackalope',
-  'Orca-Base': 'orca',
-  'Bear-Veteran': 'veteranBear',
-  'Hippogriff-Hopeful': 'hopefulHippogriffPet',
-  'Fox-Veteran': 'veteranFox',
-  'JackOLantern-Glow': 'glowJackolantern',
-  'Gryphon-Gryphatrice': 'gryphatrice',
+  'Wolf-Veteran': {
+    translationString: 'veteranWolf',
+    canFind: false,
+  },
+  'Wolf-Cerberus': {
+    translationString: 'cerberusPup',
+    canFind: false,
+  },
+  'Dragon-Hydra': {
+    translationString: 'hydra',
+    canFind: true,
+  },
+  'Turkey-Base': {
+    translationString: 'turkey',
+    canFind: false,
+  },
+  'BearCub-Polar': {
+    translationString: 'polarBearPup',
+    canFind: true,
+  },
+  'MantisShrimp-Base': {
+    translationString: 'mantisShrimp',
+    canFind: true,
+  },
+  'JackOLantern-Base': {
+    translationString: 'jackolantern',
+    canFind: false,
+  },
+  'Mammoth-Base': {
+    translationString: 'mammoth',
+    canFind: true,
+  },
+  'Tiger-Veteran': {
+    translationString: 'veteranTiger',
+    canFind: false,
+  },
+  'Phoenix-Base': {
+    translationString: 'phoenix',
+    canFind: true,
+  },
+  'Turkey-Gilded': {
+    translationString: 'gildedTurkey',
+    canFind: true,
+  },
+  'MagicalBee-Base': {
+    translationString: 'magicalBee',
+    canFind: true,
+  },
+  'Lion-Veteran': {
+    translationString: 'veteranLion',
+    canFind: true,
+  },
+  'Gryphon-RoyalPurple': {
+    translationString: 'royalPurpleGryphon',
+    canFind: false,
+  },
+  'JackOLantern-Ghost': {
+    translationString: 'ghostJackolantern',
+    canFind: false,
+  },
+  'Jackalope-RoyalPurple': {
+    translationString: 'royalPurpleJackalope',
+    canFind: true,
+  },
+  'Orca-Base': {
+    translationString: 'orca',
+    canFind: false,
+  },
+  'Bear-Veteran': {
+    translationString: 'veteranBear',
+    canFind: false,
+  },
+  'Hippogriff-Hopeful': {
+    translationString: 'hopefulHippogriffPet',
+    canFind: true,
+  },
+  'Fox-Veteran': {
+    translationString: 'veteranFox',
+    canFind: false,
+  },
+  'JackOLantern-Glow': {
+    translationString: 'glowJackolantern',
+    canFind: false,
+  },
+  'Gryphon-Gryphatrice': {
+    translationString: 'gryphatrice',
+    canFind: false,
+  },
 };
 
 const specialMounts = {
-  'BearCub-Polar': 'polarBear',
-  'LionCub-Ethereal': 'etherealLion',
-  'MantisShrimp-Base': 'mantisShrimp',
-  'Turkey-Base': 'turkey',
-  'Mammoth-Base': 'mammoth',
-  'Orca-Base': 'orca',
-  'Gryphon-RoyalPurple': 'royalPurpleGryphon',
-  'Phoenix-Base': 'phoenix',
-  'JackOLantern-Base': 'jackolantern',
-  'MagicalBee-Base': 'magicalBee',
-  'Turkey-Gilded': 'gildedTurkey',
-  'Jackalope-RoyalPurple': 'royalPurpleJackalope',
-  'Aether-Invisible': 'invisibleAether',
-  'JackOLantern-Ghost': 'ghostJackolantern',
-  'Hippogriff-Hopeful': 'hopefulHippogriffMount',
-  'Gryphon-Gryphatrice': 'gryphatrice',
-  'JackOLantern-Glow': 'glowJackolantern',
+  'BearCub-Polar': {
+    translationString: 'polarBear',
+    canFind: false,
+  },
+  'LionCub-Ethereal': {
+    translationString: 'etherealLion',
+    canFind: true,
+  },
+  'MantisShrimp-Base': {
+    translationString: 'mantisShrimp',
+    canFind: true,
+  },
+  'Turkey-Base': {
+    translationString: 'turkey',
+    canFind: false,
+  },
+  'Mammoth-Base': {
+    translationString: 'mammoth',
+    canFind: true,
+  },
+  'Orca-Base': {
+    translationString: 'orca',
+    canFind: false,
+  },
+  'Gryphon-RoyalPurple': {
+    translationString: 'royalPurpleGryphon',
+    canFind: false,
+  },
+  'Phoenix-Base': {
+    translationString: 'phoenix',
+    canFind: true,
+  },
+  'JackOLantern-Base': {
+    translationString: 'jackolantern',
+    canFind: false,
+  },
+  'MagicalBee-Base': {
+    translationString: 'magicalBee',
+    canFind: true,
+  },
+  'Turkey-Gilded': {
+    translationString: 'gildedTurkey',
+    canFind: false,
+  },
+  'Jackalope-RoyalPurple': {
+    translationString: 'royalPurpleJackalope',
+    canFind: true,
+  },
+  'Aether-Invisible': {
+    translationString: 'invisibleAether',
+    canFind: true,
+  },
+  'JackOLantern-Ghost': {
+    translationString: 'ghostJackolantern',
+    canFind: false,
+  },
+  'Hippogriff-Hopeful': {
+    translationString: 'hopefulHippogriffMount',
+    canFind: true,
+  },
+  'Gryphon-Gryphatrice': {
+    translationString: 'gryphatrice',
+    canFind: false,
+  },
+  'JackOLantern-Glow': {
+    translationString: 'glowJackolantern',
+    canFind: true,
+  },
 };
 
-each(specialPets, (translationString, key) => {
+each(specialPets, (entry, key) => {
   petInfo[key] = {
     key,
     type: 'special',
-    text: t(translationString),
+    text: t(entry.translationString),
   };
 });
 
-each(specialMounts, (translationString, key) => {
+each(specialMounts, (entry, key) => {
   mountInfo[key] = {
     key,
     type: 'special',
-    text: t(translationString),
+    text: t(entry.translationString),
   };
 });
 

--- a/website/common/script/content/stable.js
+++ b/website/common/script/content/stable.js
@@ -81,181 +81,133 @@ const [premiumPets, premiumMounts] = constructSet('premium', dropEggs, premiumPo
 const [questPets, questMounts] = constructSet('quest', questEggs, dropPotions);
 const wackyPets = constructPetOnlySet('wacky', dropEggs, wackyPotions);
 
+const canFindSpecial = {
+  pets: {
+    // Veteran Pet Ladder - verifyUserName
+    'Wolf-Veteran': true,
+    'Tiger-Veteran': false,
+    'Lion-Veteran': false,
+    'Bear-Veteran': false,
+    'Fox-Veteran': false,
+
+    // Thanksgiving pet ladder
+    'Turkey-Base': false,
+    'Turkey-Gilded': false,
+    // Habitoween pet ladder
+    'JackOLantern-Base': false,
+    'JackOLantern-Glow': false,
+    'JackOLantern-Ghost': false,
+    // Naming Day
+    'Gryphon-RoyalPurple': false,
+    // Summer Splash Orca
+    'Orca-Base': false,
+
+    // Quest pets
+    'BearCub-Polar': true, // evilsanta
+    // World Quest Pets - Found in Time Travel Stable
+    'MantisShrimp-Base': true, // dilatory
+    'Mammoth-Base': true, // stressbeast
+    'Phoenix-Base': true, // burnout
+    'MagicalBee-Base': true, // bewilder
+    'Hippogriff-Hopeful': true, // dysheartener
+
+    // Contributor/Backer pets
+    'Dragon-Hydra': true, // Contributor level 6
+    'Jackalope-RoyalPurple': true, // subscription
+    'Wolf-Cerberus': false, // Pet once granted to backers
+    'Gryphon-Gryphatrice': false, // Pet once granted to kickstarter
+  },
+  mounts: {
+    // Thanksgiving pet ladder
+    'Turkey-Base': false,
+    'Turkey-Gilded': false,
+
+    // Habitoween pet ladder
+    'JackOLantern-Base': false,
+    'JackOLantern-Glow': false,
+    'JackOLantern-Ghost': false,
+    // Naming Day
+    'Gryphon-RoyalPurple': false,
+    // Summer Splash Orca
+    'Orca-Base': false,
+
+    // Quest mounts
+    'BearCub-Polar': true, // evilsanta
+    'Aether-Invisible': true, // lostMasterclasser4
+    // World Quest Pets - Found in Time Travel
+    'MantisShrimp-Base': true, // dilatory
+    'Mammoth-Base': true, // stressbeast
+    'Phoenix-Base': true, // burnout
+    'MagicalBee-Base': true,
+    'Hippogriff-Hopeful': true,
+
+    // Contributor/Backer pets
+    'LionCub-Ethereal': true, // Backer tier 90
+    'Jackalope-RoyalPurple': true, // subscription
+    'Gryphon-Gryphatrice': false, // Pet once granted to kickstarter
+  },
+};
+
 const specialPets = {
-  'Wolf-Veteran': {
-    translationString: 'veteranWolf',
-    canFind: false,
-  },
-  'Wolf-Cerberus': {
-    translationString: 'cerberusPup',
-    canFind: false,
-  },
-  'Dragon-Hydra': {
-    translationString: 'hydra',
-    canFind: true,
-  },
-  'Turkey-Base': {
-    translationString: 'turkey',
-    canFind: false,
-  },
-  'BearCub-Polar': {
-    translationString: 'polarBearPup',
-    canFind: true,
-  },
-  'MantisShrimp-Base': {
-    translationString: 'mantisShrimp',
-    canFind: true,
-  },
-  'JackOLantern-Base': {
-    translationString: 'jackolantern',
-    canFind: false,
-  },
-  'Mammoth-Base': {
-    translationString: 'mammoth',
-    canFind: true,
-  },
-  'Tiger-Veteran': {
-    translationString: 'veteranTiger',
-    canFind: false,
-  },
-  'Phoenix-Base': {
-    translationString: 'phoenix',
-    canFind: true,
-  },
-  'Turkey-Gilded': {
-    translationString: 'gildedTurkey',
-    canFind: true,
-  },
-  'MagicalBee-Base': {
-    translationString: 'magicalBee',
-    canFind: true,
-  },
-  'Lion-Veteran': {
-    translationString: 'veteranLion',
-    canFind: true,
-  },
-  'Gryphon-RoyalPurple': {
-    translationString: 'royalPurpleGryphon',
-    canFind: false,
-  },
-  'JackOLantern-Ghost': {
-    translationString: 'ghostJackolantern',
-    canFind: false,
-  },
-  'Jackalope-RoyalPurple': {
-    translationString: 'royalPurpleJackalope',
-    canFind: true,
-  },
-  'Orca-Base': {
-    translationString: 'orca',
-    canFind: false,
-  },
-  'Bear-Veteran': {
-    translationString: 'veteranBear',
-    canFind: false,
-  },
-  'Hippogriff-Hopeful': {
-    translationString: 'hopefulHippogriffPet',
-    canFind: true,
-  },
-  'Fox-Veteran': {
-    translationString: 'veteranFox',
-    canFind: false,
-  },
-  'JackOLantern-Glow': {
-    translationString: 'glowJackolantern',
-    canFind: false,
-  },
-  'Gryphon-Gryphatrice': {
-    translationString: 'gryphatrice',
-    canFind: false,
-  },
+  'Wolf-Veteran': 'veteranWolf',
+  'Wolf-Cerberus': 'cerberusPup',
+  'Dragon-Hydra': 'hydra',
+  'Turkey-Base': 'turkey',
+  'BearCub-Polar': 'polarBearPup',
+  'MantisShrimp-Base': 'mantisShrimp',
+  'JackOLantern-Base': 'jackolantern',
+  'Mammoth-Base': 'mammoth',
+  'Tiger-Veteran': 'veteranTiger',
+  'Phoenix-Base': 'phoenix',
+  'Turkey-Gilded': 'gildedTurkey',
+  'MagicalBee-Base': 'magicalBee',
+  'Lion-Veteran': 'veteranLion',
+  'Gryphon-RoyalPurple': 'royalPurpleGryphon',
+  'JackOLantern-Ghost': 'ghostJackolantern',
+  'Jackalope-RoyalPurple': 'royalPurpleJackalope',
+  'Orca-Base': 'orca',
+  'Bear-Veteran': 'veteranBear',
+  'Hippogriff-Hopeful': 'hopefulHippogriffPet',
+  'Fox-Veteran': 'veteranFox',
+  'JackOLantern-Glow': 'glowJackolantern',
+  'Gryphon-Gryphatrice': 'gryphatrice',
 };
 
 const specialMounts = {
-  'BearCub-Polar': {
-    translationString: 'polarBear',
-    canFind: false,
-  },
-  'LionCub-Ethereal': {
-    translationString: 'etherealLion',
-    canFind: true,
-  },
-  'MantisShrimp-Base': {
-    translationString: 'mantisShrimp',
-    canFind: true,
-  },
-  'Turkey-Base': {
-    translationString: 'turkey',
-    canFind: false,
-  },
-  'Mammoth-Base': {
-    translationString: 'mammoth',
-    canFind: true,
-  },
-  'Orca-Base': {
-    translationString: 'orca',
-    canFind: false,
-  },
-  'Gryphon-RoyalPurple': {
-    translationString: 'royalPurpleGryphon',
-    canFind: false,
-  },
-  'Phoenix-Base': {
-    translationString: 'phoenix',
-    canFind: true,
-  },
-  'JackOLantern-Base': {
-    translationString: 'jackolantern',
-    canFind: false,
-  },
-  'MagicalBee-Base': {
-    translationString: 'magicalBee',
-    canFind: true,
-  },
-  'Turkey-Gilded': {
-    translationString: 'gildedTurkey',
-    canFind: false,
-  },
-  'Jackalope-RoyalPurple': {
-    translationString: 'royalPurpleJackalope',
-    canFind: true,
-  },
-  'Aether-Invisible': {
-    translationString: 'invisibleAether',
-    canFind: true,
-  },
-  'JackOLantern-Ghost': {
-    translationString: 'ghostJackolantern',
-    canFind: false,
-  },
-  'Hippogriff-Hopeful': {
-    translationString: 'hopefulHippogriffMount',
-    canFind: true,
-  },
-  'Gryphon-Gryphatrice': {
-    translationString: 'gryphatrice',
-    canFind: false,
-  },
-  'JackOLantern-Glow': {
-    translationString: 'glowJackolantern',
-    canFind: true,
-  },
+  'BearCub-Polar': 'polarBear',
+  'LionCub-Ethereal': 'etherealLion',
+  'MantisShrimp-Base': 'mantisShrimp',
+  'Turkey-Base': 'turkey',
+  'Mammoth-Base': 'mammoth',
+  'Orca-Base': 'orca',
+  'Gryphon-RoyalPurple': 'royalPurpleGryphon',
+  'Phoenix-Base': 'phoenix',
+  'JackOLantern-Base': 'jackolantern',
+  'MagicalBee-Base': 'magicalBee',
+  'Turkey-Gilded': 'gildedTurkey',
+  'Jackalope-RoyalPurple': 'royalPurpleJackalope',
+  'Aether-Invisible': 'invisibleAether',
+  'JackOLantern-Ghost': 'ghostJackolantern',
+  'Hippogriff-Hopeful': 'hopefulHippogriffMount',
+  'Gryphon-Gryphatrice': 'gryphatrice',
+  'JackOLantern-Glow': 'glowJackolantern',
 };
 
-each(specialPets, (entry, key) => {
+each(specialPets, (translationString, key) => {
   petInfo[key] = {
     key,
     type: 'special',
-    text: t(entry.translationString),
+    text: t(translationString),
+    canFind: canFindSpecial.pets[key],
   };
 });
 
-each(specialMounts, (entry, key) => {
+each(specialMounts, (translationString, key) => {
   mountInfo[key] = {
     key,
     type: 'special',
-    text: t(entry.translationString),
+    text: t(translationString),
+    canFind: canFindSpecial.mounts[key],
   };
 });
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #9498

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Extend specialPets and specialMount with canFind attribute.
Only show special pets and mounts that can be obtained, or are owned.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: c4d64716-9f93-4356-a436-0df52dbf44d5
