### PR TITLE
fix(banned words): fix partial matching of words containing diacritic…

### DIFF
--- a/test/api/unit/libs/stringUtils.test.js
+++ b/test/api/unit/libs/stringUtils.test.js
@@ -8,5 +8,10 @@ describe('stringUtils', () => {
       const matches = getMatchesByWordArray(message, bannedWords);
       expect(matches.length).to.equal(bannedWords.length);
     });
+    it('doesn\'t flag names with accented characters', () => {
+      const name = 'TESTPLACEHOLDERSWEARWORDHEREé';
+      const matches = getMatchesByWordArray(name, bannedWords);
+      expect(matches.length).to.equal(0);
+    });
   });
 });

--- a/website/server/libs/stringUtils.js
+++ b/website/server/libs/stringUtils.js
@@ -4,8 +4,8 @@ export function removePunctuationFromString (str) {
 
 // NOTE: the wordsToMatch aren't escaped in order to support regular expressions,
 // so this method should not be used if wordsToMatch contains unsanitized user input
-export function getMatchesByWordArray (str, wordsToMatch) {
 
+export function getMatchesByWordArray (str, wordsToMatch) {
   // remove accented characters from the string, which would trip up the regEx
   // later on, by using the built-in Unicode normalisation methods
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize

--- a/website/server/libs/stringUtils.js
+++ b/website/server/libs/stringUtils.js
@@ -10,6 +10,7 @@ export function getMatchesByWordArray (str, wordsToMatch) {
   // later on, by using the built-in Unicode normalisation methods
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize
   // https://www.unicode.org/reports/tr15/#Canon_Compat_Equivalence
+  // https://unicode-table.com/en/#combining-diacritical-marks
 
   const normalizedStr = str.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
 

--- a/website/server/libs/stringUtils.js
+++ b/website/server/libs/stringUtils.js
@@ -5,11 +5,19 @@ export function removePunctuationFromString (str) {
 // NOTE: the wordsToMatch aren't escaped in order to support regular expressions,
 // so this method should not be used if wordsToMatch contains unsanitized user input
 export function getMatchesByWordArray (str, wordsToMatch) {
+
+  // remove accented characters from the string, which would trip up the regEx
+  // later on, by using the built-in Unicode normalisation methods
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize
+  // https://www.unicode.org/reports/tr15/#Canon_Compat_Equivalence
+
+  const normalizedStr = str.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+
   const matchedWords = [];
   const wordRegexs = wordsToMatch.map(word => new RegExp(`\\b([^a-z]+)?${word}([^a-z]+)?\\b`, 'i'));
   for (let i = 0; i < wordRegexs.length; i += 1) {
     const regEx = wordRegexs[i];
-    const match = str.match(regEx);
+    const match = normalizedStr.match(regEx);
     if (match !== null && match[0] !== null) {
       const trimmedMatch = removePunctuationFromString(match[0]).trim();
       matchedWords.push(trimmedMatch);


### PR DESCRIPTION
…s against banned words list (#12309)

[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #12309 

### Changes

Added Unicode normalization of input strings in the `getMatchesByWordArray()` function. This prevents diacritics from tripping up the regEx and resulting in false partial matches like the one reported by @Alys. This works since:

`TESTPLACEHOLDERSWEARWORDHEREé`

...is now tested against the banned words list as:

`TESTPLACEHOLDERSWEARWORDHEREe`

...rather than as:

`TESTPLACEHOLDERSWEARWORDHERE,,`

...which of course would, and should, fail.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API) 

----
UUID: 7e694dc6-6c80-4d4a-bc7d-264b6d5022a0
