### PR TITLE
On-the-fly fix for tasks missing from tasksOrder

### DIFF
--- a/website/server/controllers/api-v3/tasks.js
+++ b/website/server/controllers/api-v3/tasks.js
@@ -838,12 +838,15 @@ api.moveTask = {
 
     // In memory updates
     const order = owner.tasksOrder[`${task.type}s`];
+
     if (order.indexOf(task._id) === -1) { // task is missing from list, list needs repair
       const taskListQuery = { type: task.type };
       if (group) {
         taskListQuery['group.id'] = owner._id;
+        taskListQuery.userId = { $exists: false };
       } else if (challenge) {
         taskListQuery['challenge.id'] = owner._id;
+        taskListQuery.userId = { $exists: false };
       } else {
         taskListQuery.userId = owner._id;
       }
@@ -860,6 +863,7 @@ api.moveTask = {
       fixQuery.$set[`tasksOrder.${task.type}s`] = order;
       await owner.update(fixQuery).exec();
     }
+
     moveTask(order, task._id, to);
 
     // Server updates

--- a/website/server/controllers/api-v3/tasks/groups.js
+++ b/website/server/controllers/api-v3/tasks/groups.js
@@ -160,6 +160,21 @@ api.groupMoveTask = {
 
     const order = group.tasksOrder[`${task.type}s`];
 
+    if (order.indexOf(task._id) === -1) { // task is missing from list, list needs repair
+      const taskList = await Tasks.Task.find(
+        { 'group.id': group._id, userId: { $exists: false }, type: task.type },
+        { _id: 1 },
+      ).exec();
+      for (const foundTask of taskList) {
+        if (order.indexOf(foundTask._id) === -1) {
+          order.push(foundTask._id);
+        }
+      }
+      const fixQuery = { $set: {} };
+      fixQuery.$set[`tasksOrder.${task.type}s`] = order;
+      await group.update(fixQuery).exec();
+    }
+
     moveTask(order, task._id, to);
 
     await group.save();


### PR DESCRIPTION
Adds a check in the task move-to-position API route that, if the UUID for the task being moved is missing from the relevant `tasksOrder` array, looks up the tasks for that user/group/challenge and type and adds any missing entries back to the array before performing the requested move.

This should help regenerate sort arrays recently emptied in a bad database operation, and catch other scenarios where potentially a task exists but has no corresponding entry (as sometimes can be spotted using e.g. the Task Adjustor tool). The user experience should be better than the current scenario, where unsorted tasks jump around unpredictably and it's necessary to move every unpaired task individually before the list as a whole starts to behave.