### PR TITLE
Fix casting items on parties that exceed it limit by showing Load More Button

### DIFF
--- a/test/api/v3/integration/groups/POST-groups_invite.test.js
+++ b/test/api/v3/integration/groups/POST-groups_invite.test.js
@@ -7,7 +7,7 @@ import {
 } from '../../../../helpers/api-integration/v3';
 
 const INVITES_LIMIT = 100;
-const PARTY_LIMIT_MEMBERS = 30;
+const PARTY_LIMIT_MEMBERS = 29;
 const MAX_EMAIL_INVITES_BY_USER = 200;
 
 describe('Post /groups/:groupId/invite', () => {

--- a/test/api/v3/integration/groups/POST-groups_invite.test.js
+++ b/test/api/v3/integration/groups/POST-groups_invite.test.js
@@ -650,7 +650,7 @@ describe('Post /groups/:groupId/invite', () => {
         .to.eventually.be.rejected.and.eql({
           code: 400,
           error: 'BadRequest',
-          message: t('partyExceedsMembersLimit', { maxMembersParty: PARTY_LIMIT_MEMBERS }),
+          message: t('partyExceedsMembersLimit', { maxMembersParty: PARTY_LIMIT_MEMBERS + 1 }),
         });
     }).timeout(10000);
   });

--- a/website/client/src/components/header/index.vue
+++ b/website/client/src/components/header/index.vue
@@ -145,6 +145,9 @@ export default {
       currentWidth: 0,
       inviteModalGroup: undefined,
       inviteModalGroupType: undefined,
+      group: {},
+      members: [],
+      membersLoaded: false,
     };
   },
   computed: {
@@ -236,14 +239,26 @@ export default {
         this.$root.$emit('bv::show::modal', 'create-party-modal');
       }
     },
-    async showPartyMembers () {
-      const party = await this.$store.dispatch('party:getParty');
+    loadMembers (payload = null) {
+      // Remove unnecessary data
+      if (payload && payload.challengeId) {
+        delete payload.challengeId;
+      }
 
+      return this.$store.dispatch('members:getGroupMembers', payload);
+    },
+    showPartyMembers () {
+      this.$store.state.memberModalOptions.loading = true;
+      this.group = this.$store.state.party.data;
+      this.membersLoaded = true;
+      this.members = this.partyMembers;
+      this.$store.state.memberModalOptions.loading = false;
       this.$root.$emit('habitica:show-member-modal', {
-        groupId: party.data._id,
-        viewingMembers: this.partyMembers,
-        group: party.data,
-        fetchMoreMembers: p => this.$store.dispatch('members:getGroupMembers', p),
+        groupId: this.group._id,
+        group: this.group,
+        memberCount: this.group.memberCount,
+        viewingMembers: this.members,
+        fetchMoreMembers: this.loadMembers,
       });
     },
     setPartyMembersWidth ($event) {

--- a/website/client/src/components/header/index.vue
+++ b/website/client/src/components/header/index.vue
@@ -249,7 +249,6 @@ export default {
     },
     async showPartyMembers () {
       this.group = await this.$store.dispatch('party:getParty');
-      this.$store.state.memberModalOptions.loading = true;
       this.group = this.$store.state.party.data;
       this.membersLoaded = true;
       this.members = this.partyMembers;

--- a/website/client/src/components/header/index.vue
+++ b/website/client/src/components/header/index.vue
@@ -247,7 +247,8 @@ export default {
 
       return this.$store.dispatch('members:getGroupMembers', payload);
     },
-    showPartyMembers () {
+    async showPartyMembers () {
+      this.group = await this.$store.dispatch('party:getParty');
       this.$store.state.memberModalOptions.loading = true;
       this.group = this.$store.state.party.data;
       this.membersLoaded = true;

--- a/website/common/script/constants.js
+++ b/website/common/script/constants.js
@@ -28,7 +28,7 @@ export const SUPPORTED_SOCIAL_NETWORKS = [
 
 export const GUILDS_PER_PAGE = 30; // number of guilds to return per page when using pagination
 
-export const PARTY_LIMIT_MEMBERS = 30;
+export const PARTY_LIMIT_MEMBERS = 29;
 
 export const MINIMUM_PASSWORD_LENGTH = 8;
 

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -491,7 +491,7 @@ schema.statics.validateInvitations = async function getInvitationErr (invites, r
     memberCount += totalInvites;
 
     if (memberCount > shared.constants.PARTY_LIMIT_MEMBERS) {
-      throw new BadRequest(res.t('partyExceedsMembersLimit', { maxMembersParty: shared.constants.PARTY_LIMIT_MEMBERS }));
+      throw new BadRequest(res.t('partyExceedsMembersLimit', { maxMembersParty: shared.constants.PARTY_LIMIT_MEMBERS + 1 }));
     }
   }
 };


### PR DESCRIPTION
fixes #13394

### Changes

This PR contains 4 commits.

1. st commit: **Fix party size and notification when inviting**
- [ ] Which files: `website/server/models/group.js` && `website/common/script/constants.js`
- [ ] Description: During development i noticed that party limit is actually 31, not 30, as it supposed to be, because party leader wasn't included previously. Code is pretty self-explanatory

2. nd commit: **Fix View Party button in header**

- [ ] Which files: `website/client/src/components/header/index.vue`
- [ ] Description: During development i noticed that when clicking View Party button in header, it doesn't show Load More button.
When clicking Member List (with this shield icon, in Party tab) it worked. I copied some code from `website/client/src/components/groups/group.vue` and modified it, so it doesn't conflict with current code.

3. rd commit:  **Fixed View Party button to properly open party** 
- [ ] Which files: `website/client/src/components/header/index.vue`
- [ ] Description: It was just a small fix to 2nd commit, as i didn't notice that after refreshing the page, View Party button doesn't work.

4. th commit: **Fixed SelectMembersModal to properly show Load More button** 
- [ ] Which files: ` website/client/src/components/selectMembersModal.vue`
- [ ] Description: It was the main fix for the issue with an id 13394 (clickable number is on top of this file). First of all i copied Load More button from previous commits, then i copied some code from previous commits as well. The main thing was to get `group` from dispatch, get some values out of it and save them to the store. I also added `const invite` and assigned it to dispatched `getGroupInvites`, but i wasn't sure what was this fragment of code doing and couldn't find it out, so i just left it here. (lines 269-273)


----
UUID: 86f37f0c-ebaf-4ee8-bf9f-00a5aa485501
