### PR TITLE
Fix height of badges in multiline achievements

### DIFF
--- a/website/client/src/components/userMenu/profile.vue
+++ b/website/client/src/components/userMenu/profile.vue
@@ -618,6 +618,7 @@
         margin-right: 8px;
         background: $gray-600;
         color: $gray-300;
+        height: fit-content;
       }
     }
   }


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes the UI bug I reported where achievement names taking up multiple lines cause badges to stretch to fill their container (no issue #).

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
This bug can be fixed by setting the height of achievements badges to `fit-content`.

Screenshot of bug: https://i.snipboard.io/07GBi4.jpg
Screenshot of fix: https://i.snipboard.io/PKvi8e.jpg


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: ba2e910a-fd1b-4381-ad65-fc1b948847ae
