### PR TITLE
#12970 Fixed 'String " not found' bug in categories while saving guild descr…

### DIFF
--- a/website/client/src/components/groups/groupFormModal.vue
+++ b/website/client/src/components/groups/groupFormModal.vue
@@ -616,14 +616,14 @@ export default {
           name: catName,
         });
       });
-      this.workingGroup.categories = serverCategories;
 
       const groupData = { ...this.workingGroup };
+      groupData.categories = serverCategories;
 
       let newgroup;
       if (groupData.id) {
         await this.$store.dispatch('guilds:update', { group: groupData });
-        this.$root.$emit('updatedGroup', this.workingGroup);
+        this.$root.$emit('updatedGroup', groupData);
         // @TODO: this doesn't work because of the async resource
         // if (updatedGroup.type === 'party') this.$store.state.party = {data: updatedGroup};
       } else {

--- a/website/client/src/components/groups/groupFormModal.vue
+++ b/website/client/src/components/groups/groupFormModal.vue
@@ -608,17 +608,16 @@ export default {
       };
 
       const categoryKeys = this.workingGroup.categories;
-      const serverCategories = [];
+      const categories = [];
       categoryKeys.forEach(key => {
         const catName = this.categoriesHashByKey[key];
-        serverCategories.push({
+        categories.push({
           slug: key,
           name: catName,
         });
       });
 
-      const groupData = { ...this.workingGroup };
-      groupData.categories = serverCategories;
+      const groupData = { ...this.workingGroup, categories };
 
       let newgroup;
       if (groupData.id) {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #12970

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

- Set categories on the copy of `this.workingGroup` which is `groupData`.
- And emit that copy instead of the original, to the `updatedGroup` event.
- The event and dispatch request both use categories that have an object array.

This ensures original `this.workingGroup.categories`, used in layout code, which is a string array remains unchanged.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 2daaf78e-75b6-4422-b69a-a7fd5477d8b7
