### PR TITLE
Fixes #12966 remove create challenge button for non-leaders if restricted

### DIFF
--- a/website/client/src/components/challenges/groupChallenges.vue
+++ b/website/client/src/components/challenges/groupChallenges.vue
@@ -20,6 +20,7 @@
           {{ $t('challengeDetails') }}
         </p>
         <button
+          v-if="canCreateChallenges"
           class="btn btn-secondary"
           @click="createChallenge()"
         >
@@ -36,6 +37,7 @@
       />
       <div class="col-12 text-center">
         <button
+          v-if="canCreateChallenges"
           class="btn btn-secondary"
           @click="createChallenge()"
         >
@@ -86,7 +88,7 @@ export default {
   directives: {
     markdown: markdownDirective,
   },
-  props: ['groupId'],
+  props: ['group'],
   data () {
     return {
       challenges: [],
@@ -98,6 +100,12 @@ export default {
   },
   computed: {
     ...mapState({ user: 'user.data' }),
+    canCreateChallenges () {
+      if (this.group.leaderOnly.challenges) {
+        return this.group.leader._id === this.user._id;
+      }
+      return true;
+    },
   },
   watch: {
     async groupId () {
@@ -109,8 +117,8 @@ export default {
   },
   methods: {
     async loadChallenges () {
-      this.groupIdForChallenges = this.groupId;
-      if (this.groupId === 'party' && this.user.party._id) this.groupIdForChallenges = this.user.party._id;
+      this.groupIdForChallenges = this.group._id;
+      if (this.group._id === 'party' && this.user.party._id) this.groupIdForChallenges = this.user.party._id;
       this.challenges = await this.$store.dispatch('challenges:getGroupChallenges', { groupId: this.groupIdForChallenges });
     },
     createChallenge () {

--- a/website/client/src/components/groups/group.vue
+++ b/website/client/src/components/groups/group.vue
@@ -176,7 +176,7 @@
           :title="$t('challenges')"
           :tooltip="$t('challengeDetails')"
         >
-          <group-challenges :group-id="searchId" />
+          <group-challenges :group="group" />
         </sidebar-section>
       </div>
       <div class="text-center">


### PR DESCRIPTION
Fixes #12966. Recreation of #13108, all code by @SpeedyLom.

### Changes
- Pass the `group` to `groupChallenges` and don't display the "**Create Challenge**" button if it would fail from the modal

![can_create_challenge](https://user-images.githubusercontent.com/10461862/111002987-37c97680-837e-11eb-9d15-17ba30263121.png)
![leader_only_not_a_leader](https://user-images.githubusercontent.com/10461862/111003001-3a2bd080-837e-11eb-9146-497254b27eed.png)

----
UUID: 76dae72e-04bb-461c-a4eb-22093c4d18c1
