### PR TITLE
Remove unnecessary modal scrollbar

### DIFF
--- a/website/client/src/app.vue
+++ b/website/client/src/app.vue
@@ -218,11 +218,6 @@
     opacity: 0.48;
   }
 
-  /* @TODO: The modal-open class is not being removed. Let's try this for now */
-  .modal {
-    overflow-y: scroll !important;
-  }
-
   .modal-backdrop {
     opacity: .9 !important;
     background-color: $purple-100 !important;


### PR DESCRIPTION
Fixes #9863

[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

**Previously**, we forced `overflow-y: scroll` on modals to try to work around a Bootstrap-Vue issue, causing extra scrollbars to appear whenever a modal was open.
**Now** (several B-Vue versions later), this CSS is removed, allowing a scrollbar to appear when needed but otherwise staying out of our way.

I couldn't reproduce the underlying issue this was meant to work around when looking at this, but some testing and poking around to ensure that the modal-related padding in the `body` element still gets cleaned up correctly would be worthwhile.
