### PR TITLE
Update gear.json

### DIFF
--- a/website/common/locales/en/gear.json
+++ b/website/common/locales/en/gear.json
@@ -2327,6 +2327,8 @@
   "shieldSpecialSummer2022WarriorNotes": "It snaps! It bites! And it never, ever stops! Increases Constitution by <%= con %>. Limited Edition 2022 Summer Gear.",
   "shieldSpecialSummer2022HealerText": "Remedial Ripples",
   "shieldSpecialSummer2022HealerNotes": "Send out restorative magic in gentle ripples through the reef. Increases Constitution by <%= con %>. Limited Edition 2022 Summer Gear.",
+  "shieldSpecialSummer2022RogueText": "Crab Claw",
+  "shieldSpecialSummer2022RogueNotes": "If you're in a pinch, don't hesitate to show these fearsome claws! Increases Strength by <%= str %>. Limited Edition 2022 Summer Gear.",
 
   "shieldMystery201601Text": "Resolution Slayer",
   "shieldMystery201601Notes": "This blade can be used to parry away all distractions. Confers no benefit. January 2016 Subscriber Item.",


### PR DESCRIPTION
[//]: # (Note: See https://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes put_#_and_issue_number_here

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Added shieldSpecialSummer2022RogueText and shieldSpecialSummer2022RogueNotes, based on in-game name & description.

Important note! I took the description for the "Notes" field from the in-game description, but it's identical to the one for the Rogue weapon, down to and including it being a Strength item, not a Constitution item.  I'm not sure whether that's accurate, or if it's just pulling from the weapon description since the shield description isn't available.

(Sorry if I shouldn't have done this without being certain of the correct description, or if I've done this wrong -- last time I reported a bug in gear.json I was encouraged to just do a pull request next time, so this is my first-ever pull request.)

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 6fa2ed29-9913-49c7-a089-2c16f1713a05

[//]: # (Note: See https://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes put_#_and_issue_number_here

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)



[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID:
