### PR TITLE
Improve Z-Indexes for Notifications / Menus / Toolbar

### DIFF
--- a/website/client/src/assets/scss/create-task.scss
+++ b/website/client/src/assets/scss/create-task.scss
@@ -2,7 +2,7 @@
   position: absolute;
   right: 24px;
   top: -24px;
-  z-index: 999;
+  z-index: 998;
   align-items: center;
 }
 

--- a/website/client/src/components/snackbars/notifications.vue
+++ b/website/client/src/components/snackbars/notifications.vue
@@ -27,7 +27,7 @@
     position: fixed;
     right: 10px;
     width: 350px;
-    z-index: 1400; // 1400 is above modal backgrounds
+    z-index: 999;
 
     top: var(--current-scrollY);
 

--- a/website/client/src/components/z-index-overview.md
+++ b/website/client/src/components/z-index-overview.md
@@ -1,0 +1,14 @@
+# List of the current zIndexes
+
+|Type|zIndex|File|
+|-|-|
+|Progress Bar|1600|app.vue|
+|Create App Menu|999|create-task.scss|
+|Loading Screen|1050|loading-screen.scss|
+|Modals|1350|modal.scss|
+|Toolbar (Habitica Menu)|1080|menu.vue|
+|Toolbar (Habitica Menu), when a Modal is opened|1035||
+|Top Banner (above Toolbar)|1300|base.vue|
+|Top Banner (above Toolbar), when a Modal is opened|1035|
+|Toolbar Dropdown|1000|.dropdown-menu|
+|Notifications|999|notifications.vue|

--- a/website/client/src/components/z-index-overview.md
+++ b/website/client/src/components/z-index-overview.md
@@ -1,7 +1,7 @@
 # List of the current zIndexes
 
 |Type|zIndex|File|
-|-|-|
+|:-|:-|:-|
 |Progress Bar|1600|app.vue|
 |Create App Menu|999|create-task.scss|
 |Loading Screen|1050|loading-screen.scss|


### PR DESCRIPTION
Improved Z-indexes and create an overview to future changes


|Type|zIndex|File|
|:-|:-|:-|
|Progress Bar|1600|app.vue|
|Create App Menu|998|create-task.scss|
|Loading Screen|1050|loading-screen.scss|
|Modals|1350|modal.scss|
|Toolbar (Habitica Menu)|1080|menu.vue|
|Toolbar (Habitica Menu), when a Modal is opened|1035||
|Top Banner (above Toolbar)|1300|base.vue|
|Top Banner (above Toolbar), when a Modal is opened|1035|
|Toolbar Dropdown|1000|.dropdown-menu|
|Notifications|999|notifications.vue|