### PR TITLE
Don't compare two blank moment() for potential race condition

### DIFF
--- a/website/client/src/mixins/avatarEditUtilities.js
+++ b/website/client/src/mixins/avatarEditUtilities.js
@@ -24,7 +24,10 @@ export const avatarEditorUtilies = { // eslint-disable-line import/prefer-defaul
           appearanceSets[setKey].availableUntil,
         );
       }
-      return moment(appearanceSets[setKey].availableUntil).isBefore(moment());
+      if (appearanceSets[setKey].availableUntil) {
+        return moment(appearanceSets[setKey].availableUntil).isBefore(moment());
+      }
+      return false;
     },
     mapKeysToFreeOption (key, type, subType) {
       const userPreference = subType


### PR DESCRIPTION
[//]: # (Note: See https://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
#10225

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
When `appearanceSets[setKey].availableUntil` is `undefined`, then we were performing `moment().isBefore(moment())` and the race condition occasionally returns `true` about 0.05-0.5% of the time (from my experience).

### How to test:
1. Go to `website/client/src/mixins/avatarEditUtilities.js`
2. Change `hide = this.hideSet(set);` to `hide = this.hideSet(set, key);`
3. Change `hideSet (setKey)` to `hideSet (setKey, key)`
4. Add below code after `if (appearanceSets[setKey].availableFrom)` block
```
      if (key === 'bear') {
        for (let i = 0; i < 10000; i += 1) {
          const tempHide = moment(appearanceSets[setKey].availableUntil).isBefore(moment());
          if (tempHide) {
            console.log(tempHide);
          }
        }
      }
```
5. Run the local instance of Habitica
6. Click User icon > Click 'Edit Avatar' > Click 'Skin'
7. You should see a few `true` cases on Console
8. Now change the above `const tempHide = ...` with below block (which has the identical logic as this PR)
```
          const tempHide = appearanceSets[setKey].availableUntil
            ? moment(appearanceSets[setKey].availableUntil).isBefore(moment())
            : false;
```
9. Repeat steps 6
10. Now you don't see any `true` printed out on Console

* The `key` above doesn't have to be `'bear'`. I just wanted a key that will return `hide` to be `false` by default. You can try any key for Skin that should return `hide = false` (e.g. `'rainbow'`)

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 662332a6-a7e7-4b70-858e-255f3e6076a8
