### PR TITLE
Enable Mongo Replication Sets in Docker / Upgrade Mongo to 5.0.23 in Docker

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -22,7 +22,8 @@ services:
       dockerfile: ./Dockerfile-Dev
     command: ["npm", "start"]
     depends_on:
-      - mongo
+      mongo:
+        condition: service_healthy
     environment:
       - NODE_DB_URI=mongodb://mongo/habitrpg
     networks:
@@ -33,7 +34,16 @@ services:
       - .:/usr/src/habitica
       - /usr/src/habitica/node_modules
   mongo:
-    image: mongo:3.6
+    image: mongo:5.0.23
+    restart: unless-stopped
+    command: ["--replSet", "rs", "--bind_ip_all", "--port", "27017"]
+    healthcheck:
+      test: echo "try { rs.status() } catch (err) { rs.initiate() }" | mongosh --port 27017 --quiet
+      interval: 10s
+      timeout: 30s
+      start_period: 0s
+      start_interval: 1s
+      retries: 30
     networks:
       - habitica
     ports:


### PR DESCRIPTION
[//]: # (Note: See https://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #14349 


### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

- Enable mongo replication sets using docker compose command
- Initialize replication set using heartbeat and then use replication set status as heartbeat.
- Prevent server from starting until mongo is in a state stable for connections.

```yaml
server:
  build:
    context: .
    dockerfile: ./Dockerfile-Dev
  command: ["npm", "start"]
  depends_on:
    mongo:
      condition: service_healthy
```
```yaml
mongo:
image: mongo:5.0.23
  restart: unless-stopped
  command: ["--replSet", "rs", "--bind_ip_all", "--port", "27017"]
  healthcheck:
    test: echo "try { rs.status() } catch (err) { rs.initiate() }" | mongosh --port 27017 --quiet
    interval: 10s
    timeout: 30s
    start_period: 0s
    start_interval: 1s
    retries: 30
```

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: Self-hosted
