### PR TITLE
Fix bug where updated webhook options failed to save (fixes #12336)

### DIFF
--- a/test/api/v3/integration/webhook/PUT-user_update_webhook.test.js
+++ b/test/api/v3/integration/webhook/PUT-user_update_webhook.test.js
@@ -127,19 +127,26 @@ describe('PUT /user/webhook/:id', () => {
   it('can update taskActivity options', async () => {
     const type = 'taskActivity';
     const options = {
+      checklistScored: true,
       updated: false,
-      deleted: true,
+      scored: false,
     };
-
-    const webhook = await user.put(`/user/webhook/${webhookToUpdate.id}`, { type, options });
-
-    expect(webhook.options).to.eql({
-      checklistScored: false, // starting value
+    const expected = {
+      checklistScored: true,
       created: true, // starting value
       updated: false,
-      deleted: true,
-      scored: true, // default value
-    });
+      deleted: false, // starting value
+      scored: false,
+    };
+
+    const returnedWebhook = await user.put(`/user/webhook/${webhookToUpdate.id}`, { type, options });
+
+    await user.sync();
+
+    const savedWebhook = user.webhooks.find(hook => webhookToUpdate.id === hook.id);
+
+    expect(returnedWebhook.options).to.eql(expected);
+    expect(savedWebhook.options).to.eql(expected);
   });
 
   it('errors if taskActivity option is not a boolean', async () => {

--- a/website/server/controllers/api-v3/webhook.js
+++ b/website/server/controllers/api-v3/webhook.js
@@ -223,9 +223,9 @@ api.updateWebhook = {
 
     webhook.formatOptions(res);
 
-    // Tell Mongoose that the webhooks array has been modified
+    // Tell Mongoose that the webhook's options have been modified
     // so it actually commits the options changes to the database
-    user.markModified('webhooks');
+    webhook.markModified('options');
 
     await user.save();
     res.respond(200, webhook);

--- a/website/server/controllers/api-v3/webhook.js
+++ b/website/server/controllers/api-v3/webhook.js
@@ -223,6 +223,10 @@ api.updateWebhook = {
 
     webhook.formatOptions(res);
 
+    // Tell Mongoose that the webhooks array has been modified
+    // so it actually commits the options changes to the database
+    user.markModified('webhooks');
+
     await user.save();
     res.respond(200, webhook);
   },


### PR DESCRIPTION
Fixes #12336

### Changes

This bug was caused by Mongoose not being able to tell when `Mixed` schema
objects (such as the `webhook.options` field) have been modified
(https://mongoosejs.com/docs/schematypes.html#mixed). So, although the webhook
was being updated properly, Mongoose was not actually committing it to the database.
Telling Mongoose that the webhook's `options` field has changed via `markModified`
fixes the issue.

Additionally, the relevant API test case was only checking whether or
not the webhook returned from the PUT endpoint matched the expected
update. Since the endpoint was returning the updated webhook without
querying the database again, this test case would pass. It has been
updated to check both the returned webhook as well as the version of the
webhook that is saved to the database against the expected. In other
words:

`assert returned === saved === expected`

----
UUID: cab16cfa-e951-4dc3-a468-1abadc1dd109
