### PR TITLE
Settings: Add missing margin to settings checkboxes - Fixes #12794

### DIFF
--- a/website/client/src/components/settings/notifications.vue
+++ b/website/client/src/components/settings/notifications.vue
@@ -9,6 +9,7 @@
           <input
             v-model="user.preferences.pushNotifications.unsubscribeFromAll"
             type="checkbox"
+            class="mr-2"
             @change="set('pushNotifications', 'unsubscribeFromAll')"
           >
           <span>{{ $t('unsubscribeAllPush') }}</span>
@@ -20,6 +21,7 @@
           <input
             v-model="user.preferences.emailNotifications.unsubscribeFromAll"
             type="checkbox"
+            class="mr-2"
             @change="set('emailNotifications', 'unsubscribeFromAll')"
           >
           <span>{{ $t('unsubscribeAllEmails') }}</span>

--- a/website/client/src/components/settings/site.vue
+++ b/website/client/src/components/settings/site.vue
@@ -101,6 +101,7 @@
             <input
               v-model="user.preferences.advancedCollapsed"
               type="checkbox"
+              class="mr-2"
               @change="set('advancedCollapsed')"
             >
             <span
@@ -116,6 +117,7 @@
             <input
               v-model="user.preferences.dailyDueDefaultView"
               type="checkbox"
+              class="mr-2"
               @change="set('dailyDueDefaultView')"
             >
             <span
@@ -134,6 +136,7 @@
             <input
               v-model="user.preferences.displayInviteToPartyWhenPartyIs1"
               type="checkbox"
+              class="mr-2"
               @change="set('displayInviteToPartyWhenPartyIs1')"
             >
             <span
@@ -148,6 +151,7 @@
           <input
             v-model="user.preferences.suppressModals.levelUp"
             type="checkbox"
+            class="mr-2"
             @change="set('suppressModals', 'levelUp')"
           >
           <label>{{ $t('suppressLevelUpModal') }}</label>
@@ -156,6 +160,7 @@
           <input
             v-model="user.preferences.suppressModals.hatchPet"
             type="checkbox"
+            class="mr-2"
             @change="set('suppressModals', 'hatchPet')"
           >
           <label>{{ $t('suppressHatchPetModal') }}</label>
@@ -164,6 +169,7 @@
           <input
             v-model="user.preferences.suppressModals.raisePet"
             type="checkbox"
+            class="mr-2"
             @change="set('suppressModals', 'raisePet')"
           >
           <label>{{ $t('suppressRaisePetModal') }}</label>
@@ -172,6 +178,7 @@
           <input
             v-model="user.preferences.suppressModals.streak"
             type="checkbox"
+            class="mr-2"
             @change="set('suppressModals', 'streak')"
           >
           <label>{{ $t('suppressStreakModal') }}</label>


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #12794

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
I added a `class="mr-2"` to the checkboxes so they have the correct margin discussed in #12794 


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 12311c76-5892-4fc6-b48a-28b45b644d36
