### PR TITLE
added validation for blocked users when inviting to groups by username

### DIFF
--- a/test/api/v3/integration/groups/POST-groups_invite.test.js
+++ b/test/api/v3/integration/groups/POST-groups_invite.test.js
@@ -48,6 +48,19 @@ describe('Post /groups/:groupId/invite', () => {
         });
     });
 
+    it('returns error when recipient has blocked the senders', async () => {
+      const inviterNoBlocks = await inviter.update({ 'inbox.blocks': [] });
+      const userWithBlockedInviter = await generateUser({ 'inbox.blocks': [inviter._id] });
+      await expect(inviterNoBlocks.post(`/groups/${group._id}/invite`, {
+        usernames: [userWithBlockedInviter.auth.local.lowerCaseUsername],
+      }))
+        .to.eventually.be.rejected.and.eql({
+          code: 401,
+          error: 'NotAuthorized',
+          message: t('notAuthorizedToSendMessageToThisUser'),
+        });
+    });
+
     it('invites a user to a group by username', async () => {
       const userToInvite = await generateUser();
 

--- a/website/server/libs/invites/index.js
+++ b/website/server/libs/invites/index.js
@@ -207,6 +207,13 @@ async function inviteByUserName (username, group, inviter, req, res) {
     throw new BadRequest(res.t('cannotInviteSelfToGroup'));
   }
 
+  const objections = inviter.getObjectionsToInteraction('group-invitation', userToInvite);
+  if (objections.length > 0) {
+    throw new NotAuthorized(res.t(
+      objections[0],
+      { userId: userToInvite._id, username: userToInvite.profile.name },
+    ));
+  }
   return addInvitationToUser(userToInvite, group, inviter, res);
 }
 


### PR DESCRIPTION
[//]: # (Note: See https://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)



[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #8190 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Currently, it's still possible for a user to be invited to a group by another user they have blocked. This adds the same validation we have for the other invite methods to the username invite code path.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID:  2d02f021-be7b-4be4-b20e-3488a00336c8
