### PR TITLE
Retire Report a Bug Guild

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -6,7 +6,7 @@
 
 [//]: # (For more guidelines see https://github.com/HabitRPG/habitica/issues/2760)
 
-[//]: # (Fill out relevant information - UUID is found from the Habitia website at User Icon > Settings > API)
+[//]: # (Fill out relevant information - UUID is found from the Habitica website at User Icon > Settings > API)
 ### General Info
   * UUID:
   * Browser:

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-[//]: # (Before logging this issue, please post to the Report a Bug guild from the Habitica website's Help menu. Most bugs can be handled quickly there. If a GitHub issue is needed, you will be advised of that by a moderator or staff member -- a player with a dark blue or purple name. It is recommended that you don't create a new issue unless advised to.)
+[//]: # (Before logging this issue, please contact site administrators from the Habitica website's Help menu. Most bugs can be handled quickly there. If a GitHub issue is needed, staff will let you know. It is recommended that you don't create a new issue unless advised to.)
 
 [//]: # (Bugs in the mobile apps can also be reported there.)
 
@@ -8,13 +8,12 @@
 
 [//]: # (Fill out relevant information - UUID is found from the Habitia website at User Icon > Settings > API)
 ### General Info
-  * UUID: 
-  * Browser: 
-  * OS: 
+  * UUID:
+  * Browser:
+  * OS:
 
 ### Description
 [//]: # (Describe bug in detail here. Include screenshots if helpful.)
 
 #### Console Errors
 [//]: # (Include any JavaScript console errors here.)
-

--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ Habitica ![Build Status](https://github.com/HabitRPG/habitica/workflows/Test/bad
 
 Habitica's code is licensed as described at https://github.com/HabitRPG/habitica/blob/develop/LICENSE
 
-**Found a bug?** Please report it to [admin email](admin@habitica.com) rather than creating an issue (an admin will advise you if a new issue is necessary; usually it is not).
+**Found a bug?** Please report it to [admin email](mailto:admin@habitica.com) rather than creating an issue (an admin will advise you if a new issue is necessary; usually it is not).
 
 **Have any questions about Habitica or its community?** See the links in the [habitica.com](https://habitica.com) website's Help menu or drop in to [Guilds > Tavern Chat](https://habitica.com/groups/tavern) to ask questions or chat socially!

--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ Habitica ![Build Status](https://github.com/HabitRPG/habitica/workflows/Test/bad
 
 Habitica's code is licensed as described at https://github.com/HabitRPG/habitica/blob/develop/LICENSE
 
-**Found a bug?** Please report it in the [Report a Bug guild](https://habitica.com/groups/guild/a29da26b-37de-4a71-b0c6-48e72a900dac) rather than creating an issue (an admin will advise you if a new issue is necessary; usually it is not).
+**Found a bug?** Please report it to [admin email](admin@habitica.com) rather than creating an issue (an admin will advise you if a new issue is necessary; usually it is not).
 
 **Have any questions about Habitica or its community?** See the links in the [habitica.com](https://habitica.com) website's Help menu or drop in to [Guilds > Tavern Chat](https://habitica.com/groups/tavern) to ask questions or chat socially!

--- a/website/client/src/components/appFooter.vue
+++ b/website/client/src/components/appFooter.vue
@@ -83,9 +83,12 @@
               </router-link>
             </li>
             <li>
-              <router-link to="/groups/guild/a29da26b-37de-4a71-b0c6-48e72a900dac">
+              <a
+                :href="bugReportMailto"
+                target="_blank"
+              >
                 {{ $t('reportBug') }}
-              </router-link>
+              </a>
             </li>
             <li>
               <a
@@ -472,12 +475,14 @@ import facebook from '@/assets/svg/facebook.svg';
 import instagram from '@/assets/svg/instagram.svg';
 import heart from '@/assets/svg/heart.svg';
 import buyGemsModal from './payments/buyGemsModal.vue';
+import reportBug from '@/mixins/reportBug.js';
 
 const IS_PRODUCTION = process.env.NODE_ENV === 'production'; // eslint-disable-line no-process-env
 export default {
   components: {
     buyGemsModal,
   },
+  mixins: [reportBug],
   data () {
     return {
       icons: Object.freeze({

--- a/website/client/src/components/groups/tavern.vue
+++ b/website/client/src/components/groups/tavern.vue
@@ -360,11 +360,12 @@
               >{{ $t('dataDisplayTool') }}</a>
             </li>
             <li>
-              <router-link
-                to="/groups/guild/a29da26b-37de-4a71-b0c6-48e72a900dac"
+              <a
+                :href="bugReportMailto"
+                target="_blank"
               >
-                {{ $t('reportProblem') }}
-              </router-link>
+                {{ $t('reportBug') }}
+              </a>
             </li>
             <li>
               <a
@@ -789,6 +790,7 @@ import tierStaff from '@/assets/svg/tier-staff.svg';
 
 import * as quests from '@/../../common/script/content/quests';
 import staffList from '../../libs/staffList';
+import reportBug from '@/mixins/reportBug.js';
 
 export default {
   components: {
@@ -797,6 +799,7 @@ export default {
     sidebarSection,
     chat,
   },
+  mixins: [reportBug],
   data () {
     return {
       groupId: TAVERN_ID,

--- a/website/client/src/components/header/menu.vue
+++ b/website/client/src/components/header/menu.vue
@@ -309,12 +309,13 @@
               >
                 {{ $t('overview') }}
               </router-link>
-              <router-link
+              <a
                 class="topbar-dropdown-item dropdown-item"
-                to="/groups/guild/a29da26b-37de-4a71-b0c6-48e72a900dac"
+                :href="bugReportMailto"
+                target="_blank"
               >
                 {{ $t('reportBug') }}
-              </router-link>
+              </a>
               <router-link
                 class="topbar-dropdown-item dropdown-item"
                 to="/groups/guild/5481ccf3-5d2d-48a9-a871-70a7380cee5a"
@@ -742,6 +743,7 @@ import sendGemsModal from '@/components/payments/sendGemsModal';
 import selectUserModal from '@/components/payments/selectUserModal';
 import sync from '@/mixins/sync';
 import userDropdown from './userDropdown';
+import reportBug from '@/mixins/reportBug.js';
 
 export default {
   components: {
@@ -753,7 +755,7 @@ export default {
     selectUserModal,
     userDropdown,
   },
-  mixins: [sync],
+  mixins: [sync, reportBug],
   data () {
     return {
       isUserDropdownOpen: false,

--- a/website/client/src/components/static/contact.vue
+++ b/website/client/src/components/static/contact.vue
@@ -7,20 +7,24 @@
           {{ $t('reportAccountProblems') }}
           &colon;&nbsp;
           <a href="mailto:admin@habitica.com">admin&commat;habitica&period;com</a>
-          <br>
-          {{ $t('reportBug') }}
-          &colon;&nbsp;
-          <a
-            target="_blank"
-            href="/groups/guild/a29da26b-37de-4a71-b0c6-48e72a900dac"
-          >Report a Bug guild</a>&nbsp;or&nbsp;
-          <a
-            target="_blank"
-            href="https://github.com/HabitRPG/habitica/issues?q=is%3Aopen"
-          >GitHub</a>
           <span v-if="user">
             <br>
+            {{ $t('reportBug') }}
+            &colon;&nbsp;
+            <a
+              :href="bugReportMailto"
+              target="_blank"
+            >
+            admin&commat;habitica&period;com
+            </a>
+            <br>
             {{ $t('reportCommunityIssues') }}
+            &colon;&nbsp;
+            <a href="mailto:admin@habitica.com">admin&commat;habitica&period;com</a>
+          </span>
+          <span v-else>
+            <br>
+            {{ $t('reportBug') }}
             &colon;&nbsp;
             <a href="mailto:admin@habitica.com">admin&commat;habitica&period;com</a>
           </span>
@@ -52,8 +56,10 @@
 <script>
 import { mapState } from '@/libs/store';
 import { goToModForm } from '@/libs/modform';
+import reportBug from '@/mixins/reportBug.js';
 
 export default {
+  mixins: [reportBug],
   computed: {
     ...mapState({
       user: 'user.data',

--- a/website/client/src/mixins/reportBug.js
+++ b/website/client/src/mixins/reportBug.js
@@ -1,0 +1,31 @@
+import { mapState } from '@/libs/store';
+
+export default {
+  computed: {
+    ...mapState({ user: 'user.data' }),
+    bugReportMailto () {
+      let subscriptionInfo = 'Not Subscribed';
+      if (this.user.purchased.plan.planId) {
+        subscriptionInfo = `
+          Subscription: ${this.user.purchased.plan.planId}%0d%0a
+          Payment Platform: ${this.user.purchased.plan.paymentMethod}%0d%0a
+          Customer ID: ${this.user.purchased.plan.customerId}%0d%0a
+          Consecutive Months: ${this.user.purchased.plan.consecutive.count}%0d%0a
+          Offset Months: ${this.user.purchased.plan.consecutive.offset}%0d%0a
+          Mystic Hourglasses: ${this.user.purchased.plan.consecutive.trinkets}
+        `;
+      }
+      return `mailto:admin@habitica.com?subject=Habitica Web Bug Report&body=
+        Please describe the issue you encountered:%0d%0a%0d%0a
+        User ID: ${this.user._id}%0d%0a
+        Level: ${this.user.stats.lvl}%0d%0a
+        Class: ${this.user.stats.class}%0d%0a
+        Dailies Paused: ${this.user.preferences.sleep}%0d%0a
+        Uses Costume: ${this.user.preferences.costume}%0d%0a
+        Custom Day Start: ${this.user.preferences.dayStart}%0d%0a
+        Timezone Offset: ${this.user.preferences.timezoneOffset}%0d%0a
+        ${subscriptionInfo}
+      `;
+    },
+  },
+};

--- a/website/common/locales/ach/groups.json
+++ b/website/common/locales/ach/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/af/groups.json
+++ b/website/common/locales/af/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/ar/groups.json
+++ b/website/common/locales/ar/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/be/groups.json
+++ b/website/common/locales/be/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/bg/groups.json
+++ b/website/common/locales/bg/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Обществени правила",
     "lookingForGroup": "Публикации за търсене на група",
     "dataDisplayTool": "Инструмент за показване на данните",
-    "reportProblem": "Докладване на проблем",
     "requestFeature": "Предлагане на функционалност",
     "askAQuestion": "Задаване на въпрос",
     "askQuestionGuild": "Задайте въпрос (помощна гилдия на Хабитика)",

--- a/website/common/locales/bn/groups.json
+++ b/website/common/locales/bn/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/bs/groups.json
+++ b/website/common/locales/bs/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Smjernice zajednice",
     "lookingForGroup": "Potraga za grupom (Partija traži) objave",
     "dataDisplayTool": "Alat za prikaz podataka",
-    "reportProblem": "Prijavi grešku",
     "requestFeature": "Zatražite novu funkcionalnost",
     "askAQuestion": "Postavi pitanje",
     "askQuestionGuild": "Postavite pitanje (Esnaf za Habitica pomoć)",

--- a/website/common/locales/ca/groups.json
+++ b/website/common/locales/ca/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/cs/groups.json
+++ b/website/common/locales/cs/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Komunitní pravidla",
     "lookingForGroup": "Hledá se skupina (Hledám Družinu) příspěvky",
     "dataDisplayTool": "Nástroj pro zobrazení dat",
-    "reportProblem": "Nahlásit chybu",
     "requestFeature": "Zažádat o funkci",
     "askAQuestion": "Zeptat se na otázku",
     "askQuestionGuild": "Zeptat se na otázku (Habitica Help guild)",

--- a/website/common/locales/da/groups.json
+++ b/website/common/locales/da/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Retningslinjer for Fællesskabet",
     "lookingForGroup": "Søger Hold (Party Wanted)",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Rapportér en fejl",
     "requestFeature": "Anmod om funktion",
     "askAQuestion": "Stil et spørgsmål",
     "askQuestionGuild": "Stil et spørgsmål (Klanen 'Habitica Help')",

--- a/website/common/locales/de/groups.json
+++ b/website/common/locales/de/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community-Richtlinien",
     "lookingForGroup": "Party gesucht (Party wanted) Posts",
     "dataDisplayTool": "Datenanzeige-Werkzeug",
-    "reportProblem": "Einen Fehler melden",
     "requestFeature": "Eine Funktion vorschlagen",
     "askAQuestion": "Stell eine Frage",
     "askQuestionGuild": "Stell eine Frage (Habitica Hilfe Gilde)",

--- a/website/common/locales/el/groups.json
+++ b/website/common/locales/el/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/en/groups.json
+++ b/website/common/locales/en/groups.json
@@ -8,7 +8,6 @@
   "communityGuidelinesLink": "Community Guidelines",
   "lookingForGroup": "Looking for Group (Party Wanted) Posts",
   "dataDisplayTool": "Data Display Tool",
-  "reportProblem": "Report a Bug",
   "requestFeature": "Request a Feature",
   "askAQuestion": "Ask a Question",
   "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/en@lolcat/groups.json
+++ b/website/common/locales/en@lolcat/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/en@pirate/groups.json
+++ b/website/common/locales/en@pirate/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Rules o’ th’ Sea",
     "lookingForGroup": "Lookin' fer Group (Crew Want'd) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Kraken",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Pose ye Quandry",
     "askQuestionGuild": "Ask a Question (Habitica Help ship)",

--- a/website/common/locales/en_GB/groups.json
+++ b/website/common/locales/en_GB/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/eo/groups.json
+++ b/website/common/locales/eo/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/es/groups.json
+++ b/website/common/locales/es/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Directrices de la Comunidad",
     "lookingForGroup": "Posts en Buscando Equipo (Se busca Equipo)",
     "dataDisplayTool": "Herramienta de monitorización de datos",
-    "reportProblem": "Reporta un error",
     "requestFeature": "Solicita una funcionalidad",
     "askAQuestion": "Realiza una pregunta",
     "askQuestionGuild": "Realiza una pregunta (Gremio de Ayuda de Habitica)",

--- a/website/common/locales/es_419/groups.json
+++ b/website/common/locales/es_419/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Normas de la Comunidad",
     "lookingForGroup": "Publicaciones para buscar un Equipo (Party Wanted)",
     "dataDisplayTool": "Herramienta de Visualización de Datos",
-    "reportProblem": "Reporta un Error",
     "requestFeature": "Solicita una Función",
     "askAQuestion": "Haz una Pregunta",
     "askQuestionGuild": "Haz una Pregunta (Gremio de Ayuda en Habitica)",

--- a/website/common/locales/et/groups.json
+++ b/website/common/locales/et/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/eu/groups.json
+++ b/website/common/locales/eu/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "",
     "lookingForGroup": "",
     "dataDisplayTool": "",
-    "reportProblem": "",
     "requestFeature": "",
     "askAQuestion": "",
     "askQuestionGuild": "",

--- a/website/common/locales/fa_IR/groups.json
+++ b/website/common/locales/fa_IR/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/fi/groups.json
+++ b/website/common/locales/fi/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Yhteisön säännöt",
     "lookingForGroup": "Etsitään ryhmää (Seurueen etsintä)-viestit",
     "dataDisplayTool": "Datan tarkastustyökalu",
-    "reportProblem": "Ilmoita bugi",
     "requestFeature": "Ehdota uusia ominaisuuksia",
     "askAQuestion": "Esitä kysymys",
     "askQuestionGuild": "Esitä kysymys (Aloittelijoiden kilta)",

--- a/website/common/locales/fil/groups.json
+++ b/website/common/locales/fil/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/fr/groups.json
+++ b/website/common/locales/fr/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Règles de vie en communauté",
     "lookingForGroup": "Messages de recherche de groupe (\"Party Wanted\")",
     "dataDisplayTool": "Outil d'affichage des données",
-    "reportProblem": "Signaler un bug",
     "requestFeature": "Demander une fonctionnalité",
     "askAQuestion": "Poser une question",
     "askQuestionGuild": "Poser une question (Guilde d'aide de Habitica)",

--- a/website/common/locales/fy/groups.json
+++ b/website/common/locales/fy/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/ga/groups.json
+++ b/website/common/locales/ga/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/gl/groups.json
+++ b/website/common/locales/gl/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/haw/groups.json
+++ b/website/common/locales/haw/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/he/groups.json
+++ b/website/common/locales/he/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "הנחיות הקהילה",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "כלי הצגת נתונים",
-    "reportProblem": "דיווח על תקלה",
     "requestFeature": "בקשת תכונה",
     "askAQuestion": "לשאול שאלה",
     "askQuestionGuild": "לשאול שאלה (בגילדת העזרה של הביטיקה)",

--- a/website/common/locales/hi_IN/groups.json
+++ b/website/common/locales/hi_IN/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/hr/groups.json
+++ b/website/common/locales/hr/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Smjernice za zajednicu",
     "lookingForGroup": "Objave potrage za grupom (Party Wanted/Traži se Družina)",
     "dataDisplayTool": "Alat za prikazivanje podataka",
-    "reportProblem": "Prijavi grešku",
     "requestFeature": "Zatraži novu mogućnost",
     "askAQuestion": "Postavi pitanje",
     "askQuestionGuild": "Postavi pitanje (ceh Pomoći Habitice)",

--- a/website/common/locales/hu/groups.json
+++ b/website/common/locales/hu/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Közösségi irányelvek",
     "lookingForGroup": "Csapat keresése (Party kereső) posztok",
     "dataDisplayTool": "Adat kimutató eszköz",
-    "reportProblem": "Jelents be egy hibát",
     "requestFeature": "Funkció kérése",
     "askAQuestion": "Tegyél fel egy kérdést",
     "askQuestionGuild": "Tegyél fel egy kérdést (Habitica Help céh)",

--- a/website/common/locales/id/groups.json
+++ b/website/common/locales/id/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Pedoman Komunitas",
     "lookingForGroup": "Kiriman Pencarian Kelompok (Party Wanted)",
     "dataDisplayTool": "Alat Penampil Data",
-    "reportProblem": "Laporkan Bug",
     "requestFeature": "Ajukan Fitur Baru",
     "askAQuestion": "Tanya Sebuah Pertanyaan",
     "askQuestionGuild": "Tanyakan sebuah Pertanyaan (Guild Bantuan Habitica)",

--- a/website/common/locales/is/groups.json
+++ b/website/common/locales/is/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/it/groups.json
+++ b/website/common/locales/it/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Linee guida della community",
     "lookingForGroup": "Sei in cerca di una squadra? Guarda qui! (in inglese)",
     "dataDisplayTool": "Visualizzazione dati utente (in inglese)",
-    "reportProblem": "Segnala un bug",
     "requestFeature": "Richiedi una funzionalità",
     "askAQuestion": "Fai una domanda",
     "askQuestionGuild": "Fai una domanda (gilda Habitica Help)",

--- a/website/common/locales/ja/groups.json
+++ b/website/common/locales/ja/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "コミュニティ ガイドライン",
     "lookingForGroup": "仲間探し（パーティー募集）の投稿",
     "dataDisplayTool": "データ表示ツール",
-    "reportProblem": "バグを報告する",
     "requestFeature": "機能を要望する",
     "askAQuestion": "質問する",
     "askQuestionGuild": "質問する ( Habitica ヘルプ ギルド )",

--- a/website/common/locales/jbo/groups.json
+++ b/website/common/locales/jbo/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/jv/groups.json
+++ b/website/common/locales/jv/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/ko/groups.json
+++ b/website/common/locales/ko/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/ku_IQ/groups.json
+++ b/website/common/locales/ku_IQ/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/la/groups.json
+++ b/website/common/locales/la/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/ln/groups.json
+++ b/website/common/locales/ln/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/lt/groups.json
+++ b/website/common/locales/lt/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/lv/groups.json
+++ b/website/common/locales/lv/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/mk/groups.json
+++ b/website/common/locales/mk/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/ml/groups.json
+++ b/website/common/locales/ml/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/mn/groups.json
+++ b/website/common/locales/mn/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/mr/groups.json
+++ b/website/common/locales/mr/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/ms/groups.json
+++ b/website/common/locales/ms/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/nl/groups.json
+++ b/website/common/locales/nl/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Gemeenschapsrichtlijnen",
     "lookingForGroup": "Berichten: gezelschap gezocht",
     "dataDisplayTool": "Gegevens weergeven",
-    "reportProblem": "Fout melden",
     "requestFeature": "Functie aanvragen",
     "askAQuestion": "Stel een vraag",
     "askQuestionGuild": "Stel een vraag ('Habitica Help'-gilde)",

--- a/website/common/locales/nn/groups.json
+++ b/website/common/locales/nn/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/no/groups.json
+++ b/website/common/locales/no/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Retningslinjene for Fellesskapet",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/pl/groups.json
+++ b/website/common/locales/pl/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Wytyczne Społeczności",
     "lookingForGroup": "Sekcja dla poszukujących drużyny (Drużyna poszukiwana)",
     "dataDisplayTool": "Narzędzie podglądu danych",
-    "reportProblem": "Zgłoś błąd",
     "requestFeature": "Zaproponuj nową funkcję",
     "askAQuestion": "Zadaj pytanie",
     "askQuestionGuild": "Zadaj pytanie (Gildia Pomocy Habitiki)",

--- a/website/common/locales/pt/groups.json
+++ b/website/common/locales/pt/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Guia de Comunidade",
     "lookingForGroup": "Procurar por Mensagens de Grupo (Procura-se Equipa)",
     "dataDisplayTool": "Ferramenta de Exibição de Dados",
-    "reportProblem": "Reportar um Erro",
     "requestFeature": "Solicitar uma Funcionalidade",
     "askAQuestion": "Fazer uma Pergunta",
     "askQuestionGuild": "Coloque uma Pergunta (Habitica - Ajuda de guilda)",

--- a/website/common/locales/pt_BR/groups.json
+++ b/website/common/locales/pt_BR/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Diretrizes da Comunidade",
     "lookingForGroup": "Procurando Grupo (Pedir Convite)",
     "dataDisplayTool": "Ferramenta de Exibição de Dados",
-    "reportProblem": "Reportar Bug",
     "requestFeature": "Solicitar funcionalidade",
     "askAQuestion": "Fazer uma pergunta",
     "askQuestionGuild": "Fazer uma Pergunta (Guilda de Ajuda)",

--- a/website/common/locales/ro/groups.json
+++ b/website/common/locales/ro/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Ghidurile Comunității",
     "lookingForGroup": "Discuții despre grupuri (căutarea de echipe)",
     "dataDisplayTool": "Unealtă de afișare a datelor",
-    "reportProblem": "Raportează o eroare",
     "requestFeature": "Cere o Facilitate",
     "askAQuestion": "Pune o întrebare",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/ru/groups.json
+++ b/website/common/locales/ru/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Правила сообщества",
     "lookingForGroup": "Объявления о поиске группы (команды)",
     "dataDisplayTool": "Отображение данных",
-    "reportProblem": "Сообщить о проблеме",
     "requestFeature": "Предложить новую функцию",
     "askAQuestion": "Задать вопрос",
     "askQuestionGuild": "Задать вопрос (гильдия Habitica Help)",

--- a/website/common/locales/sco/groups.json
+++ b/website/common/locales/sco/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/si/groups.json
+++ b/website/common/locales/si/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/sk/groups.json
+++ b/website/common/locales/sk/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/sl/groups.json
+++ b/website/common/locales/sl/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Etični kodeks",
     "lookingForGroup": "Objave ceha Iščem druščino (Party Wanted)",
     "dataDisplayTool": "Prikazovalnik podatkov",
-    "reportProblem": "Prijavite napako",
     "requestFeature": "Zahtevaj izboljšavo",
     "askAQuestion": "Postavite vprašanje",
     "askQuestionGuild": "Postavi vprašanje (Ceh Habitica Help)",

--- a/website/common/locales/sr/groups.json
+++ b/website/common/locales/sr/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/su/groups.json
+++ b/website/common/locales/su/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/sv/groups.json
+++ b/website/common/locales/sv/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Gemenskapens riktlinjer",
     "lookingForGroup": "Letar efter Grupp (Sällskap Sökes) Inlägg",
     "dataDisplayTool": "Datavisningsverktyg",
-    "reportProblem": "Rapportera ett fel",
     "requestFeature": "Föreslå ny funktion",
     "askAQuestion": "Ställ en fråga",
     "askQuestionGuild": "Ställ en fråga (Habitica Hjälp gille)",

--- a/website/common/locales/sw/groups.json
+++ b/website/common/locales/sw/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/ta/groups.json
+++ b/website/common/locales/ta/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/th/groups.json
+++ b/website/common/locales/th/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/tl_PH/groups.json
+++ b/website/common/locales/tl_PH/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Alituntunin ng Komunidad",
     "lookingForGroup": "Naghahanap ng Grupo (Party Wanted) na mga Post",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Ibalita ang Bug",
     "requestFeature": "Humiling ng Tampok",
     "askAQuestion": "Magtanong",
     "askQuestionGuild": "Magtanong (Samahang-Damayan ng Tulong Habitica)",

--- a/website/common/locales/tlh/groups.json
+++ b/website/common/locales/tlh/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/tr/groups.json
+++ b/website/common/locales/tr/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Topluluk Kuralları",
     "lookingForGroup": "Takım Aranıyor Gönderileri",
     "dataDisplayTool": "Veri Gösterim Aracı",
-    "reportProblem": "Bir Hata Bildir",
     "requestFeature": "Bir Özellik Öner",
     "askAQuestion": "Bir Soru Sor",
     "askQuestionGuild": "Bir Soru Sor (Habitica Yardım Loncası)",

--- a/website/common/locales/uk/groups.json
+++ b/website/common/locales/uk/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Повідомити про помилку",
     "requestFeature": "Запросити функцію",
     "askAQuestion": "Задати запитання",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/ur_PK/groups.json
+++ b/website/common/locales/ur_PK/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/vi/groups.json
+++ b/website/common/locales/vi/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Nội quy Cộng đồng",
     "lookingForGroup": "Tìm kiếm Nhóm (",
     "dataDisplayTool": "Công cụ hiển thị Dữ liệu",
-    "reportProblem": "Báo cáo lỗi",
     "requestFeature": "Đề nghị một Chức năng",
     "askAQuestion": "Hỏi",
     "askQuestionGuild": "Ask a Question (Bang hội Giúp đỡ của Habitica)",

--- a/website/common/locales/zh/groups.json
+++ b/website/common/locales/zh/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "社区准则",
     "lookingForGroup": "寻找小组（队伍招募）帖",
     "dataDisplayTool": "数据展示工具",
-    "reportProblem": "报告bug",
     "requestFeature": "请求新功能",
     "askAQuestion": "问个问题",
     "askQuestionGuild": "请教问题（Habitica帮助公会）",

--- a/website/common/locales/zh_HK/groups.json
+++ b/website/common/locales/zh_HK/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "Community Guidelines",
     "lookingForGroup": "Looking for Group (Party Wanted) Posts",
     "dataDisplayTool": "Data Display Tool",
-    "reportProblem": "Report a Bug",
     "requestFeature": "Request a Feature",
     "askAQuestion": "Ask a Question",
     "askQuestionGuild": "Ask a Question (Habitica Help guild)",

--- a/website/common/locales/zh_TW/groups.json
+++ b/website/common/locales/zh_TW/groups.json
@@ -8,7 +8,6 @@
     "communityGuidelinesLink": "社群守則",
     "lookingForGroup": "尋找隊伍（徵求隊伍）貼文",
     "dataDisplayTool": "數據顯示工具",
-    "reportProblem": "回報Bug",
     "requestFeature": "請求新功能",
     "askAQuestion": "提出問題",
     "askQuestionGuild": "提出問題（Habitica 諮詢台公會）",


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Updates the Habitica web site to route users' bug reports to admin email, including troubleshooting data where possible, instead of to a Habitica guild. After this goes live, we'll set the Report a Bug Guild to private and remove its membership--if this route ends up not working out, we can restore it with minimal loss!

"Report a Bug" links changed:
* App footer
* Help menu
* Contact Us page (uses the prefilled variant only if the user object is loaded)
* Tavern sidebar

Also removes a redundant string token `reportProblem` that was only used in the Tavern and had the same English text as the other links.