### PR TITLE
fix "push to bottom" for user tasks in API

### DIFF
--- a/test/api/v3/integration/tasks/POST-tasks_move_taskId_to_position.test.js
+++ b/test/api/v3/integration/tasks/POST-tasks_move_taskId_to_position.test.js
@@ -91,7 +91,9 @@ describe('POST /tasks/:taskId/move/to/:position', () => {
 
     const taskToMove = tasks[1];
     expect(taskToMove.text).to.equal('habit 2');
-    const newOrder = await user.post(`/tasks/${tasks[1]._id}/move/to/-1`);
+    await user.post(`/tasks/${tasks[1]._id}/move/to/-1`);
+    await user.sync();
+    const newOrder = user.tasksOrder.habits;
     expect(newOrder[4]).to.equal(taskToMove._id);
     expect(newOrder.length).to.equal(5);
   });

--- a/website/server/controllers/api-v3/tasks.js
+++ b/website/server/controllers/api-v3/tasks.js
@@ -794,9 +794,9 @@ api.scoreTask = {
  * @apiGroup Task
  *
  * @apiParam (Path) {String} taskId The task _id or alias
- * @apiParam (Path) {Number} position Where to move the task. 0 = top of the list.
- é                           -1 = bottom of the list.
- é                           (-1 means push to bottom). First position is 0
+ * @apiParam (Path) {Number} position Where to move the task.
+ *                                    0 = top of the list ("push to top").
+ *                                   -1 = bottom of the list ("push to bottom").
  *
  * @apiSuccess {Array} data The new tasks order for the specific type that the taskID belongs to.
  *
@@ -837,9 +837,8 @@ api.moveTask = {
     pullQuery.$pull[`tasksOrder.${task.type}s`] = task.id;
     await user.update(pullQuery).exec();
 
-    // Handle push to bottom
     let position = to;
-    if (to === -1) position = [`tasksOrder.${task.type}s`].length - 1;
+    if (to === -1) position = order.length - 1; // push to bottom
 
     const updateQuery = { $push: {} };
     updateQuery.$push[`tasksOrder.${task.type}s`] = {

--- a/website/server/controllers/api-v3/tasks/groups.js
+++ b/website/server/controllers/api-v3/tasks/groups.js
@@ -122,8 +122,9 @@ api.getGroupTasks = {
  * @apiGroup Task
  *
  * @apiParam (Path) {String} taskId The task _id
- * @apiParam (Path) {Number} position Where to move the task (-1 means push to bottom).
- *                                    First position is 0
+ * @apiParam (Path) {Number} position Where to move the task.
+ *                                    0 = top of the list ("push to top").
+ *                                   -1 = bottom of the list ("push to bottom").
  *
  * @apiSuccess {Array} data The new tasks order (group.tasksOrder.{task.type}s)
  */

--- a/website/server/controllers/api-v3/user.js
+++ b/website/server/controllers/api-v3/user.js
@@ -1691,9 +1691,9 @@ api.togglePinnedItem = {
  * @apiGroup User
  *
  * @apiParam (Path) {String} path The unique item path used for pinning
- * @apiParam (Path) {Number} position Where to move the task. 0 = top of the list.
- *                                    -1 = bottom of the list.
- *                                    (-1 means push to bottom). First position is 0.
+ * @apiParam (Path) {Number} position Where to move the task.
+ *                                    0 = top of the list ("push to top").
+ *                                   -1 = bottom of the list ("push to bottom").
  *
  * @apiSuccess {Array} data The new pinned items order.
  *


### PR DESCRIPTION
The API's "push to bottom" feature for user tasks has been broken for a few years from the looks of it. This PR fixes it (confirmed by manual testing on a local install).

This PR also:
- Fixes the test for "push to bottom" which has been equally broken.
- Simplifies the position (0 / -1) information in the apidoc comment.
- Makes that information consistent in two similar routes.
- Replaces non-ascii characters in the apidoc comment, which were causing `é` to appear in https://habitica.com/apidoc/#api-Task-MoveTask

----

_Thanks to @khing (ccba770f-b79b-4fb6-8694-53b31bc27d88) for reporting this bug:_
_"How to move task to bottom?_
_In the [api-doc](https://habitica.com/apidoc/#api-Task-MoveTask) it says: "é -1 = bottom of the list". Don't know what does "é -1" mean. I tried -1, api success, but the task is not moved."_
