### PR TITLE
Revert "build(deps): bump mongoose from 5.9.27 to 5.9.28"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9391,9 +9391,9 @@
       }
     },
     "mongoose": {
-      "version": "5.9.28",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.9.28.tgz",
-      "integrity": "sha512-A8lNRk4eCQDzk+DagSMYdH94LAYrbTK83LgrUlzqdig3YXvizW3DApJqOWQ5DdhuimvsfiD0Z5NTVzXl/rgi2w==",
+      "version": "5.9.27",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.9.27.tgz",
+      "integrity": "sha512-N8zj4pj9J2xJ2BnQ4NiIHEtmjPldtbmbEZOMz4phLTQr3KFWPR0T0I6EzQxNioHwmDbHD4VFzbEd755oD2SJxA==",
       "requires": {
         "bson": "^1.1.4",
         "kareem": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "method-override": "^3.0.0",
     "moment": "^2.27.0",
     "moment-recur": "^1.0.7",
-    "mongoose": "^5.9.28",
+    "mongoose": "^5.9.27",
     "morgan": "^1.10.0",
     "nconf": "^0.10.0",
     "node-gcm": "^1.0.3",


### PR DESCRIPTION
Reverts HabitRPG/habitica#12449

Looks like a bug is breaking our user updates https://github.com/Automattic/mongoose/issues/9313