### PR TITLE
Prevent user from altering the pin state of 'fixed' items as per api spec

### DIFF
--- a/website/client/src/components/tasks/column.vue
+++ b/website/client/src/components/tasks/column.vue
@@ -131,6 +131,7 @@
             >
               <span
                 class="badge-top"
+                :class="{'disabled': !ctx.item.pinTogglable}"
                 @click.prevent.stop="togglePinned(ctx.item)"
                 @keypress.enter.prevent.stop="togglePinned(ctx.item)"
               >
@@ -155,6 +156,13 @@
 
   .badge-pin {
     display: none;
+  }
+
+  .badge-top.disabled {
+    .badge-pin {
+      background-color: $gray-50;
+      cursor: default;
+    }
   }
 
   .item:hover .badge-pin {
@@ -787,6 +795,10 @@ export default {
     togglePinned (item) {
       if (!item.pinType) {
         this.error(this.$t('errorTemporaryItem'));
+        return;
+      }
+
+      if (!item.pinTogglable) {
         return;
       }
 

--- a/website/common/script/libs/getItemInfo.js
+++ b/website/common/script/libs/getItemInfo.js
@@ -37,6 +37,13 @@ function isItemSuggested (officialPinnedItems, itemInfo) {
   }) > -1;
 }
 
+function pinIsTogglable (itemInfo) {
+  if (itemInfo.path === 'armoire' || itemInfo.path === 'potion' || itemInfo.type === 'debuffPotion') {
+    return false;
+  }
+  return true;
+}
+
 function getDefaultGearProps (item, language) {
   return {
     key: item.key,
@@ -483,6 +490,7 @@ export default function getItemInfo (user, type, item, officialPinnedItems, lang
   if (itemInfo) {
     itemInfo.isSuggested = isItemSuggested(officialPinnedItems, itemInfo);
     itemInfo.pinned = isPinned(user, itemInfo, officialPinnedItems);
+    itemInfo.pinTogglable = pinIsTogglable(itemInfo);
   } else {
     throw new BadRequest(i18n.t('wrongItemType', { type }, language));
   }


### PR DESCRIPTION
### Changes

Restrict users from pinning or unpinning items that the API does not allow to be toggled. This prevents confusion for web application users, as there is currently no feedback or message provided when such actions are attempted.

#### Old visual (Current live version of web client)

![image](https://github.com/user-attachments/assets/081ec9c2-0304-4a1c-a145-228518457687)

#### New visual (As per commit)

![image](https://github.com/user-attachments/assets/f504ebb9-befc-4322-82dc-cd097abacff8)

(The hover effect for the icon has also been disabled -> cursor default => not really possible to screenshot on this device)


----
UUID: f0c0dd64-8826-4848-a9ca-e770f4ecd17a
