### PR TITLE
Removes the Year Sub Menu for Unlocked Background (Fixes Issue #13373)

### DIFF
--- a/website/client/src/components/creatorIntro.vue
+++ b/website/client/src/components/creatorIntro.vue
@@ -159,7 +159,7 @@
           <toggle-switch
             v-model="filterBackgrounds"
             class="backgroundFilterToggle"
-            :label="'Hide locked backgrounds'"
+            :label="'Show Unlocked Backgrounds'"
           />
         </div>
         <div
@@ -247,6 +247,7 @@
           </div>
         </div>
         <sub-menu
+          v-if="!filterBackgrounds"
           class="text-center"
           :items="bgSubMenuItems"
           :active-sub-page="activeSubPage"


### PR DESCRIPTION
[//]: # (Note: See https://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #13373

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
The changes that were made were adding the conditional v-if="!filterBackgrounds" to the submenu so that the years would only show up if the "Show Unlocked Backgrounds" toggle was not toggled.  We also changed the "Hide Locked Background" toggle string to say 
"Show Unlocked Backgrounds" instead

![asdaddsda](https://user-images.githubusercontent.com/43458157/163277051-3c219429-f4de-4264-ae6f-4e5d135391d6.jpg)

<img width="416" alt="adasddddd" src="https://user-images.githubusercontent.com/43458157/163277019-68acf721-be46-4e69-96fe-4a1c16a1a6af.PNG">

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)


----
UUID: b271337f-3964-4e58-92e0-af9cbbeba79a
