### PR TITLE
Add support for getting chat limit from database

### DIFF
--- a/website/server/libs/chat/group-chat.js
+++ b/website/server/libs/chat/group-chat.js
@@ -10,7 +10,12 @@ const questScrolls = shared.content.quests;
 
 // @TODO: Don't use this method when the group can be saved.
 export async function getGroupChat (group) {
-  const maxChatCount = (group.chatLimitCount && group.chatLimitCount >= MAX_CHAT_COUNT) ? group.chatLimitCount : (group.hasActiveGroupPlan() ? MAX_SUBBED_GROUP_CHAT_COUNT : MAX_CHAT_COUNT);
+  let maxChatCount = MAX_CHAT_COUNT;
+  if (group.chatLimitCount && group.chatLimitCount >= MAX_CHAT_COUNT) {
+    maxChatCount = group.chatLimitCount;
+  } else if (group.hasActiveGroupPlan()) {
+    maxChatCount = MAX_SUBBED_GROUP_CHAT_COUNT;
+  }
 
   const groupChat = await Chat.find({ groupId: group._id })
     .limit(maxChatCount)

--- a/website/server/libs/chat/group-chat.js
+++ b/website/server/libs/chat/group-chat.js
@@ -10,7 +10,7 @@ const questScrolls = shared.content.quests;
 
 // @TODO: Don't use this method when the group can be saved.
 export async function getGroupChat (group) {
-  const maxChatCount = group.hasActiveGroupPlan() ? MAX_SUBBED_GROUP_CHAT_COUNT : MAX_CHAT_COUNT;
+  const maxChatCount = (group.chatLimitCount && group.chatLimitCount >= MAX_CHAT_COUNT) ? group.chatLimitCount : (group.hasActiveGroupPlan() ? MAX_SUBBED_GROUP_CHAT_COUNT : MAX_CHAT_COUNT);
 
   const groupChat = await Chat.find({ groupId: group._id })
     .limit(maxChatCount)

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -91,6 +91,7 @@ export const schema = new Schema({
   },
   memberCount: { $type: Number, default: 1 },
   challengeCount: { $type: Number, default: 0 },
+  chatLimitCount: { $type: Number },
   balance: { $type: Number, default: 0 },
   logo: String,
   leaderMessage: String,


### PR DESCRIPTION
Smal change. Adds a new optional field to groups to store the number of chat messages it should load. If that number is not set, it falls back to the old behavior. The new field is not exposed in a UI anywhere currently.