### PR TITLE
new users: do not show bailey news on second login

### DIFF
--- a/test/api/unit/models/user.test.js
+++ b/test/api/unit/models/user.test.js
@@ -592,6 +592,36 @@ describe('User Model', () => {
   });
 
   context('pre-save hook', () => {
+    it('marks the last news post as read for new users', async () => {
+      const lastNewsPost = { _id: '1' };
+      sandbox.stub(NewsPost, 'lastNewsPost').returns(lastNewsPost);
+
+      let user = new User();
+      expect(user.isNew).to.equal(true);
+      user = await user.save();
+
+      expect(user.checkNewStuff()).to.equal(false);
+      expect(user.toJSON().flags.newStuff).to.equal(false);
+      expect(user.flags.lastNewStuffRead).to.equal(lastNewsPost._id);
+    });
+
+    it('does not mark the last news post as read for existing users', async () => {
+      const lastNewsPost = { _id: '1' };
+      const lastNewsPostStub = sandbox.stub(NewsPost, 'lastNewsPost');
+      lastNewsPostStub.returns(lastNewsPost);
+
+      let user = new User();
+      user = await user.save();
+
+      expect(user.isNew).to.equal(false);
+      user.profile.name = 'new name';
+
+      lastNewsPostStub.returns({ _id: '2' });
+      user = await user.save();
+
+      expect(user.flags.lastNewStuffRead).to.equal(lastNewsPost._id); // not _id: 2
+    });
+
     it('does not try to award achievements when achievements or items not selected in query', async () => {
       let user = new User();
       user = await user.save(); // necessary for user.isSelected to work correctly

--- a/website/server/models/user/hooks.js
+++ b/website/server/models/user/hooks.js
@@ -12,6 +12,9 @@ import {
 import {
   model as Tag,
 } from '../tag';
+import {
+  model as NewsPost,
+} from '../newsPost';
 import { // eslint-disable-line import/no-cycle
   userActivityWebhook,
 } from '../../libs/webhook';
@@ -129,6 +132,12 @@ function pinBaseItems (user) {
 }
 
 function _setUpNewUser (user) {
+  // Mark the last news post as read
+  const lastNewsPost = NewsPost.lastNewsPost();
+  if (lastNewsPost) {
+    user.flags.lastNewStuffRead = lastNewsPost._id;
+  }
+
   let taskTypes;
   const iterableFlags = user.flags.toObject();
 


### PR DESCRIPTION
This PR automatically marks as read the last news post when an user signs up.