### PR TITLE
Fixes #14461: Avatar stats don't update after another user uses a buffing abililty

### DIFF
--- a/website/client/src/mixins/spells.js
+++ b/website/client/src/mixins/spells.js
@@ -1,4 +1,5 @@
 import isArray from 'lodash/isArray';
+import { merge, each } from 'lodash';
 import * as quests from '@/../../common/script/content/quests';
 
 // @TODO: Let's separate some of the business logic out of Vue if possible
@@ -142,6 +143,16 @@ export default {
 
       if (apiResult.data.data.user) {
         Object.assign(this.$store.state.user.data, apiResult.data.data.user);
+      }
+
+      if (apiResult.data.data.partyMembers) {
+        each(this.$store.state.partyMembers.data, partyMember => {
+          const updatedPartyMember = apiResult.data.data.partyMembers
+            .find(
+              member => member.profile.name === partyMember.profile.name,
+            );
+          merge(partyMember, updatedPartyMember);
+        });
       }
 
       let msg = '';


### PR DESCRIPTION
[//]: # (Note: See https://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #14461
Party members' state wasn't always being updated when casting spells.
If the spell is is a bulk spell (`bulk: true`), the state would not update when the spell is cast. The state was being updated during casting in `website\common\script\content\spells.js` until bulk spells were introduced in #14544.

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Updates the `partyMembers` state using the updated data returned by the `cast` API call 
in the `castEnd()` method in `website\client\src\mixins\spells.js` rather than relying on each spell's `cast` method in the common scripts to update it.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 00cfc368-4bf7-4d50-8100-6e3f21707e10
