### PR TITLE
added missing space in Herald's Tunic description

### DIFF
--- a/website/common/locales/en/gear.json
+++ b/website/common/locales/en/gear.json
@@ -1218,7 +1218,7 @@
   "armorArmoireBagpipersKiltText": "Bagpiper's Kilt",
   "armorArmoireBagpipersKiltNotes": "A good sturdy kilt will serve you well. Increases Constitution by <%= con %>. Enchanted Armoire: Bagpiper Set (Item 2 of 3).",
   "armorArmoireHeraldsTunicText": "Herald's Tunic",
-  "armorArmoireHeraldsTunicNotes": "Get ready to spread good news far and wide in this colorful, royal outfit. Increases Constitution by <%= con %>. Enchanted Armoire: Herald Set (Item1 of 4).",
+  "armorArmoireHeraldsTunicNotes": "Get ready to spread good news far and wide in this colorful, royal outfit. Increases Constitution by <%= con %>. Enchanted Armoire: Herald Set (Item 1 of 4).",
 
   "headgear": "helm",
   "headgearCapitalized": "Headgear",


### PR DESCRIPTION
[//]: # (Note: See http://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes put_#_and_issue_number_here

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

What it says on the tin, I found a missing space while translating and this adds it.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: c073342f-4a65-4a13-9ffd-9e7fa5410d6b
