### PR TITLE
added scroll bar to tag filter

### DIFF
--- a/website/client/src/components/tasks/user.vue
+++ b/website/client/src/components/tasks/user.vue
@@ -300,6 +300,11 @@
       }
     }
 
+    .tags-list {
+      max-height: 400px;
+      overflow-y: scroll;
+    }
+
     .tag-edit-input {
       border-bottom: 1px solid $gray-500 !important;
 


### PR DESCRIPTION
Fixes #12613

Added a scroll bar to the tag filter screen such that when tags exceed a certain number, the height of the tag window is fixed and a scroll bar appears. As a result, the tag panel doesn't extend beyond the page when a lot of tags are added. The user can click within the tags window to scroll through the tags list with either a mouse or the up/down arrow keys. They can click outside the tags window if they want to scroll up/down the tasks page.

UUID: cc74fe22-6903-434d-a60f-ee9cd29deb9f

<img width="589" alt="Screenshot 2020-12-04 at 12 43 40 AM" src="https://user-images.githubusercontent.com/44884163/101059959-d0a36580-35c9-11eb-9dde-8700c49abfda.png">
