### PR TITLE
Added bannedWordsAllowed attribute to Group attributes (Partial fix for #12405)

### DIFF
--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -85,6 +85,7 @@ export const schema = new Schema({
     $type: String, enum: ['private', 'public'], default: 'private', required: true,
   },
   chat: Array, // Used for backward compatibility, but messages aren't stored here
+  bannedWordsAllowed: { $type: Boolean, required: false },
   leaderOnly: { // restrict group actions to leader (members can't do them)
     challenges: { $type: Boolean, default: false, required: true },
     // invites: {$type: Boolean, default: false, required: true},

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -151,7 +151,7 @@ export const schema = new Schema({
 });
 
 schema.plugin(baseModel, {
-  noSet: ['_id', 'balance', 'quest', 'memberCount', 'chat', 'challengeCount', 'tasksOrder', 'purchased', 'managers'],
+  noSet: ['_id', 'balance', 'quest', 'memberCount', 'chat', 'bannedWordsAllowed', 'challengeCount', 'tasksOrder', 'purchased', 'managers'],
   private: ['purchased.plan'],
   toJSONTransform (plainObj, originalDoc) {
     if (plainObj.purchased) plainObj.purchased.active = originalDoc.hasActiveGroupPlan();


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Partial fix for #12405
### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Added an optional Boolean attribute which will determine if banned words are allowed. Allows Step 1 to be completed and for Step 2 to become unblocked once merged and deployed to production. (As listed in the issue)


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 
9cbaf3a3-1f48-4557-9f0a-4d403df1f3eb