### PR TITLE
Bugfix/show the correct negative icon in challenge habit

### DIFF
--- a/website/client/src/components/tasks/task.vue
+++ b/website/client/src/components/tasks/task.vue
@@ -317,7 +317,7 @@
             @click="(isUser && task.down) ? score('down') : null"
           >
             <div
-              v-if="task.group && !isUser"
+              v-if="!isUser"
               class="svg-icon lock"
               :class="task.down ? controlClass.down.icon : 'negative'"
               v-html="icons.lock"

--- a/website/client/src/components/tasks/task.vue
+++ b/website/client/src/components/tasks/task.vue
@@ -317,7 +317,7 @@
             @click="(isUser && task.down) ? score('down') : null"
           >
             <div
-              v-if="task.group.id && !isUser"
+              v-if="task.group && !isUser"
               class="svg-icon lock"
               :class="task.down ? controlClass.down.icon : 'negative'"
               v-html="icons.lock"


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #12311

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Removed the check for `task.group.id` since it seems to also be removed for the positive icon and since it does not exist either resulting in the usage of the incorrect icon and styling on the challenges detail page.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 4464eb1b-ea57-4490-a3d1-d0f3ed4a7d7a
