### PR TITLE
[WIP] ToDos - Start Showing field

### DIFF
--- a/website/client/src/components/tasks/taskModal.vue
+++ b/website/client/src/components/tasks/taskModal.vue
@@ -220,6 +220,23 @@
           />
         </template>
         <div
+          v-if="task.type === 'todo' && (!challengeAccessRequired || task.startShowing)"
+          class="option mt-3"
+        >
+          <div class="form-group">
+            <lockable-label
+              :locked="challengeAccessRequired"
+              :text="$t('startShowing')"
+            />
+            <datepicker
+              :date.sync="task.startShowing"
+              :disabled="challengeAccessRequired"
+              :highlighted="calendarHighlights"
+              :clear-button="true"
+            />
+          </div>
+        </div>
+        <div
           v-if="task.type === 'todo' && (!challengeAccessRequired || task.date)"
           class="option mt-3"
         >

--- a/website/client/src/libs/store/helpers/filterTasks.js
+++ b/website/client/src/libs/store/helpers/filterTasks.js
@@ -23,7 +23,7 @@ const taskFilters = {
     label: 'todos',
     filters: [
       { label: 'remaining', filterFn: t => !t.completed, default: true }, // active
-      { label: 'scheduled', filterFn: t => !t.completed && t.date, sort: t => t.date },
+      { label: 'scheduled', filterFn: t => !t.completed && t.date && (!t.startShowing || new Date(t.startShowing) <= new Date()), sort: t => t.date },
       { label: 'complete2', filterFn: t => t.completed },
     ],
   },

--- a/website/common/locales/en/tasks.json
+++ b/website/common/locales/en/tasks.json
@@ -138,5 +138,6 @@
   "pressEnterToAddTag": "Press Enter to add tag: '<%= tagName %>'",
   "taskSummary": "<%= type %> Summary",
   "scoreUp": "Score up",
-  "scoreDown": "Score down"
+  "scoreDown": "Score down",
+  "startShowing": "Start showing"
 }

--- a/website/server/controllers/api-v3/tasks.js
+++ b/website/server/controllers/api-v3/tasks.js
@@ -67,8 +67,8 @@ const api = {};
  * @apiParam (Body) {Boolean} [collapseChecklist=false] Determines if a checklist will be displayed
  * @apiParam (Body) {String} [notes] Extra notes
  * @apiParam (Body) {Date} [date] Due date to be shown in task list. Only valid for type "todo."
- * @apiParam (Body) {Date} [startShowing] Date to start showing the ToDo, used for planning and have 
- *                                        a clean toDo list. Only valid for type "todo." 
+ * @apiParam (Body) {Date} [startShowing] Date to start showing the ToDo, used for planning and
+ *                                        have a clean toDo list. Only valid for type "todo."
  * @apiParam (Body) {Number="0.1","1","1.5","2"} [priority=1] Difficulty, options are 0.1, 1,
  *                                                            1.5, 2; equivalent of Trivial,
  *                                                            Easy, Medium, Hard.

--- a/website/server/controllers/api-v3/tasks.js
+++ b/website/server/controllers/api-v3/tasks.js
@@ -67,6 +67,8 @@ const api = {};
  * @apiParam (Body) {Boolean} [collapseChecklist=false] Determines if a checklist will be displayed
  * @apiParam (Body) {String} [notes] Extra notes
  * @apiParam (Body) {Date} [date] Due date to be shown in task list. Only valid for type "todo."
+ * @apiParam (Body) {Date} [startShowing] Date to start showing the ToDo, used for planning and have 
+ *                                        a clean toDo list. Only valid for type "todo." 
  * @apiParam (Body) {Number="0.1","1","1.5","2"} [priority=1] Difficulty, options are 0.1, 1,
  *                                                            1.5, 2; equivalent of Trivial,
  *                                                            Easy, Medium, Hard.

--- a/website/server/models/task.js
+++ b/website/server/models/task.js
@@ -411,6 +411,7 @@ export const daily = Task.discriminator('daily', DailySchema);
 export const TodoSchema = new Schema(_.defaults({
   dateCompleted: Date,
   date: Date, // due date for todos
+  startShowing: Date, // Start showing date for ToDo planning.
 }, dailyTodoSchema()), subDiscriminatorOptions);
 export const todo = Task.discriminator('todo', TodoSchema);
 


### PR DESCRIPTION
[//]: # (Note: See https://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes **NO ISSUE YET**

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Basically a new field that blocks the ToDo from appearing when using ´Scheduling´ mode.

Lets say that I want to add a ToDo for a medical thing 6 months in the future, even when I can do it with Habitica as it is, is very bad for planning and the list can grow a lot if I see it there all the time.

With this field an user can just specify the task to appear only after 5 months, so 1 month prior its due date the task will appear.

I added some little code to serve as an example, does not look difficult to add in mobile either IMO.

**EXAMPLES**
- Doctor appointment in 6 months
- Family reunions
- Stuff you want to do for next halloween
- New years resolutions
- Stuff you want to focus on specific months
- Improvements to your home for following months

Overall having a cleaner list will make users focus better on those ToDos, avoiding very big lists with stuff that is not relevant yet at the bottom.

<img width="525" alt="image" src="https://github.com/HabitRPG/habitica/assets/16009004/eb9fc7c7-9184-48af-8624-f938193907c0">

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 9ba01c32-cbc9-4d74-97d2-b196151e2b1f
