### PR TITLE
change currency to gold if the gear is owned

### DIFF
--- a/website/common/script/libs/shops.js
+++ b/website/common/script/libs/shops.js
@@ -419,6 +419,11 @@ shops.getSeasonalGearBySet = function getSeasonalGearBySet (
     const itemInfo = getItemInfo(null, currentSet ? 'marketGear' : 'gear', gear, officialPinnedItems, language);
     itemInfo.locked = currentSet && user.stats.class !== gear.specialClass;
 
+    // gear that has previously been owned should be repurchaseable with gold
+    if (user.items.gear.owned[gear.key] !== undefined) {
+      itemInfo.currency = "gold";
+    }
+
     return itemInfo;
   });
 };

--- a/website/common/script/libs/shops.js
+++ b/website/common/script/libs/shops.js
@@ -421,7 +421,7 @@ shops.getSeasonalGearBySet = function getSeasonalGearBySet (
 
     // gear that has previously been owned should be repurchaseable with gold
     if (user.items.gear.owned[gear.key] !== undefined) {
-      itemInfo.currency = "gold";
+      itemInfo.currency = 'gold';
     }
 
     return itemInfo;


### PR DESCRIPTION
[//]: # (Note: See https://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #13923 

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Added an ownership check when fetching seasonal items and change currency to gold if so. This will prevent items from having to be repurchased for gems if they had previously owned and lost them.


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 2d02f021-be7b-4be4-b20e-3488a00336c8
