### PR TITLE
Fix: new pm - canReceive

### DIFF
--- a/website/client/src/pages/private-messages.vue
+++ b/website/client/src/pages/private-messages.vue
@@ -656,6 +656,7 @@ export default {
         backer: data.backer,
         contributor: data.contributor,
         userStyles: data.userStyles,
+        canReceive: true,
       };
 
       this.$store.state.privateMessageOptions = {};
@@ -896,6 +897,7 @@ export default {
         username: this.user.auth.local.username,
         contributor: this.user.contributor,
         backer: this.user.backer,
+        canReceive: true,
       });
 
       // Remove the placeholder message


### PR DESCRIPTION
At first I thought `canReceive` was missing in the messages, but it was rather the `initiatedConversion`


fixed #12366