### PR TITLE
Don't send delta around as an array when scoring tasks

### DIFF
--- a/website/common/script/ops/scoreTask.js
+++ b/website/common/script/ops/scoreTask.js
@@ -362,5 +362,5 @@ export default function scoreTask (options = {}, req = {}, analytics) {
     checkOnboardingStatus(user, req, analytics);
   }
 
-  return [delta];
+  return delta;
 }

--- a/website/server/libs/tasks/index.js
+++ b/website/server/libs/tasks/index.js
@@ -404,7 +404,7 @@ async function scoreTask (user, task, direction, req, res) {
   const wasCompleted = task.completed;
 
   const firstTask = !user.achievements.completedTask;
-  const [delta] = shared.ops.scoreTask({ task, user, direction }, req, res.analytics);
+  const delta = shared.ops.scoreTask({ task, user, direction }, req, res.analytics);
   // Drop system (don't run on the client,
   // as it would only be discarded since ops are sent to the API, not the results)
   if (direction === 'up' && !firstTask) shared.fns.randomDrop(user, { task, delta }, req, res.analytics);


### PR DESCRIPTION
**Previously,**
When `delta` was calculated during task scoring for Challenge and Group tasks, it was being wrapped in an array, but still added directly to the task value as if it were a number. This caused "cast to number" validation errors on task values and histories.

**Now,**
`delta` is assigned and passed between functions as a numeric value.

**Reviewers** -- do you have any idea why this would have been written as it was? I feel like there was some JavaScript trick being attempted here that I'm not familiar with, ha.