### PR TITLE
remove timer for quests in inventory (fixes #13224)

### DIFF
--- a/website/client/src/components/inventory/items/index.vue
+++ b/website/client/src/components/inventory/items/index.vue
@@ -194,7 +194,7 @@
                   <h4 class="popover-content-title">
                     {{ context.item.text }}
                   </h4>
-                  <questInfo :quest="context.item" />
+                  <questInfo :quest="context.item" :purchased="true" />
                 </div>
                 <div v-else>
                   <h4 class="popover-content-title">

--- a/website/client/src/components/shops/quests/questInfo.vue
+++ b/website/client/src/components/shops/quests/questInfo.vue
@@ -152,6 +152,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    purchased: {
+      type: Boolean,
+      default: false,
+    },
   },
   data () {
     return {
@@ -206,7 +210,7 @@ export default {
       return collect.text;
     },
     countdownString () {
-      if (!this.quest.event) return;
+      if (!this.quest.event || this.purchased) return;
       const diffDuration = moment.duration(moment(this.quest.event.end).diff(moment()));
 
       if (diffDuration.asSeconds() <= 0) {


### PR DESCRIPTION
Fixes #13224 

### Changes
Removes the timer in the quest popup for quests in the inventory.

Before:
![inventory-questtimer before](https://user-images.githubusercontent.com/78376862/132371698-e5ff3fce-1707-4054-b863-6d6ed4214ccc.png)
After:
![inventory-questtimer after](https://user-images.githubusercontent.com/78376862/132371706-13e9b27d-c94d-4e85-8e6a-3aad16938f74.png)

----
UUID: 7127f673-c5f6-4b92-84f0-ffcd002d364c
