### PR TITLE
fix mage gear being shown as twohanded

### DIFF
--- a/test/content/gear.test.js
+++ b/test/content/gear.test.js
@@ -68,6 +68,16 @@ describe('Gear', () => {
     });
   });
 
+  it('only assigns mage weapons twoHanded', () => {
+    each([allGear.armor.special, allGear.head.special, allGear.shield.special], gearType => {
+      each(gearType, gear => {
+        if (gear.specialClass === 'wizard') {
+          expect(gear.twoHanded, gear.key).to.not.eql(true);
+        }
+      });
+    });
+  });
+
   describe('backer gear', () => {
     let user;
 

--- a/website/common/script/content/gear/sets/special/index.js
+++ b/website/common/script/content/gear/sets/special/index.js
@@ -36,7 +36,7 @@ function fillSpecialGear (gearItems, gearType, value, stats) {
         value: actualValue,
         season,
       }, actualStats);
-      if (klass === 'wizard') {
+      if (klass === 'wizard' && gearType === 'weapon') {
         defaults(gearItems[key], {
           twoHanded: true,
         });


### PR DESCRIPTION
[//]: # (Note: See https://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes put_#_and_issue_number_here

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)



[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID:
