### PR TITLE
Fix redirect after register issue

### DIFF
--- a/website/client/src/components/auth/registerLoginReset.vue
+++ b/website/client/src/components/auth/registerLoginReset.vue
@@ -757,8 +757,7 @@ export default {
     }, 500),
     sanitizeRedirect (redirect) {
       if (!redirect) return '/';
-      let sanitizedString = DOMPurify.sanitize(redirect).replace(/\\|\/\/|\./g, '');
-      sanitizedString = `/${sanitizedString}`;
+      const sanitizedString = DOMPurify.sanitize(redirect).replace(/\\|\/\/|\./g, '');
       return sanitizedString;
     },
     async register () {


### PR DESCRIPTION
[//]: # (Note: See https://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #14176

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
The description of the issue (#14176) explains the problem very well, so please read that if the following explanation is unclear.

After the sanitization of the redirect part of the URI, a slash was prepended, but the redirect string already started with a slash. This double slash confused this line:

```
window.location.href = redirectTo;
```

It thought the // was the start of the url, similar to https:// is the start of a url I guess.

So I just removed the prepended slash and it works. There is a small but though...
Because when a new user registers, the welcome to Habitica modal is shown (you can see the redirected page blurred in the background) and then you select your appearance and after that step you are redirected to the homepage. 

So the user doesn't end up at the desired page, but at least the app isn't breaking any more.
If you want I can also look into adding a "redirect check" after the welcome modal.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: d100d5d4-0257-46d4-ac05-51ca01f49189
