### PR TITLE
Fix avatar circle on private messages so snowmen actually show up (fixes #12941)

### DIFF
--- a/website/client/src/components/faceAvatar.vue
+++ b/website/client/src/components/faceAvatar.vue
@@ -112,7 +112,7 @@ export default {
     },
     visualBuffs () {
       return {
-        snowball: 'snowman',
+        snowball: `avatar_snowball_${this.member.stats.class}`,
         spookySparkles: 'ghost',
         shinySeed: `avatar_floral_${this.member.stats.class}`,
         seafoam: 'seafoam_star',


### PR DESCRIPTION
[//]: # (Note: See https://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #12941 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

When snowmen were changed to include class-specific transformations, the faceAvatar.vue was not updated alongside the other avatar edits so it was still trying to display the older nonspecific snowman and failing to do so.

This makes it so it works the same as avatar.vue and uses the class specific snowman. (Note the snowman now present in the circle below, compared to its non-presence in the image in the issue.)

![The circle in the private message window now shows the snowman transformation as it should](https://user-images.githubusercontent.com/14182450/160668274-6d473228-cff8-4688-b97b-df5220498c61.png)

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----

UUID: 2d6ef231-50b4-4a22-90e7-45eb97147a2c
