### PR TITLE
Force message to center in the drawer

### DIFF
--- a/website/client/src/components/ui/drawer.vue
+++ b/website/client/src/components/ui/drawer.vue
@@ -167,9 +167,10 @@
       justify-content: center;
 
       top: calc(50% - 30px);
-      left: 24px;
       right: 0;
       position: absolute;
+
+      width: 100%;
 
       & .content {
         background-color: rgba($gray-200, 0.5);


### PR DESCRIPTION
Currently if there is an error message in the content drawer it will be shifted to the left.
I believe the intended styling was for the message to be centered in the drawer.

### Old visual

![image](https://github.com/user-attachments/assets/7bd7d7e2-f83d-4bb1-a9ac-599affd44a7c)

### New visual (Forcing the message to take 100% of the drawer container)

![image](https://github.com/user-attachments/assets/681cddf4-f0f3-4c97-a106-a840d1ac801c)
----
UUID: f0c0dd64-8826-4848-a9ca-e770f4ecd17a
