### PR TITLE
Various Patches (L10N boss num, selList overflow, chat middle mention+refocus on click)

### DIFF
--- a/website/client/src/components/chat/autoComplete.vue
+++ b/website/client/src/components/chat/autoComplete.vue
@@ -135,12 +135,10 @@ export default {
     text (newTextParam, prevTextParam) {
       const delCharFocusBool = prevTextParam.length > newTextParam.length;
       const caretPosition = this.textbox.selectionEnd;
-      const charFocus = (
-        delCharFocusBool ? prevTextParam : newTextParam
-      )[caretPosition - (delCharFocusBool ? 0 : 1)];
+      const lastFocussedChar = isDeleting ? prevText[caretPosition] : newText[caretPosition - 1];
       if (
         newTextParam.length === 0 // Delete all
-        || (charFocus === ' ' && !delCharFocusBool) // End Search
+        || /\s/.test(lastFocussed) // End Search
         || (charFocus === '@' && delCharFocusBool) // Cancel Search
       ) {
         this.searchActive = false;
@@ -172,11 +170,8 @@ export default {
       const lowerCaseSearch = this.currentSearch.toLowerCase();
 
       return this.tmpSelections
-        .filter(option => { // eslint-disable-line arrow-body-style
-          return option.displayName.toLowerCase().indexOf(lowerCaseSearch) !== -1
-            || (option.username
-              && option.username.toLowerCase().indexOf(lowerCaseSearch) !== -1);
-        })
+        .filter(option => option.displayName.toLowerCase().includes(lowerCaseSearch)
+            || (option.username && option.username.toLowerCase().includes(lowerCaseSearch)))
         .slice(0, 4);
     },
     resetDefaults () {

--- a/website/client/src/components/chat/autoComplete.vue
+++ b/website/client/src/components/chat/autoComplete.vue
@@ -90,8 +90,6 @@ export default {
   props: ['selections', 'text', 'caretPosition', 'coords', 'chat', 'textbox'],
   data () {
     return {
-      // Old Regex
-      // atRegex: /(?!\b)@([\w-]*)$/,
       atRegex: /@([\w-]*)$/,
       currentSearch: '',
       searchActive: false,
@@ -132,23 +130,21 @@ export default {
     },
   },
   watch: {
-    text (newTextParam, prevTextParam) {
-      const delCharFocusBool = prevTextParam.length > newTextParam.length;
+    text (newText, prevText) {
+      const delCharsBool = prevText.length > newText.length;
       const caretPosition = this.textbox.selectionEnd;
-      const lastFocussedChar = isDeleting ? prevText[caretPosition] : newText[caretPosition - 1];
+      const lastFocusChar = delCharsBool ? prevText[caretPosition] : newText[caretPosition - 1];
       if (
-        newTextParam.length === 0 // Delete all
-        || /\s/.test(lastFocussed) // End Search
-        || (charFocus === '@' && delCharFocusBool) // Cancel Search
+        newText.length === 0 // Delete all
+        || /\s/.test(lastFocusChar) // End Search
+        || (lastFocusChar === '@' && delCharsBool) // Cancel Search
       ) {
         this.searchActive = false;
         this.searchResults = [];
       } else {
-        if (charFocus === '@') {
-          this.searchActive = true;
-        }
+        if (lastFocusChar === '@') this.searchActive = true;
         if (this.searchActive) {
-          this.searchResults = this.solveSearchResults(newTextParam.substring(0, caretPosition));
+          this.searchResults = this.solveSearchResults(newText.substring(0, caretPosition));
         }
       }
     },
@@ -161,9 +157,9 @@ export default {
     this.grabUserNames();
   },
   methods: {
-    solveSearchResults (searchTextWip) {
+    solveSearchResults (textFocus) {
       if (!this.searchActive) return [];
-      const regexRes = this.atRegex.exec(searchTextWip);
+      const regexRes = this.atRegex.exec(textFocus);
       if (!regexRes) return [];
       this.currentSearch = regexRes[1]; // eslint-disable-line vue/no-side-effects-in-computed-properties, max-len, prefer-destructuring
 

--- a/website/client/src/components/groups/chat.vue
+++ b/website/client/src/components/groups/chat.vue
@@ -117,7 +117,7 @@ export default {
         TOP: 0,
         LEFT: 0,
       },
-      textbox: this.$refs,
+      textbox: null,
       MAX_MESSAGE_LENGTH: MAX_MESSAGE_LENGTH.toString(),
     };
   },
@@ -129,6 +129,9 @@ export default {
     communityGuidelinesAccepted () {
       return this.user.flags.communityGuidelinesAccepted;
     },
+  },
+  mounted () {
+    this.textbox = this.$refs['user-entry'];
   },
   methods: {
     // https://medium.com/@_jh3y/how-to-where-s-the-caret-getting-the-xy-position-of-the-caret-a24ba372990a
@@ -249,8 +252,13 @@ export default {
       }
     },
 
-    selectedAutocomplete (newText) {
+    selectedAutocomplete (newText, newCaret) {
       this.newMessage = newText;
+      // Wait for v-modal to update
+      this.$nextTick(() => {
+        this.textbox.setSelectionRange(newCaret, newCaret);
+        this.textbox.focus();
+      });
     },
 
     fetchRecentMessages () {

--- a/website/client/src/components/groups/membersModal.vue
+++ b/website/client/src/components/groups/membersModal.vue
@@ -42,7 +42,7 @@
               :placeholder="$t('search')"
             >
           </div>
-          <div class="col">
+          <div class="col-5">
             <select-list
               :items="sortOptions"
               :value="optionEntryBySelectedValue"

--- a/website/client/src/components/groups/questSidebarSection.vue
+++ b/website/client/src/components/groups/questSidebarSection.vue
@@ -149,7 +149,19 @@
             <div class="row boss-details">
               <div class="col-6">
                 <span class="float-left">
-                  {{ Math.ceil(parseFloat(group.quest.progress.hp) * 100) / 100 }} / {{ parseFloat(questData.boss.hp).toFixed(2) }} <!-- eslint-disable-line max-len -->
+                  {{
+                    (Math.ceil(parseFloat(group.quest.progress.hp) * 100) / 100)
+                      .toLocaleString(user.preferences.language, {
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 2
+                      })
+                  }} / {{
+                    parseFloat(questData.boss.hp)
+                      .toLocaleString(user.preferences.language, {
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 2
+                      })
+                  }} <!-- eslint-disable-line max-len -->
                   <!-- current boss hp uses ceil so
                     you don't underestimate damage needed to end quest-->
                 </span>
@@ -160,9 +172,15 @@
               >
                 <!-- @TODO: Why do we not sync quest
                   progress on the group doc? Each user could have different progress.-->
-                <span
-                  class="float-right"
-                >{{ (user.party.quest.progress.up || 0) | floor(10) }} {{ $t('pendingDamageLabel') }}</span> <!-- eslint-disable-line max-len -->
+                <span class="float-right">
+                  {{
+                    (Math.floor((user.party.quest.progress.up || 0) * 10) / 10)
+                      .toLocaleString(user.preferences.language, {
+                        minimumFractionDigits: 1,
+                        maximumFractionDigits: 1
+                      })
+                  }} {{ $t('pendingDamageLabel') }}
+                </span> <!-- eslint-disable-line max-len -->
                 <!-- player's pending damage uses floor so you
                   don't overestimate damage you've already done-->
               </div>

--- a/website/client/src/components/groups/questSidebarSection.vue
+++ b/website/client/src/components/groups/questSidebarSection.vue
@@ -180,7 +180,7 @@
                         maximumFractionDigits: 1
                       })
                   }} {{ $t('pendingDamageLabel') }}
-                </span> <!-- eslint-disable-line max-len -->
+                </span>
                 <!-- player's pending damage uses floor so you
                   don't overestimate damage you've already done-->
               </div>

--- a/website/client/src/components/groups/questSidebarSection.vue
+++ b/website/client/src/components/groups/questSidebarSection.vue
@@ -151,17 +151,11 @@
                 <span class="float-left">
                   {{
                     (Math.ceil(parseFloat(group.quest.progress.hp) * 100) / 100)
-                      .toLocaleString(user.preferences.language, {
-                        minimumFractionDigits: 2,
-                        maximumFractionDigits: 2
-                      })
+                      | localizeNumber(user.preferences.language, { toFixed:2 })
                   }} / {{
                     parseFloat(questData.boss.hp)
-                      .toLocaleString(user.preferences.language, {
-                        minimumFractionDigits: 2,
-                        maximumFractionDigits: 2
-                      })
-                  }} <!-- eslint-disable-line max-len -->
+                      | localizeNumber(user.preferences.language, { toFixed:2 })
+                  }}
                   <!-- current boss hp uses ceil so
                     you don't underestimate damage needed to end quest-->
                 </span>
@@ -174,11 +168,9 @@
                   progress on the group doc? Each user could have different progress.-->
                 <span class="float-right">
                   {{
-                    (Math.floor((user.party.quest.progress.up || 0) * 10) / 10)
-                      .toLocaleString(user.preferences.language, {
-                        minimumFractionDigits: 1,
-                        maximumFractionDigits: 1
-                      })
+                    (user.party.quest.progress.up || 0)
+                      | floor(10)
+                      | localizeNumber(user.preferences.language, { toFixed:1 })
                   }} {{ $t('pendingDamageLabel') }}
                 </span>
                 <!-- player's pending damage uses floor so you

--- a/website/client/src/components/ui/selectList.vue
+++ b/website/client/src/components/ui/selectList.vue
@@ -10,15 +10,13 @@
       @hide="isOpened = false"
     >
       <template v-slot:button-content>
-        <div class="select-list-button-wrap">
-          <slot
-            name="item"
-            :item="selected"
-            :button="true"
-          >
-            {{ value }}
-          </slot>
-        </div>
+        <slot
+          name="item"
+          :item="selected"
+          :button="true"
+        >
+          {{ value }}
+        </slot>
       </template>
       <b-dropdown-item
         v-for="item in items"
@@ -32,16 +30,14 @@
         }"
         @click="selectItem(item)"
       >
-        <span class="select-list-item-wrap">
-          <slot
-            name="item"
-            :item="item"
-            :button="false"
-          >
-            <!-- Fallback content -->
-            {{ item }}
-          </slot>
-        </span>
+        <slot
+          name="item"
+          :item="item"
+          :button="false"
+        >
+          <!-- Fallback content -->
+          {{ item }}
+        </slot>
         <div
           v-once
           class="svg-icon color check-icon"
@@ -55,33 +51,32 @@
 <style lang="scss" scoped>
   @import '~@/assets/scss/colors.scss';
 
-  .select-list .select-list-button-wrap {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  .select-list ::v-deep .selectListItem {
-    position: relative;
-
-    .select-list-item-wrap {
-      padding-right: 1rem;
+  .select-list ::v-deep {
+    .dropdown-toggle {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
-    &:not(.showIcon) {
-      .svg-icon.check-icon {
-        display: none;
+    .selectListItem {
+      position: relative;
+      padding-right: 1.625rem;
+
+      &:not(.showIcon) {
+        .svg-icon.check-icon {
+          display: none;
+        }
       }
-    }
 
-    .svg-icon.check-icon.color {
-      position: absolute;
-      right: 0.855rem;
-      top: 0.688rem;
-      bottom: 0.688rem;
-      width: 0.77rem;
-      height: 0.615rem;
-      color: $purple-300;
+      .svg-icon.check-icon.color {
+        position: absolute;
+        right: 0.855rem;
+        top: 0.688rem;
+        bottom: 0.688rem;
+        width: 0.77rem;
+        height: 0.615rem;
+        color: $purple-300;
+      }
     }
   }
 </style>

--- a/website/client/src/components/ui/selectList.vue
+++ b/website/client/src/components/ui/selectList.vue
@@ -10,6 +10,7 @@
       @hide="isOpened = false"
     >
       <template v-slot:button-content>
+        BLAH BLAH BLAH
         <slot
           name="item"
           :item="selected"
@@ -52,6 +53,12 @@
 
 <style lang="scss" scoped>
   @import '~@/assets/scss/colors.scss';
+
+  .select-list .btn.dropdown-toggle {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 
   .select-list ::v-deep .selectListItem {
     position: relative;

--- a/website/client/src/components/ui/selectList.vue
+++ b/website/client/src/components/ui/selectList.vue
@@ -10,15 +10,15 @@
       @hide="isOpened = false"
     >
       <template v-slot:button-content>
-        BLAH BLAH BLAH
-        <slot
-          name="item"
-          :item="selected"
-          :button="true"
-        >
-          <!-- Fallback content -->
-          {{ value }}
-        </slot>
+        <div class="select-list-button-wrap">
+          <slot
+            name="item"
+            :item="selected"
+            :button="true"
+          >
+            {{ value }}
+          </slot>
+        </div>
       </template>
       <b-dropdown-item
         v-for="item in items"
@@ -32,15 +32,16 @@
         }"
         @click="selectItem(item)"
       >
-        <slot
-          name="item"
-          :item="item"
-          :button="false"
-        >
-          <!-- Fallback content -->
-          {{ item }}
-        </slot>
-
+        <span class="select-list-item-wrap">
+          <slot
+            name="item"
+            :item="item"
+            :button="false"
+          >
+            <!-- Fallback content -->
+            {{ item }}
+          </slot>
+        </span>
         <div
           v-once
           class="svg-icon color check-icon"
@@ -54,7 +55,7 @@
 <style lang="scss" scoped>
   @import '~@/assets/scss/colors.scss';
 
-  .select-list .btn.dropdown-toggle {
+  .select-list .select-list-button-wrap {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -62,6 +63,10 @@
 
   .select-list ::v-deep .selectListItem {
     position: relative;
+
+    .select-list-item-wrap {
+      padding-right: 1rem;
+    }
 
     &:not(.showIcon) {
       .svg-icon.check-icon {

--- a/website/client/src/components/ui/selectList.vue
+++ b/website/client/src/components/ui/selectList.vue
@@ -39,6 +39,7 @@
           <!-- Fallback content -->
           {{ item }}
         </slot>
+
         <div
           v-once
           class="svg-icon color check-icon"

--- a/website/client/src/components/ui/selectList.vue
+++ b/website/client/src/components/ui/selectList.vue
@@ -15,6 +15,7 @@
           :item="selected"
           :button="true"
         >
+          <!-- Fallback content -->
           {{ value }}
         </slot>
       </template>

--- a/website/client/src/filters/localizeNumber.js
+++ b/website/client/src/filters/localizeNumber.js
@@ -1,0 +1,14 @@
+export default function localizeNumber (valIn, lang, optIn) {
+  // Extra catch just incase non number
+  const val = (typeof valIn === 'number') ? valIn : parseFloat(valIn);
+
+  // Options Management
+  const { toFixed } = optIn;
+  const optOut = {};
+  if (typeof toFixed !== 'undefined') {
+    optOut.maximumFractionDigits = toFixed;
+    optOut.minimumFractionDigits = toFixed;
+  }
+
+  return val.toLocaleString(lang, optOut);
+}

--- a/website/client/src/filters/registerGlobals.js
+++ b/website/client/src/filters/registerGlobals.js
@@ -3,8 +3,10 @@ import round from './round';
 import floor from './floor';
 import roundBigNumber from './roundBigNumber';
 import floorWholeNumber from './floorWholeNumber';
+import localizeNumber from './localizeNumber';
 
 Vue.filter('round', round);
 Vue.filter('floor', floor);
 Vue.filter('roundBigNumber', roundBigNumber);
 Vue.filter('floorWholeNumber', floorWholeNumber);
+Vue.filter('localizeNumber', localizeNumber);


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
* Fixes #9470
* Fixes #12891
* Fixes #12377

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
* Uses browser JS `toLocaleString` to convert numbers to appropriately "marked" numbers
* Limit `membersModal` list selector to 12-unit grid (to prevent wrap around on long text for `sortOptions`)
* Add ellipse based overflow for `membersModal` list selector
* Add padding so that the checkmark for `membersModal` list doesn't overlap with text
* Allow adding `@mention` anywhere (previously was fixed at the end of the text)
* Add re-focus after mouseclick on `@mention` choice



[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 10cbe941-0e10-4763-9f4f-7a3ae5bb2198
