### PR TITLE
Removed (duplicated) unused I18N strings from the `content.json` files (related to issue #9957)

### DIFF
--- a/website/common/locales/en/content.json
+++ b/website/common/locales/en/content.json
@@ -39,12 +39,6 @@
   "dropEggCactusMountText": "Cactus",
   "dropEggCactusAdjective": "a prickly",
 
-  "dropEggFlyingPigText": "Flying Pig",
-  "dropEggFlyingPigAdjective": "a whimsical",
-
-  "dropEggDragonText": "Dragon",
-  "dropEggDragonAdjective": "a mighty",
-
   "dropEggBearCubText": "Bear Cub",
   "dropEggBearCubMountText": "Bear",
   "dropEggBearCubAdjective": "a brave",


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
This PR fixes part of issue #9957

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
The `content` files are well maintained. With the exception of the following duplicate strings that I already removed, all the others are being used. 

- dropEggFlyingPigText
- dropEggFlyingPigAdjective
- dropEggDragonText
- dropEggDragonAdjective

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 6544e17f-237b-4915-ae7e-47744c0dc1bd