### PR TITLE
Storybook: disable DuplicatesPlugin while running in storybook:serve

### DIFF
--- a/website/client/vue.config.js
+++ b/website/client/vue.config.js
@@ -38,7 +38,7 @@ envVars
     envObject[key] = nconf.get(key);
   });
 
-const enableDuplicatesPlugin = process.env['npm_lifecycle_event'] !== 'storybook:serve';
+const enableDuplicatesPlugin = process.env.npm_lifecycle_event !== 'storybook:serve';
 
 const webpackPlugins = [
   new webpack.EnvironmentPlugin(envObject),
@@ -46,9 +46,9 @@ const webpackPlugins = [
 ];
 
 if (enableDuplicatesPlugin) {
-  webpackPlugins.splice(0,0,  new DuplicatesPlugin({
-        verbose: true,
-      }));
+  webpackPlugins.splice(0, 0, new DuplicatesPlugin({
+    verbose: true,
+  }));
 }
 
 module.exports = {

--- a/website/client/vue.config.js
+++ b/website/client/vue.config.js
@@ -38,16 +38,23 @@ envVars
     envObject[key] = nconf.get(key);
   });
 
+const enableDuplicatesPlugin = process.env['npm_lifecycle_event'] !== 'storybook:serve';
+
+const webpackPlugins = [
+  new webpack.EnvironmentPlugin(envObject),
+  new webpack.ContextReplacementPlugin(/moment[\\/]locale$/, /^\.\/(NOT_EXISTING)$/),
+];
+
+if (enableDuplicatesPlugin) {
+  webpackPlugins.splice(0,0,  new DuplicatesPlugin({
+        verbose: true,
+      }));
+}
+
 module.exports = {
   assetsDir: 'static',
   configureWebpack: {
-    plugins: [
-      new DuplicatesPlugin({
-        verbose: true,
-      }),
-      new webpack.EnvironmentPlugin(envObject),
-      new webpack.ContextReplacementPlugin(/moment[\\/]locale$/, /^\.\/(NOT_EXISTING)$/),
-    ],
+    plugins: webpackPlugins,
   },
   chainWebpack: config => {
     // Fix issue with duplicated deps in monorepos


### PR DESCRIPTION
Currently every change while running storybook gives you some thousand lines of various  outdated package messages due to DuplicatesPlugin.

With this change it is less spammy :) 