### PR TITLE
docs: fix grammar and clarity in client README

### DIFF
--- a/website/client/README.md
+++ b/website/client/README.md
@@ -30,9 +30,9 @@ See [Configuration Reference](https://cli.vuejs.org/config/).
 
 ### Vue Structure
 
-Currently pages and components are mixed in `/src/components` this is not a good way to find the files easy.
+Currently, pages and components are mixed together in `/src/components`, which makes it difficult to find files easily.
 
-Thats why each changed / upcoming page / component should be put in either `/src/components` or in the `/src/pages` directory.
+That's why each changed / upcoming page / component should be put in either `/src/components` or in the `/src/pages` directory.
 
 Inside Pages, each page can have a subfolder which contains sub-components only needed for that page - otherwise it has to be added to the normal components folder.
 


### PR DESCRIPTION
### Summary

This PR proposes a minor documentation improvement to the last paragraph of `website/client/README.md`.

Specifically:
- Corrected a grammatical error: "find the files easy" → "find files easily"
- Fixed a small typo: "Thats" → "That's"
- Slightly restructured the sentence for improved clarity, while carefully preserving the original intent and tone

These changes are intended to enhance readability and maintain the quality of the documentation.  
No functional code or logic has been modified.

Thank you for your consideration.

### Type
- [x] Documentation
