### PR TITLE
Fix multiple purchases with Amazon Pay

### DIFF
--- a/website/client/src/components/payments/amazonButton.vue
+++ b/website/client/src/components/payments/amazonButton.vue
@@ -74,6 +74,7 @@ export default {
     setupAmazon () {
       if (this.isAmazonSetup) return;
       this.isAmazonSetup = true;
+      this.amazonLogout();
       this.showButton();
     },
     showButton () {

--- a/website/client/src/components/payments/amazonModal.vue
+++ b/website/client/src/components/payments/amazonModal.vue
@@ -205,8 +205,6 @@ export default {
 
       setLocalSetting(CONSTANTS.savedAppStateValues.SAVED_APP_STATE, JSON.stringify(appState));
 
-      this.reset();
-
       if (url) {
         window.location.assign(url);
       } else {
@@ -251,8 +249,6 @@ export default {
             paymentType: 'Amazon',
           });
 
-          this.$root.$emit('bv::hide::modal', 'amazon-payment');
-
           const newGroup = response.data.data;
           if (newGroup && newGroup._id) {
             // Handle new user signup
@@ -281,6 +277,7 @@ export default {
           this.storePaymentStatusAndReload();
         } catch (e) {
           this.$set(this, 'amazonButtonEnabled', true);
+          this.$root.$emit('bv::hide::modal', 'amazon-payment');
           // @TODO: do we need this? this.amazonPaymentsreset();
         }
       }

--- a/website/client/src/components/payments/amazonModal.vue
+++ b/website/client/src/components/payments/amazonModal.vue
@@ -2,8 +2,9 @@
   <b-modal
     id="amazon-payment"
     title="Amazon"
-    :hide-footer="true"
     size="md"
+    :hide-footer="true"
+    @hide="reset()"
   >
     <h2 class="text-center">
       Continue with Amazon
@@ -58,10 +59,12 @@ import pick from 'lodash/pick';
 import * as Analytics from '@/libs/analytics';
 import { mapState } from '@/libs/store';
 import { CONSTANTS, setLocalSetting } from '@/libs/userlocalManager';
+import paymentsMixin from '@/mixins/payments';
 
 const habiticaUrl = `${window.location.protocol}//${window.location.host}`;
 
 export default {
+  mixins: [paymentsMixin],
   data () {
     return {
       amazonPayments: {
@@ -201,6 +204,9 @@ export default {
       }
 
       setLocalSetting(CONSTANTS.savedAppStateValues.SAVED_APP_STATE, JSON.stringify(appState));
+
+      this.reset();
+
       if (url) {
         window.location.assign(url);
       } else {

--- a/website/client/src/mixins/payments.js
+++ b/website/client/src/mixins/payments.js
@@ -266,6 +266,10 @@ export default {
     reset () {
       // @TODO: Ensure we are using all of these
       // some vars are set in the payments mixin. We should try to edit in one place
+      if (window.amazon) {
+        window.amazon.Login.logout();
+      }
+
       this.amazonPayments.modal = null;
       this.amazonPayments.type = null;
       this.amazonPayments.loggedIn = false;

--- a/website/client/src/mixins/payments.js
+++ b/website/client/src/mixins/payments.js
@@ -263,12 +263,16 @@ export default {
       window.alert(error.getErrorMessage());
       this.reset();
     },
+    // Make sure the amazon session is reset between different sessions and after each purchase
+    amazonLogout () {
+      if (window.amazon && window.amazon.Login && typeof window.amazon.Login.logout === 'function') {
+        window.amazon.Login.logout();
+      }
+    },
     reset () {
       // @TODO: Ensure we are using all of these
       // some vars are set in the payments mixin. We should try to edit in one place
-      if (window.amazon) {
-        window.amazon.Login.logout();
-      }
+      this.amazonLogout();
 
       this.amazonPayments.modal = null;
       this.amazonPayments.type = null;


### PR DESCRIPTION
Fixes #11681 by resetting the amazon cookies when the amazon pay modal is closed using `amazon.Login.logout()` as used in amazon's own examples at https://amzn.github.io/amazon-pay-sdk-samples/

There's an edge case where this could keep happening: when the user opens the amazon modal but reloads or close the page before completing the transaction or closing the modal.

cc @Alys 