### PR TITLE
issue#14461:fix(party): update party member tooltips on sync to refle…

### DIFF
--- a/website/client/src/components/header/index.vue
+++ b/website/client/src/components/header/index.vue
@@ -219,9 +219,12 @@ export default {
       this.inviteModalGroupType = group.type === 'guild' ? 'Guild' : 'Party';
       this.$root.$emit('bv::show::modal', 'invite-modal');
     });
+    // Listen for party updates and force-refresh party members
+    this.$root.$on('habitica:party-updated', this.forceRefreshPartyMembers);
   },
   beforeDestroy () {
     this.$root.$off('inviteModal::inviteToGroup');
+    this.$root.$off('habitica:party-updated', this.forceRefreshPartyMembers);
   },
   methods: {
     ...mapActions({
@@ -281,6 +284,9 @@ export default {
       if (this.currentWidth !== $event.width) {
         this.currentWidth = $event.width;
       }
+    },
+    forceRefreshPartyMembers () {
+      this.getPartyMembers({ forceLoad: true });
     },
   },
 };

--- a/website/client/src/mixins/spells.js
+++ b/website/client/src/mixins/spells.js
@@ -165,6 +165,7 @@ export default {
           msg = this.$t('youCastParty', {
             spell: spellText,
           });
+          this.$root.$emit('habitica:party-updated');
           break;
         default:
           msg = this.$t('youCast', {

--- a/website/client/src/mixins/sync.js
+++ b/website/client/src/mixins/sync.js
@@ -12,6 +12,7 @@ export default {
         this.$store.dispatch('tasks:fetchUserTasks', { forceLoad: true }),
       ]);
       this.$root.$emit(EVENTS.RESYNC_COMPLETED);
+      this.$root.$emit('habitica:party-updated');
     },
   },
 };


### PR DESCRIPTION
##  Bug Fix: Party Tooltip Stats Not Updating After Sync

###  What Was the Issue?
The header shows party member stats using data stored in the app’s memory (Vuex store).  
When you use an ability or sync, the backend updates, but the header’s data wasn’t being refreshed from the server.  
So, the tooltips kept showing the old, stale data.

###  How did I fix it?

- **Event System**:  
  We used a special event (`habitica:party-updated`) to tell the app, “Hey! The party data has changed, go get the latest info!”

- **Triggered After Sync/Abilities**:  
  After you hit Sync or use a party ability, this event is now triggered.

- **Header Reacts to Event**:  
  The header listens for the `habitica:party-updated` event and reloads the party data from the server.

###  Result
Now, whenever you use a party ability or sync, the header fetches the latest stats, and the mouseover tooltips show the correct, up-to-date values.

---

