### PR TITLE
Fixes aborted Quest should appear in Quest Inventory without manual sync · Issue #13289

### DIFF
--- a/website/client/src/components/groups/questActions.mixin.js
+++ b/website/client/src/components/groups/questActions.mixin.js
@@ -53,6 +53,7 @@ export default {
         });
         this.group.quest = quest;
         partyState.data.quest = quest;
+        this.$store.dispatch('party:getMembers', { forceLoad: true });
       } else {
         if (!window.confirm(this.$t('sureCancel'))) {
           return false;


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #13289

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Refresh the member's data while the inventory page is loading.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 9929ec3f-d3c9-46b1-bedb-be6b234d502a
