### PR TITLE
feat: prevent user from purchasing a quest if prerequisites are not met

### DIFF
--- a/test/api/v3/integration/user/buy/POST-user_buy_quest.test.js
+++ b/test/api/v3/integration/user/buy/POST-user_buy_quest.test.js
@@ -39,25 +39,38 @@ describe('POST /user/buy-quest/:key', () => {
     }));
   });
 
-  it('returns an error if quest prerequisites are not met', async () => {
-    const key = 'dilatoryDistress2';
+  it('returns an error if not all quest prerequisites are met', async () => {
+    const prerequisites = ['dilatoryDistress1', 'dilatoryDistress2'];
+    const key = 'dilatoryDistress3';
+
+    const achievementName1 = `achievements.quests.${prerequisites[0]}`;
+
+    await user.update({
+      [achievementName1]: true,
+      'stats.gp': 9999,
+    });
 
     await expect(user.post(`/user/buy-quest/${key}`))
       .to.eventually.be.rejected.and.eql({
         code: 401,
         error: 'NotAuthorized',
-        message: t('mustComplete', { quest: 'dilatoryDistress1' }),
+        message: t('mustComplete', { quest: prerequisites[1] }),
       });
   });
 
   it('allows purchase of a quest if prerequisites are met', async () => {
-    const prerequisite = 'dilatoryDistress1';
-    const key = 'dilatoryDistress2';
+    const prerequisites = ['dilatoryDistress1', 'dilatoryDistress2'];
+    const key = 'dilatoryDistress3';
     const item = content.quests[key];
 
-    const achievementName = `achievements.quests.${prerequisite}`;
+    const achievementName1 = `achievements.quests.${prerequisites[0]}`;
+    const achievementName2 = `achievements.quests.${prerequisites[1]}`;
 
-    await user.update({ [achievementName]: true, 'stats.gp': 9999 });
+    await user.update({
+      [achievementName1]: true,
+      [achievementName2]: true,
+      'stats.gp': 9999,
+    });
     const res = await user.post(`/user/buy-quest/${key}`);
     await user.sync();
 

--- a/test/common/ops/buy/buyQuestGold.js
+++ b/test/common/ops/buy/buyQuestGold.js
@@ -162,7 +162,9 @@ describe('shared.ops.buyQuest', () => {
     }
   });
 
-  it('does not buy a quest without completing previous quests', async () => {
+  it('returns error if user has not completed all prerequisite quests', async () => {
+    user.stats.gp = 9999;
+    user.achievements.quests.dilatoryDistress1 = 1;
     try {
       await buyQuest(user, {
         params: {
@@ -174,5 +176,23 @@ describe('shared.ops.buyQuest', () => {
       expect(err.message).to.equal(i18n.t('mustComplete', { quest: 'dilatoryDistress2' }));
       expect(user.items.quests).to.eql({});
     }
+  });
+
+  it('successfully purchases quest if user has completed all prerequisite quests', async () => {
+    user.stats.gp = 500;
+    user.achievements.quests.dilatoryDistress1 = 1;
+    user.achievements.quests.dilatoryDistress2 = 1;
+
+    await buyQuest(user, {
+      params: {
+        key: 'dilatoryDistress3',
+      },
+    }, analytics);
+
+    expect(user.items.quests).to.eql({
+      dilatoryDistress3: 1,
+    });
+    expect(user.stats.gp).to.equal(100);
+    expect(analytics.track).to.be.calledOnce;
   });
 });

--- a/website/common/script/ops/buy/buyQuestGem.js
+++ b/website/common/script/ops/buy/buyQuestGem.js
@@ -42,6 +42,18 @@ export class BuyQuestWithGemOperation extends AbstractGemItemOperation { // esli
     this.canUserPurchase(user, item);
   }
 
+  canUserPurchase (user, item) {
+    if (item && item.prereqQuests) {
+      for (const prereq of item.prereqQuests) {
+        if (!user.achievements.quests[prereq]) {
+          throw new NotAuthorized(this.i18n('mustComplete', { quest: prereq }));
+        }
+      }
+    }
+
+    super.canUserPurchase(user, item);
+  }
+
   async executeChanges (user, item, req) {
     if (
       !user.items.quests[item.key]

--- a/website/common/script/ops/buy/buyQuestGold.js
+++ b/website/common/script/ops/buy/buyQuestGold.js
@@ -46,20 +46,22 @@ export class BuyQuestWithGoldOperation extends AbstractGoldItemOperation { // es
       throw new NotAuthorized(this.i18n('questNotGoldPurchasable', { key }));
     }
 
-    this.checkPrerequisites(user, key);
-
     this.canUserPurchase(user, item);
   }
 
-  checkPrerequisites (user, questKey) {
-    const item = content.quests[questKey];
-    if (questKey === 'lostMasterclasser1' && !this.userAbleToStartMasterClasser(user)) {
+  canUserPurchase (user, item) {
+    if (this.getItemKey() === 'lostMasterclasser1' && !this.userAbleToStartMasterClasser(user)) {
       throw new NotAuthorized(this.i18n('questUnlockLostMasterclasser'));
     }
 
-    if (item && item.previous && !user.achievements.quests[item.previous]) {
-      throw new NotAuthorized(this.i18n('mustComplete', { quest: item.previous }));
+    if (item && item.prereqQuests) {
+      for (const prereq of item.prereqQuests) {
+        if (!user.achievements.quests[prereq]) {
+          throw new NotAuthorized(this.i18n('mustComplete', { quest: prereq }));
+        }
+      }
     }
+    super.canUserPurchase(user, item);
   }
 
   executeChanges (user, item, req) {


### PR DESCRIPTION
[//]: # (Note: See https://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)
I'm a first time contributor. Can an admin please start the automatic test workflow? 🙏 

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #14052

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
- In quest purchase request handlers: check that the user has completed all prerequisite quests, and throws an error if there are any prerequisite quests not in the user's achievements.
- Instead of checking that the previous quest is completed, just check that all prerequisite quests have been completed.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 80b23d68-9bd6-4962-8146-636b20aece8c
