### PR TITLE
Fix negative quest scroll number on bundle purchase

### DIFF
--- a/website/common/script/ops/buy/purchase.js
+++ b/website/common/script/ops/buy/purchase.js
@@ -54,7 +54,7 @@ function purchaseItem (user, item, price, type, key) {
   } else if (type === 'bundles') {
     const subType = item.type;
     forEach(item.bundleKeys, bundledKey => {
-      if (!user.items[subType][bundledKey] || user.items[subType][key] < 0) {
+      if (!user.items[subType][bundledKey] || user.items[subType][bundledKey] < 0) {
         user.items[subType][bundledKey] = 0;
       }
       user.items[subType][bundledKey] += 1;


### PR DESCRIPTION
fixes #13305

### Changes
Fix negative quest scroll number on quest bundle purchase
It's an additional fix to repair negative quest scroll number when buying quest bundle for gems.
The "if statement" i changed in commit was not checking for bundledKey in the second criterium.
I changed key to bundledKey and now it works properly.

----
UUID: 86f37f0c-ebaf-4ee8-bf9f-00a5aa485501
