### PR TITLE
fix(payments): credit gems before marking IAP receipt consumed & add retry

### DIFF
--- a/website/server/libs/payments/apple.js
+++ b/website/server/libs/payments/apple.js
@@ -22,9 +22,10 @@ api.constants = {
   RESPONSE_NO_ITEM_PURCHASED: 'NO_ITEM_PURCHASED',
 };
 
-async function safeBuySkuItem(opts) {
+// eslint-disable no-await-in-loop
+async function safeBuySkuItem (opts) {
   const maxRetries = 3;
-  for (let i = 1; i <= maxRetries; i++) {
+  for (let i = 1; i <= maxRetries; i += 1) {
     try {
       await payments.buySkuItem(opts);
       return;
@@ -35,7 +36,7 @@ async function safeBuySkuItem(opts) {
   }
 }
 
-api.verifyPurchase = async function verifyPurchase(options) {
+api.verifyPurchase = async function verifyPurchase (options) {
   const {
     gift, user, receipt, headers,
   } = options;
@@ -67,7 +68,6 @@ api.verifyPurchase = async function verifyPurchase(options) {
     }).exec();
 
     if (!existingReceipt) {
-
       await safeBuySkuItem({
         user,
         gift,
@@ -82,12 +82,12 @@ api.verifyPurchase = async function verifyPurchase(options) {
         // This should always be the buying user even for a gift.
         userId: user._id,
       });
-      
     }
   }
 
   return appleRes;
 };
+// eslint-enable no-await-in-loop
 
 api.subscribe = async function subscribe(user, receipt, headers, nextPaymentProcessing) {
   await iap.setup();

--- a/website/server/libs/payments/apple.js
+++ b/website/server/libs/payments/apple.js
@@ -22,7 +22,7 @@ api.constants = {
   RESPONSE_NO_ITEM_PURCHASED: 'NO_ITEM_PURCHASED',
 };
 
-// eslint-disable no-await-in-loop
+/* eslint-disable no-await-in-loop */
 async function safeBuySkuItem (opts) {
   const maxRetries = 3;
   for (let i = 1; i <= maxRetries; i += 1) {
@@ -87,9 +87,9 @@ api.verifyPurchase = async function verifyPurchase (options) {
 
   return appleRes;
 };
-// eslint-enable no-await-in-loop
+/* eslint-enable no-await-in-loop */
 
-api.subscribe = async function subscribe(user, receipt, headers, nextPaymentProcessing) {
+api.subscribe = async function subscribe (user, receipt, headers, nextPaymentProcessing) {
   await iap.setup();
 
   const appleRes = await iap.validate(iap.APPLE, receipt);
@@ -184,7 +184,7 @@ api.subscribe = async function subscribe(user, receipt, headers, nextPaymentProc
   }
 };
 
-api.noRenewSubscribe = async function noRenewSubscribe(options) {
+api.noRenewSubscribe = async function noRenewSubscribe (options) {
   const {
     sku, gift, user, receipt, headers,
   } = options;
@@ -260,10 +260,10 @@ api.noRenewSubscribe = async function noRenewSubscribe(options) {
   if (!correctReceipt) throw new NotAuthorized(api.constants.RESPONSE_INVALID_ITEM);
 
   return appleRes;
+  /* eslint-enable no-await-in-loop */
 };
-/* eslint-enable no-await-in-loop */
 
-api.cancelSubscribe = async function cancelSubscribe(user, headers) {
+api.cancelSubscribe = async function cancelSubscribe (user, headers) {
   const { plan } = user.purchased;
 
   if (plan.paymentMethod !== api.constants.PAYMENT_METHOD_APPLE) throw new NotAuthorized(shared.i18n.t('missingSubscription'));

--- a/website/server/libs/payments/apple.js
+++ b/website/server/libs/payments/apple.js
@@ -22,7 +22,20 @@ api.constants = {
   RESPONSE_NO_ITEM_PURCHASED: 'NO_ITEM_PURCHASED',
 };
 
-api.verifyPurchase = async function verifyPurchase (options) {
+async function safeBuySkuItem(opts) {
+  const maxRetries = 3;
+  for (let i = 1; i <= maxRetries; i++) {
+    try {
+      await payments.buySkuItem(opts);
+      return;
+    } catch (err) {
+      if (i === maxRetries) throw err;
+      await new Promise(r => setTimeout(r, 1000 * 2 ** i));
+    }
+  }
+}
+
+api.verifyPurchase = async function verifyPurchase(options) {
   const {
     gift, user, receipt, headers,
   } = options;
@@ -54,27 +67,29 @@ api.verifyPurchase = async function verifyPurchase (options) {
     }).exec();
 
     if (!existingReceipt) {
-      await IapPurchaseReceipt.create({ // eslint-disable-line no-await-in-loop
-        _id: token,
-        consumed: true,
-        // This should always be the buying user even for a gift.
-        userId: user._id,
-      });
 
-      await payments.buySkuItem({ // eslint-disable-line no-await-in-loop
+      await safeBuySkuItem({
         user,
         gift,
         paymentMethod: api.constants.PAYMENT_METHOD_APPLE,
         sku: purchaseData.productId,
         headers,
       });
+
+      await IapPurchaseReceipt.create({
+        _id: token,
+        consumed: true,
+        // This should always be the buying user even for a gift.
+        userId: user._id,
+      });
+      
     }
   }
 
   return appleRes;
 };
 
-api.subscribe = async function subscribe (user, receipt, headers, nextPaymentProcessing) {
+api.subscribe = async function subscribe(user, receipt, headers, nextPaymentProcessing) {
   await iap.setup();
 
   const appleRes = await iap.validate(iap.APPLE, receipt);
@@ -169,7 +184,7 @@ api.subscribe = async function subscribe (user, receipt, headers, nextPaymentPro
   }
 };
 
-api.noRenewSubscribe = async function noRenewSubscribe (options) {
+api.noRenewSubscribe = async function noRenewSubscribe(options) {
   const {
     sku, gift, user, receipt, headers,
   } = options;
@@ -248,7 +263,7 @@ api.noRenewSubscribe = async function noRenewSubscribe (options) {
 };
 /* eslint-enable no-await-in-loop */
 
-api.cancelSubscribe = async function cancelSubscribe (user, headers) {
+api.cancelSubscribe = async function cancelSubscribe(user, headers) {
   const { plan } = user.purchased;
 
   if (plan.paymentMethod !== api.constants.PAYMENT_METHOD_APPLE) throw new NotAuthorized(shared.i18n.t('missingSubscription'));

--- a/website/server/libs/payments/google.js
+++ b/website/server/libs/payments/google.js
@@ -21,6 +21,20 @@ api.constants = {
   RESPONSE_STILL_VALID: 'SUBSCRIPTION_STILL_VALID',
 };
 
+async function safeBuySkuItem(opts) {
+  const maxRetries = 3;
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      await payments.buySkuItem(opts);
+      return;
+    } catch (err) {
+      if (attempt === maxRetries) throw err;
+      // exponential backoff: 1s, 2s, 4s
+      await new Promise(res => setTimeout(res, 1000 * Math.pow(2, attempt)));
+    }
+  }
+}
+
 api.verifyPurchase = async function verifyPurchase (options) {
   const {
     gift, user, receipt, signature, headers,
@@ -54,19 +68,22 @@ api.verifyPurchase = async function verifyPurchase (options) {
   }).exec();
   if (existingReceipt) throw new NotAuthorized(this.constants.RESPONSE_ALREADY_USED);
 
-  await IapPurchaseReceipt.create({
-    _id: token,
-    consumed: true,
-    // This should always be the buying user even for a gift.
-    userId: user._id,
-  });
 
-  await payments.buySkuItem({ // eslint-disable-line no-await-in-loop
+  // Credit the purchase (with retry logic) before ever touching the receipt record
+   await safeBuySkuItem({
     user,
     gift,
     paymentMethod: api.constants.PAYMENT_METHOD_GOOGLE,
     sku: googleRes.productId,
     headers,
+  });
+  
+  // Only once purchase have been successfully credited, mark the purchase token as consumed
+  await IapPurchaseReceipt.create({
+    _id: token,
+    consumed: true,
+    // This should always be the buying user even for a gift.
+    userId: user._id,
   });
 
   return googleRes;

--- a/website/server/libs/payments/google.js
+++ b/website/server/libs/payments/google.js
@@ -21,19 +21,21 @@ api.constants = {
   RESPONSE_STILL_VALID: 'SUBSCRIPTION_STILL_VALID',
 };
 
-async function safeBuySkuItem(opts) {
+/* eslint-disable no-await-in-loop */
+async function safeBuySkuItem (opts) {
   const maxRetries = 3;
-  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+  for (let attempt = 1; attempt <= maxRetries; attempt += 1) {
     try {
       await payments.buySkuItem(opts);
       return;
     } catch (err) {
       if (attempt === maxRetries) throw err;
       // exponential backoff: 1s, 2s, 4s
-      await new Promise(res => setTimeout(res, 1000 * Math.pow(2, attempt)));
+      await new Promise(res => setTimeout(res, 1000 * 2 ** attempt));
     }
   }
 }
+/* eslint-enable no-await-in-loop */
 
 api.verifyPurchase = async function verifyPurchase (options) {
   const {
@@ -68,16 +70,15 @@ api.verifyPurchase = async function verifyPurchase (options) {
   }).exec();
   if (existingReceipt) throw new NotAuthorized(this.constants.RESPONSE_ALREADY_USED);
 
-
   // Credit the purchase (with retry logic) before ever touching the receipt record
-   await safeBuySkuItem({
+  await safeBuySkuItem({
     user,
     gift,
     paymentMethod: api.constants.PAYMENT_METHOD_GOOGLE,
     sku: googleRes.productId,
     headers,
   });
-  
+
   // Only once purchase have been successfully credited, mark the purchase token as consumed
   await IapPurchaseReceipt.create({
     _id: token,


### PR DESCRIPTION
Previously we marked the IAP receipt consumed in the DB before attempting
to credit gems. If crediting failed (e.g. transient DB/network error),
the token was "burned" and the Android/iOS client would consume it on
their side, making retries impossible and causing players to pay without
receiving gems.

This change:
- Introduces "safeBuySkuItem" in googlePlay.js/apple.js with a 3-attempt
  exponential-backoff wrapper around payments.buySkuItem.
- Swaps the order in verifyPurchase/noRenewSubscribe: first call
  'safeBuySkuItem', then 'IapPurchaseReceipt.create' only on success.
- Ensures any failure bubbles up before the receipt is marked consumed.

Now purchases are retried on transient failures and receipts are only
burned once delivery succeeds.
