### PR TITLE
Group category update issue

### DIFF
--- a/test/api/v3/integration/groups/PUT-groups.test.js
+++ b/test/api/v3/integration/groups/PUT-groups.test.js
@@ -75,7 +75,26 @@ describe('PUT /group', () => {
       categories,
     });
 
-    expect(updatedGroup.categories.length).to.eql(0);
+    expect(updatedGroup.categories.length).to.equal(0);
+  });
+
+  it('removes duplicate group categories', async () => {
+    const categories = [
+      {
+        slug: 'newCat',
+        name: 'New Category',
+      },
+      {
+        slug: 'newCat',
+        name: 'New Category',
+      },
+    ];
+
+    const updatedGroup = await leader.put(`/groups/${groupToUpdate._id}`, {
+      categories,
+    });
+
+    expect(updatedGroup.categories.length).to.equal(1);
   });
 
   it('allows an admin to update a guild', async () => {

--- a/test/api/v3/integration/groups/PUT-groups.test.js
+++ b/test/api/v3/integration/groups/PUT-groups.test.js
@@ -11,6 +11,12 @@ describe('PUT /group', () => {
   const groupName = 'Test Public Guild';
   const groupType = 'guild';
   const groupUpdatedName = 'Test Public Guild Updated';
+  const groupCategories = [
+    {
+      slug: 'initialCat',
+      name: 'Initial Category',
+    },
+  ];
 
   beforeEach(async () => {
     const { group, groupLeader, members } = await createAndPopulateGroup({
@@ -18,6 +24,7 @@ describe('PUT /group', () => {
         name: groupName,
         type: groupType,
         privacy: 'public',
+        categories: groupCategories,
       },
       members: 1,
     });
@@ -59,6 +66,16 @@ describe('PUT /group', () => {
 
     expect(updatedGroup.categories[0].slug).to.eql(categories[0].slug);
     expect(updatedGroup.categories[0].name).to.eql(categories[0].name);
+  });
+
+  it('removes the initial group category', async () => {
+    const categories = [];
+
+    const updatedGroup = await leader.put(`/groups/${groupToUpdate._id}`, {
+      categories,
+    });
+
+    expect(updatedGroup.categories.length).to.eql(0);
   });
 
   it('allows an admin to update a guild', async () => {

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -492,7 +492,11 @@ api.updateGroup = {
 
     if (req.body.leader !== user._id && group.hasNotCancelled()) throw new NotAuthorized(res.t('cannotChangeLeaderWithActiveGroupPlan'));
 
-    _.assign(group, _.merge(group.toObject(), Group.sanitizeUpdate(req.body)));
+    _.assign(group, _.mergeWith(group.toObject(), Group.sanitizeUpdate(req.body),
+      (currentValue, updatedValue) => {
+        if (_.isArray(currentValue)) return updatedValue;
+        return undefined;
+      }));
 
     const savedGroup = await group.save();
     const response = await Group.toJSONCleanChat(savedGroup, user);

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -492,11 +492,17 @@ api.updateGroup = {
 
     if (req.body.leader !== user._id && group.hasNotCancelled()) throw new NotAuthorized(res.t('cannotChangeLeaderWithActiveGroupPlan'));
 
-    _.assign(group, _.mergeWith(group.toObject(), Group.sanitizeUpdate(req.body),
-      (currentValue, updatedValue) => {
-        if (_.isArray(currentValue)) return updatedValue;
+    const handleArrays = (currentValue, updatedValue) => {
+      if (!_.isArray(currentValue)) {
         return undefined;
-      }));
+      }
+
+      // Previously, categories could get duplicated. By making the updated category list unique,
+      // the duplication issue is fixed on every group edit
+      return _.uniqBy(updatedValue, 'slug');
+    };
+
+    _.assign(group, _.mergeWith(group.toObject(), Group.sanitizeUpdate(req.body), handleArrays));
 
     const savedGroup = await group.save();
     const response = await Group.toJSONCleanChat(savedGroup, user);


### PR DESCRIPTION
[//]: # (Note: See https://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11162

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
When the categories of a group are updated, the list of all selected categories gets send to the API.
In the group update endpoint the current and the updated group are merged. This works fine for properties like the name. For example:

Current group:
```js
{
  name: "old",
  ...
}
```

Updated group:
```js
{
  name: "new",
  ...
}
```

When these two are merged, the result is:
```js
{
  name: "new",
  ...
}
```

But when merging arrays, the current and updated array are basically concatenated:
Current group:
```js
{
  categories: [
    { name: "a", slug: "a"},
    { name: "b", slug: "b"},
  ],
  ...
}
```

Remove categories a and b and add category c:
```js
{
  categories: [
    { name: "c", slug: "c"},
  ],
  ...
}
```

Result after merge:
```js
{
  categories: [
    { name: "a", slug: "a"},
    { name: "b", slug: "b"},
    { name: "c", slug: "c"},
  ],
  ...
}
```

Another thing that was happening, was that the categories duplicated even when you didn't change them. That was because when saving, every category object gets and _id property. So, the merge function doesn't see `{ name: "a", slug: "a"}` as the same as `{ _id: 123456, name: "a", slug: "b"}`.

#### Solution
To solve this problem I changed the lodash merge function to mergeWith. This function takes another function to customize the merge. In this case I check for arrays, if an array is found, the updated array is returned instead of a merge of the current and updated array. If no array is found, it returns undefined, which means to merge in the default manner.

I also changed `PUT-groups.test.js` to include an initial category in the beforeEach and I added a test to remove that initial category. 

### EDIT
To make sure previously duplicated categories get cleaned up on every edit of a group, I make sure the list of updated categories is unique, by slug, with the lodash.uniqBy function. 

Also added a test for this: 'removes duplicate group categories'.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: d100d5d4-0257-46d4-ac05-51ca01f49189
