### PR TITLE
[WIP][Fixes Issue #12256] New variable addition & new FormatUser instance. Fixes Slack Notification Email Error

### DIFF
--- a/website/server/libs/chatReporting/inboxChatReporter.js
+++ b/website/server/libs/chatReporting/inboxChatReporter.js
@@ -30,8 +30,9 @@ export default class InboxChatReporter extends ChatReporter {
     const validationErrors = this.req.validationErrors();
     if (validationErrors) throw validationErrors;
 
+    // added .exec() to the end of line 35 as suggested by @paglias
     if (this.user.contributor.admin && this.req.query.userId) {
-      this.inboxUser = await User.findOne({ _id: this.req.query.userId });
+      this.inboxUser = await User.findOne({ _id: this.req.query.userId }).exec();
     }
 
     const message = await inboxLib.getUserInboxMessage(this.inboxUser, this.req.params.messageId);
@@ -56,8 +57,10 @@ export default class InboxChatReporter extends ChatReporter {
 
     sendTxn(FLAG_REPORT_EMAILS, 'flag-report-to-mods-with-comments', emailVariables);
 
+    // added variable to hold recipient email
     slack.sendInboxFlagNotification({
       authorEmail: this.authorEmail,
+      recipientEmail: this.recipientEmail,
       flagger: this.user,
       message,
       userComment,
@@ -83,7 +86,9 @@ export default class InboxChatReporter extends ChatReporter {
     const sendingUser = message.sent ? reporter : messageUser;
     const recipient = message.sent ? messageUser : reporter;
 
+    // added variable to hold recipient's email
     this.authorEmail = sendingUser.email;
+    this.recipientEmail = recipient.email;
 
     return [
       ...this.createGenericAuthorVariables('AUTHOR', sendingUser),

--- a/website/server/libs/slack.js
+++ b/website/server/libs/slack.js
@@ -4,6 +4,7 @@ import nconf from 'nconf';
 import moment from 'moment';
 import logger from './logger';
 import { TAVERN_ID } from '../models/group'; // eslint-disable-line import/no-cycle
+import ChatReporter from './chatReporting/chatReporter';
 
 const SLACK_FLAGGING_URL = nconf.get('SLACK_FLAGGING_URL');
 const SLACK_FLAGGING_FOOTER_LINK = nconf.get('SLACK_FLAGGING_FOOTER_LINK');
@@ -107,8 +108,10 @@ function sendFlagNotification ({
   });
 }
 
+// added variab;e to hold recipient email
 function sendInboxFlagNotification ({
   authorEmail,
+  recipientEmail,
   flagger,
   message,
   userComment,
@@ -141,11 +144,20 @@ function sendInboxFlagNotification ({
     email: authorEmail,
     uuid: message.uuid,
   });
+  // added to represent recipient of message
+  const RecipientFormat = formatUser({
+    displayName: message.user,
+    name: message.username,
+    email: recipientEmail,
+    uuid: message.uuid,
+  });
 
   if (message.sent) {
+    // sender of PM is person who flagged PM
     sender = flaggerFormat;
-    recipient = messageUserFormat;
+    recipient = RecipientFormat;
   } else {
+    // recipient flagged PM
     sender = messageUserFormat;
     recipient = flaggerFormat;
   }


### PR DESCRIPTION
[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes issue #12256

### Changes
(line 35): .exec() appended to function call
(line 91): A variable for the recipient email was created
(line 63): this variable was passed to the Slack.SendInboxFlagNotification function. 
Slack.js:
(line 148-152): New formatUser instance created to hold recipient information
(line 158): The recipient is set to the new formatUser instance
(line 114): A variable that holds the recipient email is added as a parameter to the sendInboxFlagNotification function

### Tests
Passes all local tests & unit tests. 
[WIP] still needs manual testing by moderators who receive the Slack notifications. The case in which a sender of a PM reports the PM needs to be checked. 

UUID: 199d9490-2253-49c3-9ff0-031937bc0ac9
