### PR TITLE
fix(client): Increase max js heap size

### DIFF
--- a/website/client/package.json
+++ b/website/client/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "serve": "vue-cli-service serve",
+    "serve": "vue-cli-service serve --max_old_space_size=4096",
     "build": "vue-cli-service build",
     "test:unit": "vue-cli-service test:unit --require ./tests/unit/helpers.js",
     "lint": "vue-cli-service lint .",


### PR DESCRIPTION
Fixes #13529 

### Changes
- Added --max_old_space_size=4096 flag to `/website/client/package.json` for the `serve` script. This increases the maximum usable memory for Node.js from 512MB to 4GB.

PS: If my PR is merged, please add the 'hacktoberfest-accepted' label to the PR.

Regards,
Snehil