### PR TITLE
Feature/warn missing config

### DIFF
--- a/website/server/libs/logger.js
+++ b/website/server/libs/logger.js
@@ -120,7 +120,7 @@ if (IS_PROD) {
   _config.loggingEnabled = false;
 }
 
-// exports a public interface insteaf of accessing directly the logger module
+// exports a public interface instead of accessing directly the logger module
 const loggerInterface = {
   info (...args) {
     if (!_config.loggingEnabled) return;

--- a/website/server/libs/logger.js
+++ b/website/server/libs/logger.js
@@ -148,6 +148,32 @@ const loggerInterface = {
     logger.info(message, data);
   },
 
+  warn (...args) {
+    if (!_config.loggingEnabled) return;
+
+    const [_message, _data] = args;
+    const isMessageString = typeof _message === 'string';
+
+    const message = isMessageString ? _message : 'No message provided for log.';
+    let data;
+
+    if (args.length === 1) {
+      if (isMessageString) {
+        data = {};
+      } else {
+        data = { extraData: _message };
+      }
+    } else if (!isMessageString || args.length > 2) {
+      throw new Error('logger.info accepts up to two arguments: a message and an object with extra data to log.');
+    } else if (_.isPlainObject(_data)) {
+      data = _data;
+    } else {
+      data = { extraData: _data };
+    }
+
+    logger.warn(message, data);
+  },
+
   // Accepts two argument,
   // an Error object (required)
   // and an object of additional data to log alongside the error

--- a/website/server/libs/setupNconf.js
+++ b/website/server/libs/setupNconf.js
@@ -2,11 +2,17 @@
 // NOTE es5 requires/exports to allow import from webpack
 const nconfDefault = require('nconf');
 const { join, resolve } = require('path');
+const fs = require('fs');
+const logger = require('./logger').default;
 
 const PATH_TO_CONFIG = join(resolve(__dirname, '../../../config.json'));
 
 module.exports = function setupNconf (file, nconfInstance = nconfDefault) {
   const configFile = file || PATH_TO_CONFIG;
+
+  if (!fs.existsSync(configFile)) {
+    logger.warn('Missing "config.json", did you forget to copy it from "config.json.example"?');
+  }
 
   nconfInstance
     .argv()


### PR DESCRIPTION
### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

#### TLDR
- Add logger.warn method for messages that may need attention but may not be errors
- Add a warning when starting the local server without a `config.json` present

#### Background and Solution
As a new developer to the project, I read the install instructions carefully the first time (cloning the lib). The second time I did the install process (forking) I forgot the step to copy `config.json.example` to `config.json`. I got an unhelpful error when starting up. 

![image](https://user-images.githubusercontent.com/675098/139601104-c8b385ec-d467-41c9-8025-073539320630.png)

I would have appreciated a bit of help to find out what was wrong, so I put in a helpful warning log. Hopefully it should make getting started developing the project just a tiny bit easier.

![image](https://user-images.githubusercontent.com/675098/139601148-f6823a86-17c6-4252-9968-df33fbefa227.png)

I had to expose a `warn` method in the logger to elevate it from `info`, but I don't think its an `error` as it looks like there are different ways to boot up the app without the use of `config.json`


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: e22287a3-189f-4acc-aa0a-36bb30fd4664
