### PR TITLE
Fix vue test stacktraces

### DIFF
--- a/website/client/src/components/avatar.vue
+++ b/website/client/src/components/avatar.vue
@@ -227,7 +227,7 @@ export default {
       return this.member.preferences.costume ? 'costume' : 'equipped';
     },
     specialMountClass () {
-      if (!this.avatarOnly && this.member.items.currentMount && this.member.items.currentMount.indexOf('Kangaroo') !== -1) {
+      if (!this.avatarOnly && this.member.items.currentMount && this.member.items.currentMount.includes('Kangaroo')) {
         return 'offset-kangaroo';
       }
 

--- a/website/client/tests/unit/components/avatar.spec.js
+++ b/website/client/tests/unit/components/avatar.spec.js
@@ -1,30 +1,33 @@
 import Vue from 'vue';
+import merge from 'lodash/merge';
+
 import Avatar from '@/components/avatar';
 import generateStore from '@/store';
 
-context.only('avatar.vue', () => { // eslint-disable-line mocha/no-exclusive-tests
+context('avatar.vue', () => {
   let Constructr;
   let vm;
+
+  const baseMember = {
+    stats: {
+      buffs: {},
+      class: 'warrior',
+    },
+    preferences: {
+      hair: {},
+    },
+    items: {
+      gear: {
+        equipped: {},
+      },
+    },
+  };
 
   beforeEach(() => {
     Constructr = Vue.extend(Avatar);
 
     vm = new Constructr({
-      propsData: {
-        member: {
-          stats: {
-            buffs: {},
-          },
-          preferences: {
-            hair: {},
-          },
-          items: {
-            gear: {
-              equipped: {},
-            },
-          },
-        },
-      },
+      propsData: { member: baseMember },
     });
 
     vm.$store = generateStore();
@@ -37,11 +40,11 @@ context.only('avatar.vue', () => { // eslint-disable-line mocha/no-exclusive-tes
 
   describe('hasClass', () => {
     beforeEach(() => {
-      vm.member = {
+      vm.member = merge({
         stats: { lvl: 17 },
         preferences: { disableClasses: true },
         flags: { classSelected: false },
-      };
+      }, baseMember);
     });
 
     it('accurately reports class status', () => {
@@ -55,10 +58,6 @@ context.only('avatar.vue', () => { // eslint-disable-line mocha/no-exclusive-tes
   });
 
   describe('isBuffed', () => {
-    beforeEach(() => {
-      vm.member.stats.buffs = {};
-    });
-
     it('accurately reports if buffed', () => {
       expect(vm.isBuffed).to.equal(undefined);
 
@@ -69,32 +68,23 @@ context.only('avatar.vue', () => { // eslint-disable-line mocha/no-exclusive-tes
   });
 
   describe('paddingTop', () => {
-    beforeEach(() => {
-      vm.member.items = {
-        gear: {
-          equipped: {},
-          warrior: {},
-        },
-      };
-    });
-
     xit('defaults to 27px', () => {
       vm.avatarOnly = true;
       expect(vm.paddingTop).to.equal('27px');
     });
 
     it('is 24px if user has a pet', () => {
-      vm.member.items = {
+      vm.member.items = merge({
         currentPet: { name: 'Foo' },
-      };
+      }, baseMember.items);
 
       expect(vm.paddingTop).to.equal('24px');
     });
 
     it('is 0px if user has a mount', () => {
-      vm.member.items = {
-        currentMount: { name: 'Bar' },
-      };
+      vm.member.items = merge({
+        currentMount: 'Bar',
+      }, baseMember.items);
 
       expect(vm.paddingTop).to.equal('0px');
     });
@@ -106,26 +96,25 @@ context.only('avatar.vue', () => { // eslint-disable-line mocha/no-exclusive-tes
   });
 
   describe('costumeClass', () => {
-    beforeEach(() => {
-      vm.member.preferences = {};
-    });
-
     it('returns if showing equipped gear', () => {
       expect(vm.costumeClass).to.equal('equipped');
     });
+
     it('returns if wearing a costume', () => {
-      vm.member.preferences = { costume: true };
+      vm.member.preferences = { costume: true, hair: {} };
+      vm.member.items.gear.costume = {};
+
       expect(vm.costumeClass).to.equal('costume');
     });
   });
 
   describe('visualBuffs', () => {
     it('returns an array of buffs', () => {
-      vm.member = {
+      vm.member = merge({
         stats: {
           class: 'warrior',
         },
-      };
+      }, baseMember);
 
       expect(vm.visualBuffs).to.include({ snowball: 'avatar_snowball_warrior' });
       expect(vm.visualBuffs).to.include({ spookySparkles: 'ghost' });
@@ -136,7 +125,10 @@ context.only('avatar.vue', () => { // eslint-disable-line mocha/no-exclusive-tes
 
   describe('backgroundClass', () => {
     beforeEach(() => {
-      vm.member.preferences = { background: 'pony' };
+      vm.member.preferences = {
+        hair: {},
+        background: 'pony',
+      };
     });
 
     it('shows the background', () => {
@@ -159,17 +151,11 @@ context.only('avatar.vue', () => { // eslint-disable-line mocha/no-exclusive-tes
 
   describe('specialMountClass', () => {
     it('checks if riding a Kangaroo', () => {
-      vm.member = {
-        stats: {
-          class: 'None',
-        },
-        items: {},
-      };
-
       expect(vm.specialMountClass).to.equal(null);
 
       vm.member.items = {
-        currentMount: ['Kangaroo'],
+        currentMount: 'Kangaroo',
+        gear: { equipped: {} },
       };
 
       expect(vm.specialMountClass).to.equal('offset-kangaroo');
@@ -178,24 +164,22 @@ context.only('avatar.vue', () => { // eslint-disable-line mocha/no-exclusive-tes
 
   describe('skinClass', () => {
     it('returns current skin color', () => {
-      vm.member = {
-        stats: {},
+      vm.member = merge({
         preferences: {
           skin: 'blue',
         },
-      };
+      }, baseMember);
 
       expect(vm.skinClass).to.equal('skin_blue');
     });
 
     it('returns if sleep or not', () => {
-      vm.member = {
-        stats: {},
+      vm.member = merge({
         preferences: {
           skin: 'blue',
           sleep: false,
         },
-      };
+      }, baseMember);
 
       expect(vm.skinClass).to.equal('skin_blue');
 
@@ -208,14 +192,14 @@ context.only('avatar.vue', () => { // eslint-disable-line mocha/no-exclusive-tes
   context('methods', () => {
     describe('getGearClass', () => {
       beforeEach(() => {
-        vm.member = {
+        vm.member = merge({
           items: {
             gear: {
               equipped: { Hat: 'Fancy Tophat' },
             },
           },
           preferences: { costume: false },
-        };
+        }, baseMember);
       });
 
       it('returns undefined if no match', () => {
@@ -240,7 +224,7 @@ context.only('avatar.vue', () => { // eslint-disable-line mocha/no-exclusive-tes
       });
 
       beforeEach(() => {
-        vm.member = {
+        vm.member = merge({
           items: {
             gear: {
               equipped: {
@@ -252,13 +236,13 @@ context.only('avatar.vue', () => { // eslint-disable-line mocha/no-exclusive-tes
             },
           },
           preferences: { costume: false },
-        };
+        }, baseMember);
       });
     });
 
     describe('show avatar', () => {
       beforeEach(() => {
-        vm.member = {
+        vm.member = merge({
           stats: {
             buffs: {
               snowball: false,
@@ -267,7 +251,7 @@ context.only('avatar.vue', () => { // eslint-disable-line mocha/no-exclusive-tes
               shinySeed: false,
             },
           },
-        };
+        }, baseMember);
       });
       it('does if not showing visual buffs', () => {
         expect(vm.showAvatar()).to.equal(true);

--- a/website/client/tests/unit/components/avatar.spec.js
+++ b/website/client/tests/unit/components/avatar.spec.js
@@ -31,7 +31,6 @@ context('avatar.vue', () => {
     });
 
     vm.$store = generateStore();
-    vm.$mount();
   });
 
   afterEach(() => {

--- a/website/client/tests/unit/components/avatar.spec.js
+++ b/website/client/tests/unit/components/avatar.spec.js
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import Avatar from '@/components/avatar';
 import generateStore from '@/store';
 
-context('avatar.vue', () => {
+context.only('avatar.vue', () => { // eslint-disable-line mocha/no-exclusive-tests
   let Constructr;
   let vm;
 
@@ -25,9 +25,10 @@ context('avatar.vue', () => {
           },
         },
       },
-    }).$mount();
+    });
 
     vm.$store = generateStore();
+    vm.$mount();
   });
 
   afterEach(() => {
@@ -55,11 +56,7 @@ context('avatar.vue', () => {
 
   describe('isBuffed', () => {
     beforeEach(() => {
-      vm.member = {
-        stats: {
-          buffs: {},
-        },
-      };
+      vm.member.stats.buffs = {};
     });
 
     it('accurately reports if buffed', () => {
@@ -73,8 +70,11 @@ context('avatar.vue', () => {
 
   describe('paddingTop', () => {
     beforeEach(() => {
-      vm.member = {
-        items: {},
+      vm.member.items = {
+        gear: {
+          equipped: {},
+          warrior: {},
+        },
       };
     });
 
@@ -107,9 +107,7 @@ context('avatar.vue', () => {
 
   describe('costumeClass', () => {
     beforeEach(() => {
-      vm.member = {
-        preferences: {},
-      };
+      vm.member.preferences = {};
     });
 
     it('returns if showing equipped gear', () => {

--- a/website/client/tests/unit/components/chat/chatCard.spec.js
+++ b/website/client/tests/unit/components/chat/chatCard.spec.js
@@ -1,3 +1,4 @@
+import Vue from 'vue';
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 
 import ChatCard from '@/components/chat/chatCard.vue';
@@ -5,6 +6,7 @@ import Store from '@/libs/store';
 
 const localVue = createLocalVue();
 localVue.use(Store);
+localVue.use(Vue.directive('b-tooltip', {}));
 
 describe('ChatCard', () => {
   function createMessage (text) {

--- a/website/client/tests/unit/components/home.spec.js
+++ b/website/client/tests/unit/components/home.spec.js
@@ -8,40 +8,102 @@ import * as Analytics from '@/libs/analytics';
 const localVue = createLocalVue();
 localVue.use(Store);
 
-describe('Home', () => { // eslint-disable-line mocha/no-exclusive-tests
-  let actionLog;
+describe('Home', () => {
+  let registerStub;
+  let socialAuthStub;
+  let store;
   let wrapper;
 
-  beforeEach(() => {
-    sinon.stub(Analytics, 'track');
-    actionLog = {};
-
-    const actions = {};
-    ['auth:register', 'auth:socialAuth'].forEach(name => {
-      actions[name] = (_, params) => {
-        actionLog[name] = actionLog[name] || { count: 0, paramses: [] };
-        actionLog[name].count += 1;
-        actionLog[name].invocationParams.push(params);
-      };
-    });
-
-    wrapper = shallowMount(Home, {
-      store: new Store({
-        state: {},
-        getters: {},
-        actions,
-      }),
+  function mountWrapper (query) {
+    return shallowMount(Home, {
+      store,
       localVue,
       mocks: {
         $t: string => string,
-        ga: () => {},
+        $route: { query: query || {} },
       },
     });
+  }
+
+  function fillOutUserForm (username, email, password) {
+    wrapper.find('#usernameInput').setValue(username);
+    wrapper.find('input[type=email]').setValue(email);
+    wrapper.findAll('input[type=password]').setValue(password);
+  }
+
+  beforeEach(() => {
+    registerStub = sinon.stub();
+    socialAuthStub = sinon.stub();
+    store = new Store({
+      state: {},
+      getters: {},
+      actions: {
+        'auth:register': registerStub,
+        'auth:socialAuth': socialAuthStub,
+      },
+    });
+
+    sinon.stub(Analytics, 'track');
+
+    wrapper = mountWrapper();
   });
 
   afterEach(sinon.restore);
 
-  it('Title is visible', () => {
+  it('has a visible title', () => {
     expect(wrapper.find('h1').text()).to.equal('motivateYourself');
+  });
+
+  describe('signup form', () => {
+    it('registers a user from the form', async () => {
+      const username = 'newUser';
+      const email = 'rookie@habitica.com';
+      const password = 'ImmaG3tProductive!';
+      fillOutUserForm(username, email, password);
+
+      await wrapper.find('form').trigger('submit');
+
+      expect(registerStub.calledOnce).to.be.true;
+      expect(registerStub.getCall(0).args[1]).to.deep.equal({
+        username,
+        email,
+        password,
+        passwordConfirm: password,
+        groupInvite: '',
+      });
+    });
+
+    it('registers a user with group invite if groupInvite in the query', async () => {
+      const groupInvite = 'TheBestGroup';
+      wrapper = mountWrapper({ groupInvite });
+      fillOutUserForm('invitedUser', 'invited@habitica.com', '1veGotFri3ndsHooray!');
+
+      await wrapper.find('form').trigger('submit');
+
+      expect(registerStub.calledOnce).to.be.true;
+      expect(registerStub.getCall(0).args[1].groupInvite).to.equal(groupInvite);
+    });
+
+    it('registers a user with group invite if p in the query', async () => {
+      const p = 'ThePiGroup';
+      wrapper = mountWrapper({ p });
+      fillOutUserForm('alsoInvitedUser', 'invited2@habitica.com', '1veGotFri3nds2!');
+
+      await wrapper.find('form').trigger('submit');
+
+      expect(registerStub.calledOnce).to.be.true;
+      expect(registerStub.getCall(0).args[1].groupInvite).to.equal(p);
+    });
+
+    it('registers a user with group invite invite if both p and groupInvite are in the query', async () => {
+      const groupInvite = 'StillTheBestGroup';
+      wrapper = mountWrapper({ p: 'LesserGroup', groupInvite });
+      fillOutUserForm('doublyInvitedUser', 'invited3@habitica.com', '1veGotSm4rtFri3nds!');
+
+      await wrapper.find('form').trigger('submit');
+
+      expect(registerStub.calledOnce).to.be.true;
+      expect(registerStub.getCall(0).args[1].groupInvite).to.equal(groupInvite);
+    });
   });
 });

--- a/website/client/tests/unit/components/home.spec.js
+++ b/website/client/tests/unit/components/home.spec.js
@@ -1,5 +1,4 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
-import sinon from 'sinon';
 
 import Home from '@/components/static/home.vue';
 import Store from '@/libs/store';
@@ -25,10 +24,10 @@ describe('Home', () => {
     });
   }
 
-  function fillOutUserForm (username, email, password) {
-    wrapper.find('#usernameInput').setValue(username);
-    wrapper.find('input[type=email]').setValue(email);
-    wrapper.findAll('input[type=password]').setValue(password);
+  async function fillOutUserForm (username, email, password) {
+    await wrapper.find('#usernameInput').setValue(username);
+    await wrapper.find('input[type=email]').setValue(email);
+    await wrapper.findAll('input[type=password]').setValue(password);
   }
 
   beforeEach(() => {
@@ -59,7 +58,7 @@ describe('Home', () => {
       const username = 'newUser';
       const email = 'rookie@habitica.com';
       const password = 'ImmaG3tProductive!';
-      fillOutUserForm(username, email, password);
+      await fillOutUserForm(username, email, password);
 
       await wrapper.find('form').trigger('submit');
 
@@ -76,7 +75,7 @@ describe('Home', () => {
     it('registers a user with group invite if groupInvite in the query', async () => {
       const groupInvite = 'TheBestGroup';
       wrapper = mountWrapper({ groupInvite });
-      fillOutUserForm('invitedUser', 'invited@habitica.com', '1veGotFri3ndsHooray!');
+      await fillOutUserForm('invitedUser', 'invited@habitica.com', '1veGotFri3ndsHooray!');
 
       await wrapper.find('form').trigger('submit');
 
@@ -87,7 +86,7 @@ describe('Home', () => {
     it('registers a user with group invite if p in the query', async () => {
       const p = 'ThePiGroup';
       wrapper = mountWrapper({ p });
-      fillOutUserForm('alsoInvitedUser', 'invited2@habitica.com', '1veGotFri3nds2!');
+      await fillOutUserForm('alsoInvitedUser', 'invited2@habitica.com', '1veGotFri3nds2!');
 
       await wrapper.find('form').trigger('submit');
 
@@ -98,7 +97,7 @@ describe('Home', () => {
     it('registers a user with group invite invite if both p and groupInvite are in the query', async () => {
       const groupInvite = 'StillTheBestGroup';
       wrapper = mountWrapper({ p: 'LesserGroup', groupInvite });
-      fillOutUserForm('doublyInvitedUser', 'invited3@habitica.com', '1veGotSm4rtFri3nds!');
+      await fillOutUserForm('doublyInvitedUser', 'invited3@habitica.com', '1veGotSm4rtFri3nds!');
 
       await wrapper.find('form').trigger('submit');
 

--- a/website/client/tests/unit/components/home.spec.js
+++ b/website/client/tests/unit/components/home.spec.js
@@ -1,0 +1,47 @@
+import { shallowMount, createLocalVue } from '@vue/test-utils';
+import sinon from 'sinon';
+
+import Home from '@/components/static/home.vue';
+import Store from '@/libs/store';
+import * as Analytics from '@/libs/analytics';
+
+const localVue = createLocalVue();
+localVue.use(Store);
+
+describe('Home', () => { // eslint-disable-line mocha/no-exclusive-tests
+  let actionLog;
+  let wrapper;
+
+  beforeEach(() => {
+    sinon.stub(Analytics, 'track');
+    actionLog = {};
+
+    const actions = {};
+    ['auth:register', 'auth:socialAuth'].forEach(name => {
+      actions[name] = (_, params) => {
+        actionLog[name] = actionLog[name] || { count: 0, paramses: [] };
+        actionLog[name].count += 1;
+        actionLog[name].invocationParams.push(params);
+      };
+    });
+
+    wrapper = shallowMount(Home, {
+      store: new Store({
+        state: {},
+        getters: {},
+        actions,
+      }),
+      localVue,
+      mocks: {
+        $t: string => string,
+        ga: () => {},
+      },
+    });
+  });
+
+  afterEach(sinon.restore);
+
+  it('Title is visible', () => {
+    expect(wrapper.find('h1').text()).to.equal('motivateYourself');
+  });
+});

--- a/website/client/tests/unit/components/home.spec.js
+++ b/website/client/tests/unit/components/home.spec.js
@@ -39,6 +39,7 @@ describe('Home', () => {
       actions: {
         'auth:register': registerStub,
         'auth:socialAuth': socialAuthStub,
+        'auth:verifyUsername': () => Promise.resolve({}),
       },
     });
 

--- a/website/client/tests/unit/components/notifications.spec.js
+++ b/website/client/tests/unit/components/notifications.spec.js
@@ -20,7 +20,7 @@ describe('Notifications', () => {
               lvl: 0,
             },
             flags: {},
-            preferences: {},
+            preferences: { suppressModals: {} },
             party: {
               quest: {
               },
@@ -55,6 +55,7 @@ describe('Notifications', () => {
 
     expect(wrapper.vm.userHasClass).to.be.true;
   });
+
   describe('user exp notifcation', () => {
     it('notifies when user gets more exp', () => {
       const expSpy = sinon.spy(wrapper.vm, 'exp');

--- a/website/client/tests/unit/components/tasks/column.spec.js
+++ b/website/client/tests/unit/components/tasks/column.spec.js
@@ -1,4 +1,4 @@
-import { mount, createLocalVue } from '@vue/test-utils';
+import { shallowMount, createLocalVue } from '@vue/test-utils';
 import TaskColumn from '@/components/tasks/column.vue';
 import Store from '@/libs/store';
 
@@ -19,9 +19,12 @@ describe('Task Column', () => {
     };
     const stubs = ['b-modal']; // <b-modal> is a custom component and not tested here
 
-    return mount(TaskColumn, {
-      propsData: {
-        type,
+    return shallowMount(TaskColumn, {
+      propsData: { type },
+      store: {
+        getters: {
+          'tasks:getFilteredTaskList': () => [],
+        },
       },
       mocks,
       stubs,

--- a/website/client/tests/unit/components/tasks/column.spec.js
+++ b/website/client/tests/unit/components/tasks/column.spec.js
@@ -7,10 +7,6 @@ localVue.use(Store);
 
 describe('Task Column', () => {
   let wrapper;
-  let store; let
-    getters;
-  let habits; let taskListOverride; let
-    tasks;
 
   function makeWrapper (additionalSetup = {}) {
     const type = 'habit';
@@ -59,6 +55,9 @@ describe('Task Column', () => {
   });
 
   describe('Computed Properties', () => {
+    let taskListOverride;
+    let habits;
+
     beforeEach(() => {
       habits = [
         { id: 1 },
@@ -70,14 +69,14 @@ describe('Task Column', () => {
         { id: 4 },
       ];
 
-      getters = {
+      const getters = {
         // (...) => { ... } will return a value
         // (...) => (...) => { ... } will return a function
         // Task Column expects a function
         'tasks:getFilteredTaskList': () => () => habits,
       };
 
-      store = new Store({ getters });
+      const store = new Store({ getters });
 
       wrapper = makeWrapper({ store });
     });
@@ -106,6 +105,8 @@ describe('Task Column', () => {
   });
 
   describe('Methods', () => {
+    let tasks;
+
     describe('Filter By Tags', () => {
       beforeEach(() => {
         tasks = [

--- a/website/client/tests/unit/components/tasks/user.spec.js
+++ b/website/client/tests/unit/components/tasks/user.spec.js
@@ -6,6 +6,19 @@ const localVue = createLocalVue();
 localVue.use(Store);
 
 describe('Tasks User', () => {
+  function createWrapper (challengeTag) {
+    const store = new Store({
+      state: { user: { data: { tags: [challengeTag] } } },
+      getters: {},
+    });
+    return shallowMount(User, {
+      store,
+      localVue,
+      mocks: { $t: s => s },
+      stubs: ['b-tooltip'],
+    });
+  }
+
   describe('Computed Properties', () => {
     it('should render a challenge tag under challenge header in tag filter popup when the challenge is active', () => {
       const activeChallengeTag = {
@@ -13,20 +26,7 @@ describe('Tasks User', () => {
         name: 'Challenge1',
         challenge: true,
       };
-      const state = {
-        user: {
-          data: {
-            tags: [activeChallengeTag],
-          },
-        },
-      };
-      const getters = {};
-      const store = new Store({ state, getters });
-      const wrapper = shallowMount(User, {
-        store,
-        localVue,
-      });
-
+      const wrapper = createWrapper(activeChallengeTag);
       const computedTagsByType = wrapper.vm.tagsByType;
 
       expect(computedTagsByType.challenges.tags.length).to.equal(1);
@@ -40,20 +40,7 @@ describe('Tasks User', () => {
         name: 'Challenge1',
         challenge: false,
       };
-      const state = {
-        user: {
-          data: {
-            tags: [inactiveChallengeTag],
-          },
-        },
-      };
-      const getters = {};
-      const store = new Store({ state, getters });
-      const wrapper = shallowMount(User, {
-        store,
-        localVue,
-      });
-
+      const wrapper = createWrapper(inactiveChallengeTag);
       const computedTagsByType = wrapper.vm.tagsByType;
 
       expect(computedTagsByType.challenges.tags.length).to.equal(0);

--- a/website/client/tests/unit/libs/store.spec.js
+++ b/website/client/tests/unit/libs/store.spec.js
@@ -84,8 +84,8 @@ describe('Store', () => {
       expect(await store.dispatch('nested:getName', 1, 2, 3)).to.deep.equal(['test', 1, 2, 3]);
     });
 
-    it('throws an error is the action doesn\'t exists', async () => {
-      expect(async () => store.dispatched('wrong')).to.throw;
+    it('throws an error if the action doesn\'t exists', () => {
+      expect(() => store.dispatched('wrong')).to.throw;
     });
   });
 

--- a/website/client/tests/unit/libs/store.spec.js
+++ b/website/client/tests/unit/libs/store.spec.js
@@ -84,8 +84,8 @@ describe('Store', () => {
       expect(await store.dispatch('nested:getName', 1, 2, 3)).to.deep.equal(['test', 1, 2, 3]);
     });
 
-    it('throws an error if the action doesn\'t exists', () => {
-      expect(() => store.dispatched('wrong')).to.throw;
+    it('throws an error is the action doesn\'t exists', async () => {
+      expect(async () => store.dispatched('wrong')).to.throw;
     });
   });
 


### PR DESCRIPTION
I started this a while back (Which also lead to resolving the zone() deprecation issue) but now that I wanted to look at a unit test for task.vue I decided to wrap this up.  This merge request resolves all the warnings and stack traces that are being thrown from the client tests, so that debugging those tests will be a bit easier.

### Changes
- Introduces extra test setup in client-side unit tests that resolves warnings and stack traces thrown while running them
- Introduces a unit test for `home.vue`
- Replaces a `indexOf === -1` call with an `includes` check in `avatar.vue`

----
UUID: d71d2c57-a73d-4591-b64d-e688584a9092
