### PR TITLE
fix(quests): Quests that are level-locked for purchase can now be used at any level fixes #12417

### DIFF
--- a/test/api/v3/integration/quests/POST-groups_groupId_quests_invite.test.js
+++ b/test/api/v3/integration/quests/POST-groups_groupId_quests_invite.test.js
@@ -83,22 +83,6 @@ describe('POST /groups/:groupId/quests/invite/:questKey', () => {
       });
     });
 
-    it('does not issue invites if the user is of insufficient Level', async () => {
-      const LEVELED_QUEST = 'atom1';
-      const LEVELED_QUEST_REQ = questScrolls[LEVELED_QUEST].lvl;
-      const leaderUpdate = {};
-      leaderUpdate[`items.quests.${LEVELED_QUEST}`] = 1;
-      leaderUpdate['stats.lvl'] = LEVELED_QUEST_REQ - 1;
-
-      await leader.update(leaderUpdate);
-
-      await expect(leader.post(`/groups/${questingGroup._id}/quests/invite/${LEVELED_QUEST}`)).to.eventually.be.rejected.and.eql({
-        code: 401,
-        error: 'NotAuthorized',
-        message: t('questLevelTooHigh', { level: LEVELED_QUEST_REQ }),
-      });
-    });
-
     it('does not issue invites if a quest is already underway', async () => {
       const QUEST_IN_PROGRESS = 'atom1';
       const leaderUpdate = {};
@@ -210,6 +194,18 @@ describe('POST /groups/:groupId/quests/invite/:questKey', () => {
 
       const returnedGroup = await groupLeader.get(`/groups/${group._id}`);
       expect(returnedGroup.chat[0]._meta).to.be.undefined;
+    });
+
+    it('successfully issues a quest invitation when quest level is higher than user level', async () => {
+      const LEVELED_QUEST = 'atom1';
+      const LEVELED_QUEST_REQ = questScrolls[LEVELED_QUEST].lvl;
+      const leaderUpdate = {};
+      leaderUpdate[`items.quests.${LEVELED_QUEST}`] = 1;
+      leaderUpdate['stats.lvl'] = LEVELED_QUEST_REQ - 1;
+
+      await leader.update(leaderUpdate);
+
+      await leader.post(`/groups/${questingGroup._id}/quests/invite/${LEVELED_QUEST}`);
     });
 
     context('sending quest activity webhooks', () => {

--- a/website/server/controllers/api-v3/quests.js
+++ b/website/server/controllers/api-v3/quests.js
@@ -73,7 +73,6 @@ api.inviteToQuest = {
     if (group.type !== 'party') throw new NotAuthorized(res.t('guildQuestsNotSupported'));
     if (!quest) throw new NotFound(apiError('questNotFound', { key: questKey }));
     if (!user.items.quests[questKey]) throw new NotAuthorized(res.t('questNotOwned'));
-    if (user.stats.lvl < quest.lvl) throw new NotAuthorized(res.t('questLevelTooHigh', { level: quest.lvl }));
     if (group.quest.key) throw new NotAuthorized(res.t('questAlreadyUnderway'));
 
     const members = await User.find({


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #12417

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Quests that are level-locked for purchase can now be used at any level


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 
80b61b73-2278-4947-b713-a10112cfe7f5
