### PR TITLE
Fix overflow in guild member text and keyboard inaccessible member/bank lists fixes #11067

### DIFF
--- a/website/client/src/components/groups/group.vue
+++ b/website/client/src/components/groups/group.vue
@@ -10,7 +10,7 @@
     <group-gems-modal />
     <div class="col-12 col-sm-8 standard-page">
       <div class="row">
-        <div class="col-12 col-md-6 title-details">
+        <div class="col-12 col-md-4 title-details">
           <h1>{{ group.name }}</h1>
           <div>
             <span class="mr-1 ml-0">
@@ -22,40 +22,36 @@
             </span>
           </div>
         </div>
-        <div class="col-12 col-md-6">
+        <div class="col-12 col-md-8">
           <div class="row icon-row">
             <div
-              :class="{ 'offset-8': isParty }"
+              class="item-with-icon"
+              tabindex="0"
+              role="button"
+              @keyup.enter="showMemberModal()"
+              @click="showMemberModal()"
             >
               <div
-                class="item-with-icon"
-                tabindex="0"
-                role="button"
-                @keyup.enter="showMemberModal()"
-                @click="showMemberModal()"
+                v-if="group.memberCount > 1000"
+                class="svg-icon shield"
+                v-html="icons.goldGuildBadgeIcon"
+              ></div>
+              <div
+                v-if="group.memberCount > 100 && group.memberCount < 999"
+                class="svg-icon shield"
+                v-html="icons.silverGuildBadgeIcon"
+              ></div>
+              <div
+                v-if="group.memberCount < 100"
+                class="svg-icon shield"
+                v-html="icons.bronzeGuildBadgeIcon"
+              ></div>
+              <span class="number">{{ group.memberCount | abbrNum }}</span>
+              <div
+                v-once
+                class="member-list label"
               >
-                <div
-                  v-if="group.memberCount > 1000"
-                  class="svg-icon shield"
-                  v-html="icons.goldGuildBadgeIcon"
-                ></div>
-                <div
-                  v-if="group.memberCount > 100 && group.memberCount < 999"
-                  class="svg-icon shield"
-                  v-html="icons.silverGuildBadgeIcon"
-                ></div>
-                <div
-                  v-if="group.memberCount < 100"
-                  class="svg-icon shield"
-                  v-html="icons.bronzeGuildBadgeIcon"
-                ></div>
-                <span class="number">{{ group.memberCount | abbrNum }}</span>
-                <div
-                  v-once
-                  class="member-list label"
-                >
-                  {{ $t('memberList') }}
-                </div>
+                {{ $t('memberList') }}
               </div>
             </div>
             <div
@@ -230,7 +226,7 @@
     box-shadow: 0 2px 2px 0 rgba(26, 24, 29, 0.16), 0 1px 4px 0 rgba(26, 24, 29, 0.12);
     padding: 1em;
     text-align: center;
-    min-width: 100px;
+    min-width: 120px;
     height: 76px;
 
     &:last-of-type {

--- a/website/client/src/components/groups/group.vue
+++ b/website/client/src/components/groups/group.vue
@@ -25,7 +25,6 @@
         <div class="col-12 col-md-6">
           <div class="row icon-row">
             <div
-              class="col-4 offset-4"
               :class="{ 'offset-8': isParty }"
             >
               <div
@@ -58,7 +57,7 @@
             </div>
             <div
               v-if="!isParty"
-              class="col-4"
+              class="offset-1"
             >
               <div
                 class="item-with-icon"
@@ -225,12 +224,15 @@
     box-shadow: 0 2px 2px 0 rgba(26, 24, 29, 0.16), 0 1px 4px 0 rgba(26, 24, 29, 0.12);
     padding: 1em;
     text-align: center;
-    min-width: 80px;
-    max-width: 120px;
+    min-width: 100px;
     height: 76px;
 
+    &:last-of-type {
+      margin-right: 1rem;
+    }
+
     .svg-icon.shield, .svg-icon.gem {
-      width: 28px;
+      min-width: 28px;
       height: auto;
       margin: 0 auto;
       display: inline-block;
@@ -312,6 +314,7 @@
 
   .icon-row {
     margin-top: 1em;
+    justify-content: flex-end;
 
     .number {
       font-size: 22px;

--- a/website/client/src/components/groups/group.vue
+++ b/website/client/src/components/groups/group.vue
@@ -66,7 +66,7 @@
                 class="item-with-icon"
                 tabindex="0"
                 role="button"
-                @keyup.enter="showMemberModal()"
+                @keyup.enter="showGroupGems()"
                 @click="showGroupGems()"
               >
                 <div

--- a/website/client/src/components/groups/group.vue
+++ b/website/client/src/components/groups/group.vue
@@ -10,7 +10,7 @@
     <group-gems-modal />
     <div class="col-12 col-sm-8 standard-page">
       <div class="row">
-        <div class="col-12 col-md-4 title-details">
+        <div class="col-12 col-md-6 title-details">
           <h1>{{ group.name }}</h1>
           <div>
             <span class="mr-1 ml-0">
@@ -22,7 +22,7 @@
             </span>
           </div>
         </div>
-        <div class="col-12 col-md-8">
+        <div class="col-12 col-md-6">
           <div class="row icon-row">
             <div
               class="item-with-icon"
@@ -54,10 +54,7 @@
                 {{ $t('memberList') }}
               </div>
             </div>
-            <div
-              v-if="!isParty"
-              class="offset-1"
-            >
+            <div v-if="!isParty">
               <div
                 class="item-with-icon"
                 tabindex="0"
@@ -228,13 +225,14 @@
     text-align: center;
     min-width: 120px;
     height: 76px;
+    margin-right: 1rem;
 
     &:last-of-type {
-      margin-right: 1rem;
+      margin-left: 0.5rem;
     }
 
     .svg-icon.shield, .svg-icon.gem {
-      min-width: 28px;
+      width: 28px;
       height: auto;
       margin: 0 auto;
       display: inline-block;

--- a/website/client/src/components/groups/group.vue
+++ b/website/client/src/components/groups/group.vue
@@ -29,6 +29,9 @@
             >
               <div
                 class="item-with-icon"
+                tabindex="0"
+                role="button"
+                @keyup.enter="showMemberModal()"
                 @click="showMemberModal()"
               >
                 <div
@@ -61,6 +64,9 @@
             >
               <div
                 class="item-with-icon"
+                tabindex="0"
+                role="button"
+                @keyup.enter="showMemberModal()"
                 @click="showGroupGems()"
               >
                 <div


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11067

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Fixes overflowing text in guild member lists with large member counts.
Fix the guild member list and gem bank divs being inaccessible to keyboard navigation.

![Screenshot from 2020-10-01 19-29-41](https://user-images.githubusercontent.com/17064002/94953497-8c1f1f00-04df-11eb-906c-1742d85aa8f8.png)

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)
cbeeb477-d5db-4efd-8f0b-68201870482b

----
UUID: 
