### PR TITLE
Filter challenge by owned

### DIFF
--- a/test/api/v3/integration/challenges/GET-challenges_user.test.js
+++ b/test/api/v3/integration/challenges/GET-challenges_user.test.js
@@ -7,7 +7,7 @@ import {
 describe('GET challenges/user', () => {
   context('no official challenges', () => {
     let user; let member; let nonMember; let challenge; let challenge2; let
-      publicGuild;
+      publicGuild; let userData; let groupData
 
     before(async () => {
       const { group, groupLeader, members } = await createAndPopulateGroup({
@@ -19,228 +19,200 @@ describe('GET challenges/user', () => {
         members: 1,
       });
 
-      user = groupLeader;
       publicGuild = group;
+      groupData = {
+        _id: publicGuild._id,
+        categories: [],
+        id: publicGuild._id,
+        type: publicGuild.type,
+        privacy: publicGuild.privacy,
+        name: publicGuild.name,
+        summary: publicGuild.name,
+        leader: publicGuild.leader._id,
+      };
+
+      user = groupLeader;
+      userData = {
+        _id: publicGuild.leader._id,
+        id: publicGuild.leader._id,
+        profile: { name: user.profile.name },
+        auth: {
+          local: {
+            username: user.auth.local.username,
+          },
+        },
+        flags: {
+          verifiedUsername: true,
+        },
+      };
+      
       member = members[0]; // eslint-disable-line prefer-destructuring
       nonMember = await generateUser();
 
       challenge = await generateChallenge(user, group);
-      await user.post(`/challenges/${challenge._id}/join`);
       challenge2 = await generateChallenge(user, group);
-      await user.post(`/challenges/${challenge2._id}/join`);
-    });
 
-    it('should return challenges user has joined', async () => {
       await nonMember.post(`/challenges/${challenge._id}/join`);
-
-      const challenges = await nonMember.get('/challenges/user');
-
-      const foundChallenge = _.find(challenges, { _id: challenge._id });
-      expect(foundChallenge).to.exist;
-      expect(foundChallenge.leader).to.eql({
-        _id: publicGuild.leader._id,
-        id: publicGuild.leader._id,
-        profile: { name: user.profile.name },
-        auth: {
-          local: {
-            username: user.auth.local.username,
+    });
+    context('all challenges', () => {
+      it('should return challenges user has joined', async () => {
+        const challenges = await nonMember.get('/challenges/user');
+  
+        const foundChallenge = _.find(challenges, { _id: challenge._id });
+        expect(foundChallenge).to.exist;
+        expect(foundChallenge.leader).to.eql(userData);
+        expect(foundChallenge.group).to.eql(groupData);
+      });
+  
+      it('should not return challenges a non-member has not joined', async () => {
+        const challenges = await nonMember.get('/challenges/user');
+  
+        const foundChallenge2 = _.find(challenges, { _id: challenge2._id });
+        expect(foundChallenge2).to.not.exist;
+      });
+  
+      it('should return challenges user has created', async () => {
+        const challenges = await user.get('/challenges/user');
+  
+        const foundChallenge1 = _.find(challenges, { _id: challenge._id });
+        expect(foundChallenge1).to.exist;
+        expect(foundChallenge1.leader).to.eql(userData);
+        expect(foundChallenge1.group).to.eql(groupData);
+        const foundChallenge2 = _.find(challenges, { _id: challenge2._id });
+        expect(foundChallenge2).to.exist;
+        expect(foundChallenge2.leader).to.eql(userData);
+        expect(foundChallenge2.group).to.eql(groupData);
+      });
+  
+      it('should return challenges in user\'s group', async () => {
+        const challenges = await member.get('/challenges/user');
+  
+        const foundChallenge1 = _.find(challenges, { _id: challenge._id });
+        expect(foundChallenge1).to.exist;
+        expect(foundChallenge1.leader).to.eql(userData);
+        expect(foundChallenge1.group).to.eql(groupData);
+        const foundChallenge2 = _.find(challenges, { _id: challenge2._id });
+        expect(foundChallenge2).to.exist;
+        expect(foundChallenge2.leader).to.eql(userData);
+        expect(foundChallenge2.group).to.eql(groupData);
+      });
+  
+      it('should return newest challenges first', async () => {
+        let challenges = await user.get('/challenges/user');
+  
+        let foundChallengeIndex = _.findIndex(challenges, { _id: challenge2._id });
+        expect(foundChallengeIndex).to.eql(0);
+  
+        const newChallenge = await generateChallenge(user, publicGuild);
+        await user.post(`/challenges/${newChallenge._id}/join`);
+  
+        challenges = await user.get('/challenges/user');
+  
+        foundChallengeIndex = _.findIndex(challenges, { _id: newChallenge._id });
+        expect(foundChallengeIndex).to.eql(0);
+      });
+  
+      it('should not return challenges user doesn\'t have access to', async () => {
+        const { group, groupLeader } = await createAndPopulateGroup({
+          groupDetails: {
+            name: 'TestPrivateGuild',
+            summary: 'summary for TestPrivateGuild',
+            type: 'guild',
+            privacy: 'private',
           },
-        },
-        flags: {
-          verifiedUsername: true,
-        },
+        });
+  
+        const privateChallenge = await generateChallenge(groupLeader, group);
+        await groupLeader.post(`/challenges/${privateChallenge._id}/join`);
+  
+        const challenges = await nonMember.get('/challenges/user');
+  
+        const foundChallenge = _.find(challenges, { _id: privateChallenge._id });
+        expect(foundChallenge).to.not.exist;
       });
-      expect(foundChallenge.group).to.eql({
-        _id: publicGuild._id,
-        categories: [],
-        id: publicGuild._id,
-        type: publicGuild.type,
-        privacy: publicGuild.privacy,
-        name: publicGuild.name,
-        summary: publicGuild.name,
-        leader: publicGuild.leader._id,
-      });
-    });
-
-    it('should return challenges user has created', async () => {
-      const challenges = await user.get('/challenges/user');
-
-      const foundChallenge1 = _.find(challenges, { _id: challenge._id });
-      expect(foundChallenge1).to.exist;
-      expect(foundChallenge1.leader).to.eql({
-        _id: publicGuild.leader._id,
-        id: publicGuild.leader._id,
-        profile: { name: user.profile.name },
-        auth: {
-          local: {
-            username: user.auth.local.username,
+  
+      it('should not return challenges user doesn\'t have access to, even with query parameters', async () => {
+        const { group, groupLeader } = await createAndPopulateGroup({
+          groupDetails: {
+            name: 'TestPrivateGuild',
+            summary: 'summary for TestPrivateGuild',
+            type: 'guild',
+            privacy: 'private',
           },
-        },
-        flags: {
-          verifiedUsername: true,
-        },
-      });
-      expect(foundChallenge1.group).to.eql({
-        _id: publicGuild._id,
-        categories: [],
-        id: publicGuild._id,
-        type: publicGuild.type,
-        privacy: publicGuild.privacy,
-        name: publicGuild.name,
-        summary: publicGuild.name,
-        leader: publicGuild.leader._id,
-      });
-      const foundChallenge2 = _.find(challenges, { _id: challenge2._id });
-      expect(foundChallenge2).to.exist;
-      expect(foundChallenge2.leader).to.eql({
-        _id: publicGuild.leader._id,
-        id: publicGuild.leader._id,
-        profile: { name: user.profile.name },
-        auth: {
-          local: {
-            username: user.auth.local.username,
-          },
-        },
-        flags: {
-          verifiedUsername: true,
-        },
-      });
-      expect(foundChallenge2.group).to.eql({
-        _id: publicGuild._id,
-        categories: [],
-        id: publicGuild._id,
-        type: publicGuild.type,
-        privacy: publicGuild.privacy,
-        name: publicGuild.name,
-        summary: publicGuild.name,
-        leader: publicGuild.leader._id,
+        });
+  
+        const privateChallenge = await generateChallenge(groupLeader, group, {
+          categories: [{
+            name: 'academics',
+            slug: 'academics',
+          }],
+        });
+        await groupLeader.post(`/challenges/${privateChallenge._id}/join`);
+  
+        const challenges = await nonMember.get('/challenges/user?categories=academics&owned=not_owned');
+  
+        const foundChallenge = _.find(challenges, { _id: privateChallenge._id });
+        expect(foundChallenge).to.not.exist;
       });
     });
-
-    it('should return challenges in user\'s group', async () => {
-      const challenges = await member.get('/challenges/user');
-
-      const foundChallenge1 = _.find(challenges, { _id: challenge._id });
-      expect(foundChallenge1).to.exist;
-      expect(foundChallenge1.leader).to.eql({
-        _id: publicGuild.leader._id,
-        id: publicGuild.leader._id,
-        profile: { name: user.profile.name },
-        auth: {
-          local: {
-            username: user.auth.local.username,
-          },
-        },
-        flags: {
-          verifiedUsername: true,
-        },
+  
+    context('my challenges', () => {
+      it('should return challenges user has joined', async () => {
+        const challenges = await nonMember.get('/challenges/user?member=${true');
+  
+        const foundChallenge = _.find(challenges, { _id: challenge._id });
+        expect(foundChallenge).to.exist;
+        expect(foundChallenge.leader).to.eql(userData);
+        expect(foundChallenge.group).to.eql(groupData);
       });
-      expect(foundChallenge1.group).to.eql({
-        _id: publicGuild._id,
-        categories: [],
-        id: publicGuild._id,
-        type: publicGuild.type,
-        privacy: publicGuild.privacy,
-        name: publicGuild.name,
-        summary: publicGuild.name,
-        leader: publicGuild.leader._id,
+  
+      it('should return challenges user has created', async () => {
+        const challenges = await user.get('/challenges/user?member=${true}');
+  
+        const foundChallenge1 = _.find(challenges, { _id: challenge._id });
+        expect(foundChallenge1).to.exist;
+        expect(foundChallenge1.leader).to.eql(userData);
+        expect(foundChallenge1.group).to.eql(groupData);
+        const foundChallenge2 = _.find(challenges, { _id: challenge2._id });
+        expect(foundChallenge2).to.exist;
+        expect(foundChallenge2.leader).to.eql(userData);
+        expect(foundChallenge2.group).to.eql(groupData);
       });
-      const foundChallenge2 = _.find(challenges, { _id: challenge2._id });
-      expect(foundChallenge2).to.exist;
-      expect(foundChallenge2.leader).to.eql({
-        _id: publicGuild.leader._id,
-        id: publicGuild.leader._id,
-        profile: { name: user.profile.name },
-        auth: {
-          local: {
-            username: user.auth.local.username,
-          },
-        },
-        flags: {
-          verifiedUsername: true,
-        },
+  
+      it('should return challenges user has created if filter by owned', async () => {
+        const challenges = await user.get('/challenges/user?member=${true}&owned=owned');
+  
+        const foundChallenge1 = _.find(challenges, { _id: challenge._id });
+        expect(foundChallenge1).to.exist;
+        expect(foundChallenge1.leader).to.eql(userData);
+        expect(foundChallenge1.group).to.eql(groupData);
+        const foundChallenge2 = _.find(challenges, { _id: challenge2._id });
+        expect(foundChallenge2).to.exist;
+        expect(foundChallenge2.leader).to.eql(userData);
+        expect(foundChallenge2.group).to.eql(groupData);
       });
-      expect(foundChallenge2.group).to.eql({
-        _id: publicGuild._id,
-        categories: [],
-        id: publicGuild._id,
-        type: publicGuild.type,
-        privacy: publicGuild.privacy,
-        name: publicGuild.name,
-        summary: publicGuild.name,
-        leader: publicGuild.leader._id,
+  
+      it('should not return challenges user has created if filter by not owned', async () => {
+        const challenges = await user.get('/challenges/user?owned=not_owned');
+  
+        const foundChallenge1 = _.find(challenges, { _id: challenge._id });
+        expect(foundChallenge1).to.not.exist;
+        const foundChallenge2 = _.find(challenges, { _id: challenge2._id });
+        expect(foundChallenge2).to.not.exist;
       });
-    });
-
-    it('should not return challenges in user groups if we send member true param', async () => {
-      const challenges = await member.get(`/challenges/user?member=${true}`);
-
-      const foundChallenge1 = _.find(challenges, { _id: challenge._id });
-      expect(foundChallenge1).to.not.exist;
-
-      const foundChallenge2 = _.find(challenges, { _id: challenge2._id });
-      expect(foundChallenge2).to.not.exist;
-    });
-
-    it('should return newest challenges first', async () => {
-      let challenges = await user.get('/challenges/user');
-
-      let foundChallengeIndex = _.findIndex(challenges, { _id: challenge2._id });
-      expect(foundChallengeIndex).to.eql(0);
-
-      const newChallenge = await generateChallenge(user, publicGuild);
-      await user.post(`/challenges/${newChallenge._id}/join`);
-
-      challenges = await user.get('/challenges/user');
-
-      foundChallengeIndex = _.findIndex(challenges, { _id: newChallenge._id });
-      expect(foundChallengeIndex).to.eql(0);
-    });
-
-    it('should not return challenges user doesn\'t have access to', async () => {
-      const { group, groupLeader } = await createAndPopulateGroup({
-        groupDetails: {
-          name: 'TestPrivateGuild',
-          summary: 'summary for TestPrivateGuild',
-          type: 'guild',
-          privacy: 'private',
-        },
+  
+      it('should not return challenges in user groups', async () => {
+        const challenges = await member.get(`/challenges/user?member=${true}`);
+  
+        const foundChallenge1 = _.find(challenges, { _id: challenge._id });
+        expect(foundChallenge1).to.not.exist;
+  
+        const foundChallenge2 = _.find(challenges, { _id: challenge2._id });
+        expect(foundChallenge2).to.not.exist;
       });
-
-      const privateChallenge = await generateChallenge(groupLeader, group);
-      await groupLeader.post(`/challenges/${privateChallenge._id}/join`);
-
-      const challenges = await nonMember.get('/challenges/user');
-
-      const foundChallenge = _.find(challenges, { _id: privateChallenge._id });
-      expect(foundChallenge).to.not.exist;
-    });
-
-    it('should not return challenges user doesn\'t have access to, even with query parameters', async () => {
-      const { group, groupLeader } = await createAndPopulateGroup({
-        groupDetails: {
-          name: 'TestPrivateGuild',
-          summary: 'summary for TestPrivateGuild',
-          type: 'guild',
-          privacy: 'private',
-        },
-      });
-
-      const privateChallenge = await generateChallenge(groupLeader, group, {
-        categories: [{
-          name: 'academics',
-          slug: 'academics',
-        }],
-      });
-      await groupLeader.post(`/challenges/${privateChallenge._id}/join`);
-
-      const challenges = await nonMember.get('/challenges/user?categories=academics&owned=not_owned');
-
-      const foundChallenge = _.find(challenges, { _id: privateChallenge._id });
-      expect(foundChallenge).to.not.exist;
     });
   });
-
+  
   context('official challenge is present', () => {
     let user; let officialChallenge; let unofficialChallenges; let
       publicGuild;

--- a/test/api/v3/integration/challenges/GET-challenges_user.test.js
+++ b/test/api/v3/integration/challenges/GET-challenges_user.test.js
@@ -6,8 +6,8 @@ import {
 
 describe('GET challenges/user', () => {
   context('no official challenges', () => {
-    let user; let member; let nonMember; let challenge; let challenge2; let
-      publicGuild; let userData; let groupData
+    let user; let member; let nonMember; let challenge; let challenge2;
+    let publicGuild; let userData; let groupData;
 
     before(async () => {
       const { group, groupLeader, members } = await createAndPopulateGroup({
@@ -45,7 +45,7 @@ describe('GET challenges/user', () => {
           verifiedUsername: true,
         },
       };
-      
+
       member = members[0]; // eslint-disable-line prefer-destructuring
       nonMember = await generateUser();
 
@@ -57,23 +57,23 @@ describe('GET challenges/user', () => {
     context('all challenges', () => {
       it('should return challenges user has joined', async () => {
         const challenges = await nonMember.get('/challenges/user');
-  
+
         const foundChallenge = _.find(challenges, { _id: challenge._id });
         expect(foundChallenge).to.exist;
         expect(foundChallenge.leader).to.eql(userData);
         expect(foundChallenge.group).to.eql(groupData);
       });
-  
+
       it('should not return challenges a non-member has not joined', async () => {
         const challenges = await nonMember.get('/challenges/user');
-  
+
         const foundChallenge2 = _.find(challenges, { _id: challenge2._id });
         expect(foundChallenge2).to.not.exist;
       });
-  
+
       it('should return challenges user has created', async () => {
         const challenges = await user.get('/challenges/user');
-  
+
         const foundChallenge1 = _.find(challenges, { _id: challenge._id });
         expect(foundChallenge1).to.exist;
         expect(foundChallenge1.leader).to.eql(userData);
@@ -83,10 +83,10 @@ describe('GET challenges/user', () => {
         expect(foundChallenge2.leader).to.eql(userData);
         expect(foundChallenge2.group).to.eql(groupData);
       });
-  
+
       it('should return challenges in user\'s group', async () => {
         const challenges = await member.get('/challenges/user');
-  
+
         const foundChallenge1 = _.find(challenges, { _id: challenge._id });
         expect(foundChallenge1).to.exist;
         expect(foundChallenge1.leader).to.eql(userData);
@@ -96,22 +96,22 @@ describe('GET challenges/user', () => {
         expect(foundChallenge2.leader).to.eql(userData);
         expect(foundChallenge2.group).to.eql(groupData);
       });
-  
+
       it('should return newest challenges first', async () => {
         let challenges = await user.get('/challenges/user');
-  
+
         let foundChallengeIndex = _.findIndex(challenges, { _id: challenge2._id });
         expect(foundChallengeIndex).to.eql(0);
-  
+
         const newChallenge = await generateChallenge(user, publicGuild);
         await user.post(`/challenges/${newChallenge._id}/join`);
-  
+
         challenges = await user.get('/challenges/user');
-  
+
         foundChallengeIndex = _.findIndex(challenges, { _id: newChallenge._id });
         expect(foundChallengeIndex).to.eql(0);
       });
-  
+
       it('should not return challenges user doesn\'t have access to', async () => {
         const { group, groupLeader } = await createAndPopulateGroup({
           groupDetails: {
@@ -121,16 +121,16 @@ describe('GET challenges/user', () => {
             privacy: 'private',
           },
         });
-  
+
         const privateChallenge = await generateChallenge(groupLeader, group);
         await groupLeader.post(`/challenges/${privateChallenge._id}/join`);
-  
+
         const challenges = await nonMember.get('/challenges/user');
-  
+
         const foundChallenge = _.find(challenges, { _id: privateChallenge._id });
         expect(foundChallenge).to.not.exist;
       });
-  
+
       it('should not return challenges user doesn\'t have access to, even with query parameters', async () => {
         const { group, groupLeader } = await createAndPopulateGroup({
           groupDetails: {
@@ -140,7 +140,7 @@ describe('GET challenges/user', () => {
             privacy: 'private',
           },
         });
-  
+
         const privateChallenge = await generateChallenge(groupLeader, group, {
           categories: [{
             name: 'academics',
@@ -148,27 +148,27 @@ describe('GET challenges/user', () => {
           }],
         });
         await groupLeader.post(`/challenges/${privateChallenge._id}/join`);
-  
+
         const challenges = await nonMember.get('/challenges/user?categories=academics&owned=not_owned');
-  
+
         const foundChallenge = _.find(challenges, { _id: privateChallenge._id });
         expect(foundChallenge).to.not.exist;
       });
     });
-  
+
     context('my challenges', () => {
       it('should return challenges user has joined', async () => {
-        const challenges = await nonMember.get('/challenges/user?member=${true');
-  
+        const challenges = await nonMember.get(`/challenges/user?member=${true}`);
+
         const foundChallenge = _.find(challenges, { _id: challenge._id });
         expect(foundChallenge).to.exist;
         expect(foundChallenge.leader).to.eql(userData);
         expect(foundChallenge.group).to.eql(groupData);
       });
-  
+
       it('should return challenges user has created', async () => {
-        const challenges = await user.get('/challenges/user?member=${true}');
-  
+        const challenges = await user.get(`/challenges/user?member=${true}`);
+
         const foundChallenge1 = _.find(challenges, { _id: challenge._id });
         expect(foundChallenge1).to.exist;
         expect(foundChallenge1.leader).to.eql(userData);
@@ -178,10 +178,10 @@ describe('GET challenges/user', () => {
         expect(foundChallenge2.leader).to.eql(userData);
         expect(foundChallenge2.group).to.eql(groupData);
       });
-  
+
       it('should return challenges user has created if filter by owned', async () => {
-        const challenges = await user.get('/challenges/user?member=${true}&owned=owned');
-  
+        const challenges = await user.get(`/challenges/user?member=${true}&owned=owned`);
+
         const foundChallenge1 = _.find(challenges, { _id: challenge._id });
         expect(foundChallenge1).to.exist;
         expect(foundChallenge1.leader).to.eql(userData);
@@ -191,28 +191,28 @@ describe('GET challenges/user', () => {
         expect(foundChallenge2.leader).to.eql(userData);
         expect(foundChallenge2.group).to.eql(groupData);
       });
-  
+
       it('should not return challenges user has created if filter by not owned', async () => {
-        const challenges = await user.get('/challenges/user?owned=not_owned');
-  
+        const challenges = await user.get(`/challenges/user?owned=not_owned&member=${true}`);
+
         const foundChallenge1 = _.find(challenges, { _id: challenge._id });
         expect(foundChallenge1).to.not.exist;
         const foundChallenge2 = _.find(challenges, { _id: challenge2._id });
         expect(foundChallenge2).to.not.exist;
       });
-  
+
       it('should not return challenges in user groups', async () => {
         const challenges = await member.get(`/challenges/user?member=${true}`);
-  
+
         const foundChallenge1 = _.find(challenges, { _id: challenge._id });
         expect(foundChallenge1).to.not.exist;
-  
+
         const foundChallenge2 = _.find(challenges, { _id: challenge2._id });
         expect(foundChallenge2).to.not.exist;
       });
     });
   });
-  
+
   context('official challenge is present', () => {
     let user; let officialChallenge; let unofficialChallenges; let
       publicGuild;

--- a/website/server/controllers/api-v3/challenges.js
+++ b/website/server/controllers/api-v3/challenges.js
@@ -371,10 +371,7 @@ api.getUserChallenges = {
       { _id: { $in: user.challenges } }, // Challenges where the user is participating
     ];
 
-    const { owned } = req.query;
-    if (!owned) {
-      orOptions.push({ leader: user._id });
-    }
+    orOptions.push({ leader: user._id });
 
     if (!req.query.member) {
       orOptions.push({
@@ -386,6 +383,7 @@ api.getUserChallenges = {
       $and: [{ $or: orOptions }],
     };
 
+    const { owned } = req.query;
     if (owned) {
       if (owned === 'not_owned') {
         query.$and.push({ leader: { $ne: user._id } });


### PR DESCRIPTION
Fixes #11145

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
 * Fixed API so that when requesting challenges with member=true parameters, challenges are returned if they are either owned by the user or joined by the user.
 * Tests added / Rewritten to check this is working correctly.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: UUID: 62b5b263-cb73-4519-8149-d214c798c17f

