### PR TITLE
Fix prop change handler for guild challenges.

### DIFF
--- a/website/client/src/components/challenges/groupChallenges.vue
+++ b/website/client/src/components/challenges/groupChallenges.vue
@@ -112,10 +112,8 @@ export default {
     },
   },
   watch: {
-    'group._id': {
-      async groupId () {
-        this.loadChallenges();
-      },
+    'group._id': function groupId () {
+      this.loadChallenges();
     },
   },
   mounted () {


### PR DESCRIPTION
Fix props' change handler which is called when guild is changed from
notification.

Tests:

+ Guild challenges updated successfully when guild is changed from
notification center.

[//]: # (Note: See https://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #13891 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)



[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID:
