### PR TITLE
Disable Loggly client by providing an empty token.

### DIFF
--- a/website/client/src/libs/logging.js
+++ b/website/client/src/libs/logging.js
@@ -11,12 +11,14 @@ export function setUpLogging () { // eslint-disable-line import/prefer-default-e
   };
 
   const _LTracker = window._LTracker || [];
-  _LTracker.push({
-    logglyKey: process.env.LOGGLY_CLIENT_TOKEN, // eslint-disable-line no-process-env
-    sendConsoleErrors: true,
-    tag: 'ClientJS',
-    json: true,
-  });
+  if (process.env.LOGGLY_CLIENT_TOKEN !== '') {
+    _LTracker.push({
+      logglyKey: process.env.LOGGLY_CLIENT_TOKEN, // eslint-disable-line no-process-env
+      sendConsoleErrors: true,
+      tag: 'ClientJS',
+      json: true,
+    });
+  }
 
   window.onunhandledrejection = event => {
     console.error(`Unhandled promise rejection: ${event.reason}`);


### PR DESCRIPTION
This is useful for self-hosters that intend to do logging a different way.