### PR TITLE
Add automatic year detection on appFooter

### DIFF
--- a/website/client/src/components/appFooter.vue
+++ b/website/client/src/components/appFooter.vue
@@ -224,7 +224,7 @@
       </div>
       <div class="row">
         <div class="col-12 col-md-5 text-center text-md-left">
-          © 2021 Habitica. All rights reserved.
+          © {{ currentYear }} Habitica. All rights reserved.
           <div
             v-if="!IS_PRODUCTION && isUserLoaded"
             class="debug float-left"
@@ -512,6 +512,10 @@ export default {
       if (!this.user) return null;
       return `${base}?uuid=${this.user._id}`;
     },
+    currentYear() {
+      const currentDate = new Date();
+      return currentDate.getFullYear();
+    }
   },
   methods: {
     plusTenHealth () {


### PR DESCRIPTION
### Changes
Hi, happy belated new year, I was thinking to just replace 2021 to 2022, but to prevent this happening again I've replaced the year for a variable that get the current year.
I've used the built-in Date to get the current year, but I was not sure if I could use it or I should use moment.

If there's anything wrong just let me know.

----
UUID: 4a7ed516-186a-4b97-ba86-b28b311d88ab
