### PR TITLE
PR to fix: Disallow line breaks in display names

### DIFF
--- a/test/api/v3/integration/user/PUT-user.test.js
+++ b/test/api/v3/integration/user/PUT-user.test.js
@@ -92,6 +92,14 @@ describe('PUT /user', () => {
         error: 'BadRequest',
         message: t('displaynameIssueSlur'),
       });
+
+      await expect(user.put('/user', {
+        'profile.name': 'namecontainsnewline\n',
+      })).to.eventually.be.rejected.and.eql({
+        code: 400,
+        error: 'BadRequest',
+        message: t('displaynameIssueNewline'),
+      });
     });
   });
 

--- a/test/api/v4/user/auth/POST-user_verify_display_name.test.js
+++ b/test/api/v4/user/auth/POST-user_verify_display_name.test.js
@@ -53,5 +53,11 @@ describe('POST /user/auth/verify-display-name', async () => {
         displayName: 'this is a very long display name over 30 characters',
       })).to.eventually.eql({ isUsable: false, issues: [t('displaynameIssueLength')] });
     });
+
+    it('errors if display name contains a newline', async () => {
+      await expect(user.post(ENDPOINT, {
+        displayName: 'namecontainsnewline\n',
+      })).to.eventually.eql({ isUsable: false, issues: [t('displaynameIssueNewline')] });
+    });
   });
 });

--- a/website/common/locales/en/settings.json
+++ b/website/common/locales/en/settings.json
@@ -202,6 +202,7 @@
     "currentUsername": "Current username:",
     "displaynameIssueLength": "Display Names must be between 1 and 30 characters.",
     "displaynameIssueSlur": "Display Names may not contain inappropriate language.",
+    "displaynameIssueNewline": "Display Names may not contain backslashes followed by the letter N.",
     "goToSettings": "Go to Settings",
     "usernameVerifiedConfirmation": "Your username, <%= username %>, is confirmed!",
     "usernameNotVerified": "Please confirm your username.",

--- a/website/server/libs/user/index.js
+++ b/website/server/libs/user/index.js
@@ -6,7 +6,7 @@ import {
   NotAuthorized,
 } from '../errors';
 import { model as User, schema as UserSchema } from '../../models/user';
-import { nameContainsSlur } from './validation';
+import { nameContainsSlur, nameContainsNewline } from './validation';
 
 export async function get (req, res, { isV3 = false }) {
   const { user } = res.locals;
@@ -112,6 +112,7 @@ export async function update (req, res, { isV3 = false }) {
     if (newName === null) throw new BadRequest(res.t('invalidReqParams'));
     if (newName.length > 30) throw new BadRequest(res.t('displaynameIssueLength'));
     if (nameContainsSlur(newName)) throw new BadRequest(res.t('displaynameIssueSlur'));
+    if (nameContainsNewline(newName)) throw new BadRequest(res.t('displaynameIssueNewline'));
   }
 
   _.each(req.body, (val, key) => {

--- a/website/server/libs/user/validation.js
+++ b/website/server/libs/user/validation.js
@@ -16,7 +16,7 @@ export function nameContainsSlur (username) {
 }
 
 export function nameContainsNewline (username) {
-  if (username.includes('\n') || username.includes('\\n')) {
+  if (username.includes('\n') {
     return true;
   }
   return false;

--- a/website/server/libs/user/validation.js
+++ b/website/server/libs/user/validation.js
@@ -18,9 +18,8 @@ export function nameContainsSlur (username) {
 export function nameContainsNewline (username) {
   if (username.includes('\n') || username.includes('\\n')) {
     return true;
-  } else {
-    return false;
   }
+  return false;
 }
 
 function usernameIsForbidden (username) {

--- a/website/server/libs/user/validation.js
+++ b/website/server/libs/user/validation.js
@@ -15,6 +15,14 @@ export function nameContainsSlur (username) {
   return false;
 }
 
+export function nameContainsNewline (username) {
+  if (username.includes('\n') || username.includes('\\n')) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
 function usernameIsForbidden (username) {
   const forbidddenWordsMatched = getMatchesByWordArray(username, forbiddenUsernames);
   return forbidddenWordsMatched.length > 0;
@@ -30,6 +38,7 @@ export function verifyDisplayName (displayName, res) {
   const issues = [];
   if (displayName.length < 1 || displayName.length > 30) issues.push(res.t('displaynameIssueLength'));
   if (nameContainsSlur(displayName)) issues.push(res.t('displaynameIssueSlur'));
+  if (nameContainsNewline(displayName)) issues.push(res.t('displaynameIssueNewline'));
 
   return issues;
 }

--- a/website/server/libs/user/validation.js
+++ b/website/server/libs/user/validation.js
@@ -16,10 +16,7 @@ export function nameContainsSlur (username) {
 }
 
 export function nameContainsNewline (username) {
-  if (username.includes('\n') {
-    return true;
-  }
-  return false;
+  return username.includes('\n');
 }
 
 function usernameIsForbidden (username) {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: #11946
Fixes #11946

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
This PR would make changes to 3 files:
1. settings.json - Needed for a new error message when a user tries to set their display name using a backslash followed by the letter N
2. validation.js - To add a validation check for the occurrence of a backslash followed by the letter N - Requires checking for '\\\n' and '\\n' because some systems automatically escape characters
3. index.js - To get the validator in the UI to check for the presence of a backslash followed by the letter N, and to prevent the user from updating their name if a backslash followed by the letter N is found

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 74ad4bd2-9de5-43f7-8efd-cfd684f47374
