### PR TITLE
Fix: Updated challenge.js to allow shortName to be editable by party leader

### DIFF
--- a/test/api/v3/integration/challenges/PUT-challenges_challengeId.test.js
+++ b/test/api/v3/integration/challenges/PUT-challenges_challengeId.test.js
@@ -74,7 +74,6 @@ describe('PUT /challenges/:challengeId', () => {
     expect(res.memberCount).to.equal(2);
     expect(res.tasksOrder).not.to.equal('new order');
     expect(res.official).to.equal(false);
-    expect(res.shortName).not.to.equal('new short name');
 
     expect(res.leader).to.eql({
       _id: user._id,

--- a/website/server/models/challenge.js
+++ b/website/server/models/challenge.js
@@ -68,7 +68,7 @@ schema.pre('init', chal => {
 });
 
 // A list of additional fields that cannot be updated (but can be set on creation)
-const noUpdate = ['group', 'leader', 'official', 'shortName', 'prize'];
+const noUpdate = ['group', 'leader', 'official', 'prize'];
 schema.statics.sanitizeUpdate = function sanitizeUpdate (updateObj) {
   return this.sanitize(updateObj, noUpdate);
 };


### PR DESCRIPTION
Fixes #10829

### Changes
Used the code from closed PR #10843 - I tested it thoroughly and it works in my development environment:
- Changing `shortName` for users already participating in the challenge has no effect--both members of the challenge and the creator of the challenge.
- Users joining the challenge after `shortName` has been updated have the new `shortName` in their tags

### Notes
I believe it would be better for usability to change the name of the input field to `challengeTag` from `shortName` because until I really dug into it, I had no idea that the field was being used to populate the tags menu on the user end. That is beyond the scope of this PR but may be something that the team wants to consider in the future.

----
UUID: f4e5c6da-0617-48bf-b3bd-9f97636774a8
