### PR TITLE
fix cloned challenge task order (#13328)

### DIFF
--- a/website/server/controllers/api-v3/challenges.js
+++ b/website/server/controllers/api-v3/challenges.js
@@ -860,10 +860,19 @@ api.cloneChallenge = {
 
     const { savedChal } = await createChallenge(user, req, res);
 
-    const challengeTasks = await Tasks.Task.find({
-      'challenge.id': challengeToClone._id,
-      userId: { $exists: false },
-    }).exec();
+    const challengeTaskIds = [
+      ...challengeToClone.tasksOrder.habits,
+      ...challengeToClone.tasksOrder.dailys,
+      ...challengeToClone.tasksOrder.todos,
+      ...challengeToClone.tasksOrder.rewards
+    ];
+
+    const challengeTasks = await Promise.all(challengeTaskIds.map(async taskId => {
+      const task = Tasks.Task.findById(taskId).exec();
+      return task;
+    }));
+    
+    challengeTasks.reverse(); // last task should be added first and vice-versa, since new tasks are prepended
 
     const tasksToClone = challengeTasks.map(task => {
       const clonedTask = cloneDeep(task.toObject());

--- a/website/server/controllers/api-v3/challenges.js
+++ b/website/server/controllers/api-v3/challenges.js
@@ -864,15 +864,16 @@ api.cloneChallenge = {
       ...challengeToClone.tasksOrder.habits,
       ...challengeToClone.tasksOrder.dailys,
       ...challengeToClone.tasksOrder.todos,
-      ...challengeToClone.tasksOrder.rewards
+      ...challengeToClone.tasksOrder.rewards,
     ];
 
     const challengeTasks = await Promise.all(challengeTaskIds.map(async taskId => {
       const task = Tasks.Task.findById(taskId).exec();
       return task;
     }));
-    
-    challengeTasks.reverse(); // last task should be added first and vice-versa, since new tasks are prepended
+
+    // last task should be added first and vice-versa, since new tasks are prepended
+    challengeTasks.reverse();
 
     const tasksToClone = challengeTasks.map(task => {
       const clonedTask = cloneDeep(task.toObject());


### PR DESCRIPTION
Fixes #13328

### Changes
https://github.com/HabitRPG/habitica/issues/13328#issuecomment-918588649 :
> I think I've fixed the issue. The problem was that when querying for the tasks to be added to the new challenge, it would just search by the challenge id, which I don't think would necessarily return the tasks in the expected order:
> 
> ```js
> const challengeTasks = await Tasks.Task.find({
>   'challenge.id': challengeToClone._id,
>   userId: { $exists: false }, 
> }).exec();
> ```
> 
> I've changed this to instead iterate over the tasksOrder arrays in the challenge, so we get the tasks in the expected order:
> 
> ```js
> const challengeTaskIds = [
>   ...challengeToClone.tasksOrder.habits,
>   ...challengeToClone.tasksOrder.dailys,
>   ...challengeToClone.tasksOrder.todos,
>   ...challengeToClone.tasksOrder.rewards
> ];
> 
> const challengeTasks = await Promise.all(challengeTaskIds.map(async taskId => {
>   const task = Tasks.Task.findById(taskId).exec();
>   return task;
> }));
> 
> challengeTasks.reverse(); // last task should be added first and vice-versa, since new tasks are prepended
> ```
> 
> I've tested this and it looks to be working, but please let me know what you think before I create the PR.

----
UUID: 7127f673-c5f6-4b92-84f0-ffcd002d364c