### PR TITLE
Fix "Not Participating" filter checkbox on Discover Challenges screen, Fixes #13025

### DIFF
--- a/website/client/src/components/challenges/findChallenges.vue
+++ b/website/client/src/components/challenges/findChallenges.vue
@@ -31,7 +31,8 @@
       </div>
       <div class="row">
         <div
-          v-if="!loading && filteredChallenges.length === 0"
+          v-if="!loading &&
+          this.filteredChallenges.length === 0"
           class="no-challenges text-center col-md-6 offset-3"
         >
           <h2 v-once>
@@ -41,7 +42,7 @@
       </div>
       <div class="row">
         <div
-          v-for="challenge in filteredChallenges"
+          v-for="challenge in this.filteredChallenges"
           :key="challenge._id"
           class="col-12 col-md-6"
         >
@@ -170,25 +171,6 @@ export default {
   },
   computed: {
     ...mapState({ user: 'user.data' }),
-    filteredChallenges () {
-      const { filters } = this;
-      const { user } = this;
-
-      return this.challenges.filter(challenge => {
-        let isMember = true;
-
-        const filteringRole = filters.membership && filters.membership.length > 0;
-        if (filteringRole && filters.membership.indexOf('participating') !== -1) {
-          isMember = this.isMemberOfChallenge(user, challenge);
-        }
-
-        if (filteringRole && filters.membership.indexOf('not_participating') !== -1) {
-          isMember = !this.isMemberOfChallenge(user, challenge);
-        }
-
-        return isMember;
-      });
-    },
   },
   mounted () {
     this.$store.dispatch('common:setTitle', {

--- a/website/client/src/components/challenges/findChallenges.vue
+++ b/website/client/src/components/challenges/findChallenges.vue
@@ -147,7 +147,7 @@ export default {
           value: 'none',
         },
         {
-          text: this.$t('participants'),
+          text: this.$t(' ipants'),
           value: 'participants',
         },
         {
@@ -171,7 +171,23 @@ export default {
   computed: {
     ...mapState({ user: 'user.data' }),
     filteredChallenges () {
-      return this.challenges;
+      const { filters } = this;
+      const { user } = this;
+
+      return this.challenges.filter(challenge => {
+        let isMember = true;
+
+        const filteringRole = filters.membership && filters.membership.length > 0;
+        if (filteringRole && filters.membership.indexOf('participating') !== -1) {
+          isMember = this.isMemberOfChallenge(user, challenge);
+        }
+
+        if (filteringRole && filters.membership.indexOf('not_participating') !== -1) {
+          isMember = !this.isMemberOfChallenge(user, challenge);
+        }
+
+        return isMember;
+      });
     },
   },
   mounted () {

--- a/website/client/src/components/challenges/findChallenges.vue
+++ b/website/client/src/components/challenges/findChallenges.vue
@@ -147,7 +147,7 @@ export default {
           value: 'none',
         },
         {
-          text: this.$t(' ipants'),
+          text: this.$t('participants'),
           value: 'participants',
         },
         {

--- a/website/client/src/components/challenges/myChallenges.vue
+++ b/website/client/src/components/challenges/myChallenges.vue
@@ -51,7 +51,7 @@
       </div>
       <div class="row">
         <div
-          v-if="!loading && challenges.length > 0 && filteredChallenges.length === 0"
+          v-if="!loading && challenges.length > 0 && this.filteredChallenges.length === 0"
           class="no-challenges text-center col-md-6 offset-3"
         >
           <h2 v-once>
@@ -61,7 +61,7 @@
       </div>
       <div class="row">
         <div
-          v-for="challenge in filteredChallenges"
+          v-for="challenge in this.filteredChallenges"
           :key="challenge._id"
           class="col-12 col-md-6"
         >
@@ -197,25 +197,6 @@ export default {
   },
   computed: {
     ...mapState({ user: 'user.data' }),
-    filteredChallenges () {
-      const { filters } = this;
-      const { user } = this;
-
-      return this.challenges.filter(challenge => {
-        let isMember = true;
-
-        const filteringRole = filters.membership && filters.membership.length > 0;
-        if (filteringRole && filters.membership.indexOf('participating') !== -1) {
-          isMember = this.isMemberOfChallenge(user, challenge);
-        }
-
-        if (filteringRole && filters.membership.indexOf('not_participating') !== -1) {
-          isMember = !this.isMemberOfChallenge(user, challenge);
-        }
-
-        return isMember;
-      });
-    },
   },
   mounted () {
     this.$store.dispatch('common:setTitle', {

--- a/website/client/src/components/challenges/myChallenges.vue
+++ b/website/client/src/components/challenges/myChallenges.vue
@@ -204,12 +204,12 @@ export default {
       return this.challenges.filter(challenge => {
         let isMember = true;
 
-        const filteringRole = filters.roles && filters.roles.length > 0;
-        if (filteringRole && filters.roles.indexOf('participating') !== -1) {
+        const filteringRole = filters.membership && filters.membership.length > 0;
+        if (filteringRole && filters.membership.indexOf('participating') !== -1) {
           isMember = this.isMemberOfChallenge(user, challenge);
         }
 
-        if (filteringRole && filters.roles.indexOf('not_participating') !== -1) {
+        if (filteringRole && filters.membership.indexOf('not_participating') !== -1) {
           isMember = !this.isMemberOfChallenge(user, challenge);
         }
 

--- a/website/client/src/components/challenges/sidebar.vue
+++ b/website/client/src/components/challenges/sidebar.vue
@@ -34,28 +34,6 @@
           </div>
         </div>
       </filter-group>
-      <!-- <filter-group :title="$t('role')">
-        <div
-          v-for="group in roleOptions"
-          :key="group.key"
-          class="form-check"
-        >
-          <div class="custom-control custom-checkbox">
-            <input
-              :id="group.key"
-              v-model="roleFilters"
-              class="custom-control-input"
-              type="checkbox"
-              :value="group.key"
-            >
-            <label
-              v-once
-              class="custom-control-label"
-              :for="group.key"
-            >{{ $t(group.label) }}</label>
-          </div>
-        </div>
-      </filter-group> -->
       <filter-group
         :title="$t('membership')"
         class="form-group"
@@ -175,21 +153,6 @@ export default {
           key: 'time_management',
         },
       ],
-      // roleFilters: [],
-      // roleOptions: [
-      //   {
-      //     label: 'participating',
-      //     key: 'participating',
-      //   },
-      //   {
-      //     label: 'not_participating',
-      //     key: 'not_participating',
-      //   },
-      //   // {
-      //   //   label: 'either',
-      //   //   key: 'either',
-      //   // },
-      // ],
       membershipFilters: [],
       membershipOptions: [
         {
@@ -223,9 +186,6 @@ export default {
     categoryFilters: function categoryFilters () {
       this.emitFilters();
     },
-    roleFilters: function roleFilters () {
-      this.emitFilters();
-    },
     ownershipFilters: function ownershipFilters () {
       this.emitFilters();
     },
@@ -242,7 +202,6 @@ export default {
     emitFilters () {
       this.$emit('filter', {
         categories: this.categoryFilters,
-        roles: this.roleFilters,
         ownership: this.ownershipFilters,
         membership: this.membershipFilters,
       });

--- a/website/client/src/components/challenges/sidebar.vue
+++ b/website/client/src/components/challenges/sidebar.vue
@@ -34,7 +34,7 @@
           </div>
         </div>
       </filter-group>
-      <filter-group :title="$t('role')">
+      <!-- <filter-group :title="$t('role')">
         <div
           v-for="group in roleOptions"
           :key="group.key"
@@ -55,21 +55,20 @@
             >{{ $t(group.label) }}</label>
           </div>
         </div>
-      </filter-group>
+      </filter-group> -->
       <filter-group
-        v-if="$route.name !== 'findChallenges'"
         :title="$t('membership')"
         class="form-group"
       >
         <div
-          v-for="group in roleOptions"
+          v-for="group in membershipOptions"
           :key="group.key"
           class="form-check"
         >
           <div class="custom-control custom-checkbox">
             <input
               :id="group.key"
-              v-model="roleFilters"
+              v-model="membershipFilters"
               class="custom-control-input"
               type="checkbox"
               :value="group.key"
@@ -176,8 +175,23 @@ export default {
           key: 'time_management',
         },
       ],
-      roleFilters: [],
-      roleOptions: [
+      // roleFilters: [],
+      // roleOptions: [
+      //   {
+      //     label: 'participating',
+      //     key: 'participating',
+      //   },
+      //   {
+      //     label: 'not_participating',
+      //     key: 'not_participating',
+      //   },
+      //   // {
+      //   //   label: 'either',
+      //   //   key: 'either',
+      //   // },
+      // ],
+      membershipFilters: [],
+      membershipOptions: [
         {
           label: 'participating',
           key: 'participating',
@@ -186,10 +200,6 @@ export default {
           label: 'not_participating',
           key: 'not_participating',
         },
-        // {
-        //   label: 'either',
-        //   key: 'either',
-        // },
       ],
       ownershipFilters: [],
       ownershipOptions: [
@@ -219,6 +229,9 @@ export default {
     ownershipFilters: function ownershipFilters () {
       this.emitFilters();
     },
+    membershipFilters: function membershipFilters () {
+      this.emitFilters();
+    },
     searchTerm: throttle(function searchTerm (newSearch) {
       this.$emit('search', {
         searchTerm: newSearch,
@@ -231,6 +244,7 @@ export default {
         categories: this.categoryFilters,
         roles: this.roleFilters,
         ownership: this.ownershipFilters,
+        membership: this.membershipFilters,
       });
     },
   },

--- a/website/client/src/mixins/challengeUtilities.js
+++ b/website/client/src/mixins/challengeUtilities.js
@@ -4,4 +4,25 @@ export default {
       return user.challenges.indexOf(challenge._id) !== -1;
     },
   },
+  computed: {
+    filteredChallenges () {
+      const { filters } = this;
+      const { user } = this;
+
+      return this.challenges.filter(challenge => {
+        let isMember = true;
+
+        const filteringRole = filters.membership && filters.membership.length > 0;
+        if (filteringRole && filters.membership.indexOf('participating') !== -1) {
+          isMember = this.isMemberOfChallenge(user, challenge);
+        }
+
+        if (filteringRole && filters.membership.indexOf('not_participating') !== -1) {
+          isMember = !this.isMemberOfChallenge(user, challenge);
+        }
+
+        return isMember;
+      });
+    },
+  },
 };

--- a/website/client/src/mixins/challengeUtilities.js
+++ b/website/client/src/mixins/challengeUtilities.js
@@ -10,18 +10,21 @@ export default {
       const { user } = this;
 
       return this.challenges.filter(challenge => {
-        let isMember = true;
+        const filteringMembership = filters.membership && filters.membership.length > 0;
 
-        const filteringRole = filters.membership && filters.membership.length > 0;
-        if (filteringRole && filters.membership.indexOf('participating') !== -1) {
-          isMember = this.isMemberOfChallenge(user, challenge);
+        // if both filters are selected, display all challenges
+        if (filteringMembership && filters.membership.indexOf('participating') !== -1
+        && filteringMembership && filters.membership.indexOf('not_participating') !== -1) {
+          return true;
         }
 
-        if (filteringRole && filters.membership.indexOf('not_participating') !== -1) {
-          isMember = !this.isMemberOfChallenge(user, challenge);
+        if (filteringMembership && filters.membership.indexOf('participating') !== -1) {
+          return this.isMemberOfChallenge(user, challenge);
         }
-
-        return isMember;
+        if (filteringMembership && filters.membership.indexOf('not_participating') !== -1) {
+          return !this.isMemberOfChallenge(user, challenge);
+        }
+        return true;
       });
     },
   },


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #13025

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

- Filtering added on the front-end of the "discover challenges" view,  to allow the user to view challenges they _are_ and _are not_ currently participating in. Mimics function in "my challenges" view. 
- Removed "role" filter from "my challenges" and "discover challenges" views (deemed extraneous by @saraolson in #13025 followups)
<img width="1680" alt="Screen Shot 2021-04-21 at 10 26 30 AM" src="https://user-images.githubusercontent.com/49509154/115570465-241e0380-a28c-11eb-995c-1103fbfa2bdd.png">
<img width="1680" alt="Screen Shot 2021-04-21 at 10 26 41 AM" src="https://user-images.githubusercontent.com/49509154/115570475-26805d80-a28c-11eb-9d0b-4e871944fcd4.png">





[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID:  6179e6e4-1070-43a1-b1df-c1aad12a3ef7
