### PR TITLE
Add alt to img tag

### DIFF
--- a/website/client/src/components/404.vue
+++ b/website/client/src/components/404.vue
@@ -5,6 +5,7 @@
       <img
         class="not-found-img"
         src="~@/assets/images/404.png"
+        alt="Not found"
       >
       <h1 class="not-found">
         Sometimes even the bravest adventurer gets lost.

--- a/website/client/src/components/achievements/onboardingComplete.vue
+++ b/website/client/src/components/achievements/onboardingComplete.vue
@@ -18,6 +18,7 @@
       <img
         class="onboarding-complete-banner d-block"
         src="~@/assets/images/onboarding-complete-banner@2x.png"
+        alt=""
       >
       <p
         v-once

--- a/website/client/src/components/groups/tavern.vue
+++ b/website/client/src/components/groups/tavern.vue
@@ -152,11 +152,13 @@
                       v-if="!group.quest.extra.worldDmg.seasonalShop"
                       class="rage-strike"
                       src="~@/assets/images/world-boss/rage_strike@2x.png"
+                      alt=""
                     >
                     <img
                       v-if="group.quest.extra.worldDmg.seasonalShop"
                       class="rage-strike-active"
                       src="~@/assets/images/world-boss/rage_strike-seasonalShop@2x.png"
+                      alt=""
                     >
                   </div>
                   <div
@@ -167,11 +169,13 @@
                       v-if="!group.quest.extra.worldDmg.market"
                       class="rage-strike"
                       src="~@/assets/images/world-boss/rage_strike@2x.png"
+                      alt=""
                     >
                     <img
                       v-if="group.quest.extra.worldDmg.market"
                       class="rage-strike-active"
                       src="~@/assets/images/world-boss/rage_strike-market@2x.png"
+                      alt=""
                     >
                   </div>
                   <div
@@ -182,11 +186,13 @@
                       v-if="!group.quest.extra.worldDmg.quests"
                       class="rage-strike"
                       src="~@/assets/images/world-boss/rage_strike@2x.png"
+                      alt=""
                     >
                     <img
                       v-if="group.quest.extra.worldDmg.quests"
                       class="rage-strike-active"
                       src="~@/assets/images/world-boss/rage_strike-quests@2x.png"
+                      alt=""
                     >
                   </div>
                 </div>

--- a/website/client/src/components/header/notifications/onboardingComplete.vue
+++ b/website/client/src/components/header/notifications/onboardingComplete.vue
@@ -14,6 +14,7 @@
       <img
         class="onboarding-complete-banner d-block"
         src="~@/assets/images/onboarding-complete-banner@2x.png"
+        alt=""
       >
       <h3 v-once>
         {{ $t('onboardingComplete') }}

--- a/website/client/src/components/static/communityGuidelines.vue
+++ b/website/client/src/components/static/communityGuidelines.vue
@@ -7,7 +7,10 @@
       {{ $t('commGuideHeadingWelcome') }}
     </h2>
     <div class="media align-items-center">
-      <img src="~@/assets/images/community-guidelines/intro.png">
+      <img
+        src="~@/assets/images/community-guidelines/intro.png"
+        :alt="$t('commGuideHeadingWelcome')"
+      >
       <div class="media-body">
         <p v-html="$t('commGuidePara001')"></p>
         <p v-html="$t('commGuidePara002')"></p>
@@ -23,7 +26,10 @@
         <p v-html="$t('commGuidePara015')"></p>
         <p v-html="$t('commGuidePara016')"></p>
       </div>
-      <img src="~@/assets/images/community-guidelines/publicSpaces.png">
+      <img
+        src="~@/assets/images/community-guidelines/publicSpaces.png"
+        :alt="$t('commGuideHeadingInteractions')"
+      >
     </div>
     <ul>
       <li v-html="$t('commGuideList02A')"></li>
@@ -47,7 +53,10 @@
       {{ $t('commGuideHeadingTavern') }}
     </h3>
     <div class="media align-items-center">
-      <img src="~@/assets/images/community-guidelines/tavern.png">
+      <img
+        src="~@/assets/images/community-guidelines/tavern.png"
+        :alt="$t('tavern')"
+      >
       <div class="media-body">
         <p v-html="$t('commGuidePara022')"></p>
         <p v-html="$t('commGuidePara023')"></p>
@@ -68,7 +77,10 @@
         <p v-html="$t('commGuidePara029')"></p>
         <p v-html="$t('commGuidePara031')"></p>
       </div>
-      <img src="~@/assets/images/community-guidelines/publicGuilds.png">
+      <img
+        src="~@/assets/images/community-guidelines/publicGuilds.png"
+        :alt="$t('publicGuilds')"
+      >
     </div>
     <p v-html="$t('commGuidePara033')"></p>
     <p v-html="$t('commGuidePara035')"></p>
@@ -82,7 +94,10 @@
       {{ $t('commGuideHeadingInfractions') }}
     </h3>
     <div class="media align-items-center">
-      <img src="~@/assets/images/community-guidelines/infractions.png">
+      <img
+        src="~@/assets/images/community-guidelines/infractions.png"
+        :alt="$t('commGuideHeadingInfractions')"
+      >
       <div class="media-body">
         <p v-html="$t('commGuidePara050')"></p>
         <p v-html="$t('commGuidePara051')"></p>
@@ -126,7 +141,10 @@
         <p v-html="$t('commGuidePara058')"></p>
         <p v-html="$t('commGuidePara059')"></p>
       </div>
-      <img src="~@/assets/images/community-guidelines/consequences.png">
+      <img
+        src="~@/assets/images/community-guidelines/consequences.png"
+        :alt="$t('commGuideHeadingConsequences')"
+      >
     </div>
     <p v-html="$t('commGuidePara060')"></p>
     <ul>
@@ -166,7 +184,10 @@
       {{ $t('commGuideHeadingRestoration') }}
     </h3>
     <div class="media align-items-center">
-      <img src="~@/assets/images/community-guidelines/restoration.png">
+      <img
+        src="~@/assets/images/community-guidelines/restoration.png"
+        :alt="$t('commGuideHeadingRestoration')"
+      >
       <div class="media-body">
         <p v-html="$t('commGuidePara061')"></p>
         <p v-html="$t('commGuidePara062')"></p>
@@ -181,7 +202,10 @@
     <p v-html="$t('commGuidePara008')"></p>
     <p v-html="$t('commGuidePara009')"></p>
     <div class="media align-items-center">
-      <img src="~@/assets/images/community-guidelines/staff.png">
+      <img
+        src="~@/assets/images/community-guidelines/staff.png"
+        :alt="$t('staff')"
+      >
       <div class="media-body">
         <ul>
           <li>{{ $t('commGuideAKA', {habitName: 'Beffymaroo', realName: 'Beth'}) }}</li>
@@ -197,7 +221,10 @@
     </div>
     <p v-html="$t('commGuidePara010')"></p>
     <div class="media align-items-center">
-      <img src="~@/assets/images/community-guidelines/moderators.png">
+      <img
+        src="~@/assets/images/community-guidelines/moderators.png"
+        :alt="$t('moderator')"
+      >
       <div class="media-body">
         <p v-html="$t('commGuidePara011')"></p>
         <ul>

--- a/website/client/src/components/static/communityGuidelines.vue
+++ b/website/client/src/components/static/communityGuidelines.vue
@@ -67,7 +67,10 @@
       <div class="media-body">
         <p v-html="$t('commGuidePara027')"></p>
       </div>
-      <img src="~@/assets/images/community-guidelines/backCorner.png">
+      <img
+        src="~@/assets/images/community-guidelines/backCorner.png"
+        alt=""
+      >
     </div>
     <h3 id="guilds">
       {{ $t('commGuideHeadingPublicGuilds') }}

--- a/website/client/src/components/static/features.vue
+++ b/website/client/src/components/static/features.vue
@@ -7,16 +7,23 @@
     </div>
     <div class="row">
       <div class="col-md-6">
-        <img src="~@/assets/images/marketing/screenshot.png">
+        <img
+          src="~@/assets/images/marketing/screenshot.png"
+          :alt="$t('marketing1Lead1Title')"
+        >
         <h2>{{ $t('marketing1Lead1Title') }}</h2>
         <p>{{ $t('marketing1Lead1') }}</p>
       </div>
       <div class="col-md-6">
-        <img src="~@/assets/images/marketing/gear.png">
+        <img
+          src="~@/assets/images/marketing/gear.png"
+          :alt="$t('gear')"
+        >
         <h2>{{ $t('marketing1Lead2Title') }}</h2>
         <p>{{ $t('marketing1Lead2') }}</p>
         <img
           src="~@/assets/images/marketing/drops.png"
+          :alt="$t('items')"
           style="max-height: 200px;"
         >
         <h2>{{ $t('marketing1Lead3Title') }}</h2>
@@ -31,15 +38,24 @@
     </div>
     <div class="row">
       <div class="col-md-6">
-        <img src="~@/assets/images/marketing/guild.png">
+        <img
+          src="~@/assets/images/marketing/guild.png"
+          :alt="$t('guild')"
+        >
         <h2>{{ $t('marketing2Lead1Title') }}</h2>
         <p>{{ $t('marketing2Lead1') }}</p>
-        <img src="~@/assets/images/marketing/vice3.png">
+        <img
+          src="~@/assets/images/marketing/vice3.png"
+          :alt="$t('greenblue')"
+        >
         <h2>{{ $t('marketing2Lead2Title') }}</h2>
         <p v-markdown="$t('marketing2Lead2')"></p>
       </div>
       <div class="col-md-6">
-        <img src="~@/assets/images/marketing/challenge.png">
+        <img
+          src="~@/assets/images/marketing/challenge.png"
+          :alt="$t('challenge')"
+        >
         <h2>{{ $t('marketing2Lead3Title') }}</h2>
         <p>{{ $t('marketing2Lead3') }}</p>
       </div>
@@ -52,12 +68,18 @@
     </div>
     <div class="row">
       <div class="col-md-6">
-        <img src="~@/assets/images/marketing/android_iphone.png">
+        <img
+          src="~@/assets/images/marketing/android_iphone.png"
+          :alt="$t('mobileApps')"
+        >
         <h2>{{ $t('footerMobile') }}</h2>
         <p v-markdown="$t('marketing3Lead1')"></p>
       </div>
       <div class="col-md-6">
-        <img src="~@/assets/images/marketing/integration.png">
+        <img
+          src="~@/assets/images/marketing/integration.png"
+          :alt="$t('thirdPartyApps')"
+        >
         <h2>{{ $t('marketing3Lead2Title') }}</h2>
         <p v-markdown="$t('marketing3Lead2')"></p>
       </div>
@@ -71,7 +93,10 @@
     <div class="row">
       <div class="col-md-6">
         <div class="media">
-          <img src="~@/assets/images/marketing/education.png">
+          <img
+            src="~@/assets/images/marketing/education.png"
+            :alt="$t('education')"
+          >
           <div class="media-body">
             <h2>{{ $t('marketing4Lead1Title') }}</h2>
             <p>{{ $t('marketing4Lead1') }}</p>
@@ -80,7 +105,10 @@
       </div>
       <div class="col-md-6">
         <div class="media">
-          <img src="~@/assets/images/marketing/wellness.png">
+          <img
+            src="~@/assets/images/marketing/wellness.png"
+            :alt="$t('health_wellness')"
+          >
           <div class="media-body">
             <h2>{{ $t('marketing4Lead2Title') }}</h2>
             <p>{{ $t('marketing4Lead2') }}</p>
@@ -91,7 +119,10 @@
     <div class="row">
       <div class="col-md-6 offset-md-3">
         <h2>{{ $t('marketing4Lead3Title') }}</h2>
-        <img src="~@/assets/images/marketing/lefnire.png">
+        <img
+          src="~@/assets/images/marketing/lefnire.png"
+          :alt="$t('marketing4Lead3Title')"
+        >
         <p class="span">
           <span>{{ $t('marketing4Lead3-1') }}</span>
           <button

--- a/website/client/src/components/static/groupPlans.vue
+++ b/website/client/src/components/static/groupPlans.vue
@@ -8,6 +8,7 @@
           <img
             class="party"
             src="../../assets/images/group-plans-static/party@3x.png"
+            :alt="$t('party')"
           >
           <h1>{{ $t('groupPlanTitle') }}</h1>
           <p>{{ $t('groupPlanDesc') }}</p>
@@ -59,6 +60,7 @@
           <img
             class="big-gem"
             src="../../assets/images/group-plans-static/big-gem@3x.png"
+            :alt="$t('gems')"
           >
           <h2>{{ $t('inGameBenefits') }}</h2>
           <p>{{ $t('inGameBenefitsDesc') }}</p>

--- a/website/client/src/components/static/home.vue
+++ b/website/client/src/components/static/home.vue
@@ -18,6 +18,7 @@
             <img
               src="~@/assets/images/home/home-main@3x.png"
               width="357px"
+              alt=""
             >
             <h1>{{ $t('motivateYourself') }}</h1>
             <p class="section-main">
@@ -173,6 +174,7 @@
               src="~@/assets/images/home/track-habits@3x.png"
               width="354px"
               height="228px"
+              :alt="$t('todos')"
             >
             <strong>{{ $t('trackYourGoals') }}</strong>
             <p>{{ $t('trackYourGoalsDesc') }}</p>
@@ -182,6 +184,7 @@
               src="~@/assets/images/home/earn-rewards@3x.png"
               width="316px"
               height="244px"
+              :alt="$t('rewards')"
             >
             <strong>{{ $t('earnRewards') }}</strong>
             <p>{{ $t('earnRewardsDesc') }}</p>
@@ -191,6 +194,7 @@
               src="~@/assets/images/home/battle-monsters@3x.png"
               width="303px"
               height="244px"
+              :alt="$t('greenblue')"
             >
             <strong>{{ $t('battleMonsters') }}</strong>
             <p>{{ $t('battleMonstersDesc') }}</p>
@@ -220,6 +224,7 @@
               src="~@/assets/images/home/health-fitness@3x.png"
               width="300px"
               height="300px"
+              :alt="$t('health_fitness')"
             >
             <strong>{{ $t('healthAndFitness') }}</strong>
             <p>{{ $t('healthAndFitnessDesc') }}</p>
@@ -229,6 +234,7 @@
               src="~@/assets/images/home/school-work@3x.png"
               width="300px"
               height="300px"
+              :alt="$t('work')"
             >
             <strong>{{ $t('schoolAndWork') }}</strong>
             <p>{{ $t('schoolAndWorkDesc') }}</p>
@@ -238,6 +244,7 @@
               src="~@/assets/images/home/much-more@3x.png"
               width="300px"
               height="300px"
+              :alt="$t('other')"
             >
             <strong>{{ $t('muchmuchMore') }}</strong>
             <p>{{ $t('muchmuchMoreDesc') }}</p>


### PR DESCRIPTION
Related #10008

### Changes
- Add alt
  - `communityGuidelines.vue`
  - `features.vue`
  - `home.vue`
  - `404.vue`
  - `groupPlans.vue`

- Add `""` for the alt text to Any image that doesn't give obvious information (i.e., any image that's just for decoration).

Not attached to images that are difficult to attach.


----
UUID: df9dbe38-5bb5-4d23-9ba5-b5e11ed03c86
