### PR TITLE
Preserve original subscription start date when creating team subscription

### DIFF
--- a/website/server/libs/payments/groupPayments.js
+++ b/website/server/libs/payments/groupPayments.js
@@ -91,7 +91,7 @@ async function addSubToGroupUser (member, group) {
     extraMonths: 0,
     dateTerminated: null,
     lastBillingDate: null,
-    dateCreated: new Date(),
+    dateCreated: member.purchased.plan.dateCreated || new Date(),
     mysteryItems: [],
     consecutive: {
       trinkets: 0,


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes an issue I noticed during user support, where users who became part of a team subscription were having their `purchased.plan.dateCreated` overwritten. Normally, we try to preserve this date as the _first_ instance of the user beginning a subscription, not the start date of the _most recent_ subscription.

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

**Previously**, when setting up the `purchased.plan` data for a user enrolled in a Party or Guild upgrade, a value of `new Date()` was set regardless of the existing data in that field.

**Now**, if data is present in `purchased.plan.dateCreated`, we use that value instead of `new Date()` when setting up a team sub for that user.