### PR TITLE
fix(chat) - graceful for failure and fix link regex

### DIFF
--- a/test/api/unit/libs/highlightMentions.test.js
+++ b/test/api/unit/libs/highlightMentions.test.js
@@ -150,12 +150,12 @@ describe('highlightMentions', () => {
       expect(result[0]).to.equal('[@user](/profile/111) `@user`');
     });
 
-    it('does not crash when a link is repeated in the message.', async () => {
-      const text = '[here](http://habitica.wikia.com/@user/The_Keep:Pirate_Cove/FAQ)\n[hier](http://habitica.wikia.com/@user/The_Keep:Pirate_Cove/FAQ)';
+    it('matches a link in between two the same links', async () => {
+      const text = '[here](http://habitica.wikia.com/wiki/The_Keep:Pirate_Cove/FAQ)\n@user\n[hier](http://habitica.wikia.com/wiki/The_Keep:Pirate_Cove/FAQ)';
 
       const result = await highlightMentions(text);
 
-      expect(result[0]).to.equal(text);
+      expect(result[0]).to.equal('[here](http://habitica.wikia.com/wiki/The_Keep:Pirate_Cove/FAQ)\n[@user](/profile/111)\n[hier](http://habitica.wikia.com/wiki/The_Keep:Pirate_Cove/FAQ)');
     });
   });
 

--- a/test/api/unit/libs/highlightMentions.test.js
+++ b/test/api/unit/libs/highlightMentions.test.js
@@ -149,6 +149,14 @@ describe('highlightMentions', () => {
 
       expect(result[0]).to.equal('[@user](/profile/111) `@user`');
     });
+
+    it('does not crash when a link is repeated in the message.', async () => {
+      const text = '[here](http://habitica.wikia.com/@user/The_Keep:Pirate_Cove/FAQ)\n[hier](http://habitica.wikia.com/@user/The_Keep:Pirate_Cove/FAQ)';
+
+      const result = await highlightMentions(text);
+
+      expect(result[0]).to.equal(text);
+    });
   });
 
   it('github issue 12118, method crashes when square brackets are used', async () => {

--- a/website/server/libs/highlightMentions.js
+++ b/website/server/libs/highlightMentions.js
@@ -86,7 +86,7 @@ function toSourceMapRegex (token) {
   } else if (type === 'link_open') {
     const texts = token.textContents.map(escapeRegExp);
     regexStr = markup === 'linkify' || markup === 'autolink' ? texts[0]
-      : `\\[.*${texts.join('.*')}.*\\]\\([^)]+\\)`;
+      : `\\[[^\\]]*${texts.join('[^\\]]*')}[^\\]]*\\]\\([^)]+\\)`;
   } else {
     throw new Error(`No source mapping regex defined for ignore blocks of type ${type}`);
   }
@@ -110,6 +110,11 @@ function findTextBlocks (text) {
   ignoreBlockRegexes.forEach(regex => {
     const targetText = text.substr(index);
     const match = targetText.match(regex);
+
+    if (!match) {
+      // Should not happen, but insert to handle bugs gracefully
+      return;
+    }
 
     if (match.index) {
       blocks.push({ text: targetText.substr(0, match.index), ignore: false });


### PR DESCRIPTION
Fixes #12223 

### Changes
 - Fix overeager dot matcher in link matcher that causes failure in double link
 - Make source-map regexes resilient to unexpected failure

----
UUID: d71d2c57-a73d-4591-b64d-e688584a9092

