### PR TITLE
Less mess for lingering pinned Seasonal Shop gear

### DIFF
--- a/website/client/src/components/inventory/equipment/attributesPopover.vue
+++ b/website/client/src/components/inventory/equipment/attributesPopover.vue
@@ -5,29 +5,30 @@
         {{ `${$t('lockedItem')}` }}
       </h4>
       <div
-        v-if="isWrongClass"
-        class="popover-content-text"
+        v-if="item.currency === 'gems'"
+      >
+        {{ `${$t('messageNotAvailable')}` }}
+      </div>
+      <div
+        v-else-if="isWrongClass"
       >
         {{ `${$t('classLockedItem')}` }}
       </div>
-      <div
-        v-else
-        class="popover-content-text"
-      >
+      <div v-else>
         {{ `${$t('tierLockedItem')}` }}
       </div>
-      <p></p>
     </div>
     <div v-else>
       <h4 class="popover-content-title">
         {{ itemText }}
       </h4>
-      <div class="popover-content-text">
+      <div>
         {{ itemNotes }}
       </div>
       <attributesGrid
         :user="user"
         :item="item"
+        class="mt-3 mb-2"
       />
     </div>
   </div>

--- a/website/client/src/components/shops/shopItem.vue
+++ b/website/client/src/components/shops/shopItem.vue
@@ -106,7 +106,6 @@
         </div>
         <div
           v-if="item.event"
-          :class="item.purchaseType === 'gear' ? 'mt-4' : 'mt-2'"
         >
           {{ limitedString }}
         </div>
@@ -313,8 +312,12 @@ export default {
       return 'gold';
     },
     limitedString () {
-      return this.item.owned === false ? ''
-        : this.$t('limitedOffer', { date: moment(seasonalShopConfig.dateRange.end).format('LL') });
+      if (this.item.owned === false
+        || moment().isAfter(seasonalShopConfig.dateRange.end)
+      ) return null;
+      return this.$t('limitedOffer', {
+        date: moment(seasonalShopConfig.dateRange.end).format('LL'),
+      });
     },
   },
   methods: {

--- a/website/common/script/content/constants/index.js
+++ b/website/common/script/content/constants/index.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
 
-export const CURRENT_SEASON = moment().isBefore('2020-08-02') ? 'summer' : '_NONE_';
+export const CURRENT_SEASON = moment().isBefore('2020-11-02') ? 'fall' : '_NONE_';
 
 export const CLASSES = [
   'warrior',

--- a/website/common/script/content/gear/sets/special/index.js
+++ b/website/common/script/content/gear/sets/special/index.js
@@ -1,8 +1,8 @@
-import moment from 'moment';
 import defaults from 'lodash/defaults';
 import upperFirst from 'lodash/upperFirst';
 import {
   CLASSES,
+  CURRENT_SEASON,
   EVENTS,
 } from '../../../constants';
 import { ownsItem } from '../../gear-helper';
@@ -11,8 +11,6 @@ import * as contributorGear from './special-contributor';
 import * as takeThisGear from './special-takeThis';
 import * as wonderconGear from './special-wondercon';
 import t from '../../../translation';
-
-const CURRENT_SEASON = moment().isBefore('2020-11-02') ? 'fall' : '_NONE_';
 
 const armor = {
   0: backerGear.armorSpecial0,

--- a/website/common/script/libs/getItemInfo.js
+++ b/website/common/script/libs/getItemInfo.js
@@ -223,6 +223,7 @@ export default function getItemInfo (user, type, item, officialPinnedItems, lang
         value: item.twoHanded ? 2 : 1,
         currency: 'gems',
         pinType: 'gear',
+        locked: !item.canBuy(user),
       });
       break;
     case 'marketGear':


### PR DESCRIPTION
Fixes #11151

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

**Previously**, in the event that a user manually pinned a Seasonal Shop item ~~buyable with Gems~~, and that item remained pinned after the end of the Gala, misleading text would appear when hovering over that item. It referred erroneously to class restrictions and provided a useless end date.

**Now**, instead, the hover text will simply say that the item is not available for purchase, and will not display an end date.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

To test this, you'll need to change the Gala end date in `website/common/script/content/constants/index.js` and `website/common/script/libs/shops-seasonal.config.js` to something earlier than the current date.