### PR TITLE
fixed overpurchase warning for potions with overlapping names

### DIFF
--- a/website/client/src/components/shops/buyModal.vue
+++ b/website/client/src/components/shops/buyModal.vue
@@ -537,7 +537,7 @@ export default {
         }
 
         const ownedPets = reduce(this.user.items.pets, (sum, petValue, petKey) => {
-          if (petKey.includes(this.item.key) && petValue > 0
+          if (petKey.match(new RegExp(`(-|^)${this.item.key}(-|$)`)) && petValue > 0
             && !petKey.includes('JackOLantern') // Jack-O-Lantern has "Ghost" version
             && !petKey.includes('RoyalPurple') // to avoid counting Royal Purple Gryphons for gryphon eggs
           ) return sum + 1;
@@ -545,7 +545,7 @@ export default {
         }, 0);
 
         const ownedMounts = reduce(this.user.items.mounts, (sum, mountValue, mountKey) => {
-          if (mountKey.includes(this.item.key) && mountValue === true
+          if (mountKey.match(new RegExp(`(-|^)${this.item.key}(-|$)`)) && mountValue === true
             && !mountKey.includes('JackOLantern')
             && !mountKey.includes('RoyalPurple')
           ) return sum + 1;


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #13358 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
I've changed the way the pet and mount names are checked so that it has to match all the egg name or all the potion name, to avoid the same Glass/StainedGlass issue with `includes`


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: c073342f-4a65-4a13-9ffd-9e7fa5410d6b
