### PR TITLE
Fixed issue with mystery sets, pets, and mounts staying pinned after purchase. Fixes issue #12905

### DIFF
--- a/website/common/script/ops/buy/buyMysterySet.js
+++ b/website/common/script/ops/buy/buyMysterySet.js
@@ -8,6 +8,8 @@ import {
   NotFound,
 } from '../../libs/errors';
 import errorMessage from '../../libs/errorMessage';
+import { removeItemByPath } from '../pinnedGearUtils';
+import getItemInfo from '../../libs/getItemInfo';
 
 export default function buyMysterySet (user, req = {}, analytics) {
   const key = get(req, 'params.key');
@@ -27,6 +29,9 @@ export default function buyMysterySet (user, req = {}, analytics) {
   each(mysterySet.items, item => {
     user.items.gear.owned[item.key] = true;
   });
+
+  const itemInfo = getItemInfo(user, 'mystery_set', mysterySet);
+  removeItemByPath(user, itemInfo.path);
 
   if (analytics) {
     analytics.track('buy', {

--- a/website/common/script/ops/buy/hourglassPurchase.js
+++ b/website/common/script/ops/buy/hourglassPurchase.js
@@ -71,6 +71,11 @@ export default function purchaseHourglass (user, req = {}, analytics, quantity =
         [key]: 5,
       };
       if (user.markModified) user.markModified('items.pets');
+      const itemInfo = getItemInfo(user, 'timeTravelersStable', {
+        key,
+        type,
+      });
+      removeItemByPath(user, itemInfo.path);
     }
 
     if (type === 'mounts') {
@@ -79,6 +84,11 @@ export default function purchaseHourglass (user, req = {}, analytics, quantity =
         [key]: true,
       };
       if (user.markModified) user.markModified('items.mounts');
+      const itemInfo = getItemInfo(user, 'timeTravelersStable', {
+        key,
+        type,
+      });
+      removeItemByPath(user, itemInfo.path);
     }
   }
 


### PR DESCRIPTION
Added logic to look up item info and remove from pinned list by path.

Fixes #12905 

### Changes
Added logic to look up item info and remove from pinned list by path using existing getItemInfo and removeItemByPath functions. The item is removed from the pinned list after it is purchased and disappears from the user's rewards panel.



[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 11334cbf-3129-4764-8970-79fcdcd4a3e6
