### PR TITLE
Subscriber drops fix

### DIFF
--- a/test/api/v3/integration/tasks/POST-tasks_id_score_direction.test.js
+++ b/test/api/v3/integration/tasks/POST-tasks_id_score_direction.test.js
@@ -125,6 +125,90 @@ describe('POST /tasks/:id/score/:direction', () => {
         expect(body.finalLvl).to.eql(user.stats.lvl);
       });
     });
+
+    context('handles drops', async () => {
+      let randomStub;
+
+      afterEach(() => {
+        randomStub.restore();
+      });
+      it('gives user a drop', async () => {
+        user = await generateUser({
+          'stats.gp': 100,
+          'achievements.completedTask': true,
+          'items.eggs': {
+            Wolf: 1,
+          },
+        });
+        randomStub = sandbox.stub(Math, 'random').returns(0.1);
+        const task = await user.post('/tasks/user', {
+          text: 'test habit',
+          type: 'habit',
+        });
+
+        const res = await user.post(`/tasks/${task.id}/score/up`);
+        expect(res._tmp.drop).to.be.ok;
+      });
+
+      it('does not give a drop when non-sub drop cap is reached', async () => {
+        user = await generateUser({
+          'stats.gp': 100,
+          'achievements.completedTask': true,
+          'items.eggs': {
+            Wolf: 1,
+          },
+          'items.lastDrop.count': 5,
+        });
+        randomStub = sandbox.stub(Math, 'random').returns(0.1);
+        const task = await user.post('/tasks/user', {
+          text: 'test habit',
+          type: 'habit',
+        });
+
+        const res = await user.post(`/tasks/${task.id}/score/up`);
+        expect(res._tmp.drop).to.be.undefined;
+      });
+
+      it('gives a drop when subscriber is over regular cap but under subscriber cap', async () => {
+        user = await generateUser({
+          'stats.gp': 100,
+          'achievements.completedTask': true,
+          'items.eggs': {
+            Wolf: 1,
+          },
+          'items.lastDrop.count': 6,
+          'purchased.plan.customerId': '123',
+        });
+        randomStub = sandbox.stub(Math, 'random').returns(0.1);
+        const task = await user.post('/tasks/user', {
+          text: 'test habit',
+          type: 'habit',
+        });
+
+        const res = await user.post(`/tasks/${task.id}/score/up`);
+        expect(res._tmp.drop).to.be.ok;
+      });
+
+      it('does not give a drop when subscriber is at subscriber drop cap', async () => {
+        user = await generateUser({
+          'stats.gp': 100,
+          'achievements.completedTask': true,
+          'items.eggs': {
+            Wolf: 1,
+          },
+          'items.lastDrop.count': 10,
+          'purchased.plan.customerId': '123',
+        });
+        randomStub = sandbox.stub(Math, 'random').returns(0.1);
+        const task = await user.post('/tasks/user', {
+          text: 'test habit',
+          type: 'habit',
+        });
+
+        const res = await user.post(`/tasks/${task.id}/score/up`);
+        expect(res._tmp.drop).to.be.undefined;
+      });
+    });
   });
 
   context('todos', () => {

--- a/website/server/controllers/api-v3/tasks.js
+++ b/website/server/controllers/api-v3/tasks.js
@@ -751,11 +751,11 @@ api.updateTask = {
 api.scoreTask = {
   method: 'POST',
   url: '/tasks/:taskId/score/:direction',
-  middlewares: [authWithHeaders({ userFieldsToInclude: [
-    'achievements', 'guilds', 'items.eggs', 'items.food', 'items.gear.equipped',
-    'items.hatchingPotions', 'items.lastDrop', 'items.quests', 'party', 'purchased.plan',
-    'stats', 'tasksOrder', 'webhooks',
-  ] })],
+  middlewares: [authWithHeaders({
+    userFieldsToInclude: ['achievements', 'guilds', 'items.eggs', 'items.food',
+      'items.gear.equipped', 'items.hatchingPotions', 'items.lastDrop', 'items.quests', 'party',
+      'purchased.plan', 'stats', 'tasksOrder', 'webhooks'],
+  })],
   async handler (req, res) {
     // Parameters are validated in scoreTasks
 

--- a/website/server/controllers/api-v3/tasks.js
+++ b/website/server/controllers/api-v3/tasks.js
@@ -751,7 +751,11 @@ api.updateTask = {
 api.scoreTask = {
   method: 'POST',
   url: '/tasks/:taskId/score/:direction',
-  middlewares: [authWithHeaders({ userFieldsToInclude: ['stats', 'guilds', 'items.gear.equipped', 'items.eggs', 'items.food', 'items.hatchingPotions', 'items.lastDrop', 'items.quests', 'achievements', 'tasksOrder', 'webhooks', 'party'] })],
+  middlewares: [authWithHeaders({ userFieldsToInclude: [
+    'achievements', 'guilds', 'items.eggs', 'items.food', 'items.gear.equipped',
+    'items.hatchingPotions', 'items.lastDrop', 'items.quests', 'party', 'purchased.plan',
+    'stats', 'tasksOrder', 'webhooks',
+  ] })],
   async handler (req, res) {
     // Parameters are validated in scoreTasks
 


### PR DESCRIPTION
**Previously**, the `purchased.plan` field was not included when fetching the user record for task scoring. This meant that subscribers, who are meant to have greater ability to obtain drops, were not receiving the benefit in the calculation for obtaining items from tasks.

**Now**, `purchased.plan` is retrieved, allowing subscribers to get all the drops they're owed again!

Note... I looked into creating integration tests for this scenario, but need a way to control the randomness of drops during the task scoring operation. Using `sinon.stub` on `common.fns.predictableRandom` seems not to work, and in fact there are comments elsewhere in the test suite noting that we've run into that problem before. Thoughts?