### PR TITLE
Updates to do confirmation toDoCheck

### DIFF
--- a/website/client/src/components/tasks/task.vue
+++ b/website/client/src/components/tasks/task.vue
@@ -1186,9 +1186,17 @@ export default {
     castEnd (e, task) {
       setTimeout(() => this.$root.$emit('castEnd', task, 'task', e), 0);
     },
-    async score (direction) {
+    async score(direction) {
       if (this.showTaskLockIcon) return;
       if (this.task.type === 'habit' && !this.task[direction]) return;
+
+      // If this is a To-Do and the user is completing it (direction = 'up'),
+      // prompt them before proceeding.
+      if (this.task.type === 'todo' && direction === 'up') {
+        const message = 'Are you sure you want to mark this To-Do as complete? It will be removed.';
+        if (!window.confirm(message)) return; // User canceled, so just return here
+      }
+
       if (
         this.isGroupTask && direction === 'down'
         && ['todo', 'daily'].indexOf(this.task.type) !== -1


### PR DESCRIPTION
[//]: # (Note: See https://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #15366

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

- Added a confirmation prompt when a user attempts to mark a To-Do as complete. This ensures that users don't accidentally remove their To-Dos without a warning.
- Specifically, updated the `score()` method in the `Task` component to show a `window.confirm` dialog for To-Dos when checking them off.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID:
