### PR TITLE
improve transactions logs + split createSubscription

### DIFF
--- a/test/api/unit/libs/payments/payments.test.js
+++ b/test/api/unit/libs/payments/payments.test.js
@@ -11,10 +11,15 @@ import {
   generateGroup,
 } from '../../../../helpers/api-unit.helper';
 import * as worldState from '../../../../../website/server/libs/worldState';
+import { model as Group } from '../../../../../website/server/models/group';
+import * as Tasks from '../../../../../website/server/models/task';
+import { TransactionModel as Transaction, TransactionModel } from '../../../../../website/server/models/transaction';
 
 describe('payments/index', () => {
-  let user; let group; let data; let
-    plan;
+  let user;
+  let group;
+  let data;
+  let plan;
 
   beforeEach(async () => {
     user = new User();
@@ -102,6 +107,23 @@ describe('payments/index', () => {
         await api.createSubscription(data);
 
         expect(recipient.purchased.plan.extraMonths).to.eql(3);
+      });
+
+      it('add a transaction entry to the recipient', async () => {
+        recipient.purchased.plan = plan;
+
+        expect(recipient.purchased.plan.extraMonths).to.eql(0);
+
+        await api.createSubscription(data);
+
+        expect(recipient.purchased.plan.extraMonths).to.eql(3);
+
+        const transactions = await TransactionModel
+          .find({ userId: recipient._id })
+          .sort({ createdAt: -1 })
+          .exec();
+
+        expect(transactions).to.have.lengthOf(1);
       });
 
       it('does not set negative extraMonths if plan has past dateTerminated date', async () => {

--- a/test/api/unit/libs/payments/payments.test.js
+++ b/test/api/unit/libs/payments/payments.test.js
@@ -11,9 +11,7 @@ import {
   generateGroup,
 } from '../../../../helpers/api-unit.helper';
 import * as worldState from '../../../../../website/server/libs/worldState';
-import { model as Group } from '../../../../../website/server/models/group';
-import * as Tasks from '../../../../../website/server/models/task';
-import { TransactionModel as Transaction, TransactionModel } from '../../../../../website/server/models/transaction';
+import { TransactionModel } from '../../../../../website/server/models/transaction';
 
 describe('payments/index', () => {
   let user;

--- a/website/server/controllers/api-v3/hall.js
+++ b/website/server/controllers/api-v3/hall.js
@@ -279,11 +279,16 @@ api.updateHero = {
       }
       if (updateData.purchased.plan.consecutive) {
         if (updateData.purchased.plan.consecutive.trinkets) {
-          await hero.updateHourglasses(
-            updateData.purchased.plan.consecutive.trinkets
-              - hero.purchased.plan.consecutive.trinkets,
-            'admin_update_hourglasses', '', 'Updated by Habitica staff',
-          );
+          const changedHourglassTrinkets = updateData.purchased.plan.consecutive.trinkets
+              - hero.purchased.plan.consecutive.trinkets;
+
+          if (changedHourglassTrinkets !== 0) {
+            await hero.updateHourglasses(
+              changedHourglassTrinkets,
+              'admin_update_hourglasses', '', 'Updated by Habitica staff',
+            );
+          }
+
           hero.purchased.plan.consecutive.trinkets = updateData.purchased.plan.consecutive.trinkets;
         }
         if (updateData.purchased.plan.consecutive.gemCapExtra) {

--- a/website/server/libs/payments/constants.js
+++ b/website/server/libs/payments/constants.js
@@ -1,0 +1,7 @@
+export const paymentConstants = {
+  UNLIMITED_CUSTOMER_ID: 'habitrpg', // Users with the customerId have an unlimted free subscription
+  GROUP_PLAN_CUSTOMER_ID: 'group-plan',
+  GROUP_PLAN_PAYMENT_METHOD: 'Group Plan',
+  GOOGLE_PAYMENT_METHOD: 'Google',
+  IOS_PAYMENT_METHOD: 'Apple',
+};

--- a/website/server/libs/payments/groupPayments.js
+++ b/website/server/libs/payments/groupPayments.js
@@ -12,6 +12,8 @@ import { // eslint-disable-line import/no-cycle
   getUserInfo,
   sendTxn as txnEmail,
 } from '../email';
+import { paymentConstants } from './constants';
+import { createSubscription } from './subscriptions';
 
 const TECH_ASSISTANCE_EMAIL = nconf.get('EMAILS_TECH_ASSISTANCE_EMAIL');
 const JOINED_GROUP_PLAN = 'joined group plan';
@@ -37,7 +39,7 @@ async function addSubscriptionToGroupUsers (group) {
     members = await User.find({ 'party._id': group._id }).select('_id purchased items auth profile.name notifications').exec();
   }
 
-  const promises = members.map(member => this.addSubToGroupUser(member, group));
+  const promises = members.map(member => addSubToGroupUser(member, group));
 
   await Promise.all(promises);
 }
@@ -63,12 +65,12 @@ async function addSubToGroupUser (member, group) {
   // When changing customerIdsToIgnore or paymentMethodsToIgnore, the code blocks below for
   // the `group-member-join` email template will probably need to be changed.
   const customerIdsToIgnore = [
-    this.constants.GROUP_PLAN_CUSTOMER_ID,
-    this.constants.UNLIMITED_CUSTOMER_ID,
+    paymentConstants.GROUP_PLAN_CUSTOMER_ID,
+    paymentConstants.UNLIMITED_CUSTOMER_ID,
   ];
   const paymentMethodsToIgnore = [
-    this.constants.GOOGLE_PAYMENT_METHOD,
-    this.constants.IOS_PAYMENT_METHOD,
+    paymentConstants.GOOGLE_PAYMENT_METHOD,
+    paymentConstants.IOS_PAYMENT_METHOD,
   ];
   let previousSubscriptionType = EMAIL_TEMPLATE_SUBSCRIPTION_TYPE_NONE;
   const leader = await User.findById(group.leader).exec();
@@ -104,7 +106,7 @@ async function addSubToGroupUser (member, group) {
   const memberPlan = member.purchased.plan;
   if (member.isSubscribed()) {
     const customerHasCancelledGroupPlan = (
-      memberPlan.customerId === this.constants.GROUP_PLAN_CUSTOMER_ID
+      memberPlan.customerId === paymentConstants.GROUP_PLAN_CUSTOMER_ID
       && !member.hasNotCancelled()
     );
     const ignorePaymentPlan = paymentMethodsToIgnore.indexOf(memberPlan.paymentMethod) !== -1;
@@ -127,13 +129,13 @@ async function addSubToGroupUser (member, group) {
     if ((ignorePaymentPlan || ignoreCustomerId) && !customerHasCancelledGroupPlan) {
       // member has been added to group plan but their subscription will not be changed
       // automatically so they need a special message in the email
-      if (memberPlan.paymentMethod === this.constants.GOOGLE_PAYMENT_METHOD) {
+      if (memberPlan.paymentMethod === paymentConstants.GOOGLE_PAYMENT_METHOD) {
         previousSubscriptionType = EMAIL_TEMPLATE_SUBSCRIPTION_TYPE_GOOGLE;
-      } else if (memberPlan.paymentMethod === this.constants.IOS_PAYMENT_METHOD) {
+      } else if (memberPlan.paymentMethod === paymentConstants.IOS_PAYMENT_METHOD) {
         previousSubscriptionType = EMAIL_TEMPLATE_SUBSCRIPTION_TYPE_IOS;
-      } else if (memberPlan.customerId === this.constants.UNLIMITED_CUSTOMER_ID) {
+      } else if (memberPlan.customerId === paymentConstants.UNLIMITED_CUSTOMER_ID) {
         previousSubscriptionType = EMAIL_TEMPLATE_SUBSCRIPTION_TYPE_LIFETIME_FREE;
-      } else if (memberPlan.customerId === this.constants.GROUP_PLAN_CUSTOMER_ID) {
+      } else if (memberPlan.customerId === paymentConstants.GROUP_PLAN_CUSTOMER_ID) {
         previousSubscriptionType = EMAIL_TEMPLATE_SUBSCRIPTION_TYPE_GROUP_PLAN;
       } else {
         // this triggers a generic message in the email template in case we forget
@@ -183,7 +185,7 @@ async function addSubToGroupUser (member, group) {
   member.markModified('items.mounts');
 
   data.user = member;
-  await this.createSubscription(data);
+  await createSubscription(data);
 
   txnEmail(data.user, 'group-member-join', [
     { name: 'LEADER', content: leader.profile.name },
@@ -207,13 +209,13 @@ async function cancelGroupUsersSubscription (group) {
     members = await User.find({ 'party._id': group._id }).select('_id guilds purchased').exec();
   }
 
-  const promises = members.map(member => this.cancelGroupSubscriptionForUser(member, group));
+  const promises = members.map(member => cancelGroupSubscriptionForUser(member, group));
 
   await Promise.all(promises);
 }
 
 async function cancelGroupSubscriptionForUser (user, group, userWasRemoved = false) {
-  if (user.purchased.plan.customerId !== this.constants.GROUP_PLAN_CUSTOMER_ID) return;
+  if (user.purchased.plan.customerId !== paymentConstants.GROUP_PLAN_CUSTOMER_ID) return;
 
   const userGroups = user.guilds.toObject();
   if (user.party._id) userGroups.push(user.party._id);
@@ -241,7 +243,7 @@ async function cancelGroupSubscriptionForUser (user, group, userWasRemoved = fal
       { name: 'LEADER', content: leader.profile.name },
       { name: 'GROUP_NAME', content: group.name },
     ]);
-    await this.cancelSubscription({ user });
+    await cancelSubscription({ user });
   }
 }
 

--- a/website/server/libs/payments/groupPayments.js
+++ b/website/server/libs/payments/groupPayments.js
@@ -15,7 +15,6 @@ import { // eslint-disable-line import/no-cycle
   sendTxn as txnEmail,
 } from '../email';
 import { paymentConstants } from './constants';
-// eslint-disable-line import/no-cycle
 import { cancelSubscription, createSubscription } from './subscriptions'; // eslint-disable-line import/no-cycle
 
 const TECH_ASSISTANCE_EMAIL = nconf.get('EMAILS_TECH_ASSISTANCE_EMAIL');

--- a/website/server/libs/payments/groupPayments.js
+++ b/website/server/libs/payments/groupPayments.js
@@ -1,3 +1,5 @@
+// TODO these files need to refactored.
+
 import nconf from 'nconf';
 import _ from 'lodash';
 import moment from 'moment';
@@ -13,7 +15,8 @@ import { // eslint-disable-line import/no-cycle
   sendTxn as txnEmail,
 } from '../email';
 import { paymentConstants } from './constants';
-import { createSubscription } from './subscriptions';
+// eslint-disable-line import/no-cycle
+import { cancelSubscription, createSubscription } from './subscriptions'; // eslint-disable-line import/no-cycle
 
 const TECH_ASSISTANCE_EMAIL = nconf.get('EMAILS_TECH_ASSISTANCE_EMAIL');
 const JOINED_GROUP_PLAN = 'joined group plan';
@@ -39,6 +42,7 @@ async function addSubscriptionToGroupUsers (group) {
     members = await User.find({ 'party._id': group._id }).select('_id purchased items auth profile.name notifications').exec();
   }
 
+  // eslint-disable-next-line no-use-before-define
   const promises = members.map(member => addSubToGroupUser(member, group));
 
   await Promise.all(promises);
@@ -209,6 +213,7 @@ async function cancelGroupUsersSubscription (group) {
     members = await User.find({ 'party._id': group._id }).select('_id guilds purchased').exec();
   }
 
+  // eslint-disable-next-line no-use-before-define
   const promises = members.map(member => cancelGroupSubscriptionForUser(member, group));
 
   await Promise.all(promises);

--- a/website/server/libs/payments/payments.js
+++ b/website/server/libs/payments/payments.js
@@ -11,16 +11,11 @@ import { // eslint-disable-line import/no-cycle
 import { // eslint-disable-line import/no-cycle
   buyGems,
 } from './gems';
+import { paymentConstants } from './constants';
 
 const api = {};
 
-api.constants = {
-  UNLIMITED_CUSTOMER_ID: 'habitrpg', // Users with the customerId have an unlimted free subscription
-  GROUP_PLAN_CUSTOMER_ID: 'group-plan',
-  GROUP_PLAN_PAYMENT_METHOD: 'Group Plan',
-  GOOGLE_PAYMENT_METHOD: 'Google',
-  IOS_PAYMENT_METHOD: 'Apple',
-};
+api.constants = paymentConstants;
 
 api.addSubscriptionToGroupUsers = addSubscriptionToGroupUsers;
 

--- a/website/server/libs/payments/subscriptions.js
+++ b/website/server/libs/payments/subscriptions.js
@@ -1,3 +1,5 @@
+// TODO these files need to refactored.
+
 import _ from 'lodash';
 import moment from 'moment';
 
@@ -18,7 +20,7 @@ import {
 import shared from '../../../common';
 import { sendNotification as sendPushNotification } from '../pushNotifications'; // eslint-disable-line import/no-cycle
 import calculateSubscriptionTerminationDate from './calculateSubscriptionTerminationDate';
-import { getCurrentEventList } from '../worldState';
+import { getCurrentEventList } from '../worldState'; // eslint-disable-line import/no-cycle
 import { paymentConstants } from './constants';
 import { addSubscriptionToGroupUsers, cancelGroupUsersSubscription } from './groupPayments'; // eslint-disable-line import/no-cycle
 

--- a/website/server/libs/payments/subscriptions.js
+++ b/website/server/libs/payments/subscriptions.js
@@ -187,11 +187,10 @@ async function prepareSubscriptionValues (data) {
     autoRenews,
     group,
     groupId,
-     itemPurchased,
+    itemPurchased,
     purchaseType,
     emailType,
-    recipientIsSubscribed,
-  }
+  };
 }
 
 async function createSubscription (data) {
@@ -206,7 +205,6 @@ async function createSubscription (data) {
     itemPurchased,
     purchaseType,
     emailType,
-    recipientIsSubscribed
   } = await prepareSubscriptionValues(data);
 
   // Block sub perks
@@ -408,7 +406,9 @@ async function cancelSubscription (data) {
     await data.user.save();
   }
 
-  if (sendEmail) txnEmail(data.user, emailType, emailMergeData);
+  if (sendEmail) {
+    txnEmail(data.user, emailType, emailMergeData);
+  }
 
   if (group) {
     cancelType = 'group-unsubscribe';


### PR DESCRIPTION
This fixes the following issues:

*    If an admin uses the 'Reset cron to yesterday' button in the timestamps section of admin panel, this will add a +0 Hourglasses event to the transaction log of the user they reset.
*    If account X gifts a sub that rewards Hourglasses(ie 3-month sub) to account Y, then the awarded Hourglass is recorded on account X's log (the gifter). Account Y shows no record of receiving that Hourglass.

