### PR TITLE
Update docker-compose.dev.yml to prevent error message on first build

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,7 +8,6 @@ services:
       - server
     environment:
       - BASE_URL=http://server:3000
-    image: habitica
     networks:
       - habitica
     ports:
@@ -26,7 +25,6 @@ services:
       - mongo
     environment:
       - NODE_DB_URI=mongodb://mongo/habitrpg
-    image: habitica
     networks:
       - habitica
     ports:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   client:
     build:


### PR DESCRIPTION
### Issue
Error pulling non-existent `habitica` image when first running `docker-compose -f docker-compose.dev.yml up -d`
<img width="2027" alt="Screen Shot 2022-08-20 at 1 46 23 AM" src="https://user-images.githubusercontent.com/8258909/185721551-65072a99-092d-4165-8b20-b54cff0d6f92.png">


### Changes
#### Change 1:
- Remove deprecated top-level element `version`

Reference: https://docs.docker.com/compose/compose-file/#version-top-level-element

> The Compose file is a YAML file defining version (DEPRECATED), services (REQUIRED), networks, volumes, configs and secrets.

> A Compose implementation SHOULD NOT use this version to select an exact schema to validate the Compose file, but prefer the most recent schema at the time it has been designed.


#### Change 2:
- Remove non-existing image `habitica` from `client` and `server` services on `docker-compose.dev.yml`

Reference: https://docs.docker.com/compose/compose-file/#image

> `image` specifies the image to start the container from. Image MUST follow the Open Container Specification addressable image format, as `[<registry>/][<project>/]<image>[:<tag>|@<digest>]`.

> `image` MAY be omitted from a Compose file as long as a build section is declared. Compose implementations without build support MUST fail when image is missing from the Compose file.

----
UUID: 5ee52be5-7f25-433b-ba72-a90ab3792f97
