### PR TITLE
Fix chat autocomplete after accepting community guidelines

### DIFF
--- a/website/client/src/components/groups/chat.vue
+++ b/website/client/src/components/groups/chat.vue
@@ -16,7 +16,7 @@
         class="row"
       >
         <textarea
-          ref="user-entry"
+          :ref="setTextbox"
           v-model="newMessage"
           dir="auto"
           :placeholder="placeholder"
@@ -135,13 +135,15 @@ export default {
     },
   },
   mounted () {
-    this.textbox = this.$refs['user-entry'];
     this.handleExternalLinks();
   },
   updated () {
     this.handleExternalLinks();
   },
   methods: {
+    setTextbox (ref) {
+      this.textbox = ref;
+    },
     // https://medium.com/@_jh3y/how-to-where-s-the-caret-getting-the-xy-position-of-the-caret-a24ba372990a
     getCoord (e, text) {
       this.caretPosition = text.selectionEnd;


### PR DESCRIPTION
The row containing the chat textarea is conditionally rendered with the v-if directive based on the acceptance of community guidelines. This means that when the chat.vue component is mounted, the textarea reference is undefined, causing autoComplete.vue to try to access properties of an undefined textbox prop.

```js
// chat.vue
mounted () {
  this.textbox = this.$refs['user-entry']; // this.textbox = undefined
},

//autoComplete.vue
const caretPosition = this.textbox.selectionEnd; // // Trying to access the selectionEnd property of an undefined value
```
```html
<!-- Fix: Use a ref function to set the textbox when the textarea has been rendered -->
 <textarea :ref="setTextbox"></textarea>
```

----
UUID: 01148fda-c7f3-4668-a83d-e519eaf9407c
