### PR TITLE
Allow including needsCron in userFields filter

### DIFF
--- a/website/server/libs/user/index.js
+++ b/website/server/libs/user/index.js
@@ -25,7 +25,7 @@ export async function get (req, res, { isV3 = false }) {
   // Remove apiToken from response TODO make it private at the user level? returned in signup/login
   delete userToJSON.apiToken;
 
-  if (!req.query.userFields) {
+  if (!req.query.userFields || req.query.userFields.includes('needsCron')) {
     const { daysMissed } = user.daysUserHasMissed(new Date(), req);
     userToJSON.needsCron = false;
     if (daysMissed > 0) userToJSON.needsCron = true;


### PR DESCRIPTION


[//]: # (Note: See https://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes put_#_and_issue_number_here

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

needsCron is only returned if userFields is not set, but including needsCron in userFields was not possible. This allows to use userFields filters to explicitly include needsCron

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 4c4ca53f-c059-4ffa-966e-9d29dd405daf
