### PR TITLE
Fixes mention link in a private message

### DIFF
--- a/website/client/src/pages/private-messages.vue
+++ b/website/client/src/pages/private-messages.vue
@@ -924,9 +924,8 @@ export default {
         message: this.newMessage,
       }).then(response => {
         const newMessage = response.data.data.message;
-        const messageToReset = messages[messages.length - 1];
-        messageToReset.id = newMessage.id; // just set the id, all other infos already set
-        Object.assign(messages[messages.length - 1], messageToReset);
+        messages[messages.length - 1] = newMessage;
+        this.selectedConversation.lastMessageText = newMessage.text;
         this.updateConversationsCounter += 1;
       });
 


### PR DESCRIPTION
[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #12764 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Previously, if you sent a private message to a user with a "@Username" in the text, you wouldn't be able to click on that mention link immediately after the message was sent. It would look like it's clickable, but you would have to refresh the page or go to a different page and come back for that mention link to be available. This change fixes that problem so that immediately after you send a text with a mention, you would be able to click on it, which would lead to that user's profile page (image provided below for context).

In terms of specific code changes, I added several lines that would update the message properties with the correct text (after the @ text was processed with a link) once the response came back.

![image](https://user-images.githubusercontent.com/33815349/102139660-224eba00-3e2c-11eb-890d-5673f5c0ead4.png)

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 127290bf-75df-4d7d-a94f-8136cb7d7032
