### PR TITLE
fix(apidoc): Make type parameter optional in apidoc as in description

### DIFF
--- a/website/server/controllers/api-v3/tasks.js
+++ b/website/server/controllers/api-v3/tasks.js
@@ -346,13 +346,13 @@ api.createChallengeTasks = {
  * @apiGroup Task
  *
  * @apiParam (Query) {String="habits","dailys",
- *                   "todos","rewards","completedTodos"} type Optional query parameter to return
- *                                                            just a type of tasks. By default all
- *                                                            types will be returned except
- *                                                            completed todos that must be
- *                                                            requested separately.
- *                                                            The "completedTodos" type returns
- *                                                            only the 30 most recently completed.
+ *                   "todos","rewards","completedTodos"} [type] Optional query parameter to return
+ *                                                              just a type of tasks. By default all
+ *                                                              types will be returned except
+ *                                                              completed todos that must be
+ *                                                              requested separately.
+ *                                                              The "completedTodos" type returns
+ *                                                              only the 30 most recently completed.
  * @apiParam (Query) [dueDate] type Optional date to use for computing the nextDue field
  *                                  for each returned task.
  *


### PR DESCRIPTION
[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes AsmfreaK/habitipy#25

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
This change is required for habitipy (a Python api client for Habitica). It parses the apidoc comments in Habitica code and makes and coding interface out of it. This change makes `type` query parameter optional not only in param's description, but also in apidoc code.

----
UUID: 1f740057-8e11-4ca3-a9b2-54886615dca6
