### PR TITLE
Task column help text hidden by tasks

### DIFF
--- a/website/client/src/components/tasks/column.vue
+++ b/website/client/src/components/tasks/column.vue
@@ -1,7 +1,9 @@
 <template>
   <div
+    v-resize="500"
     class="tasks-column"
     :class="type"
+    @resized="setColumnBackgroundVisibility"
   >
     <b-modal ref="editTaskModal" />
     <buy-quest-modal
@@ -354,6 +356,7 @@ import { mapState, mapActions, mapGetters } from '@/libs/store';
 import shopItem from '../shops/shopItem';
 import BuyQuestModal from '@/components/shops/quests/buyQuestModal.vue';
 import PinBadge from '@/components/ui/pinBadge';
+import ResizeDirective from '@/directives/resize.directive';
 
 import notifications from '@/mixins/notifications';
 import { shouldDo } from '@/../../common/script/cron';
@@ -374,6 +377,9 @@ import rewardIcon from '@/assets/svg/reward.svg';
 import { EVENTS } from '@/libs/events';
 
 export default {
+  directives: {
+    resize: ResizeDirective,
+  },
   components: {
     Task,
     ClearCompletedTodos,


### PR DESCRIPTION
Fixes #13542 

### Changes

Checked whether to show column background when a resize event occurs.

It seems that there was logic to hide the help text when the help text was covered by tasks in the past. I thought the problem was that it was only called the first time.

There are other workarounds, but I think this is the way to solve the problem with the fewest changes to the project.
I don't know exactly what the value 150 in setColumnBackgroundVisibility refers to.

If there is something I misunderstood or solved, please feel free to give me feedback.

----
UUID: 1ba464e6-fd6e-4a4c-be54-b66a8ff5001e
