### PR TITLE
Fixes Issue13749 Alternative way

### DIFF
--- a/website/client/src/components/tasks/task.vue
+++ b/website/client/src/components/tasks/task.vue
@@ -268,17 +268,19 @@
                 <span v-if="task.type === 'daily'">{{ task.streak }}</span>
                 <span v-if="task.type === 'habit'">
                   <span
-                    v-if="task.up"
+                    v-if="task.up && task.counterUp != 0"
                     class="m-0"
                   >+{{ task.counterUp }}</span>
+                  <span v-else-if="task.up">0</span>
                   <span
                     v-if="task.up && task.down"
                     class="m-0"
                   >&nbsp;|&nbsp;</span>
                   <span
-                    v-if="task.down"
+                    v-if="task.down && task.counterDown != 0"
                     class="m-0"
                   >-{{ task.counterDown }}</span>
+                  <span v-else-if="task.down">0</span>
                 </span>
               </div>
               <div


### PR DESCRIPTION
Fixes #13749

Negative habits don't display 0 correctly #13749

Changes :
In order to fix the issue of Negative habits ,(Issue #13749), not displaying as 0 but as -0,In the Task.vue file I added a 0 check in the span v-if and added a span after it that checks if the "task.up" or "task.down" is active to display 0.

Just a value check basically :

* If the value is not 0 and (+/-) value is active show the number with a +/-

* If the value is 0 and (+/-) value is active show the number 0

(this applies to all habits as long as it's a 0 it won't have the +/- next to it)
 The Issue : 

![Issue13749 on Live Version](https://user-images.githubusercontent.com/57879188/150977685-5b231d55-a4f1-4c0c-aa9b-f3b6a243b1c2.png)


The Solution : 

![My Solution on Local Setup](https://user-images.githubusercontent.com/57879188/150977787-35b04090-f189-445d-aeb8-7c0ea7b4db35.png)



----
UUID: 14267ccc-dff1-4dce-9836-e4aab5c5c8b6



