### PR TITLE
Skills are not greyed out when you don't have enough mana #13286

### DIFF
--- a/website/client/src/components/tasks/spells.vue
+++ b/website/client/src/components/tasks/spells.vue
@@ -37,7 +37,7 @@
               v-for="(skill, key) in spells[user.stats.class]"
               :id="`spell_${skill.key}`"
               :key="key"
-              @click="!spellDisabled(key) ? castStart(skill) : null"
+              @click="!spellDisabled(skill) ? castStart(skill) : null"
               >
               <b-popover
                 :target="`spell_${skill.key}`"

--- a/website/client/src/components/tasks/spells.vue
+++ b/website/client/src/components/tasks/spells.vue
@@ -37,8 +37,8 @@
               v-for="(skill, key) in spells[user.stats.class]"
               :id="`spell_${skill.key}`"
               :key="key"
-              @click="!spellDisabled(key) ? castStart(skill) : null"
-            >
+              @click="!spellDisabled(skill) ? test(key, castStart) : null"
+              >
               <b-popover
                 :target="`spell_${skill.key}`"
                 triggers="hover"
@@ -68,7 +68,7 @@
               </b-popover>
               <div
                 class="spell-border"
-                :class="{ disabled: spellDisabled(key) || user.stats.lvl < skill.lvl }"
+                :class="{ disabled: spellDisabled(skill) || user.stats.lvl < skill.lvl }"
               >
                 <div
                   class="spell"
@@ -88,7 +88,7 @@
                     </div>
                   </div>
                   <div
-                    v-else-if="spellDisabled(key) === true"
+                    v-else-if="spellDisabled(skill) === true"
                     class="mana"
                   >
                     <div class="mana-text">
@@ -468,22 +468,22 @@ export default {
         .filter(daily => !daily.completed && daily.isDue)
         .length;
 
-      if (skill === 'frost' && this.user.stats.buffs.streaks) {
+      if (skill.key === 'frost' && this.user.stats.buffs.streaks) {
         return true;
       }
 
-      if (skill === 'stealth' && this.user.stats.buffs.stealth >= incompleteDailiesDue) {
+      if (skill.key === 'stealth' && this.user.stats.buffs.stealth >= incompleteDailiesDue) {
         return true;
       }
 
-      return false;
+      return (this.user.stats.mp < skill.mana);
     },
     skillNotes (skill) {
       let notes = skill.notes();
 
-      if (skill.key === 'frost' && this.spellDisabled(skill.key)) {
+      if (skill.key === 'frost' && this.spellDisabled(skill)) {
         notes = this.$t('spellAlreadyCast');
-      } else if (skill.key === 'stealth' && this.spellDisabled(skill.key)) {
+      } else if (skill.key === 'stealth' && this.spellDisabled(skill)) {
         notes = this.$t('spellAlreadyCast');
       } else if (skill.key === 'stealth') {
         notes = this.$t('spellRogueStealthDaliesAvoided', {

--- a/website/client/src/components/tasks/spells.vue
+++ b/website/client/src/components/tasks/spells.vue
@@ -37,7 +37,7 @@
               v-for="(skill, key) in spells[user.stats.class]"
               :id="`spell_${skill.key}`"
               :key="key"
-              @click="!spellDisabled(skill) ? test(key, castStart) : null"
+              @click="!spellDisabled(key) ? castStart(skill) : null"
               >
               <b-popover
                 :target="`spell_${skill.key}`"


### PR DESCRIPTION
[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes https://github.com/HabitRPG/habitica/issues/13286

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Everything seems to be there already, but the checking functionality doesn't include the check for user mana level.
In summery what we needed was to know all the spell properties and check if is available. Previously the method was in broken state and doesn't work for its purpose as it described what to do.  

** This is may first pull request so I don't judge me hard. I see this is fixed in another PR but what I see its not completely solved. https://github.com/HabitRPG/habitica/pull/14100  

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 3fc3ecd9-f45a-456b-b79e-281bfcd96adf
