### PR TITLE
Add API call to check if an email is already used

### DIFF
--- a/test/api/v3/integration/user/auth/POST-user_auth_social.test.js
+++ b/test/api/v3/integration/user/auth/POST-user_auth_social.test.js
@@ -7,7 +7,7 @@ import {
   getProperty,
 } from '../../../../../helpers/api-integration/v3';
 
-describe.only('POST /user/auth/social', () => {
+describe('POST /user/auth/social', () => {
   let api;
   let user;
   const endpoint = '/user/auth/social';

--- a/test/api/v3/integration/user/auth/POST-user_auth_social.test.js
+++ b/test/api/v3/integration/user/auth/POST-user_auth_social.test.js
@@ -7,7 +7,7 @@ import {
   getProperty,
 } from '../../../../../helpers/api-integration/v3';
 
-describe('POST /user/auth/social', () => {
+describe.only('POST /user/auth/social', () => {
   let api;
   let user;
   const endpoint = '/user/auth/social';
@@ -62,6 +62,18 @@ describe('POST /user/auth/social', () => {
       await expect(getProperty('users', response.id, 'auth.google.id')).to.eventually.equal(randomGoogleId);
       await expect(getProperty('users', response.id, 'auth.local.email')).to.eventually.equal(`${user.auth.local.username}+google@example.com`);
       await expect(getProperty('users', response.id, 'profile.name')).to.eventually.equal('a google user');
+    });
+
+    it('fails if allowRegister is false and user does not exist', async () => {
+      await expect(api.post(endpoint, {
+        authResponse: { access_token: randomAccessToken }, // eslint-disable-line camelcase
+        network,
+        allowRegister: false,
+      })).to.eventually.be.rejected.and.eql({
+        code: 404,
+        error: 'NotFound',
+        message: t('userNotFound'),
+      });
     });
 
     it('logs an existing user in', async () => {
@@ -122,6 +134,36 @@ describe('POST /user/auth/social', () => {
       const response = await api.post(endpoint, {
         authResponse: { access_token: randomAccessToken }, // eslint-disable-line camelcase
         network,
+      });
+
+      expect(response.apiToken).to.eql(registerResponse.apiToken);
+      expect(response.id).to.eql(registerResponse.id);
+      expect(response.apiToken).not.to.eql(user.apiToken);
+      expect(response.id).not.to.eql(user._id);
+      expect(response.newUser).to.be.false;
+    });
+
+    it('logs an existing user into their social account if allowRegister is false', async () => {
+      const registerResponse = await api.post(endpoint, {
+        authResponse: { access_token: randomAccessToken }, // eslint-disable-line camelcase
+        network,
+      });
+      expect(registerResponse.newUser).to.be.true;
+      // This is important for existing accounts before the new social handling
+      passport._strategies.google.userProfile.restore();
+      const expectedResult = {
+        id: randomGoogleId,
+        displayName: 'a google user',
+        emails: [
+          { value: user.auth.local.email },
+        ],
+      };
+      sandbox.stub(passport._strategies.google, 'userProfile').yields(null, expectedResult);
+
+      const response = await api.post(endpoint, {
+        authResponse: { access_token: randomAccessToken }, // eslint-disable-line camelcase
+        network,
+        allowRegister: false,
       });
 
       expect(response.apiToken).to.eql(registerResponse.apiToken);

--- a/test/api/v4/user/auth/POST-check_email.test.js
+++ b/test/api/v4/user/auth/POST-check_email.test.js
@@ -1,0 +1,56 @@
+import {
+  translate as t,
+  requester,
+  generateUser,
+} from '../../../../helpers/api-integration/v4';
+
+const ENDPOINT = '/user/auth/check-email';
+
+describe('POST /user/auth/check-email', () => {
+  const email = 'SOmE-nEw-emAIl_2@example.net';
+  let api;
+
+  beforeEach(async () => {
+    api = requester();
+  });
+
+  it('returns email if it is not used yet', async () => {
+    const response = await api.post(ENDPOINT, {
+      email,
+    });
+    expect(response.email).to.eql(email);
+  });
+
+  it('rejects if email is not provided', async () => {
+    await expect(api.post(ENDPOINT, {
+    })).to.eventually.be.rejected.and.eql({
+      code: 400,
+      error: 'BadRequest',
+      message: 'Invalid request parameters.',
+    });
+  });
+
+  it('rejects if email is already taken', async () => {
+    const user = await generateUser();
+
+    await expect(api.post(ENDPOINT, {
+      email: user.auth.local.email,
+    })).to.eventually.be.rejected.and.eql({
+      code: 401,
+      error: 'NotAuthorized',
+      message: t('emailTaken'),
+    });
+  });
+
+  it('rejects if casing is different', async () => {
+    const user = await generateUser();
+
+    await expect(api.post(ENDPOINT, {
+      email: user.auth.local.email.toUpperCase(),
+    })).to.eventually.be.rejected.and.eql({
+      code: 401,
+      error: 'NotAuthorized',
+      message: t('emailTaken'),
+    });
+  });
+});

--- a/website/server/controllers/api-v3/hall.js
+++ b/website/server/controllers/api-v3/hall.js
@@ -479,7 +479,7 @@ api.updateHero = {
       }
 
       if (updateData.auth.local && updateData.auth.local.email) {
-        hero.auth.local.email = updateData.auth.local.email;
+        hero.auth.local.email = updateData.auth.local.email.toLowerCase();
       }
     }
 

--- a/website/server/controllers/api-v4/auth.js
+++ b/website/server/controllers/api-v4/auth.js
@@ -1,4 +1,3 @@
-import nconf from 'nconf';
 import {
   authWithHeaders,
 } from '../../middlewares/auth';

--- a/website/server/controllers/api-v4/auth.js
+++ b/website/server/controllers/api-v4/auth.js
@@ -101,6 +101,15 @@ api.checkEmail = {
   method: 'POST',
   url: '/user/auth/check-email',
   async handler (req, res) {
+    req.checkBody({
+      email: {
+        notEmpty: { errorMessage: res.t('missingEmail') },
+      },
+    });
+
+    const validationErrors = req.validationErrors();
+    if (validationErrors) throw validationErrors;
+
     const emailAlreadyInUse = await User.findOne({
       'auth.local.email': req.body.email.toLowerCase(),
     }).select({ _id: 1 }).lean().exec();

--- a/website/server/controllers/api-v4/auth.js
+++ b/website/server/controllers/api-v4/auth.js
@@ -1,6 +1,10 @@
+import nconf from 'nconf';
 import {
   authWithHeaders,
 } from '../../middlewares/auth';
+import {
+  NotAuthorized,
+} from '../../libs/errors';
 import * as authLib from '../../libs/auth';
 import { model as User } from '../../models/user';
 import { verifyUsername } from '../../libs/user/validation';
@@ -80,6 +84,30 @@ api.registerLocal = {
   url: '/user/auth/local/register',
   async handler (req, res) {
     await authLib.registerLocal(req, res, { isV3: false });
+  },
+};
+
+/**
+ * @api {put} /api/v3/user/auth/check-email Check if email is used
+ * @apiDescription Check if the email is already used by another user
+ * @apiName CheckEmail
+ * @apiGroup User
+ *
+ * @apiParam (Body) {String} email The checked email address.
+ *
+ * @apiSuccess {String} data.email The checked email address
+ */
+api.checkEmail = {
+  method: 'POST',
+  url: '/user/auth/check-email',
+  async handler (req, res) {
+    const emailAlreadyInUse = await User.findOne({
+      'auth.local.email': req.body.email.toLowerCase(),
+    }).select({ _id: 1 }).lean().exec();
+
+    if (emailAlreadyInUse) throw new NotAuthorized(res.t('emailTaken'));
+
+    return res.respond(200, { email: req.body.email });
   },
 };
 

--- a/website/server/libs/auth/social.js
+++ b/website/server/libs/auth/social.js
@@ -40,7 +40,7 @@ export async function socialEmailToLocal (user) {
 
 export async function loginSocial (req, res) { // eslint-disable-line import/prefer-default-export
   let existingUser = res.locals.user;
-  const { network } = req.body;
+  const { network, allowRegister = true } = req.body;
 
   const isSupportedNetwork = common.constants.SUPPORTED_SOCIAL_NETWORKS
     .find(supportedNetwork => supportedNetwork.key === network);
@@ -72,6 +72,10 @@ export async function loginSocial (req, res) { // eslint-disable-line import/pre
       }
     }
     return loginRes(user, req, res);
+  }
+
+  if (!allowRegister) {
+    return res.respond(404, {});
   }
 
   let email;

--- a/website/server/libs/auth/social.js
+++ b/website/server/libs/auth/social.js
@@ -1,6 +1,6 @@
 import passport from 'passport';
 import common from '../../../common';
-import { BadRequest, NotAuthorized } from '../errors';
+import { BadRequest, NotAuthorized, NotFound } from '../errors';
 import logger from '../logger';
 import {
   generateUsername,
@@ -75,7 +75,7 @@ export async function loginSocial (req, res) { // eslint-disable-line import/pre
   }
 
   if (!allowRegister) {
-    return res.respond(404, {});
+    throw new NotFound(res.t('userNotFound'));
   }
 
   let email;

--- a/website/server/libs/auth/social.js
+++ b/website/server/libs/auth/social.js
@@ -33,7 +33,7 @@ export async function socialEmailToLocal (user) {
       { 'auth.local.email': socialEmail },
       { _id: 1 },
     ).exec();
-    if (!conflictingUser) return socialEmail;
+    if (!conflictingUser) return socialEmail.toLowerCase();
   }
   return undefined;
 }


### PR DESCRIPTION
- Adds a new api call to check if an email is already used without triggering registration
- Similarly adds an `allowRegister` field to the social login call. If set to false, the call logs users in but won't register new accounts.