### PR TITLE
Group task fixes

### DIFF
--- a/website/server/libs/user/index.js
+++ b/website/server/libs/user/index.js
@@ -237,7 +237,7 @@ export async function update (req, res, { isV3 = false }) {
         user.flags.lastNewStuffRead = lastNewsPost._id;
       }
     } else if (key === 'preferences.tasks.mirrorGroupTasks') {
-      user.preferences.mirrorGroupTasks = _.intersection(groupsToMirror, matchingGroupsArray);
+      user.preferences.tasks.mirrorGroupTasks = _.intersection(groupsToMirror, matchingGroupsArray);
     } else if (acceptablePUTPaths[key]) {
       let adjustedVal = val;
       if (key === 'stats.lvl' && val > common.constants.MAX_LEVEL_HARD_CAP) {

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -1432,11 +1432,6 @@ schema.methods.syncTask = async function groupSyncTask (taskToSync, users, assig
       completed: false,
     };
 
-    if (!taskToSync.group.assignedUsers) {
-      taskToSync.group.assignedUsers = [];
-    }
-    taskToSync.group.assignedUsers.push(user._id);
-
     if (!taskToSync.group.assignedUsersDetail) {
       taskToSync.group.assignedUsersDetail = {};
     }
@@ -1444,6 +1439,8 @@ schema.methods.syncTask = async function groupSyncTask (taskToSync, users, assig
       taskToSync.group.assignedUsersDetail[user._id] = assignmentData;
     }
     taskToSync.markModified('group.assignedUsersDetail');
+
+    taskToSync.group.assignedUsers = _.keys(taskToSync.group.assignedUsersDetail);
 
     // Sync tags
     const userTags = user.tags;

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -1475,8 +1475,7 @@ schema.methods.unlinkTask = async function groupUnlinkTask (
   };
 
   delete unlinkingTask.group.assignedUsersDetail[user._id];
-  const assignedUserIndex = unlinkingTask.group.assignedUsers.indexOf(user._id);
-  unlinkingTask.group.assignedUsers.splice(assignedUserIndex, 1);
+  unlinkingTask.group.assignedUsers = _.keys(unlinkingTask.group.assignedUsersDetail);
   unlinkingTask.markModified('group');
 
   const promises = [unlinkingTask.save()];


### PR DESCRIPTION
Two under the hood fixes for Group Plans:

1. If there's an entry in the user's `preferences.tasks.mirrorGroupTasks` corresponding to a group that is no longer subscribed, remove it from the array on next update of that field instead of throwing an error.
2. Force group tasks' `assignedUsers` and `assignedUsersDetail` fields to synchronize by setting the former to be an array of the latter's keys on sync, instead of trying to push and pull entries ad hoc.