### PR TITLE
Remove and clean up unused invite notif

### DIFF
--- a/migrations/archive/2024/2024_purge_invite_accepted.js
+++ b/migrations/archive/2024/2024_purge_invite_accepted.js
@@ -1,0 +1,51 @@
+/* eslint-disable no-console */
+const MIGRATION_NAME = '2024_purge_invite_accepted';
+import { model as User } from '../../../website/server/models/user';
+
+const progressCount = 1000;
+let count = 0;
+
+async function updateUser (user) {
+  count++;
+
+  return await User.updateOne(
+    { _id: user._id },
+    { $pull: { notifications: { type: 'GROUP_INVITE_ACCEPTED' } } },
+  ).exec();
+}
+
+export default async function processUsers () {
+  let query = {
+    migration: {$ne: MIGRATION_NAME},
+    'notifications.type': 'GROUP_INVITE_ACCEPTED',
+    'auth.timestamps.loggedin': { $gt: new Date('2024-06-25') },
+  };
+
+  const fields = {
+    _id: 1,
+    items: 1,
+    migration: 1,
+    contributor: 1,
+  };
+
+  while (true) { // eslint-disable-line no-constant-condition
+    const users = await User // eslint-disable-line no-await-in-loop
+      .find(query)
+      .limit(250)
+      .sort({_id: 1})
+      .select(fields)
+      .exec();
+
+    if (users.length === 0) {
+      console.warn('All appropriate users found and modified.');
+      console.warn(`\n${count} users processed\n`);
+      break;
+    } else {
+      query._id = {
+        $gt: users[users.length - 1],
+      };
+    }
+
+    await Promise.all(users.map(updateUser)); // eslint-disable-line no-await-in-loop
+  }
+};

--- a/test/api/v3/integration/groups/POST-groups_groupId_join.test.js
+++ b/test/api/v3/integration/groups/POST-groups_groupId_join.test.js
@@ -85,22 +85,6 @@ describe('POST /group/:groupId/join', () => {
         await expect(user.get('/user')).to.eventually.have.nested.property('items.quests.basilist', 1);
       });
 
-      it('notifies inviting user that their invitation was accepted', async () => {
-        await invitedUser.post(`/groups/${guild._id}/join`);
-
-        const inviter = await user.get('/user');
-        const expectedData = {
-          headerText: t('invitationAcceptedHeader'),
-          bodyText: t('invitationAcceptedBody', {
-            username: invitedUser.auth.local.username,
-            groupName: guild.name,
-          }),
-        };
-
-        expect(inviter.notifications[1].type).to.eql('GROUP_INVITE_ACCEPTED');
-        expect(inviter.notifications[1].data).to.eql(expectedData);
-      });
-
       it('awards Joined Guild achievement', async () => {
         await invitedUser.post(`/groups/${guild._id}/join`);
 
@@ -153,23 +137,6 @@ describe('POST /group/:groupId/join', () => {
         await invitedUser.post(`/groups/${party._id}/join`);
 
         await expect(invitedUser.get('/user')).to.eventually.have.nested.property('party._id', party._id);
-      });
-
-      it('notifies inviting user that their invitation was accepted', async () => {
-        await invitedUser.post(`/groups/${party._id}/join`);
-
-        const inviter = await user.get('/user');
-
-        const expectedData = {
-          headerText: t('invitationAcceptedHeader'),
-          bodyText: t('invitationAcceptedBody', {
-            username: invitedUser.auth.local.username,
-            groupName: party.name,
-          }),
-        };
-
-        expect(inviter.notifications[0].type).to.eql('GROUP_INVITE_ACCEPTED');
-        expect(inviter.notifications[0].data).to.eql(expectedData);
       });
 
       it('clears invitation from user when joining party', async () => {

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -657,7 +657,6 @@ api.joinGroup = {
           username: user.profile.name,
         }, inviter.preferences.language),
       };
-      inviter.addNotification('GROUP_INVITE_ACCEPTED', data);
 
       // Reward Inviter
       if (group.type === 'party') {

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -650,14 +650,6 @@ api.joinGroup = {
 
     // Check the inviter again, could be a deleted account
     if (inviter) {
-      const data = {
-        headerText: common.i18n.t('invitationAcceptedHeader', inviter.preferences.language),
-        bodyText: common.i18n.t('invitationAcceptedBody', {
-          groupName: group.name,
-          username: user.profile.name,
-        }, inviter.preferences.language),
-      };
-
       // Reward Inviter
       if (group.type === 'party') {
         if (!inviter.items.quests.basilist) {

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -641,7 +641,7 @@ api.joinGroup = {
       const currentMembers = await group.getMemberCount();
       // Load the inviter
       if (inviter) inviter = await User.findById(inviter).exec();
-  
+
       // Check the inviter again, could be a deleted account
       if (inviter) {
         // Reward Inviter


### PR DESCRIPTION
Fixes #10752 

**Previously**, whenever a user accepted an invitation to a Party or Group Plan, the inviting user would receive a GROUP_INVITE_ACCEPTED notification. This notification was not displayed on the client, and thus it was possible for a user to continue to accumulate junk data in this array over time.

**Now**:
1. GROUP_INVITE_ACCEPTED notifications are no longer posted to the user in these flows.
2. We no longer check for GROUP_INVITE_ACCEPTED notifications in related tests.
3. A migration has been created to remove extant GROUP_INVITE_ACCEPTED notifications from affected users.

For now, GROUP_INVITE_ACCEPTED remains as an enum in the user model `notifications` property. We shouldn't remove this until the migration has been run over all users. Once no more such notifications remain in the database, we can delete the enum.