### PR TITLE
fix(chat) - Issue 12217 - Allow url-escapable characters in links.

### DIFF
--- a/test/api/unit/libs/highlightMentions.test.js
+++ b/test/api/unit/libs/highlightMentions.test.js
@@ -100,6 +100,13 @@ describe('highlightMentions', () => {
       const result = await highlightMentions(text);
       expect(result[0]).to.equal('http://www.medium.com/@user/blog [@user](/profile/111)');
     });
+
+    // https://github.com/HabitRPG/habitica/issues/12217
+    it('doesn\'t highlight user in link with url-escapable characters', async () => {
+      const text = '[test](https://habitica.fandom.com/ru/@wiki/Снаряжение)';
+      const result = await highlightMentions(text);
+      expect(result[0]).to.equal(text);
+    });
   });
 
   describe('exceptions in code blocks', () => {

--- a/website/server/libs/highlightMentions.js
+++ b/website/server/libs/highlightMentions.js
@@ -86,7 +86,7 @@ function toSourceMapRegex (token) {
   } else if (type === 'link_open') {
     const texts = token.textContents.map(escapeRegExp);
     regexStr = markup === 'linkify' || markup === 'autolink' ? texts[0]
-      : `\\[.*${texts.join('.*')}.*\\]\\(${escapeRegExp(token.attrs[0][1])}\\)`;
+      : `\\[.*${texts.join('.*')}.*\\]\\([^)]+\\)`;
   } else {
     throw new Error(`No source mapping regex defined for ignore blocks of type ${type}`);
   }


### PR DESCRIPTION
Fixes #12217 

### Changes
Use broader selector for link matching source-mapper.

----
UUID: d71d2c57-a73d-4591-b64d-e688584a9092
