### PR TITLE
WIP: Only unlock Masterclasser 2-4 if 1 is unlocked

### DIFF
--- a/website/client/src/components/shops/quests/questPopover.vue
+++ b/website/client/src/components/shops/quests/questPopover.vue
@@ -13,7 +13,7 @@
       {{ item.text }}
     </h4>
     <div
-      v-if="item.locked && item.key === 'lostMasterclasser1'"
+      v-if="item.locked && item.key.startsWith('lostMasterclasser')"
       class="popover-content-text"
     >
       {{ $t('questUnlockLostMasterclasser') }}

--- a/website/common/script/libs/getItemInfo.js
+++ b/website/common/script/libs/getItemInfo.js
@@ -8,8 +8,18 @@ import isPinned from './isPinned';
 import isFreeRebirth from './isFreeRebirth';
 import getOfficialPinnedItems from './getOfficialPinnedItems';
 
+function userAbleToStartMasterclasser (user) {
+  return user.achievements.quests.dilatoryDistress3
+    && user.achievements.quests.mayhemMistiflying3
+    && user.achievements.quests.stoikalmCalamity3
+    && user.achievements.quests.taskwoodsTerror3;
+}
+
 function lockQuest (quest, user) {
-  if (quest.key === 'lostMasterclasser1') return !(user.achievements.quests.dilatoryDistress3 && user.achievements.quests.mayhemMistiflying3 && user.achievements.quests.stoikalmCalamity3 && user.achievements.quests.taskwoodsTerror3);
+  if (quest.key === 'lostMasterclasser1') return !userAbleToStartMasterclasser(user);
+  if (quest.key === 'lostMasterclasser2' || quest.key === 'lostMasterclasser3' || quest.key === 'lostMasterclasser4') {
+    return !(userAbleToStartMasterclasser(user) && user.achievements.quests[quest.previous]);
+  }
   if (quest.lvl && user.stats.lvl < quest.lvl) return true;
   if (quest.unlockCondition && (quest.key === 'moon1' || quest.key === 'moon2' || quest.key === 'moon3')) {
     return user.loginIncentives < quest.unlockCondition.incentiveThreshold;

--- a/website/common/script/ops/buy/buyQuestGold.js
+++ b/website/common/script/ops/buy/buyQuestGold.js
@@ -53,7 +53,7 @@ export class BuyQuestWithGoldOperation extends AbstractGoldItemOperation { // es
 
   checkPrerequisites (user, questKey) {
     const item = content.quests[questKey];
-    if (questKey === 'lostMasterclasser1' && !this.userAbleToStartMasterClasser(user)) {
+    if (questKey.startsWith('lostMasterclasser') && !this.userAbleToStartMasterClasser(user)) {
       throw new NotAuthorized(this.i18n('questUnlockLostMasterclasser'));
     }
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #13013

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Purchasing any of the quests in the Mystery of the Masterclasser questline now requires the user to have completed the last part of each of the four quest chains that unlock the first one, even if they've already completed the previous quest in the questline in a party. The quest popover displays the unlock requirement text for lostMasterclasser1 in addition to the requirement for unlocking the previous Masterclasser quest when necessary.

It works as-is, but I'm making it a draft because I have some outstanding questions/I think it could be improved.

Here's how it looks right now:

![image](https://user-images.githubusercontent.com/6620594/124815042-6d1e5380-df6f-11eb-91b9-281a77393843.png)

A more concise option would be to just change the message from "To unlock this quest, complete…" to "To unlock this quest, unlock and complete…", instead of displaying the two conditions separately, but that would require adding some new translatable strings, and changing a bit more of the logic in `questPopover.vue`.

### Open questions

Working on this revealed some strange behavior with the way locked quests are handled in general, especially ones with multiple unlock requirements. The approach I took is convenient because it doesn't require adding any new strings and it also doesn't require any significant refactoring, but there are a few reasons I'm not satisfied with it:

1. It shows both parts of the message whenever lostMasterclasser2, 3, or 4 is locked, even if one of the two requirements has been met. This is consistent with the behavior of other quest unlock popovers—for example, a user who has completed Attack of the Mundane Part 1 in a party but hasn't yet reached level 15 will see both the message about needing to complete AtoM 1 and about needing to reach level 15—but it feels confusing to me.
2. It's not clear to the user whether both requirements need to be met, or only one of them. I found an old issue (#10295) implying that users read multiple conditions as an "or" rather than an "and", but the PR that closed that issue actually didn't change anything (I'll open a separate issue about that when I have a minute), and no one seems to have complained about it in the meantime, so maybe most people do understand that it's an "and"?
3. It's just a lot of text to show all at once :(

It seems to me like there's a deeper design question here, which is whether the text in the locked quest popover is meant to be a general statement about the requirements for unlocking the quest, or an instruction informing the user what they still need to do to unlock the quest, taking into account what they've already achieved. Because of the way the logic in `questPopover.vue` is structured, requirements like "log in N times" or "reach level N" disappear as soon as the user satisfies them, but requirements of the "complete another quest" variety are displayed whenever the quest is locked, even if it's only locked for some other reason.

Like I mentioned above, this brings Masterclassers in line with the other quest lines in terms of this behavior, so maybe it's fine, but I think it would be nice to eventually make all the different types of unlock requirements behave consistently.

One other tiny thing to note is that the function `userAbleToStartMasterclasser` now exists in two places, which isn't ideal:

https://github.com/ashaindlin/habitica/blob/5d4f1b868618e36a55ae6c1c5ec0b9ff5cd34bdd/website/common/script/libs/getItemInfo.js#L11
https://github.com/ashaindlin/habitica/blob/5d4f1b868618e36a55ae6c1c5ec0b9ff5cd34bdd/website/common/script/ops/buy/buyQuestGold.js#L17

But the logic itself was already duplicated; all I've done is pull that logic out to a function in `getItemInfo.js`, so I don't think it makes the situation worse. There's probably a way to move this function into the user object itself by putting it in `server/models/user/methods.js`, but I wasn't able to figure out how to make it work (I haven't used Mongoose before) and I'm not sure if it's worth it.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 451e223c-f9b6-4a19-af4b-2a45aba3044d
