### PR TITLE
Bugfix in ko/front.json

### DIFF
--- a/website/common/locales/ko/front.json
+++ b/website/common/locales/ko/front.json
@@ -15,5 +15,5 @@
     "footerCompany": "회사",
     "footerDevs": "개발자들",
     "communityExtensions": "<a href='http://habitica.fandom.com/wiki/Extensions,_Add-Ons,_and_Customizations' target='_blank'>Add-ons & Extensions</a>\n(그냥 링크 같음)",
-    "clearBrowserData": "브라우저 데이터 없애기",
+    "clearBrowserData": "브라우저 데이터 없애기"
 }


### PR DESCRIPTION
In weblate we have the allert:
> Weblate could not parse the translation files while updating the translations.
> 
> The following occurrences were found:
> Filename	Error
> website/common/locales/ko/front.json	JSONDecodeError('Expecting property name enclosed in double quotes: line 19 column 1 (char 805)',)

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)


I deleted the trailing comma (so that no further entry is expected when the file is read).


----
UUID: 89c5e715-e3e5-408b-b343-79f470c586ac
