### PR TITLE
update group members after accepting the quest (without page reload)

### DIFF
--- a/website/client/src/components/groups/questSidebarSection.vue
+++ b/website/client/src/components/groups/questSidebarSection.vue
@@ -425,6 +425,7 @@ export default {
     async questAccept (partyId) {
       const quest = await this.$store.dispatch('quests:sendAction', { groupId: partyId, action: 'quests/accept' });
       this.user.party.quest = quest;
+      this.group.quest.members = quest.members;
     },
     async questReject (partyId) {
       const quest = await this.$store.dispatch('quests:sendAction', { groupId: partyId, action: 'quests/reject' });

--- a/website/client/src/components/groups/questSidebarSection.vue
+++ b/website/client/src/components/groups/questSidebarSection.vue
@@ -424,8 +424,9 @@ export default {
     },
     async questAccept (partyId) {
       const quest = await this.$store.dispatch('quests:sendAction', { groupId: partyId, action: 'quests/accept' });
+      quest.progress.up = this.user.party.quest.progress.up;
       this.user.party.quest = quest;
-      this.group.quest.members = quest.members;
+      this.group.quest = quest;
     },
     async questReject (partyId) {
       const quest = await this.$store.dispatch('quests:sendAction', { groupId: partyId, action: 'quests/reject' });

--- a/website/client/src/components/groups/questSidebarSection.vue
+++ b/website/client/src/components/groups/questSidebarSection.vue
@@ -162,7 +162,7 @@
                   progress on the group doc? Each user could have different progress.-->
                 <span
                   class="float-right"
-                >{{ user.party.quest.progress.up | floor(10) }} {{ $t('pendingDamageLabel') }}</span> <!-- eslint-disable-line max-len -->
+                >{{ (user.party.quest.progress.up || 0) | floor(10) }} {{ $t('pendingDamageLabel') }}</span> <!-- eslint-disable-line max-len -->
                 <!-- player's pending damage uses floor so you
                   don't overestimate damage you've already done-->
               </div>
@@ -424,7 +424,6 @@ export default {
     },
     async questAccept (partyId) {
       const quest = await this.$store.dispatch('quests:sendAction', { groupId: partyId, action: 'quests/accept' });
-      quest.progress.up = this.user.party.quest.progress.up;
       this.user.party.quest = quest;
       this.group.quest = quest;
     },


### PR DESCRIPTION
Fixes #11173

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

- Current scenario

As mentioned in the request, when accepting a mission invite, the participant count was not increased by +1, remaining static even when the user has just accepted.

To update the number of participants who accepted, it was necessary to reload the browser page (F5).

- Investigation

I noticed that the number of group members was updated only when the page was loaded, which made the count remain the same until a new update.

- Adjustment

After the player clicked the "Accept" button, I updated the `this.group.quest.members` based on the `quest` returned in the`quests: sendAction` request.

Images:

**Before Click**
![alt before_accept](https://i.imgur.com/f3yDNEr.png)

**After Click (Without page reload)**
![alt after_accept](https://imgur.com/2afeEAS.png)

- Specs

I tried to find some way to test this functionality unitarily, but I didn't find it, if anyone knows, please tell me :)
I did the tests through the local application (running on my computer) where I managed to run via the docker.

----
**UUID:** ef556559-6c3c-4ac3-8d70-6714007d2e51
First Pull Request =P
