### PR TITLE
Updating daysOfMonths array when the startDate of a monthly is updated in the API - Fixes #12041

### DIFF
--- a/test/api/v3/integration/tasks/PUT-tasks_id.test.js
+++ b/test/api/v3/integration/tasks/PUT-tasks_id.test.js
@@ -499,6 +499,40 @@ describe('PUT /tasks/:id', () => {
     });
   });
 
+  context('monthly dailys', () => {
+    let monthly;
+
+    beforeEach(async () => {
+      const date1 = moment.utc('2020-07-01').toDate()
+      monthly = await user.post('/tasks/user', {
+        text: 'test monthly',
+        type: 'daily',
+        frequency: 'monthly',
+        startDate: date1,
+        daysOfMonth: [date1.getDate()],
+      });
+    });
+
+    it('updates days of month when start date updated', async () => {
+      const date2 = moment.utc('2020-07-01').toDate()
+      const savedMonthly = await user.put(`/tasks/${monthly._id}`, {
+        startDate: date2,
+      });
+
+      expect(savedMonthly.daysOfMonth).to.deep.equal([moment(date2).date()]);
+    });
+
+    it('updates next due when start date updated', async () => {
+      const date2 = moment.utc('2020-07-01').toDate()
+      const savedMonthly = await user.put(`/tasks/${monthly._id}`, {
+        startDate: date2,
+      });
+
+      expect(savedMonthly.nextDue.length).to.eql(6);
+      expect(moment(savedMonthly.nextDue[0]).toDate()).to.eql(moment.utc('2020-08-01').toDate());
+    });
+  });
+
   context('rewards', () => {
     let reward;
 

--- a/test/api/v3/integration/tasks/PUT-tasks_id.test.js
+++ b/test/api/v3/integration/tasks/PUT-tasks_id.test.js
@@ -503,7 +503,7 @@ describe('PUT /tasks/:id', () => {
     let monthly;
 
     beforeEach(async () => {
-      const date1 = moment.utc('2020-07-01').toDate()
+      const date1 = moment.utc('2020-07-01').toDate();
       monthly = await user.post('/tasks/user', {
         text: 'test monthly',
         type: 'daily',
@@ -514,7 +514,7 @@ describe('PUT /tasks/:id', () => {
     });
 
     it('updates days of month when start date updated', async () => {
-      const date2 = moment.utc('2020-07-01').toDate()
+      const date2 = moment.utc('2020-07-01').toDate();
       const savedMonthly = await user.put(`/tasks/${monthly._id}`, {
         startDate: date2,
       });
@@ -523,13 +523,18 @@ describe('PUT /tasks/:id', () => {
     });
 
     it('updates next due when start date updated', async () => {
-      const date2 = moment.utc('2020-07-01').toDate()
+      const date2 = moment.utc('2020-07-01').toDate();
       const savedMonthly = await user.put(`/tasks/${monthly._id}`, {
         startDate: date2,
       });
 
       expect(savedMonthly.nextDue.length).to.eql(6);
       expect(moment(savedMonthly.nextDue[0]).toDate()).to.eql(moment.utc('2020-08-01').toDate());
+      expect(moment(savedMonthly.nextDue[1]).toDate()).to.eql(moment.utc('2020-09-01').toDate());
+      expect(moment(savedMonthly.nextDue[2]).toDate()).to.eql(moment.utc('2020-10-01').toDate());
+      expect(moment(savedMonthly.nextDue[3]).toDate()).to.eql(moment.utc('2020-11-01').toDate());
+      expect(moment(savedMonthly.nextDue[4]).toDate()).to.eql(moment.utc('2020-12-01').toDate());
+      expect(moment(savedMonthly.nextDue[5]).toDate()).to.eql(moment.utc('2021-01-01').toDate());
     });
   });
 

--- a/website/server/controllers/api-v3/tasks.js
+++ b/website/server/controllers/api-v3/tasks.js
@@ -678,6 +678,10 @@ api.updateTask = {
       task.group.sharedCompletion = sanitizedObj.sharedCompletion;
     }
 
+    if (task.frequency === 'monthly' && task) {
+      task.daysOfMonth = [ moment(task.startDate).date() ];
+    }
+
     setNextDue(task, user);
     const savedTask = await task.save();
 

--- a/website/server/controllers/api-v3/tasks.js
+++ b/website/server/controllers/api-v3/tasks.js
@@ -678,7 +678,12 @@ api.updateTask = {
       task.group.sharedCompletion = sanitizedObj.sharedCompletion;
     }
 
-    if (task.frequency === 'monthly' && task.startDate) {
+    // If the task was set to repeat monthly on a day of the month, and the start date was updated,
+    // the task will then need to be updated to repeat on the same day of the month as the new
+    // start date.  For example, if the start date is updated to 7/2/2020, the daily should
+    // repeat on the 2nd day of the month.  It's possible that a task can repeat monthly on a 
+    // week of the month, in which case we won't update the repetition at all.
+    if (task.frequency === 'monthly' && task.daysOfMonth.length && task.startDate) {
       task.daysOfMonth = [moment(task.startDate).date()];
     }
 

--- a/website/server/controllers/api-v3/tasks.js
+++ b/website/server/controllers/api-v3/tasks.js
@@ -678,8 +678,8 @@ api.updateTask = {
       task.group.sharedCompletion = sanitizedObj.sharedCompletion;
     }
 
-    if (task.frequency === 'monthly' && task) {
-      task.daysOfMonth = [ moment(task.startDate).date() ];
+    if (task.frequency === 'monthly' && task.startDate) {
+      task.daysOfMonth = [moment(task.startDate).date()];
     }
 
     setNextDue(task, user);

--- a/website/server/controllers/api-v3/tasks.js
+++ b/website/server/controllers/api-v3/tasks.js
@@ -680,8 +680,8 @@ api.updateTask = {
 
     // If the task was set to repeat monthly on a day of the month, and the start date was updated,
     // the task will then need to be updated to repeat on the same day of the month as the new
-    // start date.  For example, if the start date is updated to 7/2/2020, the daily should
-    // repeat on the 2nd day of the month.  It's possible that a task can repeat monthly on a 
+    // start date. For example, if the start date is updated to 7/2/2020, the daily should
+    // repeat on the 2nd day of the month. It's possible that a task can repeat monthly on a
     // week of the month, in which case we won't update the repetition at all.
     if (task.frequency === 'monthly' && task.daysOfMonth.length && task.startDate) {
       task.daysOfMonth = [moment(task.startDate).date()];


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #12041

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
I adjusted the 'Update Task' API endpoint to update the daysOfMonth array whenever the start date is updated.  Whenever the start date for a task with a frequency of 'monthly' is updated, the recurrence should be updated so that the daily occurs on the same day of the month.  For example, if a monthly daily is initially created with a start date of 7/1/2020, the daysOfMonth array will equal [1], indicating that the monthly will recur on the 1st of every month.  If this start date is updated to 7/2/2020, the daysOfMonth array should be updated to equal [2].

I also wrote two integration tests in PUT-tasks_id.test.js that test that (1) the daysOfMonth array is updated whenever start date is updated and (2) the nextDue array is updated to the hold the next six due dates with the correct day of the month.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 04ec9b30-1464-41f5-af67-fb2482f108a0

