### PR TITLE
(fix): add quest modal text horizontal padding

### DIFF
--- a/website/client/src/components/shops/quests/buyQuestModal.vue
+++ b/website/client/src/components/shops/quests/buyQuestModal.vue
@@ -177,6 +177,7 @@
 
     .inner-content {
       margin: 33px auto auto;
+      padding: 0px 24px;
     }
 
     .item-notes {


### PR DESCRIPTION
Change horizontal `padding` on the quest modal to `24px`.
