### PR TITLE
fix system messages not being translated

### DIFF
--- a/website/server/libs/chat/group-chat.js
+++ b/website/server/libs/chat/group-chat.js
@@ -129,9 +129,5 @@ export function translateMessage (lang, info) {
     default:
       msg = 'Error translating party chat. Unknown message type.';
   }
-
-  if (!msg.includes('`')) {
-    msg = `\`${msg}\``;
-  }
   return msg;
 }

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -359,7 +359,11 @@ schema.statics.toJSONCleanChat = async function groupToJSONCleanChat (group, use
     .map(chatMsg => {
       // Translate system messages
       if (!_.isEmpty(chatMsg.info)) {
-        chatMsg.text = translateMessage(userLang, chatMsg.info);
+        chatMsg.unformattedText = translateMessage(userLang, chatMsg.info);
+        chatMsg.text = chatMsg.unformattedText;
+        if (!chatMsg.text.includes('`')) {
+          chatMsg.text = `\`${chatMsg.text}\``;
+        }
       }
 
       // Convert to timestamps because Android expects it


### PR DESCRIPTION
the unformattedText version of the message was never translated. Previously the website use the formatted version.  Now it seems to use the unformattedText version, which made this bug apparent.