### PR TITLE
Potential fix for API documentation endpoint: "mark multiple notifications as read"

### DIFF
--- a/website/server/controllers/api-v3/notifications.js
+++ b/website/server/controllers/api-v3/notifications.js
@@ -55,7 +55,9 @@ api.readNotification = {
  * @apiName ReadNotifications
  * @apiGroup Notification
  *
- * @apiSuccess {Object} data user.notifications
+ * @apiParam {String[]} notificationIds Array of UUIDs of notification IDs to mark as read (required) 
+ * 
+ * @apiSuccess {Object} data Updated user.notifications array
  */
 api.readNotifications = {
   method: 'POST',


### PR DESCRIPTION
Fixes #14484 

### Changes
Changes were made to the readNotification API endpoint docs, added notificationIds parameter and description, as it does not currently show up in the API docs.

----
UUID:
b283f0e9-592f-4f0b-a915-267b2ee2013b
