### PR TITLE
Bump dev mongodb version and ubuntu image

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,8 +109,8 @@
     "start": "gulp nodemon",
     "start:simple": "node ./website/server/index.js",
     "debug": "gulp nodemon --inspect",
-    "mongo:dev": "run-rs -v 5.0.23 -l ubuntu1804 --keep --dbpath mongodb-data --number 1 --quiet",
-    "mongo:test": "run-rs -v 5.0.23 -l ubuntu1804 --keep --dbpath mongodb-data-testing --number 1 --quiet",
+    "mongo:dev": "run-rs -v 7.0.21 -l ubuntu2404 --keep --dbpath mongodb-data --number 1 --quiet",
+    "mongo:test": "run-rs -v 7.0.21 -l ubuntu2404 --keep --dbpath mongodb-data-testing --number 1 --quiet",
     "postinstall": "git config --global url.\"https://\".insteadOf git:// && gulp build && cd website/client && npm install",
     "apidoc": "gulp apidoc",
     "heroku-postbuild": ".heroku/report_deploy.sh"


### PR DESCRIPTION
This updates the mongodb version to 7.0, which is the version we currently use in production. It also updates the image used by `run-rs` to be the latest ubuntu LTS version.

Since this is an upgrade of 2 major versions, running the `mongo:dev` command with an existing 5.0 database will result in an error.

Upgrade steps:

1. run `run-rs -v 6.0.24 -l ubuntu1804 --keep --dbpath mongodb-data --number 1 --quiet` in a shell
2. connect via `mongosh`
3. in the mongo shell execute `db.adminCommand( { setFeatureCompatibilityVersion: "6.0" } )`
4. disconnect and stop the database
5. run the `npm run mongo:dev` command
6. connect via `mongosh`
7. in the mongo shell execute `db.adminCommand( { setFeatureCompatibilityVersion: "7.0", confirm: true } )`