### PR TITLE
Remove party banner when below tablet size  (fixes 10827)

### DIFF
--- a/website/client/src/components/header/index.vue
+++ b/website/client/src/components/header/index.vue
@@ -19,10 +19,10 @@
       />
       <div
         v-if="hasParty"
-        class="view-party d-flex align-items-center"
+        class="view-party d-none d-md-flex align-items-center"
       >
         <button
-          class="btn btn-primary view-party-button"
+          class="btn btn-primary"
           @click="showPartyMembers()"
         >
           {{ $t('viewParty') }}
@@ -32,7 +32,7 @@
         v-if="hasParty"
         ref="partyMembersDiv"
         v-resize="1500"
-        class="party-members d-flex"
+        class="party-members d-none d-md-flex "
         @resized="setPartyMembersWidth($event)"
       >
         <!-- eslint-disable vue/no-use-v-if-with-v-for -->
@@ -51,7 +51,7 @@
       </div>
       <div
         v-else
-        class="no-party d-flex justify-content-center text-center"
+        class="no-party d-none d-md-flex  justify-content-center text-center mr-4"
       >
         <div class="align-self-center">
           <h3>{{ $t('battleWithFriends') }}</h3>
@@ -117,12 +117,6 @@
 
     .btn {
       margin-top: 16px;
-    }
-  }
-
-  @media only screen and (max-width: 768px) {
-    .view-party-button {
-      display: none;
     }
   }
 </style>

--- a/website/client/src/components/ui/statsbar.vue
+++ b/website/client/src/components/ui/statsbar.vue
@@ -60,6 +60,9 @@
     border-radius: 1px;
     height: 12px;
     background-color: $header-dark-background;
+    @media (max-width: 992px) {
+      min-width: 160px;
+    }
   }
 
   .progress-container > .progress > .progress-bar {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #10827

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
- Remove Party Banner when screen width is below 768px
- Remove media query that is no longer needed
- Add some right margin to 'no party' div
- Add media query to decrease size of progress-bars as party banner starts crowding it
#### No Party
![No-Party](https://media.giphy.com/media/fSkL4oqI9gw42X9OJr/giphy.gif)
#### Party
![Party](https://media.giphy.com/media/kdiX5VrXWD2B5bHxxR/giphy.gif)

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 234319eb-3c97-4cf7-9248-9feff04a31b6
