### PR TITLE
Fix chat @-mentions not opening in a modal

### DIFF
--- a/website/client/src/components/chat/chatCard.vue
+++ b/website/client/src/components/chat/chatCard.vue
@@ -285,7 +285,7 @@ export default {
       let link = links[i].pathname;
 
       // Internet Explorer does not provide the leading slash character in the pathname
-      link = link.charAt(0) === '/' ? link : '/' + link;
+      link = link.charAt(0) === '/' ? link : `/${link}`;
 
       if (link.startsWith('/profile/')) {
         links[i].onclick = ev => {

--- a/website/client/src/components/chat/chatCard.vue
+++ b/website/client/src/components/chat/chatCard.vue
@@ -282,11 +282,15 @@ export default {
   mounted () {
     const links = this.$refs.markdownContainer.getElementsByTagName('a');
     for (let i = 0; i < links.length; i += 1) {
-      const link = links[i];
-      if (links[i].getAttribute('href').startsWith('/profile/')) {
+      let link = links[i].pathname;
+
+      // Internet Explorer does not provide the leading slash character in the pathname
+      link = link.charAt(0) === '/' ? link : '/' + link;
+
+      if (link.startsWith('/profile/')) {
         links[i].onclick = ev => {
           ev.preventDefault();
-          this.$router.push({ path: link.getAttribute('href') });
+          this.$router.push({ path: link });
         };
       }
     }


### PR DESCRIPTION
Fixes #13276

### Changes
Extract the relative link using pathname property to correctly add the event listener to open the modal on mention links (since those are absolute links).

----
UUID: 7127f673-c5f6-4b92-84f0-ffcd002d364c