### PR TITLE
Fix toLocalString language key - Fixes #13255

### DIFF
--- a/website/client/src/components/groups/questSidebarSection.vue
+++ b/website/client/src/components/groups/questSidebarSection.vue
@@ -198,7 +198,13 @@
               <div class="col-6">
                 <span
                   class="float-left"
-                >{{ $t('rage') }} {{ parseFloat(group.quest.progress.rage).toFixed(2) }} / {{ questData.boss.rage.value }}</span> <!-- eslint-disable-line max-len -->
+                >{{ $t('rage') }} {{
+                  parseFloat(group.quest.progress.rage)
+                    | localizeNumber(user.preferences.language, { toFixed:2 })
+                }} / {{
+                  questData.boss.rage.value
+                    | localizeNumber(user.preferences.language)
+                }}</span>
               </div>
             </div>
           </div>

--- a/website/client/src/filters/localizeNumber.js
+++ b/website/client/src/filters/localizeNumber.js
@@ -10,5 +10,13 @@ export default function localizeNumber (valIn, lang, optIn) {
     optOut.minimumFractionDigits = toFixed;
   }
 
-  return val.toLocaleString(lang, optOut);
+  return val.toLocaleString(
+    // Catch null just incase
+    (lang || '')
+      // Strip beyond @ symbol to allow custom languages
+      .replace(/@(?:.+)$/, '')
+      // We use underscore, this mthd uses dash
+      .replace('_', '-'),
+    optOut,
+  );
 }

--- a/website/client/src/filters/localizeNumber.js
+++ b/website/client/src/filters/localizeNumber.js
@@ -12,7 +12,7 @@ export default function localizeNumber (valIn, lang, optIn) {
 
   return val.toLocaleString(
     // Catch null just incase
-    (lang || '')
+    (lang || [])
       // Strip beyond @ symbol to allow custom languages
       .replace(/@(?:.+)$/, '')
       // We use underscore, this mthd uses dash


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #13255

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
* We use underscore, they use dash
* Strip beyond @ symbol to allow custom languages
* Catch null (hinted in issue)

Add L10N to a location that was noticed while editing (optional)

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 10cbe941-0e10-4763-9f4f-7a3ae5bb2198
