### PR TITLE
Grey out skill when insufficient mana fixes #13286

### DIFF
--- a/website/client/src/components/tasks/spells.vue
+++ b/website/client/src/components/tasks/spells.vue
@@ -68,8 +68,8 @@
               </b-popover>
               <div
                 class="spell-border"
-                :class="{ disabled: spellDisabled(key) || user.stats.lvl < skill.lvl
-                  || user.stats.mp < skill.mana }"
+                :class="{ disabled: spellDisabled(key) || user.stats.lvl < skill.lvl,
+                 'insufficient-mana': user.stats.mp < skill.mana }"
               >
                 <div
                   class="spell"
@@ -92,10 +92,7 @@
                     v-else
                     class="mana"
                   >
-                    <div
-                      class="mana-text"
-                      :class="{ insufficient: user.stats.mp < skill.mana }"
-                    >
+                    <div class="mana-text">
                       <div
                         v-once
                         class="svg-icon"
@@ -191,7 +188,7 @@
     border-radius: 4px;
     margin-bottom: 1rem;
 
-    &:hover:not(.disabled) {
+    &:hover:not(.disabled):not(.insufficient-mana) {
       background-color: $purple-400;
       cursor: pointer;
       box-shadow: 0 4px 4px 0 rgba(26, 24, 29, 0.16),
@@ -207,16 +204,15 @@
           background-color: rgba(26, 24, 29, 0.5);
         }
 
-        .insufficient {
-          color: $white;
-          font-weight: normal;
-        }
-
         .level {
           color: $white;
           font-weight: normal;
         }
       }
+    }
+
+    &.insufficient-mana:not(.disabled) {
+      opacity: 0.5;
     }
 
     .spell {

--- a/website/client/src/components/tasks/spells.vue
+++ b/website/client/src/components/tasks/spells.vue
@@ -204,6 +204,10 @@
           background-color: rgba(26, 24, 29, 0.5);
         }
 
+        .mana-text {
+          color: $blue-500;
+        }
+
         .level {
           color: $white;
           font-weight: normal;

--- a/website/client/src/components/tasks/spells.vue
+++ b/website/client/src/components/tasks/spells.vue
@@ -473,7 +473,9 @@ export default {
     skillNotes (skill) {
       let notes = skill.notes();
 
-      if (skill.key === 'frost' && this.spellDisabled(skill.key)) {
+      if (this.user.stats.lvl < skill.lvl) {
+        notes = this.$t('spellLevelTooHigh', { level: skill.lvl });
+      } else if (skill.key === 'frost' && this.spellDisabled(skill.key)) {
         notes = this.$t('spellAlreadyCast');
       } else if (skill.key === 'stealth' && this.spellDisabled(skill.key)) {
         notes = this.$t('spellAlreadyCast');

--- a/website/client/src/components/tasks/spells.vue
+++ b/website/client/src/components/tasks/spells.vue
@@ -69,7 +69,7 @@
               <div
                 class="spell-border"
                 :class="{ disabled: spellDisabled(key) || user.stats.lvl < skill.lvl
-                || user.stats.mp < skill.mana }"
+                  || user.stats.mp < skill.mana }"
               >
                 <div
                   class="spell"
@@ -89,23 +89,13 @@
                     </div>
                   </div>
                   <div
-                    v-else-if="spellDisabled(key) === true"
-                    class="mana"
-                  >
-                    <div class="mana-text">
-                      <div
-                        v-once
-                        class="svg-icon"
-                        v-html="icons.mana"
-                      ></div>
-                      <div>{{ skill.mana }}</div>
-                    </div>
-                  </div>
-                  <div
                     v-else
                     class="mana"
                   >
-                    <div class="mana-text">
+                    <div
+                    class="mana-text"
+                    :class="{ insufficient: user.stats.mp < skill.mana }"
+                    >
                       <div
                         v-once
                         class="svg-icon"
@@ -217,7 +207,7 @@
           background-color: rgba(26, 24, 29, 0.5);
         }
 
-        .mana-text {
+        .insufficient {
           color: $white;
           font-weight: normal;
         }

--- a/website/client/src/components/tasks/spells.vue
+++ b/website/client/src/components/tasks/spells.vue
@@ -93,8 +93,8 @@
                     class="mana"
                   >
                     <div
-                    class="mana-text"
-                    :class="{ insufficient: user.stats.mp < skill.mana }"
+                      class="mana-text"
+                      :class="{ insufficient: user.stats.mp < skill.mana }"
                     >
                       <div
                         v-once

--- a/website/client/src/components/tasks/spells.vue
+++ b/website/client/src/components/tasks/spells.vue
@@ -68,7 +68,8 @@
               </b-popover>
               <div
                 class="spell-border"
-                :class="{ disabled: spellDisabled(key) || user.stats.lvl < skill.lvl }"
+                :class="{ disabled: spellDisabled(key) || user.stats.lvl < skill.lvl
+                || user.stats.mp < skill.mana }"
               >
                 <div
                   class="spell"
@@ -214,6 +215,11 @@
 
         .mana {
           background-color: rgba(26, 24, 29, 0.5);
+        }
+
+        .mana-text {
+          color: $white;
+          font-weight: normal;
         }
 
         .level {


### PR DESCRIPTION
[//]: # (Note: See https://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #13286 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Grey out skills when there is insufficient mana.
Before:
![image](https://user-images.githubusercontent.com/55836477/177036263-c29e1cb4-2338-4725-9708-b4916896ea4e.png)
After when sufficient mana but skill not available:
![image](https://user-images.githubusercontent.com/55836477/177036287-89d125f3-9408-41db-8230-3e30e4b79d31.png)
After when not enough mana:
![image](https://user-images.githubusercontent.com/55836477/177036316-e14803c7-4a29-4cdf-80fe-0be77c1dd8c7.png)


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID:4591b9fd-9f56-4a02-b5f0-411ab0dcda8d
