### PR TITLE
remove references to codetriage.com

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,8 +13,3 @@ Habitica uses [this Google form](https://docs.google.com/forms/d/e/1FAIpQLScPhrw
 # Contributing Code
 
 See [Contributing to Habitica](http://habitica.fandom.com/wiki/Contributing_to_Habitica#Coders_.28Web_.26_Mobile.29)
-
-## Issue Triage [![Open Source Helpers](https://www.codetriage.com/habitrpg/habitica/badges/users.svg)](https://www.codetriage.com/habitrpg/habitica)
-
-You can triage issues which may include reproducing bug reports or asking for vital information, such as version numbers or reproduction instructions. If you would like to start triaging issues, one easy way to get started is to [subscribe to habitrpg on CodeTriage](https://www.codetriage.com/habitrpg/habitica).
-

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Habitica ![Build Status](https://github.com/HabitRPG/habitica/workflows/Test/badge.svg) [![Code Climate](https://codeclimate.com/github/HabitRPG/habitrpg.svg)](https://codeclimate.com/github/HabitRPG/habitrpg) [![Bountysource](https://api.bountysource.com/badge/tracker?tracker_id=68393)](https://www.bountysource.com/trackers/68393-habitrpg?utm_source=68393&utm_medium=shield&utm_campaign=TRACKER_BADGE) [![Open Source Helpers](https://www.codetriage.com/habitrpg/habitica/badges/users.svg)](https://www.codetriage.com/habitrpg/habitica)
+Habitica ![Build Status](https://github.com/HabitRPG/habitica/workflows/Test/badge.svg) [![Code Climate](https://codeclimate.com/github/HabitRPG/habitrpg.svg)](https://codeclimate.com/github/HabitRPG/habitrpg) [![Bountysource](https://api.bountysource.com/badge/tracker?tracker_id=68393)](https://www.bountysource.com/trackers/68393-habitrpg?utm_source=68393&utm_medium=shield&utm_campaign=TRACKER_BADGE)
 ===============
 
 [Habitica](https://habitica.com) is an open source habit building program which treats your life like a Role Playing Game. Level up as you succeed, lose HP as you fail, earn money to buy weapons and armor.


### PR DESCRIPTION
This is a suggested change to remove the codetriage.com information and badge that had been added in https://github.com/HabitRPG/habitica/pull/10028 and https://github.com/HabitRPG/habitica/pull/11205 . I have not discussed this with any staff; I figured I might as well explain in a PR that shows the change. I understand you will want to close this if it's not desirable. :)

It's a nice service but it doesn't yet give the ability to control which issues are advertised by it. As shown at https://www.codetriage.com/habitrpg/habitica#help-out , it's currently presenting issues that are "in progress" (e.g., https://github.com/HabitRPG/habitica/issues/12248), "on hold: needs design" (e.g., https://github.com/HabitRPG/habitica/issues/11911), probably other kinds of issues too that also aren't "help wanted". It's also showing pull requests.

This means that it's going to be more misleading than useful for anyone subscribed to it, since we have a large proportion of issues that are not "help wanted". The ones that are "help wanted" are advertised in the Aspiring Blacksmiths guild, which all code contributors should be a member of, so codetriage currently isn't offering significant benefit over that.

It looks like codetriage has plans to allow label filtering in future (https://github.com/codetriage/codetriage/issues/498, https://github.com/HabitRPG/habitica/pull/11205#issuecomment-499693510) so we could add it back after that.

