### PR TITLE
over-purchase warning for Gryphon eggs now ignore Royal Purple pets a…

### DIFF
--- a/website/client/src/components/shops/buyModal.vue
+++ b/website/client/src/components/shops/buyModal.vue
@@ -566,6 +566,7 @@ export default {
         const ownedPets = reduce(this.user.items.pets, (sum, petValue, petKey) => {
           if (petKey.includes(this.item.key) && petValue > 0
             && !petKey.includes('JackOLantern') // Jack-O-Lantern has "Ghost" version
+            && !petKey.includes('royalPurple') // to avoid counting Royal Purple Gryphons for gryphon eggs
           ) return sum + 1;
           return sum;
         }, 0);
@@ -573,6 +574,7 @@ export default {
         const ownedMounts = reduce(this.user.items.mounts, (sum, mountValue, mountKey) => {
           if (mountKey.includes(this.item.key) && mountValue === true
             && !mountKey.includes('JackOLantern')
+            && !mountKey.includes('royalPurple')
           ) return sum + 1;
           return sum;
         }, 0);

--- a/website/client/src/components/shops/buyModal.vue
+++ b/website/client/src/components/shops/buyModal.vue
@@ -566,7 +566,7 @@ export default {
         const ownedPets = reduce(this.user.items.pets, (sum, petValue, petKey) => {
           if (petKey.includes(this.item.key) && petValue > 0
             && !petKey.includes('JackOLantern') // Jack-O-Lantern has "Ghost" version
-            && !petKey.includes('royalPurple') // to avoid counting Royal Purple Gryphons for gryphon eggs
+            && !petKey.includes('RoyalPurple') // to avoid counting Royal Purple Gryphons for gryphon eggs
           ) return sum + 1;
           return sum;
         }, 0);
@@ -574,7 +574,7 @@ export default {
         const ownedMounts = reduce(this.user.items.mounts, (sum, mountValue, mountKey) => {
           if (mountKey.includes(this.item.key) && mountValue === true
             && !mountKey.includes('JackOLantern')
-            && !mountKey.includes('royalPurple')
+            && !mountKey.includes('RoyalPurple')
           ) return sum + 1;
           return sum;
         }, 0);


### PR DESCRIPTION
…nd mounts

[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #13042 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
I've added a check to exclude any Royal Purple pet and mount from the calculation of the over-purchase warning. I tested locally and there are no issues, ~the modal works, but I've not been able to test with an account that owns royal purple gryphons (I set up Habitica on GitPod and have not been able to edit the database directly to add the pet and mount to the account, I have not been able to set it up on my laptop)~ (now tested locally)

Now up to 20 eggs there are no alerts, when you go to purchase the 21st there is the alert that you don't need anymore


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: c073342f-4a65-4a13-9ffd-9e7fa5410d6b
