### PR TITLE
Add `require-await`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,5 +7,14 @@ module.exports = {
   rules: {
     'prefer-regex-literals': 'warn',
     'import/no-extraneous-dependencies': 'off',
+    'require-await': 'error',
   },
+  overrides: [
+    {
+      files: ['migrations/**', 'gulp/**'], // Or *.test.js
+      rules: {
+        'require-await': 'off',
+      },
+    },
+  ],
 };


### PR DESCRIPTION
Imho makes sense. Probably can't catch all cases, but might save us some issues. Totally not inspired by me having forgotten await.

Should pass all main code currently. I excluded the `gulp` and `migrations` directory, because they currently don't pass and with the code that is in there, that is also fine.