### PR TITLE
Count down notification regarding issue-11172

### DIFF
--- a/test/api/v3/integration/user/POST-user_mark_pms_read.test.js
+++ b/test/api/v3/integration/user/POST-user_mark_pms_read.test.js
@@ -15,9 +15,9 @@ describe('GET /user/mark-pms-read', () => {
     await user.update({
       'inbox.newMessages': 1,
     });
-    const unreadMessageCount = 1
+    const unreadMessageCount = 1;
     await user.get(`/user/mark-pms-read?count=${unreadMessageCount}&to=${user._id}`);
     await user.sync();
-    expect(user.inbox.newMessages).to.equal(1);
+    expect(user.inbox.newMessages).to.equal(0);
   });
 });

--- a/test/api/v3/integration/user/POST-user_mark_pms_read.test.js
+++ b/test/api/v3/integration/user/POST-user_mark_pms_read.test.js
@@ -1,11 +1,11 @@
 import {
   generateUser,
-} from '../../../../helpers/api-integration/v3';
+} from '../../../../helpers/api-integration/v4';
 
-describe('POST /user/mark-pms-read', () => {
+describe('GET /user/mark-pms-read', () => {
   let user;
 
-  beforeEach(async () => {
+  before(async () => {
     user = await generateUser();
   });
 
@@ -15,8 +15,9 @@ describe('POST /user/mark-pms-read', () => {
     await user.update({
       'inbox.newMessages': 1,
     });
-    await user.post('/user/mark-pms-read');
+    const unreadMessageCount = 1
+    await user.get(`/user/mark-pms-read?count=${unreadMessageCount}&to=${user._id}`);
     await user.sync();
-    expect(user.inbox.newMessages).to.equal(0);
+    expect(user.inbox.newMessages).to.equal(1);
   });
 });

--- a/website/client/src/pages/private-messages.vue
+++ b/website/client/src/pages/private-messages.vue
@@ -830,8 +830,6 @@ export default {
 
       await this.loadConversations();
 
-      await this.$store.dispatch('user:markPrivMessagesRead');
-
       this.loaded = true;
     },
     async loadConversations () {
@@ -964,6 +962,11 @@ export default {
       const requestUrl = `/api/v4/inbox/paged-messages?conversation=${conversationKey}&page=${this.selectedConversation.page}`;
       const res = await axios.get(requestUrl);
       const loadedMessages = res.data.data;
+
+      const unreadMessageCount = loadedMessages.filter(msg => !msg.read).length;
+      const toUserUuid = this.selectedConversation.key;
+      await this.$store.dispatch('user:markPrivMessagesRead', unreadMessageCount);
+      await axios.get(`/api/v4/user/mark-pms-read?count=${unreadMessageCount}&to=${toUserUuid}`);
 
       /* eslint-disable max-len */
       this.messagesByConversation[conversationKey] = this.messagesByConversation[conversationKey] || [];

--- a/website/client/src/store/actions/user.js
+++ b/website/client/src/store/actions/user.js
@@ -175,6 +175,7 @@ export function unblock (store, params) {
 
 export function markPrivMessagesRead (store, ct) {
   markPMSRead(store.state.user.data, ct);
+  return axios.post('/api/v4/user/mark-pms-read');
 }
 
 export function newPrivateMessageTo (store, params) {

--- a/website/client/src/store/actions/user.js
+++ b/website/client/src/store/actions/user.js
@@ -173,9 +173,8 @@ export function unblock (store, params) {
   return axios.post(`/api/v4/user/block/${params.uuid}`);
 }
 
-export function markPrivMessagesRead (store) {
-  markPMSRead(store.state.user.data);
-  return axios.post('/api/v4/user/mark-pms-read');
+export function markPrivMessagesRead (store, ct) {
+  markPMSRead(store.state.user.data, ct);
 }
 
 export function newPrivateMessageTo (store, params) {

--- a/website/client/src/store/actions/user.js
+++ b/website/client/src/store/actions/user.js
@@ -175,7 +175,6 @@ export function unblock (store, params) {
 
 export function markPrivMessagesRead (store, ct) {
   markPMSRead(store.state.user.data, ct);
-  return axios.post('/api/v4/user/mark-pms-read');
 }
 
 export function newPrivateMessageTo (store, params) {

--- a/website/common/script/ops/markPMSRead.js
+++ b/website/common/script/ops/markPMSRead.js
@@ -1,7 +1,7 @@
 import i18n from '../i18n';
 
-export default function markPmsRead (user) {
-  user.inbox.newMessages = 0;
+export default function markPmsRead (user, count) {
+  user.inbox.newMessages -= count;
 
   return [
     user.inbox.newMessages,

--- a/website/server/controllers/api-v4/inbox.js
+++ b/website/server/controllers/api-v4/inbox.js
@@ -4,7 +4,7 @@ import {
   NotFound,
 } from '../../libs/errors';
 import { listConversations } from '../../libs/inbox/conversation.methods';
-import { clearPMs, deleteMessage, getUserInbox } from '../../libs/inbox';
+import { clearPMs, deleteMessage, getUserInbox, markPmsRead } from '../../libs/inbox';
 
 const api = {};
 
@@ -146,5 +146,36 @@ api.getInboxMessages = {
     res.respond(200, userInbox);
   },
 };
+
+/**
+ * @api {post} /api/v3/user/mark-pms-read Mark Private Messages as read
+ * @apiName markPmsRead
+ * @apiGroup User
+ * 
+ * @apiParam (Path) {Integer} count The count of pms marked as read
+ * @apiParam (Path) {UUID} to The uuid of user that is opposed to you in the conversation
+ *
+ * @apiSuccess {Object} data user.inbox.newMessages
+ * @apiSuccessExample {json}
+ * {"success":true,"message":["Your private messages have been marked as read"],"notifications":[]}
+ *
+ */
+
+api.markPmsRead = {
+    method: 'GET',
+    middlewares: [authWithHeaders()],
+    url: '/user/mark-pms-read',
+    async handler (req, res) {
+      const { user } = res.locals;
+      const { count, to } = req.query;
+
+      await markPmsRead(to, user, count);
+      res.respond(200, {
+        message: res.t('pmsMarkedRead'),
+      });
+    },
+  };
+   
+  
 
 export default api;

--- a/website/server/controllers/api-v4/inbox.js
+++ b/website/server/controllers/api-v4/inbox.js
@@ -4,7 +4,12 @@ import {
   NotFound,
 } from '../../libs/errors';
 import { listConversations } from '../../libs/inbox/conversation.methods';
-import { clearPMs, deleteMessage, getUserInbox, markPmsRead } from '../../libs/inbox';
+import {
+  clearPMs,
+  deleteMessage,
+  getUserInbox,
+  markPmsRead,
+} from '../../libs/inbox';
 
 const api = {};
 
@@ -151,7 +156,6 @@ api.getInboxMessages = {
  * @api {post} /api/v3/user/mark-pms-read Mark Private Messages as read
  * @apiName markPmsRead
  * @apiGroup User
- * 
  * @apiParam (Path) {Integer} count The count of pms marked as read
  * @apiParam (Path) {UUID} to The uuid of user that is opposed to you in the conversation
  *
@@ -162,20 +166,18 @@ api.getInboxMessages = {
  */
 
 api.markPmsRead = {
-    method: 'GET',
-    middlewares: [authWithHeaders()],
-    url: '/user/mark-pms-read',
-    async handler (req, res) {
-      const { user } = res.locals;
-      const { count, to } = req.query;
+  method: 'GET',
+  middlewares: [authWithHeaders()],
+  url: '/user/mark-pms-read',
+  async handler (req, res) {
+    const { user } = res.locals;
+    const { count, to } = req.query;
 
-      await markPmsRead(to, user, count);
-      res.respond(200, {
-        message: res.t('pmsMarkedRead'),
-      });
-    },
-  };
-   
-  
+    await markPmsRead(to, user, count);
+    res.respond(200, {
+      message: res.t('pmsMarkedRead'),
+    });
+  },
+};
 
 export default api;

--- a/website/server/libs/inbox/index.js
+++ b/website/server/libs/inbox/index.js
@@ -103,7 +103,7 @@ export async function clearPMs (user) {
 export async function markPmsRead (to, user, count) {
   if (user.inbox.newMessages < 0) {
     user.inbox.newMessages = 0;
-  } 
+  }
   user.inbox.newMessages -= count;
 
   const findObj = { ownerId: user._id, uuid: to };

--- a/website/server/libs/inbox/index.js
+++ b/website/server/libs/inbox/index.js
@@ -99,3 +99,16 @@ export async function clearPMs (user) {
     Inbox.remove({ ownerId: user._id }).exec(),
   ]);
 }
+
+export async function markPmsRead (to, user, count) {
+  if (user.inbox.newMessages < 0) {
+    user.inbox.newMessages = 0;
+  } 
+  user.inbox.newMessages -= count;
+
+  const findObj = { ownerId: user._id, uuid: to };
+  await Promise.all([
+    user.save(),
+    Inbox.find(findObj).updateMany({}, { $set: { read: true } }).exec(),
+  ]);
+}

--- a/website/server/models/message.js
+++ b/website/server/models/message.js
@@ -45,6 +45,7 @@ const inboxSchema = new mongoose.Schema({
   // we store two copies of each inbox messages:
   // one for the sender and one for the receiver
   ownerId: { $type: String, ref: 'User' },
+  read: { $type: Boolean, default: false },
   ...defaultSchema(),
 }, {
   minimize: false, // Allow for empty flags to be saved

--- a/website/server/models/user/methods.js
+++ b/website/server/models/user/methods.js
@@ -128,10 +128,11 @@ schema.methods.sendMessage = async function sendMessage (userToReceiveMessage, o
   });
   Object.assign(newReceiverMessage, messageDefaults(options.receiverMsg, sender));
   setUserStyles(newReceiverMessage, sender);
-
+  if (userToReceiveMessage.inbox.newMessages < 0) {
+    userToReceiveMessage.inbox.newMessages = 0;
+  }
   userToReceiveMessage.inbox.newMessages += 1;
   userToReceiveMessage._v += 1;
-
   /* @TODO disabled until mobile is ready
 
   let excerpt;
@@ -163,6 +164,7 @@ schema.methods.sendMessage = async function sendMessage (userToReceiveMessage, o
     newSenderMessage = new Inbox({
       sent: true,
       ownerId: sender._id,
+      read: true,
     });
     Object.assign(newSenderMessage, messageDefaults(senderMsg, userToReceiveMessage));
     setUserStyles(newSenderMessage, sender);


### PR DESCRIPTION
Sorry for taking so long to come up with the solution for this issue, I am still pretty new to coding and it took me a hot minute to figure out how the frontend and backend were talking to each other. I got it working and I am sure there are things I missed but this is what I have so far.

I want to give some of the credit to @ResamVi. I missed that he already submitted a PR few months ago regarding this issue and I wish I saw his PR earlier because that could have saved me a few days of research. His PR had a lot of the things solved already that I took and tweaked to work with the new develop version. 

Before:
When a sender sends a message to the receiver, it creates two messages, one for the sender and one for the receiver. It also increments the `store.state.user.data.inbox.newMessage` for the receiver per message. When user goes to the messages under user dropdown menu, it calls the api v3 mark_pms_read which resets the `inbox.newMessages` counter to 0 and refreshes the frontend.

[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

Fixes #11172 

### Changes
[//]: # Starting from the backend, I added a read property to the inbox schema and set it to false on default. When user sends the message, in the methods.js file I added a read property set as true for the sender's message in the sender's inbox so that it doesn't count the message as unread later in the chain. I also added an if statement that basically resets the counter to 0 if for some reason the counter goes to a negative number. I noticed during testing when counter became negative it was triggering all sorts of weird issues for notification and that might have some relations to issue #11199. 
In the private-messages.vue file, under `loadMessages` method, I added the function that @ResamVi had in his code that looks for any messages that were loaded that had the `read`property as false and saves it in `unreadMessagesCount` object. It emits a function call for `markPrivMessagesRead` which updates the `newMessages` counter on the frontend side. Also api is called using `axios.get` and passes `unreadMessagesCount` and `toUserUuid `to backend in api-v4/inbox.js file. This api takes the request and passes it to `markPmsRead` from inbox/index.js which subtracts the `unreadMessagesCount` from `user.inbox.newMessages` and saves the state and changes the message read property to true. 


----
UUID: 228f739f-b42c-4801-932c-10b4d739b460
