### PR TITLE
Fix issue with l4p not resetting properly

### DIFF
--- a/test/api/v3/integration/groups/POST-groups.test.js
+++ b/test/api/v3/integration/groups/POST-groups.test.js
@@ -147,7 +147,7 @@ describe('POST /group', () => {
 
     it('removes seeking from user', async () => {
       await user.updateOne({ 'party.seeking': new Date() });
-      const party = await user.post('/groups', {
+      await user.post('/groups', {
         name: partyName,
         type: partyType,
       });

--- a/test/api/v3/integration/groups/POST-groups.test.js
+++ b/test/api/v3/integration/groups/POST-groups.test.js
@@ -145,6 +145,18 @@ describe('POST /group', () => {
       expect(updatedUser.party._id).to.eql(party._id);
     });
 
+    it('removes seeking from user', async () => {
+      await user.updateOne({ 'party.seeking': new Date() });
+      const party = await user.post('/groups', {
+        name: partyName,
+        type: partyType,
+      });
+
+      const updatedUser = await user.get('/user');
+
+      expect(updatedUser.party.seeking).to.not.exist;
+    });
+
     it('does not award Party Up achievement to solo partier', async () => {
       await user.post('/groups', {
         name: partyName,

--- a/test/api/v3/integration/groups/POST-groups_groupId_join.test.js
+++ b/test/api/v3/integration/groups/POST-groups_groupId_join.test.js
@@ -178,6 +178,15 @@ describe('POST /group/:groupId/join', () => {
         await expect(invitedUser.get('/user')).to.eventually.not.have.nested.property('invitations.parties[0].id');
       });
 
+      it('clears party.seeking from user when joining party', async () => {
+        await invitedUser.updateOne({ 'party.seeking': new Date() });
+        await invitedUser.post(`/groups/${party._id}/join`);
+
+        const updatedUser = await invitedUser.get('/user');
+
+        await expect(updatedUser.party.seeking).to.not.exist;
+      });
+
       it('increments memberCount when joining party', async () => {
         const oldMemberCount = party.memberCount;
 

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -136,6 +136,7 @@ api.createGroup = {
       if (user.party._id) throw new NotAuthorized(res.t('messageGroupAlreadyInParty'));
 
       user.party._id = group._id;
+      user.party.seeking = undefined;
     }
 
     let savedGroup;
@@ -590,7 +591,7 @@ api.joinGroup = {
         // Clear all invitations of new user and reset looking for party state
         user.invitations.parties = [];
         user.invitations.party = {};
-        user.party.seeking = null;
+        user.party.seeking = undefined;
 
         // invite new user to pending quest
         if (group.quest.key && !group.quest.active) {


### PR DESCRIPTION
- sets field to undefined since null still counts as it existing
- also sets it to undefined when a user creates a new party