### PR TITLE
Make sure no userhistory exists before initializing it

### DIFF
--- a/website/server/models/user/hooks.js
+++ b/website/server/models/user/hooks.js
@@ -365,9 +365,13 @@ schema.pre('save', true, async function preSaveUser (next, done) {
     }
     if (!this.flags.initializedUserHistory) {
       this.flags.initializedUserHistory = true;
-      const history = UserHistory();
-      history.userId = this._id;
-      await history.save();
+      // Ensure that it does not try to create a new history if it already exists
+      const existingHistory = await UserHistory.findOne({ userId: this._id });
+      if (!existingHistory) {
+        const history = UserHistory();
+        history.userId = this._id;
+        await history.save();
+      }
     }
   }
 


### PR DESCRIPTION
Fixes an issue where if a user gets into a strange state, saving the user always times out