### PR TITLE
API: Fixes #13287 to unpin backgrounds when unlocking full set 

### DIFF
--- a/website/common/script/ops/unlock.js
+++ b/website/common/script/ops/unlock.js
@@ -275,6 +275,15 @@ export default function unlock (user, req = {}, analytics) {
 
   if (isFullSet) {
     paths.forEach(pathPart => purchaseItem(pathPart, setType, user));
+
+    if (isBackground) {
+      paths.forEach(pathPart => {
+        const [key, value] = splitPathItem(pathPart);
+        const backgroundContent = content.backgroundsFlat[value];
+        const itemInfo = getItemInfo(user, key, backgroundContent);
+        removeItemByPath(user, itemInfo.path);
+      });
+    }
   } else {
     const [key, value] = splitPathItem(path);
 


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #13287

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

- In website/common/script/ops/unlock.js : I implemented a loop for full background sets that removes each background from the user's pinned item list with removeItemByPath() after the backgrounds were purchased. This loop ensures that pinned items are unpinned when a full set of backgrounds are purchased and unlocked.
- After 1 or more backgrounds are removed from the pinned item list in the database, the pinned item list does not display the removed backgrounds in the Rewards column. 
- The removal of pinned items from the Rewards column prevents the user from accessing the purchase item modal. 

**PURCHASING A FULL BACKGROUND SET WITHOUT THE FIX:**

Before purchasing the full set of July 2021 backgrounds:
- All three backgrounds from the July 2021 set were pinned in Rewards column.
![screenshot1_3pinnedbgs_rewards_before_purchase](https://user-images.githubusercontent.com/15676972/127725772-ead770bd-ef55-4483-9da0-3a50254ed6c2.jpg)


- Database: All three backgrounds from the July 2021 set were in the user's pinned item list.
![screenshot1_3pinnedbgs_before_purchase_pinneditems](https://user-images.githubusercontent.com/15676972/127725820-68e98e5f-d84c-4815-bb58-f8357cdb0000.jpg)


After purchasing the full set of July 2021 backgrounds:
- All three backgrounds were still pinned in the Rewards column. The gem amount decreased by 15 gems after purchase.
![screenshot1_3pinnedbgs_rewards_after_purchase](https://user-images.githubusercontent.com/15676972/127725848-7ac48f33-985f-4bb3-a9ed-7b4da192ff85.jpg)


- Database: All three backgrounds were not removed from the user's pinned item list.
![screenshot1_pinned_items_after_purchase](https://user-images.githubusercontent.com/15676972/127725870-2f38561e-4415-4fe5-94dd-e8f60870303c.jpg)


- The user can select the pinned background items from the Rewards column. A modal window for item purchase can appear if the user selects a background item.
![screenshot1_3pinnedbgs_rewards_after_purchase_pinned_item_](https://user-images.githubusercontent.com/15676972/127725898-7c175900-ca6e-4d90-a9da-c92aebf74d43.jpg)


- After the user purchased the item from the modal window, the gem amount did not decrease by 7.
![screenshot1_3pinnedbgs_rewards_after_purchase_pinned_item_purchase_attempt_](https://user-images.githubusercontent.com/15676972/127725971-a729e007-7aca-4b36-8334-d123f4f39ed9.jpg)


**PURCHASING A FULL BACKGROUND SET WITH THE FIX:**

Before purchasing the full set of July 2021 backgrounds:
- The three backgrounds were pinned in the Rewards column.
![screenshot2_3pinned_items_rewards_column_before_purchase](https://user-images.githubusercontent.com/15676972/127726315-546ac848-561d-4a52-b1b8-dcd036cc0ae4.jpg)

- Database: The backgrounds were in the pinned item list.
![screenshot2_3pinned_items_pinneditemslist_before_purchase](https://user-images.githubusercontent.com/15676972/127726344-cf6ace2a-4822-4755-a124-fc3c23216868.jpg)


After purchasing the full set of July 2021 backgrounds:
- The formerly pinned backgrounds did not appear in the Rewards column. The gem amount decreased by 15.
![screenshot2_0pinned_items_rewards_column_after_purchase](https://user-images.githubusercontent.com/15676972/127726392-1fabb25b-b711-4d28-9c63-4372ef2f65a8.jpg)


- Database: The backgrounds from the set were removed from the user's pinned item list.
![screenshot2_0pinned_items_pinneditemslist_after_purchase](https://user-images.githubusercontent.com/15676972/127726413-93337189-1928-4235-b3e5-6b9b9c9f0947.jpg)


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: dd149105-7688-46c3-ac55-a74689396088
