### PR TITLE
remove PER bonus for Brilliant Bloom (summer 2019 mage weapon)

### DIFF
--- a/website/common/script/content/gear/sets/special/index.js
+++ b/website/common/script/content/gear/sets/special/index.js
@@ -2916,6 +2916,7 @@ const weapon = {
     notes: t('weaponSpecialSummer2019MageNotes', { int: 15 }),
     value: 90,
     int: 15,
+    per: 0,
     twoHanded: false,
     canBuy: () => CURRENT_EVENT && CURRENT_EVENT.season === 'summer',
   },


### PR DESCRIPTION
A recent refactor in how seasonal gear stats are populated ([commit 9450f9e](https://github.com/HabitRPG/habitica/commit/9450f9ee1d74db527b8850dae2245d2ba845a1b3)) created a bug with this one odd mage weapon that doesn't have the usual stats.

Related discussion: Pull #11318

### Changes

Added a PER = 0 override to the Brilliant Bloom definition so that the default PER = 7 won't get applied.

----
UUID: 19af148a-5e61-41e4-a002-cbfa5219bd66
