### PR TITLE
Correct member modal behavior in the party section when selecting the invite tab before the invited user accepts the invitation 

### DIFF
--- a/website/client/src/components/groups/membersModal.vue
+++ b/website/client/src/components/groups/membersModal.vue
@@ -577,6 +577,7 @@ export default {
           groupId,
           includeAllPublicFields: true,
         });
+        if (this.selectedPage === 'invites' && invites.length === 0) this.viewMembers();
         this.invites = invites;
       }
     },


### PR DESCRIPTION
Fixes #13107 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Update the `getMembers` method to change the selectedPage(or tab selected) data to be equal to `'members'` if the last tab selected by the user was the `invites tab` but there's no pending invites left.

UUID: 79fc8f1a-fa61-4ed2-aeee-999d4c3f3ee1

