### PR TITLE
add  prop to task-wrapper so that the cursor remains consistent

### DIFF
--- a/website/client/src/components/tasks/task.vue
+++ b/website/client/src/components/tasks/task.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="task-wrapper">
+  <div class="task-wrapper" draggable>
     <div
       class="task transition"
       :class="[{


### PR DESCRIPTION
[//]: # (Note: See https://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #12936

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary) 
Added the `draggable` property onto `task-wrapper` class. This addresses a consistency issue where the property was being added after interacting with the draggable elements which added a `grab` or `move` styled cursor on hover. 

This way, the styled cursor will be used regardless of if the task has been interacted with. Previously, mousing over the sidebar of a task would just show the default pointer cursor.



[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API) 

----
UUID: 2d02f021-be7b-4be4-b20e-3488a00336c8
