### PR TITLE
Groups: always show checklist-toggle

### DIFF
--- a/website/client/src/components/tasks/task.vue
+++ b/website/client/src/components/tasks/task.vue
@@ -169,7 +169,6 @@
           >
             <div class="d-inline-flex">
               <div
-                v-if="isUser"
                 v-b-tooltip.hover.right="$t(`${task.collapseChecklist
                   ? 'expand': 'collapse'}Checklist`)"
                 class="collapse-checklist d-flex align-items-center expand-toggle"


### PR DESCRIPTION
Fixing the visibility of checklist-toggle, mentioned in #12142


I think `isUser` is outdated there, if the checklist items itself are visible

Now everyone can change the collapseChecklist field.

> But that also means if User A collapse it, and User B expands it, it'll be expanded again when User A refreshes it