### PR TITLE
fix: update currency display in setting for change class

### DIFF
--- a/website/client/src/components/shops/balanceInfo.vue
+++ b/website/client/src/components/shops/balanceInfo.vue
@@ -71,43 +71,40 @@ export default {
   computed: {
     currencies () {
       const currencies = [];
-      currencies.push({
-        type: 'hourglasses',
-        icon: this.icons.hourglasses,
-        value: this.userHourglasses,
-      });
+      if (this.neededCurrencyOnly === true) {
+        currencies.push({
+          type: 'gems',
+          icon: this.icons.gem,
+          value: this.userGems,
+        });
+      } else {
+        currencies.push({
+          type: 'hourglasses',
+          icon: this.icons.hourglasses,
+          value: this.userHourglasses,
+        });
 
-      currencies.push({
-        type: 'gems',
-        icon: this.icons.gem,
-        value: this.userGems,
-      });
+        currencies.push({
+          type: 'gems',
+          icon: this.icons.gem,
+          value: this.userGems,
+        });
 
-      currencies.push({
-        type: 'gold',
-        icon: this.icons.gold,
-        value: this.userGold,
-      });
+        currencies.push({
+          type: 'gold',
+          icon: this.icons.gold,
+          value: this.userGold,
+        });
 
-      for (const currency of currencies) {
-        if (
-          currency.type === this.currencyNeeded
-          && !this.enoughCurrency(this.currencyNeeded, this.amountNeeded)
-        ) {
-          currency.notEnough = true;
+        for (const currency of currencies) {
+          if (
+            currency.type === this.currencyNeeded
+            && !this.enoughCurrency(this.currencyNeeded, this.amountNeeded)
+          ) {
+            currency.notEnough = true;
+          }
         }
       }
-
-      for (const currency of currencies) {
-        if (
-          currency.type === this.neededCurrencyOnly
-        ) {
-          return this.currencyNeeded;
-        }
-      }
-      console.log(currencies);
-      console.log(this.neededCurrencyOnly);
-      console.log(this.currencyNeeded);
       return currencies;
     },
   },

--- a/website/client/src/components/shops/balanceInfo.vue
+++ b/website/client/src/components/shops/balanceInfo.vue
@@ -88,33 +88,14 @@ export default {
         value: this.userGold,
       }];
 
-      const currencyNeeded = [];
+      const findCurrency = currency => currency.type === this.currencyNeeded;
+      const reqCurrency = currencies.find(type => findCurrency(type));
+      console.log(reqCurrency);
+      // this console logs the correct amount but doesn't effect the display.
+      // still not sure I'm on the right track.
 
+      reqCurrency();
       for (const currency of currencies) {
-        if (this.currencyNeeded === 'gems') {
-          currencyNeeded.push({
-            type: 'gems',
-            icon: this.icons.gem,
-            value: this.userGems,
-          });
-        } else if (this.currencyNeeded === 'hourglasses') {
-          currencyNeeded.push({
-            type: 'hourglasses',
-            icon: this.icons.hourglasses,
-            value: this.userHourglasses,
-          });
-        } else if (this.currencyNeeded === 'gold') {
-          currencyNeeded.push({
-            type: 'gold',
-            icon: this.icons.gold,
-            value: this.userGold,
-          });
-        } 
-
-        // filter/map might still be the way to go
-        // or maybe emptying out currencies[] and push items there if they're needed and then 
-        // if all are needed then push them all in at the end? 
-
         if (currency.type === this.currencyNeeded
           && !this.enoughCurrency(this.currencyNeeded, this.amountNeeded)) {
           currency.notEnough = true;

--- a/website/client/src/components/shops/balanceInfo.vue
+++ b/website/client/src/components/shops/balanceInfo.vue
@@ -7,7 +7,7 @@
       class="d-flex align-items-center"
     >
       <div
-        class="svg-icon icon-16 ml-1"
+        class="svg-icon icon-16 ml-1 my-auto"
         v-html="currency.icon"
       ></div>
       <div
@@ -103,5 +103,3 @@ export default {
   },
 };
 </script>
-
-<!-- currency.filter(type => type === this.currencyNeeded); -->

--- a/website/client/src/components/shops/balanceInfo.vue
+++ b/website/client/src/components/shops/balanceInfo.vue
@@ -87,9 +87,34 @@ export default {
         icon: this.icons.gold,
         value: this.userGold,
       }];
-      // need some sort of filter or map function to check currency.type vs neededCurrencyOnly
-      // and then return a new array; not sure if this is the right approach
+
+      const currencyNeeded = [];
+
       for (const currency of currencies) {
+        if (this.currencyNeeded === 'gems') {
+          currencyNeeded.push({
+            type: 'gems',
+            icon: this.icons.gem,
+            value: this.userGems,
+          });
+        } else if (this.currencyNeeded === 'hourglasses') {
+          currencyNeeded.push({
+            type: 'hourglasses',
+            icon: this.icons.hourglasses,
+            value: this.userHourglasses,
+          });
+        } else if (this.currencyNeeded === 'gold') {
+          currencyNeeded.push({
+            type: 'gold',
+            icon: this.icons.gold,
+            value: this.userGold,
+          });
+        } 
+
+        // filter/map might still be the way to go
+        // or maybe emptying out currencies[] and push items there if they're needed and then 
+        // if all are needed then push them all in at the end? 
+
         if (currency.type === this.currencyNeeded
           && !this.enoughCurrency(this.currencyNeeded, this.amountNeeded)) {
           currency.notEnough = true;

--- a/website/client/src/components/shops/balanceInfo.vue
+++ b/website/client/src/components/shops/balanceInfo.vue
@@ -87,20 +87,9 @@ export default {
         icon: this.icons.gold,
         value: this.userGold,
       }];
-
+      // need some sort of filter or map function to check currency.type vs neededCurrencyOnly
+      // and then return a new array; not sure if this is the right approach
       for (const currency of currencies) {
-        if (this.neededCurrencyOnly) {
-          const neededCurrency = [
-            // need to figure out how to abstract this so any currency can be called, not just gems
-            {
-              type: 'gems',
-              icon: this.icons.gem,
-              value: this.userGems,
-            },
-          ];
-          return neededCurrency;
-        }
-
         if (currency.type === this.currencyNeeded
           && !this.enoughCurrency(this.currencyNeeded, this.amountNeeded)) {
           currency.notEnough = true;

--- a/website/client/src/components/shops/balanceInfo.vue
+++ b/website/client/src/components/shops/balanceInfo.vue
@@ -3,6 +3,7 @@
     <div
       v-for="currency of currencies"
       :key="currency.key"
+      :needed-currency-only="neededCurrencyOnly"
       class="d-flex align-items-center"
     >
       <div
@@ -55,7 +56,7 @@ export default {
       type: Number,
     },
     neededCurrencyOnly: {
-      type: String,
+      type: Boolean,
     },
   },
   data () {
@@ -97,6 +98,16 @@ export default {
         }
       }
 
+      for (const currency of currencies) {
+        if (
+          currency.type === this.neededCurrencyOnly
+        ) {
+          return this.currencyNeeded;
+        }
+      }
+      console.log(currencies);
+      console.log(this.neededCurrencyOnly);
+      console.log(this.currencyNeeded);
       return currencies;
     },
   },

--- a/website/client/src/components/shops/balanceInfo.vue
+++ b/website/client/src/components/shops/balanceInfo.vue
@@ -94,9 +94,9 @@ export default {
         ) {
           currency.notEnough = true;
         }
-        if (this.neededCurrencyOnly) {
-          return currencies.filter(curr => curr.type === this.currencyNeeded);
-        }
+      }
+      if (this.neededCurrencyOnly) {
+        return currencies.filter(curr => curr.type === this.currencyNeeded);
       }
       return currencies;
     },

--- a/website/client/src/components/shops/balanceInfo.vue
+++ b/website/client/src/components/shops/balanceInfo.vue
@@ -7,12 +7,12 @@
       class="d-flex align-items-center"
     >
       <div
-        class="svg-icon icon-16 ml-1 my-auto"
+        class="svg-icon icon-16 ml-1"
         v-html="currency.icon"
       ></div>
       <div
         :class="{'notEnough': currency.notEnough}"
-        class="currency-value mx-1"
+        class="currency-value mx-1 my-auto"
       >
         {{ currency.value | roundBigNumber }}
       </div>

--- a/website/client/src/components/shops/balanceInfo.vue
+++ b/website/client/src/components/shops/balanceInfo.vue
@@ -12,7 +12,7 @@
       ></div>
       <div
         :class="{'notEnough': currency.notEnough}"
-        class="currency-value mx-1 my-auto"
+        class="currency-value mx-1"
       >
         {{ currency.value | roundBigNumber }}
       </div>
@@ -94,24 +94,14 @@ export default {
         ) {
           currency.notEnough = true;
         }
+        if (this.neededCurrencyOnly) {
+          return currencies.filter(curr => curr.type === this.currencyNeeded);
+        }
       }
       return currencies;
     },
-
-    requiredCurrency () {
-      if (this.currencies.type === this.currencyNeeded) {
-        const currencyRequired = [{
-          type: this.currencies.type,
-          icon: this.currencies.icon,
-          value: this.currencies.value,
-        }];
-        console.log(currencyRequired);
-        return currencyRequired;
-      }
-    },
-
-    //   this.currencies.find(type => type === this.currencyNeeded);
-
   },
 };
 </script>
+
+<!-- currency.filter(type => type === this.currencyNeeded); -->

--- a/website/client/src/components/shops/balanceInfo.vue
+++ b/website/client/src/components/shops/balanceInfo.vue
@@ -54,6 +54,9 @@ export default {
     amountNeeded: {
       type: Number,
     },
+    neededCurrencyOnly: {
+      type: String,
+    },
   },
   data () {
     return {

--- a/website/client/src/components/shops/balanceInfo.vue
+++ b/website/client/src/components/shops/balanceInfo.vue
@@ -94,7 +94,6 @@ export default {
       // this console logs the correct amount but doesn't effect the display.
       // still not sure I'm on the right track.
 
-      reqCurrency();
       for (const currency of currencies) {
         if (currency.type === this.currencyNeeded
           && !this.enoughCurrency(this.currencyNeeded, this.amountNeeded)) {

--- a/website/client/src/components/shops/balanceInfo.vue
+++ b/website/client/src/components/shops/balanceInfo.vue
@@ -88,15 +88,13 @@ export default {
         value: this.userGold,
       }];
 
-      const findCurrency = currency => currency.type === this.currencyNeeded;
-      const reqCurrency = currencies.find(type => findCurrency(type));
-      console.log(reqCurrency);
-      // this console logs the correct amount but doesn't effect the display.
-      // still not sure I'm on the right track.
-
       for (const currency of currencies) {
+        if (currency.find(type => type === this.currencyNeeded)
+        && this.neededCurrencyOnly) {
+          console.log(this.currencies);
+        }
         if (currency.type === this.currencyNeeded
-          && !this.enoughCurrency(this.currencyNeeded, this.amountNeeded)) {
+        && !this.enoughCurrency(this.currencyNeeded, this.amountNeeded)) {
           currency.notEnough = true;
         }
       }

--- a/website/client/src/components/shops/balanceInfo.vue
+++ b/website/client/src/components/shops/balanceInfo.vue
@@ -89,17 +89,29 @@ export default {
       }];
 
       for (const currency of currencies) {
-        if (currency.find(type => type === this.currencyNeeded)
-        && this.neededCurrencyOnly) {
-          console.log(this.currencies);
-        }
         if (currency.type === this.currencyNeeded
-        && !this.enoughCurrency(this.currencyNeeded, this.amountNeeded)) {
+        && !this.enoughCurrency(this.currencyNeeded, this.amountNeeded)
+        ) {
           currency.notEnough = true;
         }
       }
       return currencies;
     },
+
+    requiredCurrency () {
+      if (this.currencies.type === this.currencyNeeded) {
+        const currencyRequired = [{
+          type: this.currencies.type,
+          icon: this.currencies.icon,
+          value: this.currencies.value,
+        }];
+        console.log(currencyRequired);
+        return currencyRequired;
+      }
+    },
+
+    //   this.currencies.find(type => type === this.currencyNeeded);
+
   },
 };
 </script>

--- a/website/client/src/components/shops/balanceInfo.vue
+++ b/website/client/src/components/shops/balanceInfo.vue
@@ -70,39 +70,40 @@ export default {
   },
   computed: {
     currencies () {
-      const currencies = [];
-      if (this.neededCurrencyOnly === true) {
-        currencies.push({
-          type: 'gems',
-          icon: this.icons.gem,
-          value: this.userGems,
-        });
-      } else {
-        currencies.push({
-          type: 'hourglasses',
-          icon: this.icons.hourglasses,
-          value: this.userHourglasses,
-        });
+      const currencies = [{
+        type: 'hourglasses',
+        icon: this.icons.hourglasses,
+        value: this.userHourglasses,
+      },
 
-        currencies.push({
-          type: 'gems',
-          icon: this.icons.gem,
-          value: this.userGems,
-        });
+      {
+        type: 'gems',
+        icon: this.icons.gem,
+        value: this.userGems,
+      },
 
-        currencies.push({
-          type: 'gold',
-          icon: this.icons.gold,
-          value: this.userGold,
-        });
+      {
+        type: 'gold',
+        icon: this.icons.gold,
+        value: this.userGold,
+      }];
 
-        for (const currency of currencies) {
-          if (
-            currency.type === this.currencyNeeded
-            && !this.enoughCurrency(this.currencyNeeded, this.amountNeeded)
-          ) {
-            currency.notEnough = true;
-          }
+      for (const currency of currencies) {
+        if (this.neededCurrencyOnly) {
+          const neededCurrency = [
+            // need to figure out how to abstract this so any currency can be called, not just gems
+            {
+              type: 'gems',
+              icon: this.icons.gem,
+              value: this.userGems,
+            },
+          ];
+          return neededCurrency;
+        }
+
+        if (currency.type === this.currencyNeeded
+          && !this.enoughCurrency(this.currencyNeeded, this.amountNeeded)) {
+          currency.notEnough = true;
         }
       }
       return currencies;

--- a/website/client/src/pages/settings/components/yourBalance.vue
+++ b/website/client/src/pages/settings/components/yourBalance.vue
@@ -28,6 +28,9 @@ export default {
     amountNeeded: {
       type: Number,
     },
+    neededCurrencyOnly: {
+      type: String,
+    },
   },
 };
 </script>

--- a/website/client/src/pages/settings/components/yourBalance.vue
+++ b/website/client/src/pages/settings/components/yourBalance.vue
@@ -11,6 +11,7 @@
       class="balance-info"
       :currency-needed="currencyNeeded"
       :amount-needed="amountNeeded"
+      neededCurrencyOnly
     />
   </div>
 </template>
@@ -29,7 +30,7 @@ export default {
       type: Number,
     },
     neededCurrencyOnly: {
-      type: String,
+      type: Boolean,
     },
   },
 };

--- a/website/client/src/pages/settings/components/yourBalance.vue
+++ b/website/client/src/pages/settings/components/yourBalance.vue
@@ -29,9 +29,6 @@ export default {
     amountNeeded: {
       type: Number,
     },
-    neededCurrencyOnly: {
-      type: Boolean,
-    },
   },
 };
 </script>

--- a/website/client/src/pages/settings/components/yourBalance.vue
+++ b/website/client/src/pages/settings/components/yourBalance.vue
@@ -11,7 +11,7 @@
       class="balance-info"
       :currency-needed="currencyNeeded"
       :amount-needed="amountNeeded"
-      neededCurrencyOnly
+      neededCurrencyOnly=""
     />
   </div>
 </template>

--- a/website/client/src/pages/settings/components/yourBalance.vue
+++ b/website/client/src/pages/settings/components/yourBalance.vue
@@ -11,7 +11,7 @@
       class="balance-info"
       :currency-needed="currencyNeeded"
       :amount-needed="amountNeeded"
-      neededCurrencyOnly=""
+      :neededCurrencyOnly="true"
     />
   </div>
 </template>

--- a/website/client/src/pages/settings/settingRows/classSetting.vue
+++ b/website/client/src/pages/settings/settingRows/classSetting.vue
@@ -66,7 +66,6 @@
           <your-balance
             :amount-needed="amountNeeded"
             currency-needed="gems"
-            :neededCurrencyOnly="true"
           />
         </div>
       </td>

--- a/website/client/src/pages/settings/settingRows/classSetting.vue
+++ b/website/client/src/pages/settings/settingRows/classSetting.vue
@@ -66,6 +66,7 @@
           <your-balance
             :amount-needed="amountNeeded"
             currency-needed="gems"
+            neededCurrencyOnly="gems"
           />
         </div>
       </td>

--- a/website/client/src/pages/settings/settingRows/classSetting.vue
+++ b/website/client/src/pages/settings/settingRows/classSetting.vue
@@ -66,6 +66,7 @@
           <your-balance
             :amount-needed="amountNeeded"
             currency-needed="gems"
+            class="d-flex"
           />
         </div>
       </td>

--- a/website/client/src/pages/settings/settingRows/classSetting.vue
+++ b/website/client/src/pages/settings/settingRows/classSetting.vue
@@ -66,7 +66,7 @@
           <your-balance
             :amount-needed="amountNeeded"
             currency-needed="gems"
-            neededCurrencyOnly="gems"
+            :neededCurrencyOnly="true"
           />
         </div>
       </td>

--- a/website/client/src/pages/settings/settingRows/classSetting.vue
+++ b/website/client/src/pages/settings/settingRows/classSetting.vue
@@ -66,7 +66,7 @@
           <your-balance
             :amount-needed="amountNeeded"
             currency-needed="gems"
-            class="d-flex"
+            class="d-flex align-items-center"
           />
         </div>
       </td>

--- a/website/client/src/pages/settings/settingRows/classSetting.vue
+++ b/website/client/src/pages/settings/settingRows/classSetting.vue
@@ -67,7 +67,6 @@
             :amount-needed="amountNeeded"
             currency-needed="gems"
             :neededCurrencyOnly="true"
-            class="currency-align"
           />
         </div>
       </td>
@@ -80,11 +79,6 @@
 
 input {
   margin-right: 2rem;
-}
-
-.currency-align {
-  display: flex;
-  align-items: center;
 }
 
 .form-group {

--- a/website/client/src/pages/settings/settingRows/classSetting.vue
+++ b/website/client/src/pages/settings/settingRows/classSetting.vue
@@ -67,6 +67,7 @@
             :amount-needed="amountNeeded"
             currency-needed="gems"
             :neededCurrencyOnly="true"
+            class="currency-align"
           />
         </div>
       </td>
@@ -79,6 +80,11 @@
 
 input {
   margin-right: 2rem;
+}
+
+.currency-align {
+  display: flex;
+  align-items: center;
 }
 
 .form-group {


### PR DESCRIPTION
Currently, when a user wishes to change their class on the Settings page, it shows hourglasses, gems, and gold. Since the currency used to change class is gems, this fix to add extra logic and a new prop was required. A small CSS change was required as well.