### PR TITLE
Fix news related permission issues

### DIFF
--- a/website/client/src/components/header/menu.vue
+++ b/website/client/src/components/header/menu.vue
@@ -297,7 +297,7 @@
             <div class="topbar-dropdown">
               <router-link
                 v-if="user.permissions.fullAccess ||
-                  user.permissions.userSupport || user.permissions.newsPoster"
+                  user.permissions.userSupport"
                 class="topbar-dropdown-item dropdown-item"
                 :to="{name: 'adminPanel'}"
               >

--- a/website/client/src/components/news/newsContent.vue
+++ b/website/client/src/components/news/newsContent.vue
@@ -107,7 +107,7 @@ export default {
       if (lastPublishedPost) this.posts.push(lastPublishedPost);
 
       // If the user is authorized, show any draft
-      if (this.user && this.user.contributor.newsPoster) {
+      if (this.user && (this.user.permissions.news || this.user.permissions.fullAccess)) {
         this.posts.unshift(
           ...postsFromServer
             .filter(p => !p.published || moment().isBefore(p.publishDate)),

--- a/website/client/src/router/index.js
+++ b/website/client/src/router/index.js
@@ -189,7 +189,6 @@ const router = new VueRouter({
       meta: {
         privilegeNeeded: [ // any one of these is enough to give access
           'userSupport',
-          'newsPoster',
         ],
       },
       children: [


### PR DESCRIPTION
This removes two instances where the newsPoster permission is not actually correct (and also wrong name)
Also fixes a bug where server would return draft posts but the client would then incorrectly filter them bc of wrong permission check