### PR TITLE
Task and party menus use normal links (fixes #12703)

### DIFF
--- a/website/client/src/components/header/menu.vue
+++ b/website/client/src/components/header/menu.vue
@@ -46,15 +46,18 @@
         class="collapse navbar-collapse"
       >
         <b-navbar-nav class="menu-list">
-          <b-nav-item
-            class="topbar-item"
-            :class="{'active': $route.path === '/'}"
-            tag="li"
-            :to="{name: 'tasks'}"
-            exact="exact"
+          <li
+            class="topbar-item droppable"
+            :class="{
+              'active': $route.path === '/'}"
           >
-            {{ $t('tasks') }}
-          </b-nav-item>
+            <router-link
+              class="nav-link"
+              :to="{name: 'tasks'}"
+            >
+              {{ $t('tasks') }}
+            </router-link>
+          </li>
           <li
             class="topbar-item droppable"
             :class="{
@@ -147,15 +150,19 @@
               </router-link>
             </div>
           </li>
-          <b-nav-item
+          <li
             v-if="user.party._id"
-            class="topbar-item"
-            :class="{'active': $route.path.startsWith('/party')}"
-            tag="li"
-            :to="{name: 'party'}"
+            class="topbar-item droppable"
+            :class="{
+              'active': $route.path.startsWith('/party')}"
           >
-            {{ $t('party') }}
-          </b-nav-item>
+            <router-link
+              class="nav-link"
+              :to="{name: 'party'}"
+            >
+              {{ $t('party') }}
+            </router-link>
+          </li>
           <b-nav-item
             v-if="!user.party._id"
             class="topbar-item"


### PR DESCRIPTION
[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #12703

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Fixes the problem with the task and party menu items using a different component and not functioning correctly as links, by using the router-link component instead of b-nav-item. Note b-nav-item is still used for the link item where the user is not part of a party as this pops up a modal to create one rather than going to another page.

----
UUID: cbeeb477-d5db-4efd-8f0b-68201870482b
