### PR TITLE
removing wrong info on updating challenge leader from apidoc

### DIFF
--- a/website/server/controllers/api-v3/challenges.js
+++ b/website/server/controllers/api-v3/challenges.js
@@ -659,7 +659,7 @@ api.exportChallengeCsv = {
 };
 
 /**
- * @api {put} /api/v3/challenges/:challengeId Update the name, description or summary of a challenge
+ * @api {put} /api/v3/challenges/:challengeId Update the name, description, or summary of a challenge
  *
  * @apiName UpdateChallenge
  * @apiGroup Challenge

--- a/website/server/controllers/api-v3/challenges.js
+++ b/website/server/controllers/api-v3/challenges.js
@@ -659,7 +659,7 @@ api.exportChallengeCsv = {
 };
 
 /**
- * @api {put} /api/v3/challenges/:challengeId Update the name, description, or summary of a challenge
+ * @api {put} /api/v3/challenges/:challengeId Update a challenge's name, description, or summary
  *
  * @apiName UpdateChallenge
  * @apiGroup Challenge

--- a/website/server/controllers/api-v3/challenges.js
+++ b/website/server/controllers/api-v3/challenges.js
@@ -659,7 +659,7 @@ api.exportChallengeCsv = {
 };
 
 /**
- * @api {put} /api/v3/challenges/:challengeId Update the name, description, or leader of a challenge
+ * @api {put} /api/v3/challenges/:challengeId Update the name or description of a challenge
  *
  * @apiName UpdateChallenge
  * @apiGroup Challenge
@@ -668,7 +668,6 @@ api.exportChallengeCsv = {
  * @apiParam (Body) {String} [challenge.name] The new full name of the challenge.
  * @apiParam (Body) {String} [challenge.summary] The new challenge summary.
  * @apiParam (Body) {String} [challenge.description] The new challenge description.
- * @apiParam (Body) {String} [challenge.leader] The UUID of the new challenge leader.
  *
  * @apiSuccess {Object} data The updated challenge
  * @apiPermission ChallengeLeader

--- a/website/server/controllers/api-v3/challenges.js
+++ b/website/server/controllers/api-v3/challenges.js
@@ -659,7 +659,7 @@ api.exportChallengeCsv = {
 };
 
 /**
- * @api {put} /api/v3/challenges/:challengeId Update the name or description of a challenge
+ * @api {put} /api/v3/challenges/:challengeId Update the name, description or summary of a challenge
  *
  * @apiName UpdateChallenge
  * @apiGroup Challenge


### PR DESCRIPTION
as discussed in the Aspiring Comrades guild, doing the change because the route `/api/v3/challenges/:challengeId` can't be used to change challenge leader, so I am deleting it from the docs

[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes put_#_and_issue_number_here

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)



[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: c073342f-4a65-4a13-9ffd-9e7fa5410d6b
