### PR TITLE
Don't load browser-script twice

### DIFF
--- a/website/client/src/pages/user-main.vue
+++ b/website/client/src/pages/user-main.vue
@@ -259,6 +259,11 @@ export default {
           return null;
         }
       }
+      if (window && window['habitica-i18n']) {
+        if (this.user.preferences.language === window['habitica-i18n'].language.code) {
+          return null;
+        }
+      }
       return axios.get(
         '/api/v4/i18n/browser-script',
         {


### PR DESCRIPTION
the browser-script call is made on page load and then again when the user is loaded. However in most cases this is unnecessary, since the translations will already have been loaded with the correct localisation on the initial load.
Adding a check for that improves initial page load speed as well as reducing the amount of traffic.