### PR TITLE
Fix keyboard inaccessible accordion in guild/party page fixes #12653

### DIFF
--- a/website/client/src/components/sidebarButton.vue
+++ b/website/client/src/components/sidebarButton.vue
@@ -1,6 +1,10 @@
 <template>
-  <button
+  <div
     class="toggle ml-auto"
+    role="button"
+    :aria-expanded="visible"
+    tabindex="0"
+    @keyup.enter="$emit('click')"
     @click="$emit('click')"
   >
     <span
@@ -13,14 +17,20 @@
       class="svg-icon"
       v-html="icons.downIcon"
     ></span>
-  </button>
+  </div>
 </template>
 
 <style lang="scss" scoped>
-.toggle {
+@import '~@/assets/scss/colors.scss';
+
+  .toggle {
     border: 0;
     background: transparent;
     cursor: pointer;
+    &:focus {
+      outline: none;
+      border: $purple-400 solid 1px;
+    }
   }
 
   .svg-icon {

--- a/website/client/src/components/sidebarButton.vue
+++ b/website/client/src/components/sidebarButton.vue
@@ -1,0 +1,50 @@
+<template>
+  <button
+    class="toggle ml-auto"
+    @click="$emit('click')"
+  >
+    <span
+      v-if="visible"
+      class="svg-icon"
+      v-html="icons.upIcon"
+    ></span>
+    <span
+      v-else
+      class="svg-icon"
+      v-html="icons.downIcon"
+    ></span>
+  </button>
+</template>
+
+<style lang="scss" scoped>
+.toggle {
+    border: 0;
+    background: transparent;
+    cursor: pointer;
+  }
+
+  .svg-icon {
+    width: 16px;
+  }
+</style>
+
+<script>
+import upIcon from '@/assets/svg/up.svg';
+import downIcon from '@/assets/svg/down.svg';
+
+export default {
+  props: {
+    visible: {
+      required: true,
+    },
+  },
+  data () {
+    return {
+      icons: {
+        upIcon,
+        downIcon,
+      },
+    };
+  },
+};
+</script>

--- a/website/client/src/components/sidebarSection.vue
+++ b/website/client/src/components/sidebarSection.vue
@@ -22,7 +22,10 @@
           :target="tooltipId"
         />
       </div>
-      <SidebarButton :visible="visible" @click="toggle" />
+      <SidebarButton
+        :visible="visible"
+        @click="toggle"
+      />
     </div>
     <div
       v-show="visible"

--- a/website/client/src/components/sidebarSection.vue
+++ b/website/client/src/components/sidebarSection.vue
@@ -22,21 +22,21 @@
           :target="tooltipId"
         />
       </div>
-      <div
+      <button
         class="section-toggle ml-auto"
         @click="toggle"
       >
-        <div
+        <span
           v-if="visible"
           class="svg-icon"
           v-html="icons.upIcon"
-        ></div>
-        <div
+        ></span>
+        <span
           v-else
           class="svg-icon"
           v-html="icons.downIcon"
-        ></div>
-      </div>
+        ></span>
+      </button>
     </div>
     <div
       v-show="visible"
@@ -65,6 +65,8 @@
   }
 
   .section-toggle {
+    border: 0;
+    background: transparent;
     cursor: pointer;
   }
 

--- a/website/client/src/components/sidebarSection.vue
+++ b/website/client/src/components/sidebarSection.vue
@@ -22,21 +22,7 @@
           :target="tooltipId"
         />
       </div>
-      <button
-        class="section-toggle ml-auto"
-        @click="toggle"
-      >
-        <span
-          v-if="visible"
-          class="svg-icon"
-          v-html="icons.upIcon"
-        ></span>
-        <span
-          v-else
-          class="svg-icon"
-          v-html="icons.downIcon"
-        ></span>
-      </button>
+      <SidebarButton :visible="visible" @click="toggle" />
     </div>
     <div
       v-show="visible"
@@ -64,29 +50,22 @@
     margin-top: 1em;
   }
 
-  .section-toggle {
-    border: 0;
-    background: transparent;
-    cursor: pointer;
-  }
-
   .section-info {
     cursor: help;
   }
 
-  .section-info .svg-icon,
-  .section-toggle .svg-icon {
+  .section-info .svg-icon {
     width: 16px;
   }
 </style>
 
 <script>
 import { v4 as uuid } from 'uuid';
-import upIcon from '@/assets/svg/up.svg';
-import downIcon from '@/assets/svg/down.svg';
+import SidebarButton from './sidebarButton';
 import informationIcon from '@/assets/svg/information.svg';
 
 export default {
+  components: { SidebarButton },
   props: {
     title: {
       required: true,
@@ -103,8 +82,6 @@ export default {
       tooltipId: uuid(),
       visible: this.show,
       icons: {
-        upIcon,
-        downIcon,
         information: informationIcon,
       },
     };

--- a/website/client/tests/unit/components/sidebarSection.spec.js
+++ b/website/client/tests/unit/components/sidebarSection.spec.js
@@ -32,9 +32,9 @@ describe('Sidebar Section', () => {
 
   it('hides contents', () => {
     expect(wrapper.find('.section-body').element.style.display).to.not.eq('none');
-    wrapper.find('.section-toggle').trigger('click');
+    wrapper.find('[role="button"').trigger('click');
     expect(wrapper.find('.section-body').element.style.display).to.eq('none');
-    wrapper.find('.section-toggle').trigger('click');
+    wrapper.find('[role="button"').trigger('click');
     expect(wrapper.find('.section-body').element.style.display).to.not.eq('none');
   });
 


### PR DESCRIPTION
# Fixes #12653

### Changes
The accordion menu on the right hand side of the guild/party page uses clickable divs to open and close items and is inaccessible to keyboard navigation. Replaced the divs with buttons and converted the nested divs holding the svg icons to spans, and styled to appear the same as before.

----
UUID: cbeeb477-d5db-4efd-8f0b-68201870482b
