### PR TITLE
Use mongoose session to ensure user and group are updated in same transaction

### DIFF
--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import nconf from 'nconf';
+import mongoose from 'mongoose';
 import { authWithHeaders } from '../../middlewares/auth';
 import {
   model as Group,
@@ -137,7 +138,13 @@ api.createGroup = {
       user.party._id = group._id;
     }
 
-    const results = await Promise.all([user.save(), group.save()]);
+    const session = await mongoose.startSession();
+    let results;
+    await session.withTransaction(async () => {
+      results = await Promise.all([user.save(), group.save()]);
+    });
+    session.endSession();
+
     const savedGroup = results[1];
 
     // Instead of populate we make a find call manually because of https://github.com/Automattic/mongoose/issues/3833


### PR DESCRIPTION
Fixes #12124

### Changes
Use mongoose session to ensure user and group are updated in same transaction

UUID: bb6ce8ce-17d5-49de-a4fc-b3486714266f

This fix seems like it would be best tested with a unit test.  However, I haven't been able to find the server tests in the code.   Can you point me to the right directory?