### PR TITLE
Make start date and day of month aware of timezones (fixes #12555)

### DIFF
--- a/test/api/v3/integration/tasks/POST-tasks_user.test.js
+++ b/test/api/v3/integration/tasks/POST-tasks_user.test.js
@@ -8,9 +8,14 @@ import {
 
 describe('POST /tasks/user', () => {
   let user;
+  let tzoffset;
+
+  before(async () => {
+    tzoffset = new Date().getTimezoneOffset();
+  });
 
   beforeEach(async () => {
-    user = await generateUser();
+    user = await generateUser({ 'preferences.timezoneOffset': tzoffset });
   });
 
   context('validates params', async () => {
@@ -532,7 +537,7 @@ describe('POST /tasks/user', () => {
       expect(task.everyX).to.eql(5);
       expect(task.daysOfMonth).to.eql([15]);
       expect(task.weeksOfMonth).to.eql([3]);
-      expect(new Date(task.startDate)).to.eql(now);
+      expect(new Date(task.startDate)).to.eql(new Date(now.setHours(0, 0, 0, 0)));
       expect(task.isDue).to.be.true;
       expect(task.nextDue.length).to.eql(6);
     });

--- a/test/api/v3/integration/tasks/PUT-tasks_id.test.js
+++ b/test/api/v3/integration/tasks/PUT-tasks_id.test.js
@@ -10,9 +10,14 @@ import {
 
 describe('PUT /tasks/:id', () => {
   let user;
+  let tzoffset;
+
+  before(async () => {
+    tzoffset = (new Date()).getTimezoneOffset();
+  });
 
   beforeEach(async () => {
-    user = await generateUser();
+    user = await generateUser({ 'preferences.timezoneOffset': tzoffset });
   });
 
   context('validates params', () => {
@@ -503,7 +508,8 @@ describe('PUT /tasks/:id', () => {
     let monthly;
 
     beforeEach(async () => {
-      const date1 = moment.utc('2020-07-01').toDate();
+      // using date literals is discouraged here, daylight savings will break everything
+      const date1 = moment().toDate();
       monthly = await user.post('/tasks/user', {
         text: 'test monthly',
         type: 'daily',
@@ -514,27 +520,39 @@ describe('PUT /tasks/:id', () => {
     });
 
     it('updates days of month when start date updated', async () => {
-      const date2 = moment.utc('2020-07-03').toDate();
+      const date2 = moment().add(6, 'months').toDate();
       const savedMonthly = await user.put(`/tasks/${monthly._id}`, {
         startDate: date2,
       });
 
-      expect(savedMonthly.daysOfMonth).to.deep.equal([moment.utc(date2).date()]);
+      expect(savedMonthly.daysOfMonth).to.deep.equal([moment(date2).date()]);
     });
 
     it('updates next due when start date updated', async () => {
-      const date2 = moment.utc('2022-07-01').toDate();
+      const date2 = moment().add(6, 'months').toDate();
       const savedMonthly = await user.put(`/tasks/${monthly._id}`, {
         startDate: date2,
       });
 
       expect(savedMonthly.nextDue.length).to.eql(6);
-      expect(moment(savedMonthly.nextDue[0]).toDate()).to.eql(moment.utc('2022-08-01').toDate());
-      expect(moment(savedMonthly.nextDue[1]).toDate()).to.eql(moment.utc('2022-09-01').toDate());
-      expect(moment(savedMonthly.nextDue[2]).toDate()).to.eql(moment.utc('2022-10-01').toDate());
-      expect(moment(savedMonthly.nextDue[3]).toDate()).to.eql(moment.utc('2022-11-01').toDate());
-      expect(moment(savedMonthly.nextDue[4]).toDate()).to.eql(moment.utc('2022-12-01').toDate());
-      expect(moment(savedMonthly.nextDue[5]).toDate()).to.eql(moment.utc('2023-01-01').toDate());
+      expect(moment(savedMonthly.nextDue[0]).toDate()).to.eql(
+        moment(date2).add(1, 'months').startOf('day').toDate(),
+      );
+      expect(moment(savedMonthly.nextDue[1]).toDate()).to.eql(
+        moment(date2).add(2, 'months').startOf('day').toDate(),
+      );
+      expect(moment(savedMonthly.nextDue[2]).toDate()).to.eql(
+        moment(date2).add(3, 'months').startOf('day').toDate(),
+      );
+      expect(moment(savedMonthly.nextDue[3]).toDate()).to.eql(
+        moment(date2).add(4, 'months').startOf('day').toDate(),
+      );
+      expect(moment(savedMonthly.nextDue[4]).toDate()).to.eql(
+        moment(date2).add(5, 'months').startOf('day').toDate(),
+      );
+      expect(moment(savedMonthly.nextDue[5]).toDate()).to.eql(
+        moment(date2).add(6, 'months').startOf('day').toDate(),
+      );
     });
   });
 

--- a/test/api/v3/integration/tasks/PUT-tasks_id.test.js
+++ b/test/api/v3/integration/tasks/PUT-tasks_id.test.js
@@ -514,12 +514,12 @@ describe('PUT /tasks/:id', () => {
     });
 
     it('updates days of month when start date updated', async () => {
-      const date2 = moment.utc('2020-07-01').toDate();
+      const date2 = moment.utc('2020-07-03').toDate();
       const savedMonthly = await user.put(`/tasks/${monthly._id}`, {
         startDate: date2,
       });
 
-      expect(savedMonthly.daysOfMonth).to.deep.equal([moment(date2).date()]);
+      expect(savedMonthly.daysOfMonth).to.deep.equal([moment.utc(date2).date()]);
     });
 
     it('updates next due when start date updated', async () => {

--- a/test/api/v3/integration/tasks/challenges/POST-tasks_challenge_id.test.js
+++ b/test/api/v3/integration/tasks/challenges/POST-tasks_challenge_id.test.js
@@ -11,13 +11,18 @@ describe('POST /tasks/challenge/:challengeId', () => {
   let user;
   let guild;
   let challenge;
+  let tzoffset;
 
   function findUserChallengeTask (memberTask) {
     return memberTask.challenge.id === challenge._id;
   }
 
+  before(async () => {
+    tzoffset = new Date().getTimezoneOffset();
+  });
+
   beforeEach(async () => {
-    user = await generateUser({ balance: 1 });
+    user = await generateUser({ balance: 1, 'preferences.timezoneOffset': tzoffset });
     guild = await generateGroup(user);
     challenge = await generateChallenge(user, guild);
     await user.post(`/challenges/${challenge._id}/join`);
@@ -165,7 +170,7 @@ describe('POST /tasks/challenge/:challengeId', () => {
     expect(task.type).to.eql('daily');
     expect(task.frequency).to.eql('daily');
     expect(task.everyX).to.eql(5);
-    expect(new Date(task.startDate)).to.eql(now);
+    expect(new Date(task.startDate)).to.eql(new Date(now.setHours(0, 0, 0, 0)));
 
     expect(userChallengeTask.notes).to.eql(task.notes);
   });

--- a/test/api/v3/integration/tasks/challenges/PUT-tasks_challenge_challengeId.test.js
+++ b/test/api/v3/integration/tasks/challenges/PUT-tasks_challenge_challengeId.test.js
@@ -12,7 +12,7 @@ describe('PUT /tasks/:id', () => {
   let challenge;
 
   before(async () => {
-    user = await generateUser();
+    user = await generateUser({ 'preferences.timezoneOffset': new Date().getTimezoneOffset() });
     guild = await generateGroup(user);
     challenge = await generateChallenge(user, guild);
     await user.post(`/challenges/${challenge._id}/join`);

--- a/test/api/v3/integration/tasks/groups/POST-tasks_group_id.test.js
+++ b/test/api/v3/integration/tasks/groups/POST-tasks_group_id.test.js
@@ -8,12 +8,18 @@ import {
 describe('POST /tasks/group/:groupid', () => {
   let user; let guild; let
     manager;
+  let tzoffset;
   const groupName = 'Test Public Guild';
   const groupType = 'guild';
 
+  before(async () => {
+    tzoffset = new Date().getTimezoneOffset();
+  });
+
   beforeEach(async () => {
-    user = await generateUser({ balance: 1 });
+    //  user = await generateUser({ balance: 1, 'preferences.timezoneOffset': tzoffset });
     const { group, groupLeader, members } = await createAndPopulateGroup({
+      leaderDetails: { balance: 10, 'preferences.timezoneOffset': tzoffset },
       groupDetails: {
         name: groupName,
         type: groupType,
@@ -128,7 +134,7 @@ describe('POST /tasks/group/:groupid', () => {
     expect(task.type).to.eql('daily');
     expect(task.frequency).to.eql('daily');
     expect(task.everyX).to.eql(5);
-    expect(new Date(task.startDate)).to.eql(now);
+    expect(new Date(task.startDate)).to.eql(new Date(now.setHours(0, 0, 0, 0)));
   });
 
   it('allows a manager to add a group task', async () => {

--- a/website/server/controllers/api-v3/tasks.js
+++ b/website/server/controllers/api-v3/tasks.js
@@ -689,7 +689,15 @@ api.updateTask = {
       && task.daysOfMonth.length
       && task.startDate
     ) {
-      task.daysOfMonth = [moment(task.startDate).date()];
+      // This updates the start date time to midnight in the user's timezone.
+      task.startDate = moment(task.startDate).utcOffset(
+        -user.preferences.timezoneOffset,
+      ).hour(0).toDate();
+      // We also need to aware of the user's timezone. Start date is represented as UTC, so the
+      // start date and day of month might be different
+      task.daysOfMonth = [moment(task.startDate).utcOffset(
+        -user.preferences.timezoneOffset,
+      ).date()];
     }
 
     setNextDue(task, user);

--- a/website/server/libs/taskManager.js
+++ b/website/server/libs/taskManager.js
@@ -124,6 +124,15 @@ export async function createTasks (req, res, options = {}) {
       }
     }
 
+    // set startDate to midnight in the user's timezone
+    if (taskType === 'daily') {
+      const awareStartDate = moment(newTask.startDate).utcOffset(-user.preferences.timezoneOffset);
+      if (awareStartDate.format('HMsS') !== '0000') {
+        awareStartDate.startOf('day');
+        newTask.startDate = awareStartDate.toDate();
+      }
+    }
+
     setNextDue(newTask, user);
 
     // Validate that the task is valid and throw if it isn't

--- a/website/server/models/task.js
+++ b/website/server/models/task.js
@@ -378,7 +378,7 @@ export const DailySchema = new Schema(_.defaults({
   startDate: {
     $type: Date,
     default () {
-      return moment().startOf('day').toDate();
+      return moment.utc().toDate();
     },
     required: true,
   },


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #12555

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Bug was caused by updateTask api method setting `daysOfMonth = startDate.date()` and because `startDate` is represented in UTC, `daysOfMonth` would be wrong if user was in a UTC+xxx timezone.

Fixed this by factoring in `user.preferences.timezoneOffset`, which sets `daysOfMonth` to reflect the date in the user's timezone instead of UTC.

Also slightly tweaked the test for this api call so that the updated task start date was different from the original.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 76ad7ada-553e-46bc-a6dc-fcead49f9228
