### PR TITLE
fix(dates) remove hard-coded end dates on bundles

### DIFF
--- a/website/common/locales/en/questsContent.json
+++ b/website/common/locales/en/questsContent.json
@@ -729,7 +729,7 @@
   "questAlligatorUnlockText": "Unlocks Alligator Eggs for purchase in the Market",
 
   "oddballsText": "Oddballs Quest Bundle",
-  "oddballsNotes": "Contains 'The Jelly Regent,' 'Escape the Cave Creature,' and 'A Tangled Yarn.' Available until April 30.",
+  "oddballsNotes": "Contains 'The Jelly Regent,' 'Escape the Cave Creature,' and 'A Tangled Yarn.' Available until November 30",
 
   "birdBuddiesText": "Bird Buddies Quest Bundle",
   "birdBuddiesNotes": "Contains 'The Fowl Frost,' 'Rooster Rampage,' and 'The Push-and-Pull Peacock.' Available until September 30.",

--- a/website/common/locales/en/questsContent.json
+++ b/website/common/locales/en/questsContent.json
@@ -576,7 +576,7 @@
   "questMayhemMistiflying3DropWeapon": "Roguish Rainbow Message (Main-Hand Item)",
 
   "featheredFriendsText": "Feathered Friends Quest Bundle",
-  "featheredFriendsNotes": "Contains 'Help! Harpy!,' 'The Night-Owl,' and 'The Birds of Preycrastination.' Available until May 31.",
+  "featheredFriendsNotes": "Contains 'Help! Harpy!,' 'The Night-Owl,' and 'The Birds of Preycrastination.'",
 
   "questNudibranchText": "Infestation of the NowDo Nudibranchs",
   "questNudibranchNotes": "You finally get around to checking your To Do's on a lazy day in Habitica. Bright against your deepest red tasks are a gaggle of vibrant blue sea slugs. You are entranced! Their sapphire colors make your most intimidating tasks look as easy as your best Habits. In a feverish stupor you get to work, tackling one task after the other in a ceaseless frenzy...<br><br>The next thing you know, @LilithofAlfheim is pouring cold water over you. “The NowDo Nudibranchs have been stinging you all over! You need to take a break!”<br><br>Shocked, you see that your skin is as bright red as your To Do list was. \"Being productive is one thing,\" @beffymaroo says, \"but you've also got to take care of yourself. Hurry, let's get rid of them!\"",
@@ -586,7 +586,7 @@
   "questNudibranchUnlockText": "Unlocks Nudibranch Eggs for purchase in the Market",
 
   "splashyPalsText": "Splashy Pals Quest Bundle",
-  "splashyPalsNotes": "Contains 'The Dilatory Derby', 'Guide the Turtle', and 'Wail of the Whale'. Available until June 30.",
+  "splashyPalsNotes": "Contains 'The Dilatory Derby', 'Guide the Turtle', and 'Wail of the Whale'.",
 
   "questHippoText": "What a Hippo-Crite",
   "questHippoNotes": "You and @awesomekitty collapse into the shade of a palm tree, exhausted. The sun beats down over the Sloensteadi Savannah, scorching the ground below. It’s been a productive day so far, conquering your Dailies, and this oasis looks like a nice place to take a break and refresh. Stooping near the water to get a drink, you stumble back in shock as a massive hippopotamus rises. “Resting so soon? Don’t be so lazy, get back to work.” You try and protest that you’ve been working hard and need a break, but the hippo isn’t having any of it.<br><br>@khdarkwolf whispers to you, “Notice how it’s lounging around all day but has the nerve to call you lazy? It’s the Hippo-Crite!”<br><br>Your friend @jumorales nods. “Let’s show it what hard work looks like!”",
@@ -596,10 +596,10 @@
   "questHippoUnlockText": "Unlocks Hippo Eggs for purchase in the Market",
 
   "farmFriendsText": "Farm Friends Quest Bundle",
-  "farmFriendsNotes": "Contains 'The Mootant Cow', 'Ride the Night-Mare', and 'The Thunder Ram'. Available until September 30.",
+  "farmFriendsNotes": "Contains 'The Mootant Cow', 'Ride the Night-Mare', and 'The Thunder Ram'.",
 
   "witchyFamiliarsText": "Witchy Familiars Quest Bundle",
-  "witchyFamiliarsNotes": "Contains 'The Rat King', 'The Icy Arachnid', and 'Swamp of the Clutter Frog'. Available until October 31.",
+  "witchyFamiliarsNotes": "Contains 'The Rat King', 'The Icy Arachnid', and 'Swamp of the Clutter Frog'.",
 
   "questGroupLostMasterclasser": "Mystery of the Masterclassers",
   "questUnlockLostMasterclasser": "To unlock this quest, complete the final quests of these quest chains: 'Dilatory Distress', 'Mayhem in Mistiflying', 'Stoïkalm Calamity', and 'Terror in the Taskwoods'.",
@@ -689,7 +689,7 @@
   "dysheartenerArtCredit": "Artwork by @AnnDeLune",
 
   "hugabugText": "Hug a Bug Quest Bundle",
-  "hugabugNotes": "Contains 'The CRITICAL BUG,' 'The Snail of Drudgery Sludge,' and 'Bye, Bye, Butterfry.' Available until August 31.",
+  "hugabugNotes": "Contains 'The CRITICAL BUG,' 'The Snail of Drudgery Sludge,' and 'Bye, Bye, Butterfry.'",
 
   "questSquirrelText": "The Sneaky Squirrel",
   "questSquirrelNotes": "You wake up and find you’ve overslept! Why didn’t your alarm go off? … How did an acorn get stuck in the ringer?<br><br>When you try to make breakfast, the toaster is stuffed with acorns. When you go to retrieve your mount, @Shtut is there, trying unsuccessfully to unlock their stable. They look into the keyhole. “Is that an acorn in there?”<br><br>@randomdaisy cries out, “Oh no! I knew my pet squirrels had gotten out, but I didn’t know they’d made such trouble! Can you help me round them up before they make any more of a mess?”<br><br>Following the trail of mischievously placed oak nuts, you track and catch the wayward sciurines, with @Cantras helping secure each one safely at home. But just when you think your task is almost complete, an acorn bounces off your helm! You look up to see a mighty beast of a squirrel, crouched in defense of a prodigious pile of seeds.<br><br>“Oh dear,” says @randomdaisy, softly. “She’s always been something of a resource guarder. We’ll have to proceed very carefully!” You circle up with your party, ready for trouble!",
@@ -699,10 +699,10 @@
   "questSquirrelUnlockText": "Unlocks Squirrel Eggs for purchase in the Market",
 
   "cuddleBuddiesText": "Cuddle Buddies Quest Bundle",
-  "cuddleBuddiesNotes": "Contains 'The Killer Bunny', 'The Nefarious Ferret', and 'The Guinea Pig Gang'. Available until March 31.",
+  "cuddleBuddiesNotes": "Contains 'The Killer Bunny', 'The Nefarious Ferret', and 'The Guinea Pig Gang'.",
 
   "aquaticAmigosText": "Aquatic Amigos Quest Bundle",
-  "aquaticAmigosNotes": "Contains 'The Magical Axolotl', 'The Kraken of Inkomplete', and 'The Call of Octothulu'. Available until June 30.",
+  "aquaticAmigosNotes": "Contains 'The Magical Axolotl', 'The Kraken of Inkomplete', and 'The Call of Octothulu'.",
 
   "questSeaSerpentText": "Danger in the Depths: Sea Serpent Strike!",
   "questSeaSerpentNotes": "Your streaks have you feeling lucky—it’s the perfect time for a trip to the seahorse racetrack. You board the submarine at Diligent Docks and settle in for the trip to Dilatory, but you’ve barely submerged when an impact rocks the sub, sending its occupants tumbling. “What’s going on?” @AriesFaries shouts.<br><br>You glance through a nearby porthole and are shocked by the wall of shimmering scales passing by it. “Sea serpent!” Captain @Witticaster calls through the intercom. “Brace yourselves, it’s coming ‘round again!” As you grip the arms of your seat, your unfinished tasks flash before your eyes. ‘Maybe if we work together and complete them,’ you think, ‘we can drive this monster away!’",
@@ -719,7 +719,7 @@
   "questKangarooUnlockText": "Unlocks Kangaroo Eggs for purchase in the Market",
 
   "forestFriendsText": "Forest Friends Quest Bundle",
-  "forestFriendsNotes": "Contains 'The Spirit of Spring', 'The Hedgebeast', and 'The Tangle Tree'. Available until September 30.",
+  "forestFriendsNotes": "Contains 'The Spirit of Spring', 'The Hedgebeast', and 'The Tangle Tree'.",
 
   "questAlligatorText": "The Insta-Gator",
   "questAlligatorNotes": "“Crikey!” exclaims @gully. “An Insta-Gator in its natural habitat! Careful, it distracts its prey with things that seem urgent THIS INSTANT, and it feeds on the unchecked Dailies that result.” You fall silent to avoid attracting its attention, but to no avail. The Insta-Gator spots you and charges! Distracting voices rise up from Swamps of Stagnation, grabbing for your attention: “Read this post! See this photo! Pay attention to me THIS INSTANT!” You scramble to mount a counterattack, completing your Dailies and bolstering your good Habits to fight off the dreaded Insta-Gator.",
@@ -729,10 +729,10 @@
   "questAlligatorUnlockText": "Unlocks Alligator Eggs for purchase in the Market",
 
   "oddballsText": "Oddballs Quest Bundle",
-  "oddballsNotes": "Contains 'The Jelly Regent,' 'Escape the Cave Creature,' and 'A Tangled Yarn.' Available until November 30",
+  "oddballsNotes": "Contains 'The Jelly Regent,' 'Escape the Cave Creature,' and 'A Tangled Yarn.'",
 
   "birdBuddiesText": "Bird Buddies Quest Bundle",
-  "birdBuddiesNotes": "Contains 'The Fowl Frost,' 'Rooster Rampage,' and 'The Push-and-Pull Peacock.' Available until September 30.",
+  "birdBuddiesNotes": "Contains 'The Fowl Frost,' 'Rooster Rampage,' and 'The Push-and-Pull Peacock.'",
 
   "questVelociraptorText": "The Veloci-Rapper",
   "questVelociraptorNotes": "You’re sharing honey cakes with @*~Seraphina~*, @Procyon P, and @Lilith of Alfheim by a lake in the Stoïkalm Steppes. Suddenly, a mournful voice interrupts your picnic.<br><br><em>My Habits took a hit, I missed my Dailies,<br>I’m losing it, sinking with doubt and maybes,<br>At the top of my game I used to be so fly,<br>But now I just let my Due Dates go by.</em><br><br>@*~Seraphina~* peers behind a stand of grass. “It’s the Veloci-Rapper. It seems... distraught?”<br><br>You pump a fist in determination. “There's only one thing to do. Rap battle time!”",
@@ -742,7 +742,7 @@
   "questVelociraptorUnlockText": "Unlocks Velociraptor Eggs for purchase in the Market",
 
   "mythicalMarvelsText": "Mythical Marvels Quest Bundle",
-  "mythicalMarvelsNotes": "Contains 'Convincing the Unicorn Queen,' 'The Fiery Gryphon,' and 'Danger in the Depths: Sea Serpent Strike!' Available until February 28.",
+  "mythicalMarvelsNotes": "Contains 'Convincing the Unicorn Queen,' 'The Fiery Gryphon,' and 'Danger in the Depths: Sea Serpent Strike!'",
 
   "questBronzeText": "Brazen Beetle Battle",
   "questBronzeNotes": "On a refreshing break between tasks, you and some friends take a stroll through the forest trails of the Taskwoods. You come upon a large hollow log and a sparkle from inside catches your attention.<br><br>Why, it's a cache of Magic Hatching Potions! The shimmering bronze liquid swirls gently in the bottles, and @Hachiseiko reaches to pick one up to examine it.<br><br>“Halt!” hisses a voice from behind you. It's a gigantic beetle with a carapace of gleaming bronze, raising her clawed feet in a fighting stance. “Those are my potions, and if you wish to earn them, you must prove yourself in a gentlefolks' duel!”",
@@ -777,10 +777,10 @@
   "questRobotUnlockText": "Unlocks purchasable Robot Eggs in the Market",
 
   "rockingReptilesText": "Rocking Reptiles Quest Bundle",
-  "rockingReptilesNotes": "Contains 'The Insta-Gator,' 'The Serpent of Distraction,' and 'The Veloci-Rapper.' Available until November 30.",
+  "rockingReptilesNotes": "Contains 'The Insta-Gator,' 'The Serpent of Distraction,' and 'The Veloci-Rapper.'",
 
   "delightfulDinosText": "Delightful Dinos Quest Bundle",
-  "delightfulDinosNotes": "Contains 'The Pterror-dactyl,' 'The Trampling Triceratops,' and 'The Dinosaur Unearthed.' Available until May 31.",
+  "delightfulDinosNotes": "Contains 'The Pterror-dactyl,' 'The Trampling Triceratops,' and 'The Dinosaur Unearthed.'",
 
   "questAmberText": "The Amber Alliance",
   "questAmberNotes": "You’re sitting in the Tavern with @beffymaroo and @-Tyr- when @Vikte bursts through the door and excitedly tells you about the rumors of another type of Magic Hatching Potion hidden in the Taskwoods. Having completed your Dailies, the three of you immediately agree to help @Vikte on their search. After all, what’s the harm in a little adventure?<br><br>After walking through the Taskwoods for hours, you’re beginning to regret joining such a wild chase. You’re about to head home, when you hear a surprised yelp and turn to see a huge lizard with shiny amber scales coiled around a tree, clutching @Vikte in her claws. @beffymaroo reaches for her sword.<br><br>“Wait!” cries @-Tyr-. “It’s the Trerezin! She’s not dangerous, just dangerously clingy!”",


### PR DESCRIPTION
Removed hard-coded end dates in quest bundles in preparation for adding dynamically generated dates.
