### PR TITLE
Revert "Make message links to deleted profiles display 404" - fixes #12364

### DIFF
--- a/website/client/src/components/chat/chatMessages.vue
+++ b/website/client/src/components/chat/chatMessages.vue
@@ -310,7 +310,27 @@ export default {
       return false;
     },
     async showMemberModal (memberId) {
-      this.$router.push({ name: 'userProfile', params: { userId: memberId } });
+      let profile = this.cachedProfileData[memberId];
+
+      if (!profile._id) {
+        const result = await this.$store.dispatch('members:fetchMember', { memberId });
+        if (result.response && result.response.status === 404) {
+          this.$store.dispatch('snackbars:add', {
+            title: 'Habitica',
+            text: this.$t('messageDeletedUser'),
+            type: 'error',
+            timeout: false,
+          });
+        } else {
+          this.cachedProfileData[memberId] = result.data.data;
+          profile = result.data.data;
+        }
+      }
+
+      // Open the modal only if the data is available
+      if (profile && !profile.rejected) {
+        this.$router.push({ name: 'userProfile', params: { userId: profile._id } });
+      }
     },
     itemWasMounted: debounce(function itemWasMounted () {
       if (this.handleScrollBack) {

--- a/website/client/src/components/userMenu/profile.vue
+++ b/website/client/src/components/userMenu/profile.vue
@@ -1,11 +1,6 @@
 <template>
   <div
-    v-if="!user && userLoaded"
-  >
-    <error404 />
-  </div>
-  <div
-    v-else-if="userLoaded"
+    v-if="user"
     class="profile"
   >
     <div class="header">
@@ -730,7 +725,6 @@ import challenge from '@/assets/svg/challenge.svg';
 import member from '@/assets/svg/member-icon.svg';
 import staff from '@/assets/svg/tier-staff.svg';
 import svgClose from '@/assets/svg/close.svg';
-import error404 from '../404';
 // @TODO: EMAILS.COMMUNITY_MANAGER_EMAIL
 const COMMUNITY_MANAGER_EMAIL = 'admin@habitica.com';
 
@@ -741,7 +735,6 @@ export default {
   components: {
     MemberDetails,
     profileStats,
-    error404,
   },
   props: ['userId', 'startingPage'],
   data () {
@@ -775,8 +768,7 @@ export default {
       achievements: {},
       achievementsCategories: {}, // number, open
       content: Content,
-      user: null,
-      userLoaded: false,
+      user: undefined,
     };
   },
   computed: {
@@ -836,56 +828,43 @@ export default {
   },
   methods: {
     async loadUser () {
-      let user = null;
+      let user = this.userLoggedIn;
 
       // Reset editing when user is changed. Move to watch or is this good?
       this.editing = false;
       this.hero = {};
-      this.userLoaded = false;
       this.adminToolsLoaded = false;
 
       const profileUserId = this.userId;
 
       if (profileUserId && profileUserId !== this.userLoggedIn._id) {
         const response = await this.$store.dispatch('members:fetchMember', { memberId: profileUserId });
-        if (response.response && response.response.status === 404) {
-          user = null;
-          this.$store.dispatch('snackbars:add', {
-            title: 'Habitica',
-            text: this.$t('messageDeletedUser'),
-            type: 'error',
-            timeout: false,
-          });
-        } else if (response.status && response.status === 200) {
-          user = response.data.data;
-
-          this.editingProfile.name = user.profile.name;
-          this.editingProfile.imageUrl = user.profile.imageUrl;
-          this.editingProfile.blurb = user.profile.blurb;
-
-          if (!user.achievements.quests) user.achievements.quests = {};
-          if (!user.achievements.challenges) user.achievements.challenges = {};
-          // @TODO: this common code should handle the above
-          this.achievements = achievementsLib.getAchievementsForProfile(user);
-
-          const achievementsCategories = {};
-          Object.keys(this.achievements).forEach(category => {
-            achievementsCategories[category] = {
-              open: false,
-              number: Object.keys(this.achievements[category].achievements).length,
-            };
-          });
-
-          this.achievementsCategories = achievementsCategories;
-
-          // @TODO For some reason markdown doesn't seem to be handling numbers or maybe undefined?
-          user.profile.blurb = user.profile.blurb ? `${user.profile.blurb}` : '';
-        }
-        this.user = user;
-      } else {
-        this.user = this.userLoggedIn;
+        user = response.data.data;
       }
-      this.userLoaded = true;
+
+      this.editingProfile.name = user.profile.name;
+      this.editingProfile.imageUrl = user.profile.imageUrl;
+      this.editingProfile.blurb = user.profile.blurb;
+
+      if (!user.achievements.quests) user.achievements.quests = {};
+      if (!user.achievements.challenges) user.achievements.challenges = {};
+      // @TODO: this common code should handle the above
+      this.achievements = achievementsLib.getAchievementsForProfile(user);
+
+      const achievementsCategories = {};
+      Object.keys(this.achievements).forEach(category => {
+        achievementsCategories[category] = {
+          open: false,
+          number: Object.keys(this.achievements[category].achievements).length,
+        };
+      });
+
+      this.achievementsCategories = achievementsCategories;
+
+      // @TODO For some reason markdown doesn't seem to be handling numbers or maybe undefined?
+      user.profile.blurb = user.profile.blurb ? `${user.profile.blurb}` : '';
+
+      this.user = user;
     },
     selectPage (page) {
       this.selectedPage = page || 'profile';


### PR DESCRIPTION
fixes https://github.com/HabitRPG/habitica/issues/12364

Commit e42518f4278c1f30defae5b39fa61720fbc06f0f was inadvertently preventing the logged-in user's achievements from being displayed, and was preventing their `profile` data from appearing in the profile edit form. This PR reverts that commit. 

This is hopefully just a temporary measure until we can adjust the new code!

Habitica's staff: If you'd prefer to fix https://github.com/HabitRPG/habitica/issues/12364 in some other way, it's fine with me if you reject this PR. :)

I haven't done a super-huge amount of testing for this so if you do merge it, it may be worth testing it in staging before making it live.