### PR TITLE
Support case-insensitive username logins

### DIFF
--- a/test/api/v3/integration/user/auth/POST-login-local.test.js
+++ b/test/api/v3/integration/user/auth/POST-login-local.test.js
@@ -28,6 +28,15 @@ describe('POST /user/auth/local/login', () => {
     expect(response.apiToken).to.eql(user.apiToken);
   });
 
+  it('success with case-insensitive username', async () => {
+    user = await generateUser({}, { username: 'CASE-INSENSITIVE' });
+    const response = await api.post(endpoint, {
+      username: 'Case-Insensitive',
+      password,
+    });
+    expect(response.apiToken).to.eql(user.apiToken);
+  });
+
   it('success with email', async () => {
     const response = await api.post(endpoint, {
       username: user.auth.local.email,


### PR DESCRIPTION
[//]: # (Note: See https://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)

Fixes https://github.com/HabitRPG/habitica/issues/14586. See issue for more product details.

---

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Previously, the login controller was searching the DB for a record with an exact case-sensitive username match (returning either a `Document` or `undefined`).

This PR makes the login controller search the DB for all records with a case-insensitive username match (returning a `Document[]`). If the resulting array's size is 0, `user = undefined`. If the size is 1, `user = result[0]`. If the size is 2+, we search the resulting `Document[]` for an exact case-sensitive username match, returning either a `Document` or `undefined`.

---

### Demo

| [Login w/out Username Collisions](https://drive.google.com/file/d/1GKUT3i0ShO-_YjYi6-Ebj4ZlUy1AXDZP/view?usp=share_link) | [Login w/ Username Collisions](https://drive.google.com/file/d/1EI5p_QH_oFJeokNJtyNEQGjrn4opDd5p/view?usp=share_link) |
| --- | --- |
| ![case-insensitive-login](https://user-images.githubusercontent.com/22078613/231629074-557f2b6e-23ab-41c4-b670-64a79ceb1cd3.gif) | ![username-collision-login](https://user-images.githubusercontent.com/22078613/231629528-8030cf2e-7f84-4a54-b110-8a0539d18da7.gif) |
###### Click the header link for a full video of creating the users if you want a fuller picture

---

### Disclaimer
I've manually tested that users with colliding usernames still log with the same case-sensitive behavior by removing the unique username constraint on my local instance's registration controller ([demonstrated in this video](https://drive.google.com/file/d/1EI5p_QH_oFJeokNJtyNEQGjrn4opDd5p/view?usp=share_link)), but I don't believe it's possible to add this case to the integration tests because we can't/shouldn't lift that constraint on the _actual_ registration controller.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 99f20106-7060-4398-b565-26e56c4de2ad