### PR TITLE
fix: task onClick outline is only around title

### DIFF
--- a/website/client/src/components/tasks/task.vue
+++ b/website/client/src/components/tasks/task.vue
@@ -497,11 +497,6 @@
     &-user {
       padding-right: 0px;
     }
-
-    &:focus {
-      border-radius: 2px;
-      border: $purple-400 solid 1px;
-    }
   }
 
   .task-title + .task-dropdown ::v-deep .dropdown-menu {


### PR DESCRIPTION
Fixes #12796

### Changes
- Removed the focus property (SCSS) from the title div of the task component.


removed the outline when the title is selected in the task component. let me know if I did something wrong or if this was not the desired behaviour. 

----
UUID: f551bd9e-abb8-4cbe-aa57-4ec6694f5354
