### PR TITLE
Quest Sidebar: Boss Pending Health inside the normal Bar

### DIFF
--- a/website/client/config/storybook/config.js
+++ b/website/client/config/storybook/config.js
@@ -38,6 +38,7 @@ import Vue from 'vue';
 import BootstrapVue from 'bootstrap-vue';
 import StoreModule from '@/libs/store';
 import getStore from '@/store';
+import '../../src/filters/registerGlobals';
 
 import i18n from '../../../common/script/i18n';
 
@@ -64,6 +65,9 @@ store.state.user.data = {
     quest: {
 
     },
+  },
+  preferences: {
+
   },
 };
 

--- a/website/client/src/components/groups/group.stories.js
+++ b/website/client/src/components/groups/group.stories.js
@@ -38,6 +38,9 @@ storiesOf('Group Components|Party/Quest States', module)
         party: {
 
         },
+        preferences: {
+
+        },
       },
     },
     challengeOptions: {},
@@ -67,6 +70,9 @@ storiesOf('Group Components|Party/Quest States', module)
       data: {
         _id: 'some-user',
         party: {
+
+        },
+        preferences: {
 
         },
       },
@@ -102,6 +108,9 @@ storiesOf('Group Components|Party/Quest States', module)
         party: {
 
         },
+        preferences: {
+
+        },
       },
     },
     challengeOptions: {},
@@ -121,6 +130,9 @@ storiesOf('Group Components|Party/Quest States', module)
       data: {
         _id: '05ca98f4-4706-47b5-8d02-142e6e78ba2e',
         party: {
+
+        },
+        preferences: {
 
         },
       },
@@ -144,6 +156,9 @@ storiesOf('Group Components|Party/Quest States', module)
         party: {
 
         },
+        preferences: {
+
+        },
       },
     },
     challengeOptions: {},
@@ -163,6 +178,9 @@ storiesOf('Group Components|Party/Quest States', module)
       data: {
         _id: 'just-a-member',
         party: {
+
+        },
+        preferences: {
 
         },
       },
@@ -189,6 +207,9 @@ storiesOf('Group Components|Party/Quest States', module)
           quest: {
             RSVPNeeded: true,
           },
+        },
+        preferences: {
+
         },
       },
     },
@@ -218,6 +239,9 @@ storiesOf('Group Components|Party/Quest States', module)
             },
           },
         },
+        preferences: {
+
+        },
       },
     },
     challengeOptions: {},
@@ -245,6 +269,9 @@ storiesOf('Group Components|Party/Quest States', module)
               collect: {},
             },
           },
+        },
+        preferences: {
+
         },
       },
     },
@@ -274,6 +301,9 @@ storiesOf('Group Components|Party/Quest States', module)
             },
           },
         },
+        preferences: {
+
+        },
       },
     },
     challengeOptions: {},
@@ -301,6 +331,9 @@ storiesOf('Group Components|Party/Quest States', module)
               collect: {},
             },
           },
+        },
+        preferences: {
+
         },
       },
     },
@@ -330,6 +363,9 @@ storiesOf('Group Components|Party/Quest States', module)
             },
           },
         },
+        preferences: {
+
+        },
       },
     },
     challengeOptions: {},
@@ -354,6 +390,9 @@ storiesOf('Group Components|Party/Quest States', module)
       data: {
         _id: 'some-user',
         party: {
+
+        },
+        preferences: {
 
         },
       },

--- a/website/client/src/components/groups/questSidebarSection.vue
+++ b/website/client/src/components/groups/questSidebarSection.vue
@@ -113,11 +113,11 @@
                   <div
                     class="boss-health-bar"
                     :style="{width: bossHpPercent + '%'}"
-                  ></div>
-                  <div
-                    class="pending-health-bar"
-                    :style="{width: pendingHpPercent + '%'}"
                   >
+                    <div
+                      class="pending-health-bar"
+                      :style="{width: pendingHpInBossHpPercent + '%'}"
+                    ></div>
                   </div>
                 </div>
               </div>
@@ -291,12 +291,16 @@
     height: 0.75rem;
 
     display: inline-block;
+    position: relative;
   }
 
   .pending-health-bar {
     height: 0.75rem;
     background-color: $yellow-50;
     display: inline-block;
+
+    position: absolute;
+    right: 0;
   }
 
   .rage-details {
@@ -676,6 +680,15 @@ export default {
     },
     pendingHpPercent () {
       return percent(this.user.party.quest.progress.up, this.questData.boss.hp);
+    },
+    pendingHpInBossHpPercent () {
+      // Pending more than the current hp left, it is the full % of the pending bar
+      if (this.user.party.quest.progress.up > this.group.quest.progress.hp) {
+        return 100;
+      }
+
+      // otherwise the percent inside that hp bar is needed
+      return percent(this.user.party.quest.progress.up, this.group.quest.progress.hp);
     },
     questData () {
       if (!this.group.quest) return {};


### PR DESCRIPTION
This puts the "pending HP bar" inside the normal one:

![grafik](https://user-images.githubusercontent.com/842273/120903745-40151300-c648-11eb-9508-04359f1a59d5.png)

Example ^  - 20 HP pending - of 30 HP current 