### PR TITLE
Change update to updateOne in gdpr-users-delete.js

### DIFF
--- a/scripts/gdpr-delete-users.js
+++ b/scripts/gdpr-delete-users.js
@@ -40,7 +40,7 @@ async function deleteHabiticaData (user, email) {
     'auth.local.passwordHashMethod': 'bcrypt',
   };
   if (!user.auth.local.email) set['auth.local.email'] = `${user._id}@example.com`;
-  await User.update(
+  await User.updateOne(
     { _id: user._id },
     { $set: set },
   );


### PR DESCRIPTION
`update` is being deprecated, so I changed it to `updateOne`. I've done a few GDPR runs with it set to `updateOne` with no problems.

----
UUID: f4e5c6da-0617-48bf-b3bd-9f97636774a8
