### PR TITLE
Fixes #13542: Task column help text hidden by tasks

### DIFF
--- a/website/client/src/components/tasks/column.vue
+++ b/website/client/src/components/tasks/column.vue
@@ -695,13 +695,13 @@ export default {
     },
     setColumnBackgroundVisibility () {
       this.$nextTick(() => {
-        if (!this.$refs.columnBackground || !this.$refs.tasksList) return;
+        if (!this.$refs.columnBackground) return;
 
         const tasksWrapperEl = this.$refs.tasksWrapper;
 
         const tasksWrapperHeight = tasksWrapperEl.offsetHeight;
         const quickAddHeight = this.$refs.quickAdd ? this.$refs.quickAdd.offsetHeight : 0;
-        const tasksListHeight = this.$refs.tasksList.$el.offsetHeight;
+        const tasksListHeight = this.$refs.tasksList ? this.$refs.tasksList.$el.offsetHeight : 0;
 
         let combinedTasksHeights = tasksListHeight + quickAddHeight;
 


### PR DESCRIPTION
Fixes #13542 

### Changes

This is a small tweak that fixes the help text being hidden by a too-long rewards list.

The other tasks columns, as designed, take into account the total height of all of the tasks and hide the "help" element if those tasks cover it up. Because the rewards list includes two different card types (tasks and rewards), the overlay-checking logic wasn't being properly applied unless there was at least one task card.

To fix, the length of the task list is now only checked when its total heigh is calculated, allowing for the rewards list to also be taken into account (with or without tasks).

See screenshots below that show the new (desired) behavior:

#### Help text hidden by reward cards
![image](https://github.com/HabitRPG/habitica/assets/920019/df8407b6-55f3-41b7-b4a1-349cd829e6c8)

#### Help text shown by fewer reward cards
![image](https://github.com/HabitRPG/habitica/assets/920019/25f7b992-5706-4219-a052-0d877182c9f0)

#### Help text hidden by mixed task and reward cards
![image](https://github.com/HabitRPG/habitica/assets/920019/87e5879a-8cfc-4d13-85ea-0bfdea4fff72)

#### Help text shown by fewer mixed task and reward cards
![image](https://github.com/HabitRPG/habitica/assets/920019/c2aeb3ee-7909-4eca-a065-b8f071fee26c)


----
UUID: 5ba84aae-6676-4ff2-9d2f-c9c0b3c85fd6

