### PR TITLE
Proper reset autocomplete - allow @mentions dropdown to close itself - Fixes #13254

### DIFF
--- a/website/client/src/components/chat/autoComplete.vue
+++ b/website/client/src/components/chat/autoComplete.vue
@@ -139,8 +139,7 @@ export default {
         || /\s/.test(lastFocusChar) // End Search
         || (lastFocusChar === '@' && delCharsBool) // Cancel Search
       ) {
-        this.searchActive = false;
-        this.searchResults = [];
+        this.cancel();
       } else {
         if (lastFocusChar === '@') this.searchActive = true;
         if (this.searchActive) {

--- a/website/client/src/components/chat/autoComplete.vue
+++ b/website/client/src/components/chat/autoComplete.vue
@@ -158,7 +158,6 @@ export default {
   },
   methods: {
     solveSearchResults (textFocus) {
-      if (!this.searchActive) return [];
       const regexRes = this.atRegex.exec(textFocus);
       if (!regexRes) return [];
       this.currentSearch = regexRes[1]; // eslint-disable-line vue/no-side-effects-in-computed-properties, max-len, prefer-destructuring
@@ -173,9 +172,8 @@ export default {
     resetDefaults () {
       // Mounted is not called when switching between group pages because they have the
       // the same parent component. So, reset the data
-      this.searchActive = false;
+      this.cancel();
       this.tmpSelections = [];
-      this.resetSelection();
     },
     grabUserNames () {
       const usersThatMessage = groupBy(this.chat, 'user');
@@ -225,10 +223,9 @@ export default {
       const newCaret = newText.length;
       newText += text.substring(oldCaret, text.length);
       this.$emit('select', newText, newCaret);
-      this.resetSelection();
 
       // Made selection, shut off searching
-      this.searchActive = false;
+      this.cancel();
     },
     setHover (result) {
       this.resetSelection();
@@ -268,7 +265,9 @@ export default {
       }
     },
     cancel () {
+      // Resets search back to normal (while in the same chat zone)
       this.searchActive = false;
+      this.searchResults = [];
       this.resetSelection();
     },
   },


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #13254

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Reset searchResults back to an empty array (utilizing an unused cancel function to reduce reused code).

(My bad lol).

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 10cbe941-0e10-4763-9f4f-7a3ae5bb2198