### PR TITLE
apidoc: Update "Render a user avatar as an HTML page" as not working

### DIFF
--- a/website/server/controllers/top-level/dataexport.js
+++ b/website/server/controllers/top-level/dataexport.js
@@ -160,6 +160,7 @@ api.exportUserDataXml = {
 /**
  * @api {get} /export/avatar-:uuid.html Render a user avatar as an HTML page
  * @apiName ExportUserAvatarHtml
+ * @apiDescription This HTML export feature is not currently working (https://github.com/HabitRPG/habitica/issues/9489).
  * @apiGroup DataExport
  *
  * @apiParam (Path) {String} uuid The User ID of the user


### PR DESCRIPTION
[//]: # (Note: See https://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #13777

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

- Updated the API docs in habitica/website/server/controllers/top-level/dataexport.js 
- Added an API description under "Render a user avatar as an HTML page" that lets users know that this feature is not working as discussed in #9489

Before Update

![data_export_render_avatar_html_before_update](https://user-images.githubusercontent.com/15676972/172039480-4a50e8ae-e8c9-4245-8625-a64acf155b9d.jpg)


After Update

![data_export_render_avatar_html_after_update](https://user-images.githubusercontent.com/15676972/172039469-b07a4f78-8022-48fa-ad5a-10a172daed23.jpg)


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: dd149105-7688-46c3-ac55-a74689396088