### PR TITLE
Hall of Heroes / Contributors: fix hasPermissions bug, merge Name and User ID columns

### DIFF
--- a/website/client/src/components/hall/heroes.vue
+++ b/website/client/src/components/hall/heroes.vue
@@ -274,7 +274,7 @@
                   />
                 </td>
                 <td
-                  v-if="hasPermission(hero, 'userSupport')"
+                  v-if="hasPermission(user, 'userSupport')"
                   :key="hero._id"
                   class="btn-link"
                 >

--- a/website/client/src/components/hall/heroes.vue
+++ b/website/client/src/components/hall/heroes.vue
@@ -247,9 +247,6 @@
             <thead>
               <tr>
                 <th>{{ $t('name') }}</th>
-                <th v-if="hasPermission(user, 'userSupport')">
-                  {{ $t('userId') }}
-                </th>
                 <th>{{ $t('contribLevel') }}</th>
                 <th>{{ $t('title') }}</th>
                 <th>{{ $t('contributions') }}</th>
@@ -272,18 +269,17 @@
                     v-else
                     :user="hero"
                   />
-                </td>
-                <td
-                  v-if="hasPermission(user, 'userSupport')"
-                  :key="hero._id"
-                  class="btn-link"
-                >
-                  <router-link
-                    :to="{ name: 'adminPanelUser',
-                           params: { userIdentifier: hero._id } }"
-                  >
+                  <span v-if="hasPermission(user, 'userSupport')">
+                    <br>
                     {{ hero._id }}
-                  </router-link>
+                    <br>
+                    <router-link
+                      :to="{ name: 'adminPanelUser',
+                             params: { userIdentifier: hero._id } }"
+                    >
+                      admin panel
+                    </router-link>
+                  </span>
                 </td>
                 <td>{{ hero.contributor.level }}</td>
                 <td>{{ hero.contributor.text }}</td>


### PR DESCRIPTION
This PR makes two changes to the Hall of Contributors.
1. Fixes the recent bug that resulted in non-admin users seeing the User IDs and links to the admin panel for any "hero" that had the `userSupport` permission.
2. Merges the "User ID" column (which only admins see) into the Name column, to allow the other columns to take up more space.

If you just want the bug fix, not the column changes, just merge the first commit 8701a7505a982448780e8037242a815aff4a9eb1 

---

### Before both commits were made:

Admin user sees:
![image](https://user-images.githubusercontent.com/1495809/167292428-92ef87c1-c646-4c82-909d-ba9e848ac0bc.png)

Normal user sees:
![image](https://user-images.githubusercontent.com/1495809/167292463-ffc9414a-6954-4c15-92dc-f39e44a819e9.png)

---

### After just the bug fix commit:

Admin user sees:
![image](https://user-images.githubusercontent.com/1495809/167292484-a1fe0ff3-3eef-4ee4-aacd-076833638208.png)

Normal user sees:
![image](https://user-images.githubusercontent.com/1495809/167292499-6dd6eafb-efa6-4e9e-867e-f63edc0cb184.png)

---

### After both commits:

Admin user sees:
![image](https://user-images.githubusercontent.com/1495809/167292522-ecf088be-ad91-4d21-a9d9-e0fd08278e06.png)

Normal user sees:
![image](https://user-images.githubusercontent.com/1495809/167292563-bf021e35-e1ba-4d06-90d1-2617d9617a8c.png)
