### PR TITLE
Fix double subscriptions, second attempt

### DIFF
--- a/test/api/unit/libs/payments/apple.test.js
+++ b/test/api/unit/libs/payments/apple.test.js
@@ -326,9 +326,12 @@ describe('Apple Payments', () => {
     it('errors when a user is already subscribed', async () => {
       payments.createSubscription.restore();
       user = new User();
+      user.purchased.plan.dateUpdated = moment().subtract(1, 'hours').toDate();
       await user.save();
 
       await applePayments.subscribe(sku, user, receipt, headers, nextPaymentProcessing);
+      user.purchased.plan.dateUpdated = moment().subtract(1, 'hours').toDate();
+      await user.save();
 
       await expect(applePayments.subscribe(sku, user, receipt, headers, nextPaymentProcessing))
         .to.eventually.be.rejected.and.to.eql({

--- a/test/api/unit/libs/payments/payments.test.js
+++ b/test/api/unit/libs/payments/payments.test.js
@@ -376,6 +376,7 @@ describe('payments/index', () => {
         user.purchased.plan = plan;
         user.purchased.plan.dateTerminated = moment(new Date()).add(2, 'months');
         expect(user.purchased.plan.extraMonths).to.eql(0);
+        data.user.purchased.plan.dateUpdated = moment().subtract(1, 'hours').toDate();
 
         await api.createSubscription(data);
 
@@ -386,6 +387,7 @@ describe('payments/index', () => {
         user.purchased.plan = plan;
         user.purchased.plan.dateTerminated = moment(new Date()).subtract(2, 'months');
         expect(user.purchased.plan.extraMonths).to.eql(0);
+        data.user.purchased.plan.dateUpdated = moment().subtract(1, 'hours').toDate();
 
         await api.createSubscription(data);
 
@@ -395,6 +397,7 @@ describe('payments/index', () => {
       it('does not reset Gold-to-Gems cap on additional subscription', async () => {
         user.purchased.plan = plan;
         user.purchased.plan.gemsBought = 10;
+        data.user.purchased.plan.dateUpdated = moment().subtract(1, 'hours').toDate();
 
         await api.createSubscription(data);
 
@@ -486,6 +489,7 @@ describe('payments/index', () => {
         data.sub.key = 'basic_12mo';
 
         await api.createSubscription(data);
+        data.user.purchased.plan.dateUpdated = moment().subtract(1, 'hours').toDate();
         await api.createSubscription(data);
 
         expect(user.purchased.plan.consecutive.gemCapExtra).to.eql(25);

--- a/test/api/unit/libs/payments/payments.test.js
+++ b/test/api/unit/libs/payments/payments.test.js
@@ -350,6 +350,10 @@ describe('payments/index', () => {
     });
 
     context('Purchasing a subscription for self', () => {
+      beforeEach(() => {
+        data.user.purchased.plan.dateUpdated = moment().subtract(1, 'hours').toDate();
+      });
+
       it('creates a subscription', async () => {
         expect(user.purchased.plan.planId).to.not.exist;
 
@@ -451,6 +455,10 @@ describe('payments/index', () => {
     });
 
     context('Block subscription perks', () => {
+      beforeEach(() => {
+        data.user.purchased.plan.dateUpdated = moment().subtract(1, 'hours').toDate();
+      });
+
       it('adds block months to plan.consecutive.offset', async () => {
         await api.createSubscription(data);
 

--- a/test/api/unit/libs/payments/payments.test.js
+++ b/test/api/unit/libs/payments/payments.test.js
@@ -536,6 +536,7 @@ describe('payments/index', () => {
           now: mayMysteryItemTimeframe,
           toFake: ['Date'],
         });
+        data.user.purchased.plan.dateUpdated = moment().subtract(1, 'hours').toDate();
       });
 
       afterEach(() => {

--- a/website/server/libs/payments/subscriptions.js
+++ b/website/server/libs/payments/subscriptions.js
@@ -81,7 +81,7 @@ async function createSubscription (data) {
   let recipientIsSubscribed = recipient.isSubscribed();
 
   if (data.user && !data.gift && !data.groupId && data.customerId !== 'group-plan') {
-    if (moment().diff(data.user.purchased.plan.dateUpdated, 'minutes' < 3)) {
+    if (moment().diff(data.user.purchased.plan.dateUpdated, 'minutes') < 3) {
       throw new TooManyRequests('Subscription already processed, likely duplicate request');
     }
   }

--- a/website/server/libs/payments/subscriptions.js
+++ b/website/server/libs/payments/subscriptions.js
@@ -15,6 +15,7 @@ import { model as User } from '../../models/user'; // eslint-disable-line import
 import {
   NotAuthorized,
   NotFound,
+  TooManyRequests,
 } from '../errors';
 import shared from '../../../common';
 import { sendNotification as sendPushNotification } from '../pushNotifications'; // eslint-disable-line import/no-cycle
@@ -81,18 +82,8 @@ async function createSubscription (data) {
   let recipientIsSubscribed = recipient.isSubscribed();
 
   if (data.user && !data.gift && !data.groupId) {
-    const unlockedUser = await User.findOneAndUpdate(
-      {
-        _id: data.user._id,
-        $or: [
-          { _subSignature: 'NOT_RUNNING' },
-          { _subSignature: { $exists: false } },
-        ],
-      },
-      { $set: { _subSignature: 'SUB_IN_PROGRESS' } },
-    );
-    if (!unlockedUser) {
-      throw new NotFound('User not found or subscription already processing.');
+    if (moment().diff(data.user.purchased.plan.dateUpdated, 'minutes' < 3)) {
+      throw new TooManyRequests('Subscription already processed, likely duplicate request');
     }
   }
 
@@ -299,6 +290,10 @@ async function createSubscription (data) {
     }
   }
 
+  if (group) await group.save();
+  if (data.user && data.user.isModified()) await data.user.save();
+  if (data.gift) await data.gift.member.save();
+
   slack.sendSubscriptionNotification({
     buyer: {
       id: data.user._id,
@@ -315,24 +310,6 @@ async function createSubscription (data) {
     groupId,
     autoRenews,
   });
-
-  if (group) {
-    await group.save();
-  }
-  if (data.user) {
-    if (data.user.isModified()) {
-      await data.user.save();
-    }
-    if (!data.gift && !data.groupId) {
-      await User.findOneAndUpdate(
-        { _id: data.user._id },
-        { $set: { _subSignature: 'NOT_RUNNING' } },
-      );
-    }
-  }
-  if (data.gift) {
-    await data.gift.member.save();
-  }
 }
 
 // Cancels a subscription or group plan, setting termination to happen later

--- a/website/server/libs/payments/subscriptions.js
+++ b/website/server/libs/payments/subscriptions.js
@@ -11,7 +11,6 @@ import { // eslint-disable-line import/no-cycle
   model as Group,
   basicFields as basicGroupFields,
 } from '../../models/group';
-import { model as User } from '../../models/user'; // eslint-disable-line import/no-cycle
 import {
   NotAuthorized,
   NotFound,

--- a/website/server/libs/payments/subscriptions.js
+++ b/website/server/libs/payments/subscriptions.js
@@ -80,7 +80,7 @@ async function createSubscription (data) {
   let emailType = 'subscription-begins';
   let recipientIsSubscribed = recipient.isSubscribed();
 
-  if (data.user && !data.gift && !data.groupId) {
+  if (data.user && !data.gift && !data.groupId && data.customerId !== 'group-plan') {
     if (moment().diff(data.user.purchased.plan.dateUpdated, 'minutes' < 3)) {
       throw new TooManyRequests('Subscription already processed, likely duplicate request');
     }


### PR DESCRIPTION
Reverts #14267 and replaces it with timing-based logic in a new attempt to catch our issue with Google Play subscriptions processing twice.

Is "less than 3 minutes" reasonable, you think?