### PR TITLE
Frost spell buff won't affect challenge or group dailies

### DIFF
--- a/website/common/script/ops/scoreTask.js
+++ b/website/common/script/ops/scoreTask.js
@@ -286,7 +286,8 @@ export default function scoreTask (options = {}, req = {}, analytics) {
     if (cron) {
       delta += _changeTaskValue(user, task, direction, times, cron);
       _subtractPoints(user, task, stats, delta);
-      if (!user.stats.buffs.streaks) task.streak = 0;
+      // Chilling frost should not affect challenge or group dailies
+      if (!user.stats.buffs.streaks || task.challenge.id || task.group.id) task.streak = 0;
     } else {
       delta += _changeTaskValue(user, task, direction, times, cron);
       if (direction === 'down') delta = _calculateDelta(task, direction, cron); // recalculate delta for unchecking so the gp and exp come out correctly


### PR DESCRIPTION
Fixes #7809

### Changes
Chilling frost applies a buff that is only checked in the scoreTask function in the line
```javascript
if (!user.stats.buffs.streaks) task.streak = 0;
```
Changed this to
```javascript
if (!user.stats.buffs.streaks || task.challenge.id || task.group.id) task.streak = 0;
```
So now the buff won't apply to challenge or groups dailies.

----
UUID: 7127f673-c5f6-4b92-84f0-ffcd002d364c
