### PR TITLE
(WIP) API summary limit - Fixes #9244

### DIFF
--- a/website/server/controllers/api-v3/challenges.js
+++ b/website/server/controllers/api-v3/challenges.js
@@ -29,8 +29,10 @@ import {
   createChallengeQuery,
 } from '../../libs/challenges';
 import apiError from '../../libs/apiError';
+import shared from '../../../common';
 
 const api = {};
+const { MAX_SUMMARY_SIZE_FOR_CHALLENGES } = shared.constants;
 
 /**
  * @apiDefine ChallengeLeader Challenge Leader
@@ -200,6 +202,7 @@ api.createChallenge = {
     const { user } = res.locals;
 
     req.checkBody('group', apiError('groupIdRequired')).notEmpty();
+    req.checkBody('summary', 'THIS IS A STRING THAT NEEDS TO BE PROPERLY DEFINED: Summary is too long.').isLength({max: MAX_SUMMARY_SIZE_FOR_CHALLENGES});
 
     const validationErrors = req.validationErrors();
     if (validationErrors) throw validationErrors;
@@ -707,6 +710,7 @@ api.updateChallenge = {
   middlewares: [authWithHeaders()],
   async handler (req, res) {
     req.checkParams('challengeId', res.t('challengeIdRequired')).notEmpty().isUUID();
+    req.checkBody('summary', 'THIS IS A STRING THAT NEEDS TO BE PROPERLY DEFINED: Summary is too long.').isLength({max: MAX_SUMMARY_SIZE_FOR_CHALLENGES});
 
     const validationErrors = req.validationErrors();
     if (validationErrors) throw validationErrors;

--- a/website/server/controllers/api-v3/challenges.js
+++ b/website/server/controllers/api-v3/challenges.js
@@ -202,7 +202,7 @@ api.createChallenge = {
     const { user } = res.locals;
 
     req.checkBody('group', apiError('groupIdRequired')).notEmpty();
-    req.checkBody('summary', 'THIS IS A STRING THAT NEEDS TO BE PROPERLY DEFINED: Summary is too long.').isLength({max: MAX_SUMMARY_SIZE_FOR_CHALLENGES});
+    req.checkBody('summary', 'THIS IS A STRING THAT NEEDS TO BE PROPERLY DEFINED: Summary is too long.').isLength({ max: MAX_SUMMARY_SIZE_FOR_CHALLENGES });
 
     const validationErrors = req.validationErrors();
     if (validationErrors) throw validationErrors;
@@ -710,7 +710,7 @@ api.updateChallenge = {
   middlewares: [authWithHeaders()],
   async handler (req, res) {
     req.checkParams('challengeId', res.t('challengeIdRequired')).notEmpty().isUUID();
-    req.checkBody('summary', 'THIS IS A STRING THAT NEEDS TO BE PROPERLY DEFINED: Summary is too long.').isLength({max: MAX_SUMMARY_SIZE_FOR_CHALLENGES});
+    req.checkBody('summary', 'THIS IS A STRING THAT NEEDS TO BE PROPERLY DEFINED: Summary is too long.').isLength({ max: MAX_SUMMARY_SIZE_FOR_CHALLENGES });
 
     const validationErrors = req.validationErrors();
     if (validationErrors) throw validationErrors;


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #9244 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
* Adds a length checker for `summary` at the express-validator level before hitting the mongoose schema level
(WIP)

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 10cbe941-0e10-4763-9f4f-7a3ae5bb2198
