### PR TITLE
style: Align Hide Locked Backgrounds to center fixes #12702

### DIFF
--- a/website/client/src/components/creatorIntro.vue
+++ b/website/client/src/components/creatorIntro.vue
@@ -883,8 +883,9 @@
       }
 
       .backgroundFilterToggle {
-        margin-left: auto;
-        margin-right: auto;
+        display: flex;
+        flex: 1;
+        justify-content: center;
       }
 
       .set-title {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #12702

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

- Remove `margin-left: auto` and `margin-right: auto` from `.backgroundFilterToggle` 
- Add new style properties `display: flex`, `flex: 1`, and `justify-content: center` to `.backgroundFilterToggle` . This aligns content "Hide locked backgrounds" and toggle to the center.
- "Hide Locked Backgrounds" and the toggle stay in the center before and after refreshing the page.
- These new style changes allow "Hide Locked Backgrounds" and the toggle to stay in the center when the Backgrounds menu is open on any page.

Navigating from Tasks to Tavern **without style fix**:
![hide_bgs_toggle_off_tasks_page_no_fix](https://user-images.githubusercontent.com/15676972/114768728-46b59700-9d37-11eb-850a-5856c43dbec2.png)
![hide_bgs_toggle_off_tasks_to_tavern_page_no_fix](https://user-images.githubusercontent.com/15676972/114768735-487f5a80-9d37-11eb-9e29-18d47094460a.png)

Navigating from Tasks to Tavern **with style fix**:
![fixed_hide_bgs_toggle_off_tasks_page](https://user-images.githubusercontent.com/15676972/114771792-00623700-9d3b-11eb-930b-88d721f7c4ee.png)
![fixed_hide_bgs_toggle_off_tasks_to_tavern_page](https://user-images.githubusercontent.com/15676972/114771808-03f5be00-9d3b-11eb-9080-a5a93c2d3491.png)


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: dd149105-7688-46c3-ac55-a74689396088
