### PR TITLE
Delay Mystery Item sets appearing in Time Travelers until after their debut month

### DIFF
--- a/website/common/script/content/time-travelers.js
+++ b/website/common/script/content/time-travelers.js
@@ -28,7 +28,7 @@ const timeTravelerStore = user => {
     if (
       k === 'wondercon'
       || ownedKeys.indexOf(v.items[0].key) !== -1
-      || (moment(k).isAfter() && moment(k).isBefore('3000-01-01'))
+      || (moment(k).add(1, 'months').isAfter() && moment(k).isBefore('3000-01-01'))
     ) {
       return m;
     }


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Fixes an issue where in some situations, a user could spend Mystic Hourglasses to purchase the current month's subscriber set. For users with lapsed subscriptions but holding on to Hourglasses, the Time Travelers are meant to make "historical" sets available, not the set that would be immediately available were the user to re-subscribe. And for users who are subscribed but due to a cron error did not obtain the current month's set, they should reach out to admin@habitica to get what they're missing, not spend some of their precious Hourglasses to get what they're already owed!

**Previously**, if a mystery set was dated before the empty `moment()`, i.e. now, it was eligible to appear in the Time Travelers shop.
**Now**, the date check looks to the Mystery Set's key value + 1 month, so the current month's items are not listed.