### PR TITLE
Fix intro guide

### DIFF
--- a/website/client/vue.config.js
+++ b/website/client/vue.config.js
@@ -39,7 +39,7 @@ envVars
   });
 
 const webpackPlugins = [
-  new webpack.ProvidePlugin({'window.jQuery': 'jquery'}),
+  new webpack.ProvidePlugin({ 'window.jQuery': 'jquery' }),
   new webpack.DefinePlugin(envObject),
   new webpack.ContextReplacementPlugin(/moment[\\/]locale$/, /^\.\/(NOT_EXISTING)$/),
 ];

--- a/website/client/vue.config.js
+++ b/website/client/vue.config.js
@@ -39,6 +39,7 @@ envVars
   });
 
 const webpackPlugins = [
+  new webpack.ProvidePlugin({'window.jQuery': 'jquery'}),
   new webpack.DefinePlugin(envObject),
   new webpack.ContextReplacementPlugin(/moment[\\/]locale$/, /^\.\/(NOT_EXISTING)$/),
 ];


### PR DESCRIPTION
**Fixes intro guide error "invalid instaceof window.jquery"**

Changes in client/vue.config.js
```diff
  const webpackPlugins = [
+    new webpack.ProvidePlugin({'window.jQuery': 'jquery'}),
    new webpack.DefinePlugin(envObject),
    new webpack.ContextReplacementPlugin(/moment[\\/]locale$/, /^\.\/(NOT_EXISTING)$/),
  ];
```

Error code: [https://gist.github.com/rafJagCode/609d8773dc553cdfad9d4cb50ecc4124](https://gist.github.com/rafJagCode/609d8773dc553cdfad9d4cb50ecc4124)
Error img before fix and intro guide displayed after providing window.jquery:
<p>
<img src="https://github.com/rafJagCode/shared/blob/master/habitica_invalid_instanceof_window_jquery/error_guide.png?raw=true" align="left" width="200" height="200"/>
<img src="https://github.com/rafJagCode/shared/blob/master/habitica_invalid_instanceof_window_jquery/fixed_guide.png?raw=true" clear="both" width="200" height="200"/>
</p>

----
UUID: 01148fda-c7f3-4668-a83d-e519eaf9407c