### PR TITLE
Fix logic of emailInvalid and emailValid, fixes #12419

### DIFF
--- a/website/client/src/components/auth/registerLoginReset.vue
+++ b/website/client/src/components/auth/registerLoginReset.vue
@@ -685,11 +685,11 @@ export default {
       return false;
     },
     emailValid () {
-      if (this.email.length <= 3) return false;
+      if (this.email.length < 1) return false;
       return isEmail(this.email);
     },
     emailInvalid () {
-      if (this.email.length <= 3) return false;
+      if (this.email.length < 1) return false;
       return !this.emailValid;
     },
     usernameValid () {

--- a/website/client/src/components/static/home.vue
+++ b/website/client/src/components/static/home.vue
@@ -841,11 +841,11 @@ export default {
   },
   computed: {
     emailValid () {
-      if (this.email.length <= 3) return false;
+      if (this.email.length < 1) return false;
       return isEmail(this.email);
     },
     emailInvalid () {
-      if (this.email.length <= 3) return false;
+      if (this.email.length < 1) return false;
       return !isEmail(this.email);
     },
     usernameValid () {


### PR DESCRIPTION
[//]: # (Note: See https://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #12419 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Fix email validation to return invalid even when 3 characters or less are present in the input field. This will fix the warning symbol not showing in the email field when 3 or less characters are entered.
Before:
![image](https://user-images.githubusercontent.com/55836477/140373692-d579b53c-4711-4d82-b40e-608ebb3d0584.png)
After:
![image](https://user-images.githubusercontent.com/55836477/140374018-54e4c0dd-2532-42cd-ad33-19e87a20de56.png)


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 714f488d-1389-4f3c-ad35-bcf97e38ce2d
