### PR TITLE
Loggly-only user support events

### DIFF
--- a/website/server/controllers/api-v3/challenges.js
+++ b/website/server/controllers/api-v3/challenges.js
@@ -221,6 +221,7 @@ api.createChallenge = {
       groupID: group._id,
       groupName: group.privacy === 'private' ? null : group.name,
       groupType: group._id === TAVERN_ID ? 'tavern' : group.type,
+      headers: req.headers,
     });
 
     res.respond(201, response);
@@ -286,6 +287,7 @@ api.joinChallenge = {
       groupID: group._id,
       groupName: group.privacy === 'private' ? null : group.name,
       groupType: group._id === TAVERN_ID ? 'tavern' : group.type,
+      headers: req.headers,
     });
 
     res.respond(200, response);
@@ -335,6 +337,7 @@ api.leaveChallenge = {
       groupID: challenge.group._id,
       groupName: challenge.group.privacy === 'private' ? null : challenge.group.name,
       groupType: challenge.group._id === TAVERN_ID ? 'tavern' : challenge.group.type,
+      headers: req.headers,
     });
 
     res.respond(200, {});
@@ -748,6 +751,7 @@ api.deleteChallenge = {
       groupID: challenge.group._id,
       groupName: challenge.group.privacy === 'private' ? null : challenge.group.name,
       groupType: challenge.group._id === TAVERN_ID ? 'tavern' : challenge.group.type,
+      headers: req.headers,
     });
 
     res.respond(200, {});
@@ -798,6 +802,7 @@ api.selectChallengeWinner = {
       groupID: challenge.group._id,
       groupName: challenge.group.privacy === 'private' ? null : challenge.group.name,
       groupType: challenge.group._id === TAVERN_ID ? 'tavern' : challenge.group.type,
+      headers: req.headers,
     });
 
     res.respond(200, {});

--- a/website/server/controllers/api-v3/quests.js
+++ b/website/server/controllers/api-v3/quests.js
@@ -157,7 +157,7 @@ api.inviteToQuest = {
       questName: questKey,
       uuid: user._id,
       headers: req.headers,
-    });
+    }, true);
   },
 };
 
@@ -218,7 +218,7 @@ api.acceptQuest = {
       questName: group.quest.key,
       uuid: user._id,
       headers: req.headers,
-    });
+    }, true);
   },
 };
 
@@ -279,7 +279,7 @@ api.rejectQuest = {
       questName: group.quest.key,
       uuid: user._id,
       headers: req.headers,
-    });
+    }, true);
   },
 };
 
@@ -339,7 +339,7 @@ api.forceStart = {
       questName: group.quest.key,
       uuid: user._id,
       headers: req.headers,
-    });
+    }, true);
   },
 };
 

--- a/website/server/controllers/top-level/payments/paypal.js
+++ b/website/server/controllers/top-level/payments/paypal.js
@@ -63,7 +63,7 @@ api.checkoutSuccess = {
     if (!customerId) throw new BadRequest(apiError('missingCustomerId'));
 
     await paypalPayments.checkoutSuccess({
-      user, gemsBlock, gift, paymentId, customerId,
+      user, gemsBlock, gift, paymentId, customerId, headers: req.headers,
     });
 
     if (req.query.noRedirect) {

--- a/website/server/controllers/top-level/payments/stripe.js
+++ b/website/server/controllers/top-level/payments/stripe.js
@@ -35,7 +35,7 @@ api.checkout = {
     const { groupId, coupon, gemsBlock } = req.query;
 
     await stripePayments.checkout({
-      token, user, gemsBlock, gift, sub, groupId, coupon,
+      token, user, gemsBlock, gift, sub, groupId, coupon, headers: req.headers,
     });
 
     res.respond(200, {});

--- a/website/server/libs/analyticsService.js
+++ b/website/server/libs/analyticsService.js
@@ -183,7 +183,7 @@ function _sendDataToAmplitude (eventType, data, loggerOnly) {
     logger.info('Amplitude Event', amplitudeData);
   }
 
-  if (loggerOnly) return new Promise();
+  if (loggerOnly) return Promise.resolve(null);
 
   return amplitude
     .track(amplitudeData)

--- a/website/server/libs/analyticsService.js
+++ b/website/server/libs/analyticsService.js
@@ -174,7 +174,7 @@ function _formatDataForAmplitude (data) {
   return ampData;
 }
 
-function _sendDataToAmplitude (eventType, data) {
+function _sendDataToAmplitude (eventType, data, loggerOnly) {
   const amplitudeData = _formatDataForAmplitude(data);
 
   amplitudeData.event_type = eventType;
@@ -182,6 +182,8 @@ function _sendDataToAmplitude (eventType, data) {
   if (LOG_AMPLITUDE_EVENTS) {
     logger.info('Amplitude Event', amplitudeData);
   }
+
+  if (loggerOnly) return new Promise();
 
   return amplitude
     .track(amplitudeData)
@@ -312,9 +314,9 @@ function _setOnce (dataToSetOnce, uuid) {
 }
 
 // There's no error handling directly here because it's handled inside _sendDataTo{Amplitude|Google}
-async function track (eventType, data) {
+async function track (eventType, data, loggerOnly = false) {
   const promises = [
-    _sendDataToAmplitude(eventType, data),
+    _sendDataToAmplitude(eventType, data, loggerOnly),
     _sendDataToGoogle(eventType, data),
   ];
   if (data.user && data.user.registeredThrough) {

--- a/website/server/libs/cron.js
+++ b/website/server/libs/cron.js
@@ -225,7 +225,7 @@ function trackCronAnalytics (analytics, user, _progress, options) {
       user,
       questName: user.party.quest.key,
       headers: options.headers,
-    });
+    }, true);
   }
 }
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

1. Per internal discussion how how to economize on Amplitude event volume while still providing data valuable to user support, this PR adds a parameter `loggerOnly` to the `analytics.track` function that, when passed `true`, calls `logger.info` as usual with `LOG_AMPLITUDE_EVENTS` on but skips sending the data to the Amplitude service itself.
2. Adds missing `headers` data to a few Analytics service function calls, so we can track e.g. the user's platform for those events.