### PR TITLE
Fix Stable A-Z sort Show More Functionality

### DIFF
--- a/website/client/src/components/inventory/stable/index.vue
+++ b/website/client/src/components/inventory/stable/index.vue
@@ -787,18 +787,15 @@ export default {
       if (sortBy === 'sortByColor') {
         groupKey = 'potionKey';
       } else if (sortBy === 'AZ') {
-        groupKey = '';
+        groupKey = i => i.eggName[0];
       } else if (sortBy === 'sortByHatchable') {
         groupKey = i => (i.isHatchable() ? 0 : 1);
       }
       const groupedPets = groupBy(pets, groupKey);
 
       // Pets are rendered as grouped "rows". Count helps decide if show more button is necessary.
-      if (sortBy === 'AZ') {
-        this.petRowCount[animalGroup.key] = 1;
-      } else {
-        this.petRowCount[animalGroup.key] = Object.keys(groupedPets).length;
-      }
+      this.petRowCount[animalGroup.key] = Object.keys(groupedPets).length;
+
       return groupedPets;
     },
     mounts (animalGroup, hideMissing, sortBy, searchText) {
@@ -814,14 +811,12 @@ export default {
       if (sortBy === 'sortByColor') {
         groupKey = 'potionKey';
       } else if (sortBy === 'AZ') {
-        groupKey = '';
+        groupKey = i => i.eggName[0];
       }
       const groupedMounts = groupBy(mounts, groupKey);
-      if (sortBy === 'AZ') {
-        this.mountRowCount[animalGroup.key] = 1;
-      } else {
-        this.mountRowCount[animalGroup.key] = Object.keys(groupedMounts).length;
-      }
+
+      this.mountRowCount[animalGroup.key] = Object.keys(groupedMounts).length;
+
       return groupedMounts;
     },
     // Actions


### PR DESCRIPTION
Previously the A-Z sortBy option when viewing pets in the Stable did not use a grouping. This caused all of the items to be displayed without the normal "Show More/Show Less" UX. 

[//]: # (Note: See https://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #9477 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Now grouping the stable A-Z sortBy option by first letter so that Show More functionality works like the other sort types


![image](https://user-images.githubusercontent.com/8363569/197323458-b7d8676e-2ed3-4dd9-9671-5718f319f242.png)


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 2d02f021-be7b-4be4-b20e-3488a00336c8
