### PR TITLE
Fix 500 when deleting a very old group plan account

### DIFF
--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -1503,8 +1503,13 @@ schema.methods.unlinkTask = async function groupUnlinkTask (
     'group.assignedUsers': user._id,
   };
 
-  delete unlinkingTask.group.assignedUsersDetail[user._id];
-  unlinkingTask.group.assignedUsers = _.keys(unlinkingTask.group.assignedUsersDetail);
+  if (unlinkingTask.group.assignedUsersDetail) {
+    delete unlinkingTask.group.assignedUsersDetail[user._id];
+    unlinkingTask.group.assignedUsers = _.keys(unlinkingTask.group.assignedUsersDetail);
+  } else {
+    // Task was created before assignedUsersDetail was added
+    removeFromArray(unlinkingTask.group.assignedUsers, user._id);
+  }
   unlinkingTask.markModified('group');
 
   const promises = [unlinkingTask.save()];


### PR DESCRIPTION
When deleted old accounts with a cancelled group plan. the `group.assignedUsersDetail` field might not be available on the task, which causes a 500 error.