### PR TITLE
fix filter reset on pinning items 

### DIFF
--- a/website/client/src/components/shops/quests/index.vue
+++ b/website/client/src/components/shops/quests/index.vue
@@ -521,9 +521,12 @@ export default {
     categories () {
       if (this.shop.categories) {
         this.shop.categories.forEach(category => {
-          this.$set(this.viewOptions, category.identifier, {
-            selected: false,
-          });
+          // do not reset the viewOptions if already set once
+          if (typeof this.viewOptions[category.identifier] === 'undefined') {
+            this.$set(this.viewOptions, category.identifier, {
+              selected: false,
+            });
+          }
         });
 
         return this.shop.categories;

--- a/website/client/src/components/shops/timeTravelers/index.vue
+++ b/website/client/src/components/shops/timeTravelers/index.vue
@@ -379,9 +379,12 @@ export default {
       normalGroups.push(setCategory);
 
       normalGroups.forEach(category => {
-        this.$set(this.viewOptions, category.identifier, {
-          selected: false,
-        });
+        // do not reset the viewOptions if already set once
+        if (typeof this.viewOptions[category.identifier] === 'undefined') {
+          this.$set(this.viewOptions, category.identifier, {
+            selected: false,
+          });
+        }
       });
 
       return normalGroups;


### PR DESCRIPTION
The filters were reset because the viewOptions[].selected was set to false on each change.

fixes #9500