### PR TITLE
Optimise chat storage by not storing both equipped and costume

### DIFF
--- a/test/api/v3/integration/chat/POST-chat.test.js
+++ b/test/api/v3/integration/chat/POST-chat.test.js
@@ -541,6 +541,34 @@ describe('POST /chat', () => {
       .to.eql(userWithStyle.preferences.background);
   });
 
+  it('creates equipped to user styles', async () => {
+    const userWithStyle = await generateUser({
+      'preferences.costume': false,
+      'auth.timestamps.created': new Date('2022-01-01'),
+    });
+    await userWithStyle.sync();
+
+    const message = await userWithStyle.post(`/groups/${groupWithChat._id}/chat`, { message: testMessage });
+
+    expect(message.message.id).to.exist;
+    expect(message.message.userStyles.items.gear.equipped).to.eql(userWithStyle.items.gear.equipped);
+    expect(message.message.userStyles.items.gear.costume).to.not.exist;
+  });
+
+  it('creates costume to user styles', async () => {
+    const userWithStyle = await generateUser({
+      'preferences.costume': true,
+      'auth.timestamps.created': new Date('2022-01-01'),
+    });
+    await userWithStyle.sync();
+
+    const message = await userWithStyle.post(`/groups/${groupWithChat._id}/chat`, { message: testMessage });
+
+    expect(message.message.id).to.exist;
+    expect(message.message.userStyles.items.gear.costume).to.eql(userWithStyle.items.gear.costume);
+    expect(message.message.userStyles.items.gear.equipped).to.not.exist;
+  });
+
   it('adds backer info to chat', async () => {
     const backerInfo = {
       npc: 'Town Crier',

--- a/test/api/v3/integration/chat/POST-chat.test.js
+++ b/test/api/v3/integration/chat/POST-chat.test.js
@@ -551,7 +551,8 @@ describe('POST /chat', () => {
     const message = await userWithStyle.post(`/groups/${groupWithChat._id}/chat`, { message: testMessage });
 
     expect(message.message.id).to.exist;
-    expect(message.message.userStyles.items.gear.equipped).to.eql(userWithStyle.items.gear.equipped);
+    expect(message.message.userStyles.items.gear.equipped)
+      .to.eql(userWithStyle.items.gear.equipped);
     expect(message.message.userStyles.items.gear.costume).to.not.exist;
   });
 

--- a/website/server/models/message.js
+++ b/website/server/models/message.js
@@ -67,8 +67,11 @@ export function setUserStyles (newMessage, user) {
 
   if (userCopy.items) {
     userStyles.items.gear = {};
-    userStyles.items.gear.costume = { ...userCopy.items.gear.costume };
-    userStyles.items.gear.equipped = { ...userCopy.items.gear.equipped };
+    if (userCopy.preferences && userCopy.preferences.costume) {
+      userStyles.items.gear.costume = { ...userCopy.items.gear.costume };
+    } else {
+      userStyles.items.gear.equipped = { ...userCopy.items.gear.equipped };
+    }
 
     userStyles.items.currentMount = userCopy.items.currentMount;
     userStyles.items.currentPet = userCopy.items.currentPet;


### PR DESCRIPTION
For display purposes only one of these is used anyway. But we always store (and transfer to the clients) both. Only storing what is actually needed reduced the size of the chat JSON object by ~12% in my test with current tavern chat.