### PR TITLE
docs(api): added info on how to use transformation items

### DIFF
--- a/website/server/controllers/api-v3/user/spells.js
+++ b/website/server/controllers/api-v3/user/spells.js
@@ -15,7 +15,8 @@ const api = {};
 
  * @apiParam (Path) {String=fireball, mpheal, earth, frost, smash, defensiveStance,
  *                  valorousPresence, intimidate, pickPocket, backStab, toolsOfTrade,
- *                  stealth, heal, protectAura, brightness, healAll} spellId The skill to cast.
+ *                  stealth, heal, protectAura, brightness, healAll,
+ *                  snowball, spookySparkles, seafoam, shinySeed} spellId The skill to cast.
  * @apiParam (Query) {UUID} targetId Query parameter, necessary if the spell is
  *                                   cast on a party member or task. Not used if the spell
  *                                   is casted on the user or the user's current party.
@@ -54,6 +55,12 @@ const api = {};
  * protectAura="Protective Aura",
  * brightness="Searing Brightness",
  * healAll="Blessing"
+ *
+ * Transformation Items:
+ * snowball="Snowball",
+ * spookySparkles="Spooky Sparkles",
+ * seafoam="Seafoam",
+ * shinySeed="Shiny Seed"
  *
  * @apiError (400) {NotAuthorized} Not enough mana.
  * @apiUse TaskNotFound


### PR DESCRIPTION
The APIdocs are missing the detail that `https://habitica.com/api/v3/user/class/cast/:spellId` can be used also with transformation items. I have added that in the documentation. @Alys told me I could in the Aspiring Comrades guild.

I hope to have written everything right, I found out it was possible by trial and error.

----
UUID: c073342f-4a65-4a13-9ffd-9e7fa5410d6b
