### PR TITLE
Add Challenge categories to content API

### DIFF
--- a/website/common/script/content/index.js
+++ b/website/common/script/content/index.js
@@ -17,7 +17,7 @@ import {
 } from './constants';
 
 import achievements from './achievements';
-
+import categoryOptions from './categoryOptions';
 import eggs from './eggs';
 import hatchingPotions from './hatching-potions';
 import stable from './stable';
@@ -84,6 +84,8 @@ api.timeTravelerStore = timeTravelers.timeTravelerStore;
 api.officialPinnedItems = officialPinnedItems;
 
 api.bundles = bundles;
+
+api.categoryOptions = categoryOptions;
 
 /*
    ---------------------------------------------------------------

--- a/website/server/controllers/api-v3/content.js
+++ b/website/server/controllers/api-v3/content.js
@@ -10,7 +10,7 @@ const MOBILE_FILTER = ['achievements', 'questSeriesAchievements', 'animalColorAc
   'stableAchievements', 'bundles', 'loginIncentives', 'pets', 'premiumPets', 'specialPets', 'questPets',
   'wackyPets', 'mounts', 'premiumMounts,specialMounts,questMounts', 'events', 'dropEggs', 'questEggs', 'dropHatchingPotions',
   'premiumHatchingPotions', 'wackyHatchingPotions', 'backgroundsFlat', 'questsByLevel', 'gear.tree', 'tasksByCategory',
-  'userDefaults', 'timeTravelStable', 'gearTypes', 'cardTypes'];
+  'userDefaults', 'timeTravelStable', 'gearTypes', 'cardTypes', 'categoryOptions'];
 
 const ANDROID_FILTER = [...MOBILE_FILTER, 'appearances.background'].join(',');
 const IOS_FILTER = [...MOBILE_FILTER, 'backgrounds'].join(',');

--- a/website/server/controllers/api-v3/content.js
+++ b/website/server/controllers/api-v3/content.js
@@ -10,7 +10,7 @@ const MOBILE_FILTER = ['achievements', 'questSeriesAchievements', 'animalColorAc
   'stableAchievements', 'bundles', 'loginIncentives', 'pets', 'premiumPets', 'specialPets', 'questPets',
   'wackyPets', 'mounts', 'premiumMounts,specialMounts,questMounts', 'events', 'dropEggs', 'questEggs', 'dropHatchingPotions',
   'premiumHatchingPotions', 'wackyHatchingPotions', 'backgroundsFlat', 'questsByLevel', 'gear.tree', 'tasksByCategory',
-  'userDefaults', 'timeTravelStable', 'gearTypes', 'cardTypes', 'categoryOptions'];
+  'userDefaults', 'timeTravelStable', 'gearTypes', 'cardTypes'];
 
 const ANDROID_FILTER = [...MOBILE_FILTER, 'appearances.background'].join(',');
 const IOS_FILTER = [...MOBILE_FILTER, 'backgrounds'].join(',');


### PR DESCRIPTION
**Before**: The list of available categories for Challenges was not available via the API. Clients needed to implement it directly, importing or copying the list from common code.

**Now**: The `categoryOptions` content file is exposed as `categoryOptions` in the content API object, and can be obtained via the usual `GET /api/v4/content`.