### PR TITLE
Styling Bugfix: 13772

### DIFF
--- a/website/client/src/assets/scss/typography.scss
+++ b/website/client/src/assets/scss/typography.scss
@@ -18,8 +18,10 @@ body {
 // Restore the default styling for a elements without an href attribute
 // that was changed in bootstrap 4.5.1
 a:not([href]), a:not([href]):hover {
-  color: inherit;
-  text-decoration: none;
+  &:not([role=button]) { 
+    color: inherit;
+    text-decoration: none;
+  }
 }
 
 a, a:not([href]):not([tabindex]) {


### PR DESCRIPTION
[//]: # (Note: See https://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #13772 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Added a `:not` selector if the hyperlink has a `role=button`. 
I'm sure this whole piece of code can go away which was added 21 months ago but I'm uncertain if that will break anything I have overlooked. 

<img width="360" alt="image" src="https://user-images.githubusercontent.com/17490821/169583739-5a7d5a16-93a4-40d4-ba91-33dcd9af070b.png">


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: a3e6a11a-9249-4660-ad14-e218b12eca45