### PR TITLE
fix(tavern): update page title after viewing profile modal - fixes #12760

### DIFF
--- a/website/client/src/components/userMenu/profile.vue
+++ b/website/client/src/components/userMenu/profile.vue
@@ -863,16 +863,13 @@ export default {
     this.loadUser();
     this.oldTitle = this.$store.state.title;
     this.selectPage(this.startingPage);
-    this.$root.$on('habitica:restoreTitle', () => {
-      if (this.oldTitle) {
-        this.$store.dispatch('common:setTitle', {
-          fullTitle: this.oldTitle,
-        });
-      }
-    });
   },
   beforeDestroy () {
-    this.$root.$off('habitica:restoreTitle');
+    if (this.oldTitle) {
+      this.$store.dispatch('common:setTitle', {
+        fullTitle: this.oldTitle,
+      });
+    }
   },
   methods: {
     async loadUser () {

--- a/website/client/src/components/userMenu/profileModal.vue
+++ b/website/client/src/components/userMenu/profileModal.vue
@@ -5,7 +5,6 @@
     :hide-footer="true"
     :hide-header="true"
     @hide="beforeHide"
-    @hidden="onHidden"
     @shown="onShown()"
   >
     <profile
@@ -55,14 +54,11 @@ export default {
     },
     beforeHide () {
       if (this.$route.path !== window.location.pathname) {
-        this.$root.$emit('habitica:restoreTitle');
-      }
-    },
-    onHidden () {
-      if (this.$route.path !== window.location.pathname) {
-        this.$router.go(-1);
+        this.$router.back();
       }
     },
   },
 };
+
+
 </script>


### PR DESCRIPTION
Fixes #12760 

@Admin: 
As a first time contributor, the workflow for tests hasn't run automatically. Can an admin please start it by clicking the button?

### Issue summary
When a user clicks on one of the modals that changes the URL (such as the Stats, Profile, and Achievements modals), the title of the page changes to the appropriate value. However, when the user exits the modal and returns to the previous view, the title does not update back to its original value. This issue has been addressed in the changes described below.


<details><summary>Bug Demo</summary>

[take1-2022-12-13_20.35.17.webm](https://user-images.githubusercontent.com/53922624/207438215-5a48b243-7130-45a6-995a-1f98f09bb700.webm)

</details>


<details><summary>Fixed Demo</summary>

[take1-2022-12-13_20.39.58.webm](https://user-images.githubusercontent.com/53922624/207439075-1c981e7a-432f-4edc-b9a0-8bc5e69969a7.webm)

</details>


### Changes
- Remove the `@hidden` attribute and it's corresponding callback function from #profile in `profileModal.vue`
- Remove all calls of 'habitica:restoreTitle', as it is no longer being used
- [Change the page title in `beforeDestroy()`](https://github.com/patdel0/habitica/blob/d23c15949a1cf347f8a12f7287f8ace57a65ebb3/website/client/src/components/userMenu/profile.vue#L867-L873)

These changes affect all pages that have access to the Stats, Profile and Achievements modals.

----
UUID: 0fc021a5-6c0d-4bb5-bcc4-7e5424f26278
