### PR TITLE
Issue 12220 stealth tooltip show protected dailies

### DIFF
--- a/website/client/src/components/tasks/spells.vue
+++ b/website/client/src/components/tasks/spells.vue
@@ -267,14 +267,10 @@ export default {
       );
     },
     spellDisabled (skill) {
-      let isSpellDisabled = false;
+      if (skill === 'frost' && this.user.stats.buffs.streaks) return true;
+      if (skill === 'stealth' && this.user.stats.buffs.stealth >= this.user.tasksOrder.dailys.length) return true;
 
-      if ((skill === 'frost' && this.user.stats.buffs.streaks)
-        || (skill === 'stealth' && this.user.stats.buffs.stealth >= this.user.tasksOrder.dailys.length)) {
-        isSpellDisabled = true;
-      }
-
-      return isSpellDisabled;
+      return false;
     },
 
     skillNotes (skill) {

--- a/website/client/src/components/tasks/spells.vue
+++ b/website/client/src/components/tasks/spells.vue
@@ -270,8 +270,10 @@ export default {
       );
     },
     spellDisabled (skill) {
+      const incompleteDailiesDue = this.getUnfilteredTaskList('daily').filter(daily => !daily.completed && daily.isDue).length;
+
       if (skill === 'frost' && this.user.stats.buffs.streaks) return true;
-      if (skill === 'stealth' && this.user.stats.buffs.stealth >= this.getUnfilteredTaskList('daily').length) return true;
+      if (skill === 'stealth' && this.user.stats.buffs.stealth >= incompleteDailiesDue) return true;
 
       return false;
     },

--- a/website/client/src/components/tasks/spells.vue
+++ b/website/client/src/components/tasks/spells.vue
@@ -206,7 +206,7 @@
 <script>
 import spells from '@/../../common/script/content/spells';
 
-import { mapState } from '@/libs/store';
+import { mapState, mapGetters } from '@/libs/store';
 import notifications from '@/mixins/notifications';
 import spellsMixin from '@/mixins/spells';
 import Drawer from '@/components/ui/drawer';
@@ -237,6 +237,9 @@ export default {
   },
   computed: {
     ...mapState({ user: 'user.data' }),
+    ...mapGetters({
+      getUnfilteredTaskList: 'tasks:getUnfilteredTaskList',
+    }),
     openStatus () {
       return this.$store.state.spellOptions.spellDrawOpen ? 1 : 0;
     },
@@ -268,7 +271,7 @@ export default {
     },
     spellDisabled (skill) {
       if (skill === 'frost' && this.user.stats.buffs.streaks) return true;
-      if (skill === 'stealth' && this.user.stats.buffs.stealth >= this.user.tasksOrder.dailys.length) return true;
+      if (skill === 'stealth' && this.user.stats.buffs.stealth >= this.getUnfilteredTaskList('daily').length) return true;
 
       return false;
     },

--- a/website/client/src/components/tasks/spells.vue
+++ b/website/client/src/components/tasks/spells.vue
@@ -40,7 +40,7 @@
                 v-for="(skill, key) in spells[user.stats.class]"
                 v-if="user.stats.lvl >= skill.lvl"
                 :key="key"
-                v-b-popover.hover.auto="skill.notes()"
+                v-b-popover.hover.auto="skillNotes(skill)"
                 class="col-12 col-md-3"
                 @click="castStart(skill)"
               >
@@ -267,18 +267,16 @@ export default {
       );
     },
     spellDisabled (skill) {
-      if (skill === 'frost' && this.user.stats.buffs.streaks) {
-        return true;
-      }
-      // @TODO: Implement
-      // } else if (skill === 'stealth' && this.user.stats.buffs.stealth
-      // >= this.user.dailys.length) {
-      //   return true;
-      // }
+      let isSpellDisabled = false;
 
-      return false;
+      if ((skill === 'frost' && this.user.stats.buffs.streaks)
+        || (skill === 'stealth' && this.user.stats.buffs.stealth >= this.user.tasksOrder.dailys.length)) {
+        isSpellDisabled = true;
+      }
+
+      return isSpellDisabled;
     },
-    // @TODO is this used?
+
     skillNotes (skill) {
       let notes = skill.notes();
 

--- a/website/client/src/components/tasks/spells.vue
+++ b/website/client/src/components/tasks/spells.vue
@@ -274,7 +274,7 @@ export default {
       if (skill === 'frost' && this.user.stats.buffs.streaks) return true;
       if (skill === 'stealth' && this.user.stats.buffs.stealth >= incompleteDailiesDue) return true;
 
-      return isSpellDisabled;
+      return false;
     },
     skillNotes (skill) {
       let notes = skill.notes();

--- a/website/client/src/components/tasks/spells.vue
+++ b/website/client/src/components/tasks/spells.vue
@@ -204,7 +204,7 @@
 </style>
 
 <script>
-import spells from '@/../../common/script/content/spells';
+import spells, { stealthBuffsToAdd } from '@/../../common/script/content/spells';
 
 import { mapState, mapGetters } from '@/libs/store';
 import notifications from '@/mixins/notifications';
@@ -271,13 +271,11 @@ export default {
     },
     spellDisabled (skill) {
       const incompleteDailiesDue = this.getUnfilteredTaskList('daily').filter(daily => !daily.completed && daily.isDue).length;
-
       if (skill === 'frost' && this.user.stats.buffs.streaks) return true;
       if (skill === 'stealth' && this.user.stats.buffs.stealth >= incompleteDailiesDue) return true;
 
       return isSpellDisabled;
     },
-
     skillNotes (skill) {
       let notes = skill.notes();
 
@@ -288,7 +286,7 @@ export default {
       } else if (skill.key === 'stealth') {
         notes = this.$t('spellRogueStealthDaliesAvoided', {
           originalText: notes,
-          number: this.user.stats.buffs.stealth,
+          number: stealthBuffsToAdd(this.user),
         });
       }
 

--- a/website/client/src/components/tasks/spells.vue
+++ b/website/client/src/components/tasks/spells.vue
@@ -275,7 +275,7 @@ export default {
       if (skill === 'frost' && this.user.stats.buffs.streaks) return true;
       if (skill === 'stealth' && this.user.stats.buffs.stealth >= incompleteDailiesDue) return true;
 
-      return false;
+      return isSpellDisabled;
     },
 
     skillNotes (skill) {

--- a/website/common/locales/en/spells.json
+++ b/website/common/locales/en/spells.json
@@ -36,7 +36,7 @@
 
   "spellRogueStealthText": "Stealth",
   "spellRogueStealthNotes": "With each cast, a few of your undone Dailies won't cause damage tonight. Their streaks and colors won't change. (Based on: PER)",
-  "spellRogueStealthDaliesAvoided": "<%= originalText %> Number of dailies avoided: <%= number %>.",
+  "spellRogueStealthDaliesAvoided": "<%= originalText %> Number of dailies that will be avoided: <%= number %>.",
   "spellRogueStealthMaxedOut": "You have already avoided all your dailies; there's no need to cast this again.",
 
   "spellHealerHealText": "Healing Light",

--- a/website/common/script/content/spells.js
+++ b/website/common/script/content/spells.js
@@ -45,6 +45,12 @@ function calculateBonus (value, stat, critVal = 1, statScale = 0.5) {
   return (value < 0 ? 1 : value + 1) + stat * statScale * critVal;
 }
 
+export function stealthBuffsToAdd (user) {
+  return Math.ceil(diminishingReturns(
+    statsComputed(user).per, user.tasksOrder.dailys.length * 0.64, 55,
+  ));
+}
+
 const spells = {};
 
 spells.wizard = {
@@ -208,9 +214,7 @@ spells.rogue = {
     notes: t('spellRogueStealthNotes'),
     cast (user) {
       if (!user.stats.buffs.stealth) user.stats.buffs.stealth = 0;
-      user.stats.buffs.stealth += Math.ceil(diminishingReturns(
-        statsComputed(user).per, user.tasksOrder.dailys.length * 0.64, 55,
-      ));
+      user.stats.buffs.stealth += stealthBuffsToAdd(user);
     },
   },
 };


### PR DESCRIPTION
Fixes #12220

### Changes
A feature on the old site showed the number of dailies protected by casting Stealth. This is now showing again in the Stealth tooltip. The skillNotes section was not being called. It adds additional skill-specific info: the dailies avoided by stealth, whether stealth no longer needs to be cast (dailies already avoided) and whether frost is no longer useful to cast.

Speculation: the spellDisabled method had some commented out code regarding Stealth, which may have broken due to a change in how dailies are referenced. I have fixed this line, so it seemed alright to keep the entirety of the skillNotes function as it had been. However, this includes more than just showing dailies in the tooltip.

Behavior changes:
- tooltip shows dailies avoided for Stealth
- tooltip shows maxed out message for Stealth when all dailies are covered
- tooltip shows frost already cast message when frost has already been cast
- logic for whether stealth should be cast again had incorrectly previously calculated based on all dailies; now we look at all due and incomplete dailies

Screenshots:

![All_dailies_avoided](https://user-images.githubusercontent.com/8680662/83343696-b2734a80-a2b2-11ea-8780-f05ccba153fd.PNG)
![Dailies_avoided_shown_in_tooltip](https://user-images.githubusercontent.com/8680662/83343697-b30be100-a2b2-11ea-9d10-d7cf548da26e.PNG)


UUID: 4a07c222-b810-4559-a574-b95785cafac4
