### PR TITLE
Correct challenges shown for guilds and parties when accessing through notifications, Fixes #13256

### DIFF
--- a/website/client/src/components/challenges/groupChallenges.vue
+++ b/website/client/src/components/challenges/groupChallenges.vue
@@ -112,8 +112,10 @@ export default {
     },
   },
   watch: {
-    async groupId () {
-      this.loadChallenges();
+    'group._id': {
+      async groupId () {
+        this.loadChallenges();
+      },
     },
   },
   mounted () {


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #13256 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
- Updated the watcher in groupChallenges component to call loadChallenges function on change of group._id.

Fix should work for guilds and parties and can be tested by navigating from one party or guild to another through notification drop down or use of the back button.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 6179e6e4-1070-43a1-b1df-c1aad12a3ef7
