### PR TITLE
Change Wikia to Fandom

### DIFF
--- a/website/common/locales/en/front.json
+++ b/website/common/locales/en/front.json
@@ -55,7 +55,7 @@
   "mobileAndroid": "Android App",
   "mobileIOS": "iOS App",
   "oldNews": "News",
-  "newsArchive": "News archive on Wikia (multilingual)",
+  "newsArchive": "News archive on Fandom (multilingual)",
   "setNewPass": "Set New Password",
   "password": "Password",
   "playButton": "Play",


### PR DESCRIPTION
### Changes
**Previously**, the Bailey screen linked to the wiki, mentioning it as "Wikia".
**This change** updates the name to Fandom.

*Note*: I sent an email to admin@habitica.com about this and it was "passed on". As this is trivial, I've created a PR without an issue being created. Hope this is okay.

----
UUID: 3886a1de-c1bb-487e-ac81-8f3565d0728b
