### PR TITLE
update(scripts):  update migration scripts to use updateOne

### DIFF
--- a/migrations/users/bulk-email.js
+++ b/migrations/users/bulk-email.js
@@ -26,7 +26,7 @@ async function updateUser (user) {
     [{ name: 'BASE_URL', content: BASE_URL }], // Add variables from template
   );
 
-  return User.update({ _id: user._id }, { $set: { migration: MIGRATION_NAME } }).exec();
+  return User.updateOne({ _id: user._id }, { $set: { migration: MIGRATION_NAME } }).exec();
 }
 
 export default async function processUsers () {

--- a/migrations/users/full-gear.js
+++ b/migrations/users/full-gear.js
@@ -27,7 +27,7 @@ async function updateUser (user) {
 
   if (count % progressCount === 0) console.warn(`${count} ${user._id}`);
 
-  return User.update({ _id: user._id }, { $set: set }).exec();
+  return User.updateOne({ _id: user._id }, { $set: set }).exec();
 }
 
 export default async function processUsers () {

--- a/migrations/users/full-stable.js
+++ b/migrations/users/full-stable.js
@@ -57,7 +57,7 @@ async function updateUser (user) {
 export default async function processUsers () {
   const query = {
     migration: { $ne: MIGRATION_NAME },
-    'auth.local.username': 'SabreTest',
+    'auth.local.lowerCaseUsername': 'SabreTest',
   };
 
   const fields = {

--- a/migrations/users/full-stable.js
+++ b/migrations/users/full-stable.js
@@ -57,7 +57,7 @@ async function updateUser (user) {
 export default async function processUsers () {
   const query = {
     migration: { $ne: MIGRATION_NAME },
-    'auth.local.lowerCaseUsername': 'SabreTest',
+    'auth.local.lowerCaseUsername': 'sabretest',
   };
 
   const fields = {

--- a/migrations/users/habit_birthday.js
+++ b/migrations/users/habit_birthday.js
@@ -100,4 +100,4 @@ export default async function processUsers () {
 
     await Promise.all(users.map(updateUser)); // eslint-disable-line no-await-in-loop
   }
-};
+}

--- a/migrations/users/habit_birthday.js
+++ b/migrations/users/habit_birthday.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import { v4 as uuid } from 'uuid';
-import { model as User } from '../../../website/server/models/user';
+import { model as User } from '../../website/server/models/user';
 
 const MIGRATION_NAME = '20240131_habit_birthday';
 const progressCount = 1000;
@@ -69,7 +69,7 @@ async function updateUser (user) {
 }
 
 export default async function processUsers () {
-  let query = {
+  const query = {
     migration: { $ne: MIGRATION_NAME },
     'auth.timestamps.loggedin': { $gt: new Date('2023-12-23') },
   };

--- a/migrations/users/habit_birthday.js
+++ b/migrations/users/habit_birthday.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-import { v4 as uuid } from 'uuid';
 import { model as User } from '../../website/server/models/user';
 
 const MIGRATION_NAME = '20240131_habit_birthday';

--- a/migrations/users/habit_birthday.js
+++ b/migrations/users/habit_birthday.js
@@ -1,0 +1,103 @@
+/* eslint-disable no-console */
+import { v4 as uuid } from 'uuid';
+import { model as User } from '../../../website/server/models/user';
+
+const MIGRATION_NAME = '20240131_habit_birthday';
+const progressCount = 1000;
+let count = 0;
+
+async function updateUser (user) {
+  count += 1;
+
+  const inc = {
+    'items.food.Cake_Skeleton': 1,
+    'items.food.Cake_Base': 1,
+    'items.food.Cake_CottonCandyBlue': 1,
+    'items.food.Cake_CottonCandyPink': 1,
+    'items.food.Cake_Shade': 1,
+    'items.food.Cake_White': 1,
+    'items.food.Cake_Golden': 1,
+    'items.food.Cake_Zombie': 1,
+    'items.food.Cake_Desert': 1,
+    'items.food.Cake_Red': 1,
+    'achievements.habitBirthdays': 1,
+  };
+  const set = {};
+  const push = {
+    notifications: {
+      type: 'ITEM_RECEIVED',
+      data: {
+        icon: 'notif_namingDay_cake',
+        title: 'Happy Habit Birthday!',
+        text: 'Habitica turns 11 today! Enjoy free party robes and cake!',
+        destination: 'inventory/equipment',
+      },
+      seen: false,
+    },
+  };
+
+  set.migration = MIGRATION_NAME;
+
+  if (typeof user.items.gear.owned.armor_special_birthday2023 !== 'undefined') {
+    set['items.gear.owned.armor_special_birthday2024'] = true;
+  } else if (typeof user.items.gear.owned.armor_special_birthday2022 !== 'undefined') {
+    set['items.gear.owned.armor_special_birthday2023'] = true;
+  } else if (typeof user.items.gear.owned.armor_special_birthday2021 !== 'undefined') {
+    set['items.gear.owned.armor_special_birthday2022'] = true;
+  } else if (typeof user.items.gear.owned.armor_special_birthday2020 !== 'undefined') {
+    set['items.gear.owned.armor_special_birthday2021'] = true;
+  } else if (typeof user.items.gear.owned.armor_special_birthday2019 !== 'undefined') {
+    set['items.gear.owned.armor_special_birthday2020'] = true;
+  } else if (typeof user.items.gear.owned.armor_special_birthday2018 !== 'undefined') {
+    set['items.gear.owned.armor_special_birthday2019'] = true;
+  } else if (typeof user.items.gear.owned.armor_special_birthday2017 !== 'undefined') {
+    set['items.gear.owned.armor_special_birthday2018'] = true;
+  } else if (typeof user.items.gear.owned.armor_special_birthday2016 !== 'undefined') {
+    set['items.gear.owned.armor_special_birthday2017'] = true;
+  } else if (typeof user.items.gear.owned.armor_special_birthday2015 !== 'undefined') {
+    set['items.gear.owned.armor_special_birthday2016'] = true;
+  } else if (typeof user.items.gear.owned.armor_special_birthday !== 'undefined') {
+    set['items.gear.owned.armor_special_birthday2015'] = true;
+  } else {
+    set['items.gear.owned.armor_special_birthday'] = true;
+  }
+
+  if (count % progressCount === 0) console.warn(`${count} ${user._id}`);
+
+  // eslint-disable-next-line no-return-await
+  return await User.updateOne({ _id: user._id }, { $inc: inc, $set: set, $push: push }).exec();
+}
+
+export default async function processUsers () {
+  let query = {
+    migration: { $ne: MIGRATION_NAME },
+    'auth.timestamps.loggedin': { $gt: new Date('2023-12-23') },
+  };
+
+  const fields = {
+    _id: 1,
+    items: 1,
+  };
+
+  while (true) { // eslint-disable-line no-constant-condition
+    const users = await User // eslint-disable-line no-await-in-loop
+      .find(query)
+      .limit(250)
+      .sort({ _id: 1 })
+      .select(fields)
+      .lean()
+      .exec();
+
+    if (users.length === 0) {
+      console.warn('All appropriate users found and modified.');
+      console.warn(`\n${count} users processed\n`);
+      break;
+    } else {
+      query._id = {
+        $gt: users[users.length - 1],
+      };
+    }
+
+    await Promise.all(users.map(updateUser)); // eslint-disable-line no-await-in-loop
+  }
+};

--- a/migrations/users/nye.js
+++ b/migrations/users/nye.js
@@ -1,0 +1,89 @@
+/* eslint-disable no-console */
+import { model as User } from '../../../website/server/models/user';
+import { v4 as uuid } from 'uuid';
+
+const MIGRATION_NAME = '20231228_nye';
+
+const progressCount = 1000;
+let count = 0;
+
+async function updateUser (user) {
+  count++;
+
+  const set = { migration: MIGRATION_NAME };
+  let push = {};
+
+  if (typeof user.items.gear.owned.head_special_nye2022 !== 'undefined') {
+    set['items.gear.owned.head_special_nye2023'] = true;
+  } else if (typeof user.items.gear.owned.head_special_nye2021 !== 'undefined') {
+    set['items.gear.owned.head_special_nye2022'] = true;
+  } else if (typeof user.items.gear.owned.head_special_nye2020 !== 'undefined') {
+    set['items.gear.owned.head_special_nye2021'] = true;
+  } else if (typeof user.items.gear.owned.head_special_nye2019 !== 'undefined') {
+    set['items.gear.owned.head_special_nye2020'] = true;
+  } else if (typeof user.items.gear.owned.head_special_nye2018 !== 'undefined') {
+    set['items.gear.owned.head_special_nye2019'] = true;
+  } else if (typeof user.items.gear.owned.head_special_nye2017 !== 'undefined') {
+    set['items.gear.owned.head_special_nye2018'] = true;
+  } else if (typeof user.items.gear.owned.head_special_nye2016 !== 'undefined') {
+    set['items.gear.owned.head_special_nye2017'] = true;
+  } else if (typeof user.items.gear.owned.head_special_nye2015 !== 'undefined') {
+    set['items.gear.owned.head_special_nye2016'] = true;
+  } else if (typeof user.items.gear.owned.head_special_nye2014 !== 'undefined') {
+    set['items.gear.owned.head_special_nye2015'] = true;
+  } else if (typeof user.items.gear.owned.head_special_nye !== 'undefined') {
+    set['items.gear.owned.head_special_nye2014'] = true;
+  } else {
+    set['items.gear.owned.head_special_nye'] = true;
+  }
+
+  push.notifications = {
+    type: 'ITEM_RECEIVED',
+    data: {
+      icon: 'notif_head_special_nye',
+      title: 'Happy New Year!',
+      text: 'Check your Equipment for this year\'s party hat!',
+      destination: 'inventory/equipment',
+    },
+    seen: false,
+  };
+
+  if (count % progressCount === 0) console.warn(`${count} ${user._id}`);
+
+  // eslint-disable-next-line no-return-await
+  return await User.updateOne({ _id: user._id }, { $set: set, $push: push }).exec();
+}
+
+export default async function processUsers () {
+  let query = {
+    'auth.timestamps.loggedin': { $gt: new Date('2023-12-01') },
+    migration: { $ne: MIGRATION_NAME },
+  };
+
+  const fields = {
+    _id: 1,
+    items: 1,
+  };
+
+  while (true) { // eslint-disable-line no-constant-condition
+    const users = await User // eslint-disable-line no-await-in-loop
+      .find(query)
+      .limit(250)
+      .sort({ _id: 1 })
+      .select(fields)
+      .lean()
+      .exec();
+
+    if (users.length === 0) {
+      console.warn('All appropriate users found and modified.');
+      console.warn(`\n${count} users processed\n`);
+      break;
+    } else {
+      query._id = {
+        $gt: users[users.length - 1],
+      };
+    }
+
+    await Promise.all(users.map(updateUser)); // eslint-disable-line no-await-in-loop
+  }
+};

--- a/migrations/users/nye.js
+++ b/migrations/users/nye.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
-import { model as User } from '../../../website/server/models/user';
 import { v4 as uuid } from 'uuid';
+import { model as User } from '../../../website/server/models/user';
 
 const MIGRATION_NAME = '20231228_nye';
 
@@ -11,7 +11,7 @@ async function updateUser (user) {
   count++;
 
   const set = { migration: MIGRATION_NAME };
-  let push = {};
+  const push = {};
 
   if (typeof user.items.gear.owned.head_special_nye2022 !== 'undefined') {
     set['items.gear.owned.head_special_nye2023'] = true;
@@ -55,7 +55,7 @@ async function updateUser (user) {
 }
 
 export default async function processUsers () {
-  let query = {
+  const query = {
     'auth.timestamps.loggedin': { $gt: new Date('2023-12-01') },
     migration: { $ne: MIGRATION_NAME },
   };
@@ -86,4 +86,4 @@ export default async function processUsers () {
 
     await Promise.all(users.map(updateUser)); // eslint-disable-line no-await-in-loop
   }
-};
+}

--- a/migrations/users/nye.js
+++ b/migrations/users/nye.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import { v4 as uuid } from 'uuid';
-import { model as User } from '../../../website/server/models/user';
+import { model as User } from '../../website/server/models/user';
 
 const MIGRATION_NAME = '20231228_nye';
 

--- a/migrations/users/nye.js
+++ b/migrations/users/nye.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-import { v4 as uuid } from 'uuid';
 import { model as User } from '../../website/server/models/user';
 
 const MIGRATION_NAME = '20231228_nye';
@@ -8,7 +7,7 @@ const progressCount = 1000;
 let count = 0;
 
 async function updateUser (user) {
-  count++;
+  count += 1;
 
   const set = { migration: MIGRATION_NAME };
   const push = {};

--- a/migrations/users/pet_group_achievements.js
+++ b/migrations/users/pet_group_achievements.js
@@ -7,14 +7,14 @@ const progressCount = 1000;
 let count = 0;
 
 async function updateUser (user) {
-  count++;
+  count += 1;
 
   const set = {
     migration: MIGRATION_NAME,
   };
 
   if (user && user.items && user.items.pets) {
-    const pets = user.items.pets;
+    const { pets } = user.items;
     if (pets['GuineaPig-Zombie'] > 0
       && pets['GuineaPig-Skeleton'] > 0
       && pets['GuineaPig-Base'] > 0

--- a/migrations/users/pet_group_achievements.js
+++ b/migrations/users/pet_group_achievements.js
@@ -1,0 +1,90 @@
+/* eslint-disable no-console */
+import { model as User } from '../../../website/server/models/user';
+
+const MIGRATION_NAME = '202403_pet_group_achievements';
+
+const progressCount = 1000;
+let count = 0;
+
+async function updateUser (user) {
+  count++;
+
+  const set = {
+    migration: MIGRATION_NAME,
+  };
+
+  if (user && user.items && user.items.pets) {
+    const pets = user.items.pets;
+    if (pets['GuineaPig-Zombie'] > 0
+      && pets['GuineaPig-Skeleton'] > 0
+      && pets['GuineaPig-Base'] > 0
+      && pets['GuineaPig-Desert'] > 0
+      && pets['GuineaPig-Red'] > 0
+      && pets['GuineaPig-Shade'] > 0
+      && pets['GuineaPig-White'] > 0
+      && pets['GuineaPig-Golden'] > 0
+      && pets['GuineaPig-CottonCandyBlue'] > 0
+      && pets['GuineaPig-CottonCandyPink'] > 0
+      && pets['Squirrel-Zombie'] > 0
+      && pets['Squirrel-Skeleton'] > 0
+      && pets['Squirrel-Base'] > 0
+      && pets['Squirrel-Desert'] > 0
+      && pets['Squirrel-Red'] > 0
+      && pets['Squirrel-Shade'] > 0
+      && pets['Squirrel-White'] > 0
+      && pets['Squirrel-Golden'] > 0
+      && pets['Squirrel-CottonCandyBlue'] > 0
+      && pets['Squirrel-CottonCandyPink'] > 0
+      && pets['Rat-Zombie'] > 0
+      && pets['Rat-Skeleton'] > 0
+      && pets['Rat-Base'] > 0
+      && pets['Rat-Desert'] > 0
+      && pets['Rat-Red'] > 0
+      && pets['Rat-Shade'] > 0
+      && pets['Rat-White'] > 0
+      && pets['Rat-Golden'] > 0
+      && pets['Rat-CottonCandyBlue'] > 0
+      && pets['Rat-CottonCandyPink'] > 0) {
+      set['achievements.rodentRuler'] = true;
+    }
+  }
+
+  if (count % progressCount === 0) console.warn(`${count} ${user._id}`);
+
+  // eslint-disable-next-line no-return-await
+  return await User.updateOne({ _id: user._id }, { $set: set }).exec();
+}
+
+export default async function processUsers () {
+  const query = {
+    migration: { $ne: MIGRATION_NAME },
+    'auth.timestamps.loggedin': { $gt: new Date('2024-02-01') },
+  };
+
+  const fields = {
+    _id: 1,
+    items: 1,
+  };
+
+  while (true) { // eslint-disable-line no-constant-condition
+    const users = await User // eslint-disable-line no-await-in-loop
+      .find(query)
+      .limit(250)
+      .sort({ _id: 1 })
+      .select(fields)
+      .lean()
+      .exec();
+
+    if (users.length === 0) {
+      console.warn('All appropriate users found and modified.');
+      console.warn(`\n${count} users processed\n`);
+      break;
+    } else {
+      query._id = {
+        $gt: users[users.length - 1]._id,
+      };
+    }
+
+    await Promise.all(users.map(updateUser)); // eslint-disable-line no-await-in-loop
+  }
+}

--- a/migrations/users/pet_group_achievements.js
+++ b/migrations/users/pet_group_achievements.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { model as User } from '../../../website/server/models/user';
+import { model as User } from '../../website/server/models/user';
 
 const MIGRATION_NAME = '202403_pet_group_achievements';
 

--- a/migrations/users/pi-day.js
+++ b/migrations/users/pi-day.js
@@ -43,11 +43,16 @@ async function updateUser (user) {
 
   if (push) {
     return User
-      .update({ _id: user._id }, { $inc: inc, $set: set, $push: { pinnedItems: { $each: push } } })
+      .updateOne(
+        { _id: user._id },
+        {
+          $inc: inc, $set: set, $push: { pinnedItems: { $each: push } },
+        },
+      )
       .exec();
   }
   return User
-    .update({ _id: user._id }, { $inc: inc, $set: set })
+    .updateOne({ _id: user._id }, { $inc: inc, $set: set })
     .exec();
 }
 

--- a/migrations/users/summer_splash_orcas.js
+++ b/migrations/users/summer_splash_orcas.js
@@ -7,7 +7,7 @@ const progressCount = 1000;
 let count = 0;
 
 async function updateUser (user) {
-  count++;
+  count += 1;
 
   const set = { migration: MIGRATION_NAME };
   const push = {};

--- a/migrations/users/summer_splash_orcas.js
+++ b/migrations/users/summer_splash_orcas.js
@@ -48,7 +48,7 @@ async function updateUser (user) {
 }
 
 export default async function processUsers () {
-  let query = {
+  const query = {
     migration: { $ne: MIGRATION_NAME },
     'auth.timestamps.loggedin': { $gt: new Date('2023-06-18') },
   };
@@ -78,4 +78,4 @@ export default async function processUsers () {
 
     await Promise.all(users.map(updateUser)); // eslint-disable-line no-await-in-loop
   }
-} 
+}

--- a/migrations/users/summer_splash_orcas.js
+++ b/migrations/users/summer_splash_orcas.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { model as User } from '../../../website/server/models/user';
+import { model as User } from '../../website/server/models/user';
 
 const MIGRATION_NAME = '20230718_summer_splash_orcas';
 

--- a/migrations/users/summer_splash_orcas.js
+++ b/migrations/users/summer_splash_orcas.js
@@ -1,0 +1,81 @@
+/* eslint-disable no-console */
+import { model as User } from '../../../website/server/models/user';
+
+const MIGRATION_NAME = '20230718_summer_splash_orcas';
+
+const progressCount = 1000;
+let count = 0;
+
+async function updateUser (user) {
+  count++;
+
+  const set = { migration: MIGRATION_NAME };
+  const push = {};
+
+  if (user && user.items && user.items.pets && typeof user.items.pets['Orca-Base'] !== 'undefined') {
+    return;
+  // eslint-disable-next-line no-else-return
+  } else if (user && user.items && user.items.mounts && typeof user.items.mounts['Orca-Base'] !== 'undefined') {
+    set['items.pets.Orca-Base'] = 5;
+    push.notifications = {
+      type: 'ITEM_RECEIVED',
+      data: {
+        icon: 'notif_orca_pet',
+        title: 'Orcas for Summer Splash!',
+        text: 'To celebrate Summer Splash, we\'ve given you an Orca Pet!',
+        destination: 'stable',
+      },
+      seen: false,
+    };
+  } else {
+    set['items.mounts.Orca-Base'] = true;
+    push.notifications = {
+      type: 'ITEM_RECEIVED',
+      data: {
+        icon: 'notif_orca_mount',
+        title: 'Orcas for Summer Splash!',
+        text: 'To celebrate Summer Splash, we\'ve given you an Orca Mount!',
+        destination: 'stable',
+      },
+      seen: false,
+    };
+  }
+
+  if (count % progressCount === 0) console.warn(`${count} ${user._id}`);
+
+  // eslint-disable-next-line consistent-return, no-return-await
+  return await user.updateOne({ $set: set, $push: push }).exec();
+}
+
+export default async function processUsers () {
+  let query = {
+    migration: { $ne: MIGRATION_NAME },
+    'auth.timestamps.loggedin': { $gt: new Date('2023-06-18') },
+  };
+
+  const fields = {
+    _id: 1,
+    items: 1,
+  };
+
+  while (true) { // eslint-disable-line no-constant-condition
+    const users = await User // eslint-disable-line no-await-in-loop
+      .find(query)
+      .limit(250)
+      .sort({ _id: 1 })
+      .select(fields)
+      .exec();
+
+    if (users.length === 0) {
+      console.warn('All appropriate users found and modified.');
+      console.warn(`\n${count} users processed\n`);
+      break;
+    } else {
+      query._id = {
+        $gt: users[users.length - 1],
+      };
+    }
+
+    await Promise.all(users.map(updateUser)); // eslint-disable-line no-await-in-loop
+  }
+} 

--- a/migrations/users/take-this.js
+++ b/migrations/users/take-this.js
@@ -3,7 +3,7 @@ import { v4 as uuid } from 'uuid';
 
 import { model as User } from '../../website/server/models/user';
 
-const MIGRATION_NAME = '20181203_take_this';
+const MIGRATION_NAME = 'take-this';
 
 const progressCount = 1000;
 let count = 0;

--- a/migrations/users/take-this.js
+++ b/migrations/users/take-this.js
@@ -41,9 +41,9 @@ async function updateUser (user) {
   if (count % progressCount === 0) console.warn(`${count} ${user._id}`);
 
   if (push) {
-    return User.update({ _id: user._id }, { $set: set, $push: push }).exec();
+    return User.updateOne({ _id: user._id }, { $set: set, $push: push }).exec();
   }
-  return User.update({ _id: user._id }, { $set: set }).exec();
+  return User.updateOne({ _id: user._id }, { $set: set }).exec();
 }
 
 export default async function processUsers () {

--- a/migrations/users/veteran_pet_ladder.js
+++ b/migrations/users/veteran_pet_ladder.js
@@ -1,0 +1,146 @@
+/* eslint-disable no-console */
+import { model as User } from '../../../../website/server/models/user';
+
+const MIGRATION_NAME = '20230808_veteran_pet_ladder';
+
+const progressCount = 1000;
+let count = 0;
+
+async function updateUser (user) {
+  count++;
+
+  const set = {};
+  let push = { notifications: { $each: [] } };
+
+  set.migration = MIGRATION_NAME;
+  if (user.items.pets['Fox-Veteran']) {
+    set['items.pets.Dragon-Veteran'] = 5;
+    push.notifications.$each.push({
+      type: 'ITEM_RECEIVED',
+      data: {
+        icon: 'icon_pet_veteran_dragon',
+        title: 'You’ve received a Veteran Pet!',
+        text: 'To commemorate being here for a new era of Habitica, we’ve awarded you a Veteran Dragon.',
+        destination: '/inventory/stable',
+      },
+      seen: false,
+    });
+  } else if (user.items.pets['Bear-Veteran']) {
+    set['items.pets.Fox-Veteran'] = 5;
+    push.notifications.$each.push({
+      type: 'ITEM_RECEIVED',
+      data: {
+        icon: 'icon_pet_veteran_fox',
+        title: 'You’ve received a Veteran Pet!',
+        text: 'To commemorate being here for a new era of Habitica, we’ve awarded you a Veteran Fox.',
+        destination: '/inventory/stable',
+      },
+      seen: false,
+    });
+  } else if (user.items.pets['Lion-Veteran']) {
+    set['items.pets.Bear-Veteran'] = 5;
+    push.notifications.$each.push({
+      type: 'ITEM_RECEIVED',
+      data: {
+        icon: 'icon_pet_veteran_bear',
+        title: 'You’ve received a Veteran Pet!',
+        text: 'To commemorate being here for a new era of Habitica, we’ve awarded you a Veteran Bear.',
+        destination: '/inventory/stable',
+      },
+      seen: false,
+    });
+  } else if (user.items.pets['Tiger-Veteran']) {
+    set['items.pets.Lion-Veteran'] = 5;
+    push.notifications.$each.push({
+      type: 'ITEM_RECEIVED',
+      data: {
+        icon: 'icon_pet_veteran_lion',
+        title: 'You’ve received a Veteran Pet!',
+        text: 'To commemorate being here for a new era of Habitica, we’ve awarded you a Veteran Lion.',
+        destination: '/inventory/stable',
+      },
+      seen: false,
+    });
+  } else if (user.items.pets['Wolf-Veteran']) {
+    set['items.pets.Tiger-Veteran'] = 5;
+    push.notifications.$each.push({
+      type: 'ITEM_RECEIVED',
+      data: {
+        icon: 'icon_pet_veteran_tiger',
+        title: 'You’ve received a Veteran Pet!',
+        text: 'To commemorate being here for a new era of Habitica, we’ve awarded you a Veteran Tiger.',
+        destination: '/inventory/stable',
+      },
+      seen: false,
+    });
+  } else {
+    set['items.pets.Wolf-Veteran'] = 5;
+    push.notifications.$each.push({
+      type: 'ITEM_RECEIVED',
+      data: {
+        icon: 'icon_pet_veteran_wolf',
+        title: 'You’ve received a Veteran Pet!',
+        text: 'To commemorate being here for a new era of Habitica, we’ve awarded you a Veteran Wolf.',
+        destination: '/inventory/stable',
+      },
+      seen: false,
+    });
+  }
+
+  if (user.contributor.level > 0) {
+    set['items.gear.owned.armor_special_heroicTunic'] = true;
+    set['items.gear.owned.back_special_heroicAureole'] = true;
+    set['items.gear.owned.headAccessory_special_heroicCirclet'] = true;
+    push.notifications.$each.push({
+      type: 'ITEM_RECEIVED',
+      data: {
+        icon: 'heroic_set_icon',
+        title: 'You’ve received the Heroic Set!',
+        text: 'To commemorate your hard work as a contributor, we’ve awarded you the Heroic Circlet, Heroic Aureole, and Heroic Tunic.',
+        destination: '/inventory/equipment',
+      },
+      seen: false,
+    });
+  }
+
+  if (count % progressCount === 0) console.warn(`${count} ${user._id}`);
+
+  // eslint-disable-next-line no-return-await
+  return await User.updateOne({ _id: user._id }, { $set: set, $push: push }).exec();
+}
+
+export default async function processUsers () {
+  let query = {
+    migration: { $ne: MIGRATION_NAME },
+    'auth.timestamps.loggedin': { $gt: new Date('2023-07-08') },
+  };
+
+  const fields = {
+    _id: 1,
+    items: 1,
+    migration: 1,
+    contributor: 1,
+  };
+
+  while (true) { // eslint-disable-line no-constant-condition
+    const users = await User // eslint-disable-line no-await-in-loop
+      .find(query)
+      .limit(250)
+      .sort({_id: 1})
+      .select(fields)
+      .lean()
+      .exec();
+
+    if (users.length === 0) {
+      console.warn('All appropriate users found and modified.');
+      console.warn(`\n${count} users processed\n`);
+      break;
+    } else {
+      query._id = {
+        $gt: users[users.length - 1],
+      };
+    }
+
+    await Promise.all(users.map(updateUser)); // eslint-disable-line no-await-in-loop
+  }
+};

--- a/migrations/users/veteran_pet_ladder.js
+++ b/migrations/users/veteran_pet_ladder.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { model as User } from '../../../../website/server/models/user';
+import { model as User } from '../../website/server/models/user';
 
 const MIGRATION_NAME = '20230808_veteran_pet_ladder';
 
@@ -126,7 +126,7 @@ export default async function processUsers () {
     const users = await User // eslint-disable-line no-await-in-loop
       .find(query)
       .limit(250)
-      .sort({_id: 1})
+      .sort({ _id: 1 })
       .select(fields)
       .lean()
       .exec();

--- a/migrations/users/veteran_pet_ladder.js
+++ b/migrations/users/veteran_pet_ladder.js
@@ -10,7 +10,7 @@ async function updateUser (user) {
   count++;
 
   const set = {};
-  let push = { notifications: { $each: [] } };
+  const push = { notifications: { $each: [] } };
 
   set.migration = MIGRATION_NAME;
   if (user.items.pets['Fox-Veteran']) {
@@ -110,7 +110,7 @@ async function updateUser (user) {
 }
 
 export default async function processUsers () {
-  let query = {
+  const query = {
     migration: { $ne: MIGRATION_NAME },
     'auth.timestamps.loggedin': { $gt: new Date('2023-07-08') },
   };
@@ -143,4 +143,4 @@ export default async function processUsers () {
 
     await Promise.all(users.map(updateUser)); // eslint-disable-line no-await-in-loop
   }
-};
+}

--- a/migrations/users/veteran_pet_ladder.js
+++ b/migrations/users/veteran_pet_ladder.js
@@ -7,7 +7,7 @@ const progressCount = 1000;
 let count = 0;
 
 async function updateUser (user) {
-  count++;
+  count += 1;
 
   const set = {};
   const push = { notifications: { $each: [] } };


### PR DESCRIPTION
Updates to the following migration scripts: 
* `bulk-email.js`
* `full-gear.js`
* `habit_birthday.js`
* `nye.js`
* `pet_group_achievements.js`
* `pi-day`
* `summer_splash_orcas.js`
* `take-this.js`
* `veteran_pet_ladder`

I have also done a little bit of code clean-up.

I have tested these scripts locally and they do what they're supposed to do.