### PR TITLE
Enable resizing of message box (#11950)

### DIFF
--- a/website/client/src/pages/private-messages.vue
+++ b/website/client/src/pages/private-messages.vue
@@ -434,6 +434,7 @@
 
       height: var(--textarea-auto-height, 40px);
       min-height: var(--textarea-auto-height, 40px);
+      max-height: 300px;
     }
   }
 

--- a/website/client/src/pages/private-messages.vue
+++ b/website/client/src/pages/private-messages.vue
@@ -429,10 +429,10 @@
       }
 
       &.has-content {
-        --textarea-auto-height: 80px
+        --textarea-auto-height: 80px;
       }
 
-      max-height: var(--textarea-auto-height, 40px);
+      height: var(--textarea-auto-height, 40px);
       min-height: var(--textarea-auto-height, 40px);
     }
   }


### PR DESCRIPTION
Fixes #11950

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Changed the max-height to just height in the SASS, so users can resize using the drag handle. Tested in Chrome & FF latest.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: e3edc05f-de97-4761-996a-a6093ded57e4

