### PR TITLE
Remove quest-rewarded gear from pinned items, fixes #11501

### DIFF
--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -871,6 +871,7 @@ function _getUserUpdateForQuestReward (itemToAward, allAwardedItems) {
   let updates = {
     $set: {},
     $inc: {},
+    $pull: {},
   };
   const dropK = itemToAward.key;
 
@@ -878,6 +879,7 @@ function _getUserUpdateForQuestReward (itemToAward, allAwardedItems) {
     case 'gear': {
       // TODO This means they can lose their new gear on death, is that what we want?
       updates.$set[`items.gear.owned.${dropK}`] = true;
+      updates.$pull.pinnedItems = { path: `gear.flat.${dropK}` };
       break;
     }
     case 'eggs':


### PR DESCRIPTION
[//]: # (Note: See https://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #11501

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Added a mongo pull field to updates to allow removal of pinned items. If a gear item is rewarded, mongo will search in the pinned items array for a matching path value and remove that element. If no such item exists, nothing happens. 


[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: c746035f-dee7-431c-95fb-34cb6249694c
