### PR TITLE
fix: remove Bird Quest Bundle from Featured Quests in Shop

### DIFF
--- a/website/common/script/content/shop-featuredItems.js
+++ b/website/common/script/content/shop-featuredItems.js
@@ -54,8 +54,8 @@ const featuredItems = {
         path: 'quests.horse',
       },
       {
-        type: 'bundles',
-        path: 'bundles.birdBuddies',
+        type: 'quests',
+        path: 'quests.butterfly',
       },
     ];
   },


### PR DESCRIPTION
Fixes #13633 

### Changes
Removes the Bird Quest Bundle from Featured Items in the Shop and replaces it with "Bye, Bye, Butterfry."

----
UUID: f4e5c6da-0617-48bf-b3bd-9f97636774a8
