### PR TITLE
Fix dockerfile

### DIFF
--- a/Dockerfile-Dev
+++ b/Dockerfile-Dev
@@ -7,8 +7,6 @@ RUN npm install -g gulp-cli mocha
 # dependencies.
 WORKDIR /usr/src/habitica
 COPY ["package.json", "package-lock.json", "./"]
-RUN npm install
-
 # Copy the remaining source files in.
 COPY . /usr/src/habitica
-RUN npm run postinstall
+RUN npm install


### PR DESCRIPTION
Fixes "gulp file not found" error while building docker image

### Changes
```diff
  # dependencies.
  WORKDIR /usr/src/habitica
  COPY ["package.json", "package-lock.json", "./"]
-  RUN npm install
  # Copy the remaining source files in.
  COPY . /usr/src/habitica
-  RUN npm run postinstall
+  RUN npm install
```
Running postinstall separately is unnecessary because npm install will run it automatically after the packages have been installed. However, the remaining source files must be copied before npm install, otherwise when postinstall runs, it will miss gulpfile, resulting in an error and breaking the Docker image build.




