### PR TITLE
Optimizing /user/buy/x in 40-50%

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -88,5 +88,4 @@
   "REDIS_PORT": "1234",
   "REDIS_PASSWORD": "12345678",
   "TRUSTED_DOMAINS": "localhost,habitica.com"
-  "NO_CLUSTER": "false"
 }

--- a/config.json.example
+++ b/config.json.example
@@ -88,4 +88,5 @@
   "REDIS_PORT": "1234",
   "REDIS_PASSWORD": "12345678",
   "TRUSTED_DOMAINS": "localhost,habitica.com"
+  "NO_CLUSTER": "false"
 }

--- a/website/common/script/libs/getOfficialPinnedItems.js
+++ b/website/common/script/libs/getOfficialPinnedItems.js
@@ -31,15 +31,16 @@ export default function getOfficialPinnedItems (user) {
     // pinnedSets == current seasonal class set are always gold purchaseable
 
     const gearsBySet = flatGearArray[setToAdd];
-    const gears = gearsBySet.map(gear => {
+
+    for (let i = 0; i < gearsBySet.length; i += 1) {
+      const gear = gearsBySet[i];
       if (!user.items.gear.owned[gear.key]) {
-        return {
+        officialItemsArray.push({
           type: 'marketGear',
           path: `gear.flat.${gear.key}`,
-        };
+        });
       }
-    });
-    officialItemsArray.push(...gears);
+    }
   }
 
   return officialItemsArray;

--- a/website/common/script/libs/getOfficialPinnedItems.js
+++ b/website/common/script/libs/getOfficialPinnedItems.js
@@ -1,26 +1,10 @@
+import _ from 'lodash';
 import content from '../content/index';
 import SeasonalShopConfig from './shops-seasonal.config';
 
 const { officialPinnedItems } = content;
 
-function groupBySet (items) {
-  const grouped = {};
-
-  Object.keys(items).forEach(key => {
-    const item = items[key];
-    const { set } = item;
-
-    if (!grouped[set]) {
-      grouped[set] = [];
-    }
-
-    grouped[set].push(item);
-  });
-
-  return grouped;
-}
-
-const flatGearArray = groupBySet(content.gear.flat);
+const flatGearArray = _.groupBy(content.gear.flat, 'set');
 
 export default function getOfficialPinnedItems (user) {
   const officialItemsArray = [...officialPinnedItems];

--- a/website/common/script/libs/getOfficialPinnedItems.js
+++ b/website/common/script/libs/getOfficialPinnedItems.js
@@ -1,10 +1,26 @@
-import toArray from 'lodash/toArray';
 import content from '../content/index';
 import SeasonalShopConfig from './shops-seasonal.config';
 
 const { officialPinnedItems } = content;
 
-const flatGearArray = toArray(content.gear.flat);
+function groupBySet (items) {
+  const grouped = {};
+
+  Object.keys(items).forEach(key => {
+    const item = items[key];
+    const { set } = item;
+
+    if (!grouped[set]) {
+      grouped[set] = [];
+    }
+
+    grouped[set].push(item);
+  });
+
+  return grouped;
+}
+
+const flatGearArray = groupBySet(content.gear.flat);
 
 export default function getOfficialPinnedItems (user) {
   const officialItemsArray = [...officialPinnedItems];
@@ -14,14 +30,16 @@ export default function getOfficialPinnedItems (user) {
 
     // pinnedSets == current seasonal class set are always gold purchaseable
 
-    flatGearArray
-      .filter(gear => user.items.gear.owned[gear.key] === undefined && gear.set === setToAdd)
-      .forEach(gear => {
-        officialItemsArray.push({
+    const gearsBySet = flatGearArray[setToAdd];
+    const gears = gearsBySet.map(gear => {
+      if (!user.items.gear.owned[gear.key]) {
+        return {
           type: 'marketGear',
           path: `gear.flat.${gear.key}`,
-        });
-      });
+        };
+      }
+    });
+    officialItemsArray.push(...gears);
   }
 
   return officialItemsArray;

--- a/website/common/script/libs/getOfficialPinnedItems.js
+++ b/website/common/script/libs/getOfficialPinnedItems.js
@@ -8,12 +8,12 @@ const flatGearArray = _.groupBy(content.gear.flat, 'set');
 
 export default function getOfficialPinnedItems (user) {
   const officialItemsArray = [...officialPinnedItems];
+  const { pinnedSets } = SeasonalShopConfig;
 
-  if (SeasonalShopConfig.pinnedSets && Boolean(user) && user.stats.class) {
-    const setToAdd = SeasonalShopConfig.pinnedSets[user.stats.class];
+  if (pinnedSets && !_.isEmpty(pinnedSets) && Boolean(user) && user.stats.class) {
+    const setToAdd = pinnedSets[user.stats.class];
 
     // pinnedSets == current seasonal class set are always gold purchaseable
-
     const gearsBySet = flatGearArray[setToAdd];
 
     for (let i = 0; i < gearsBySet.length; i += 1) {

--- a/website/server/index.js
+++ b/website/server/index.js
@@ -22,9 +22,10 @@ const logger = require('./libs/logger').default;
 const IS_PROD = nconf.get('IS_PROD');
 const IS_DEV = nconf.get('IS_DEV');
 const CORES = Number(nconf.get('WEB_CONCURRENCY')) || 0;
+const NO_CLUSTER = Number(nconf.get('NO_CLUSTER')) || 0;
 
 // Setup the cluster module
-if (CORES !== 0 && cluster.isMaster && (IS_DEV || IS_PROD)) {
+if (!NO_CLUSTER && CORES !== 0 && cluster.isMaster && (IS_DEV || IS_PROD)) {
   // Fork workers. If config.json has WEB_CONCURRENCY=x,
   // use that - otherwise, use all cpus-1 (production)
   for (let i = 0; i < CORES; i += 1) {

--- a/website/server/index.js
+++ b/website/server/index.js
@@ -22,10 +22,9 @@ const logger = require('./libs/logger').default;
 const IS_PROD = nconf.get('IS_PROD');
 const IS_DEV = nconf.get('IS_DEV');
 const CORES = Number(nconf.get('WEB_CONCURRENCY')) || 0;
-const NO_CLUSTER = Number(nconf.get('NO_CLUSTER')) || 0;
 
 // Setup the cluster module
-if (!NO_CLUSTER && CORES !== 0 && cluster.isMaster && (IS_DEV || IS_PROD)) {
+if (CORES !== 0 && cluster.isMaster && (IS_DEV || IS_PROD)) {
   // Fork workers. If config.json has WEB_CONCURRENCY=x,
   // use that - otherwise, use all cpus-1 (production)
   for (let i = 0; i < CORES; i += 1) {

--- a/website/server/index.js
+++ b/website/server/index.js
@@ -38,5 +38,5 @@ if (!NO_CLUSTER && CORES !== 0 && cluster.isMaster && (IS_DEV || IS_PROD)) {
     logger.info(`[${new Date()}] [master:${process.pid}] worker:${worker.process.pid} disconnect! new worker:${w.process.pid} fork`);
   });
 } else {
-  module.exports = require('./server.js');
+  module.exports = require('./server');
 }


### PR DESCRIPTION
I'm experimenting with some performance monitoring tools on Habitica for my studies, so I found a little unoptimized code

## Changes

### 1

Optimized `website/common/script/libs/getOfficialPinnedItems.js > getOfficialPinnedItems` function, we are using 2 optimizations: 
- I'm grouping the gears by Set, it will reduce the cost of filtering the items
- using a JSON structure to get the `set to be added`, will avoid the filter usage

It reduced  the endpoint time by ~40%

That values in my local environment, in prod this same endpoint is consuming  ~200ms

Unptimized
<img width="751" alt="Screenshot 2023-10-30 at 18 07 29" src="https://github.com/HabitRPG/habitica/assets/12226189/db30d6db-3261-408f-88b6-d04cd1bff91c">

Optimized
<img width="751" alt="Screenshot 2023-10-30 at 17 41 41" src="https://github.com/HabitRPG/habitica/assets/12226189/dc1ce666-0868-4d66-ac6f-2625f7899972">


### 2
Added a flag to avoid using clustering, it helps when we are monitoring the application to tunning stuff



[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: aa5a278e-675d-4d8f-ae2b-90391b2d7218
