### PR TITLE
Don't collapse different spell targets in party chat

### DIFF
--- a/website/server/libs/spells.js
+++ b/website/server/libs/spells.js
@@ -249,56 +249,56 @@ async function castSpell (req, res, { isV3 = false }) {
         if (lastMessage && lastMessage.info.spell === spellId
           && lastMessage.info.user === user.profile.name
           && lastMessage.info.target === partyMembers.profile.name) {
-            const newChatMessage = party.sendChat({
-              message: `\`${common.i18n.t('chatCastSpellUserTimes', {
-                username: user.profile.name,
-                spell: spell.text(),
-                target: partyMembers.profile.name,
-                times: lastMessage.info.times + 1,
-              }, 'en')}\``,
-              info: {
-                type: 'spell_cast_user_multi',
-                user: user.profile.name,
-                class: klass,
-                spell: spellId,
-                target: partyMembers.profile.name,
-                times: lastMessage.info.times + 1,
-              },
-            });
-            await newChatMessage.save();
-            await lastMessage.remove();
-          } else { // Single target spell, not repeated
-            const newChatMessage = party.sendChat({
-              message: `\`${common.i18n.t('chatCastSpellUser', { username: user.profile.name, spell: spell.text(), target: partyMembers.profile.name }, 'en')}\``,
-              info: {
-                type: 'spell_cast_user',
-                user: user.profile.name,
-                class: klass,
-                spell: spellId,
-                target: partyMembers.profile.name,
-                times: 1,
-              },
-            });
-            await newChatMessage.save();
-          }
-      } else if (lastMessage && lastMessage.info.spell === spellId // Partywide spell, check for repeat
-        && lastMessage.info.user === user.profile.name) {
           const newChatMessage = party.sendChat({
-            message: `\`${common.i18n.t('chatCastSpellPartyTimes', {
+            message: `\`${common.i18n.t('chatCastSpellUserTimes', {
               username: user.profile.name,
               spell: spell.text(),
+              target: partyMembers.profile.name,
               times: lastMessage.info.times + 1,
             }, 'en')}\``,
             info: {
-              type: 'spell_cast_party_multi',
+              type: 'spell_cast_user_multi',
               user: user.profile.name,
               class: klass,
               spell: spellId,
+              target: partyMembers.profile.name,
               times: lastMessage.info.times + 1,
             },
           });
           await newChatMessage.save();
           await lastMessage.remove();
+        } else { // Single target spell, not repeated
+          const newChatMessage = party.sendChat({
+            message: `\`${common.i18n.t('chatCastSpellUser', { username: user.profile.name, spell: spell.text(), target: partyMembers.profile.name }, 'en')}\``,
+            info: {
+              type: 'spell_cast_user',
+              user: user.profile.name,
+              class: klass,
+              spell: spellId,
+              target: partyMembers.profile.name,
+              times: 1,
+            },
+          });
+          await newChatMessage.save();
+        }
+      } else if (lastMessage && lastMessage.info.spell === spellId // Party spell, check for repeat
+        && lastMessage.info.user === user.profile.name) {
+        const newChatMessage = party.sendChat({
+          message: `\`${common.i18n.t('chatCastSpellPartyTimes', {
+            username: user.profile.name,
+            spell: spell.text(),
+            times: lastMessage.info.times + 1,
+          }, 'en')}\``,
+          info: {
+            type: 'spell_cast_party_multi',
+            user: user.profile.name,
+            class: klass,
+            spell: spellId,
+            times: lastMessage.info.times + 1,
+          },
+        });
+        await newChatMessage.save();
+        await lastMessage.remove();
       } else {
         const newChatMessage = party.sendChat({ // Non-repetitive partywide spell
           message: `\`${common.i18n.t('chatCastSpellParty', { username: user.profile.name, spell: spell.text() }, 'en')}\``,

--- a/website/server/libs/spells.js
+++ b/website/server/libs/spells.js
@@ -245,28 +245,44 @@ async function castSpell (req, res, { isV3 = false }) {
       const lastMessage = await Chat.findOne({ groupId: party._id })
         .sort('-timestamp')
         .exec();
-      if (lastMessage && lastMessage.info.spell === spellId
+      if (targetType === 'user') { // Single target spell, check for repeat
+        if (lastMessage && lastMessage.info.spell === spellId
+          && lastMessage.info.user === user.profile.name
+          && lastMessage.info.target === partyMembers.profile.name) {
+            const newChatMessage = party.sendChat({
+              message: `\`${common.i18n.t('chatCastSpellUserTimes', {
+                username: user.profile.name,
+                spell: spell.text(),
+                target: partyMembers.profile.name,
+                times: lastMessage.info.times + 1,
+              }, 'en')}\``,
+              info: {
+                type: 'spell_cast_user_multi',
+                user: user.profile.name,
+                class: klass,
+                spell: spellId,
+                target: partyMembers.profile.name,
+                times: lastMessage.info.times + 1,
+              },
+            });
+            await newChatMessage.save();
+            await lastMessage.remove();
+          } else { // Single target spell, not repeated
+            const newChatMessage = party.sendChat({
+              message: `\`${common.i18n.t('chatCastSpellUser', { username: user.profile.name, spell: spell.text(), target: partyMembers.profile.name }, 'en')}\``,
+              info: {
+                type: 'spell_cast_user',
+                user: user.profile.name,
+                class: klass,
+                spell: spellId,
+                target: partyMembers.profile.name,
+                times: 1,
+              },
+            });
+            await newChatMessage.save();
+          }
+      } else if (lastMessage && lastMessage.info.spell === spellId // Partywide spell, check for repeat
         && lastMessage.info.user === user.profile.name) {
-        if (targetType === 'user') {
-          const newChatMessage = party.sendChat({
-            message: `\`${common.i18n.t('chatCastSpellUserTimes', {
-              username: user.profile.name,
-              spell: spell.text(),
-              target: partyMembers.profile.name,
-              times: lastMessage.info.times + 1,
-            }, 'en')}\``,
-            info: {
-              type: 'spell_cast_user_multi',
-              user: user.profile.name,
-              class: klass,
-              spell: spellId,
-              target: partyMembers.profile.name,
-              times: lastMessage.info.times + 1,
-            },
-          });
-          await newChatMessage.save();
-          await lastMessage.remove();
-        } else {
           const newChatMessage = party.sendChat({
             message: `\`${common.i18n.t('chatCastSpellPartyTimes', {
               username: user.profile.name,
@@ -283,22 +299,8 @@ async function castSpell (req, res, { isV3 = false }) {
           });
           await newChatMessage.save();
           await lastMessage.remove();
-        }
-      } else if (targetType === 'user') {
-        const newChatMessage = party.sendChat({
-          message: `\`${common.i18n.t('chatCastSpellUser', { username: user.profile.name, spell: spell.text(), target: partyMembers.profile.name }, 'en')}\``,
-          info: {
-            type: 'spell_cast_user',
-            user: user.profile.name,
-            class: klass,
-            spell: spellId,
-            target: partyMembers.profile.name,
-            times: 1,
-          },
-        });
-        await newChatMessage.save();
       } else {
-        const newChatMessage = party.sendChat({
+        const newChatMessage = party.sendChat({ // Non-repetitive partywide spell
           message: `\`${common.i18n.t('chatCastSpellParty', { username: user.profile.name, spell: spell.text() }, 'en')}\``,
           info: {
             type: 'spell_cast_party',


### PR DESCRIPTION
Fixes an issue where using a seasonal transformation (Shiny Seed, Snowball, etc.) on different targets in the party would erroneously collapse them into a single message reporting that the same user was targeted repeatedly.

Now, the message will only be overwritten and updated if it's

* Same user "casting" (using skill or item)
* Same target--either the party, or the same user in the case of individual-target items