### PR TITLE
docs: add notificationIds param for mark multiple notifications as read

### DIFF
--- a/website/server/controllers/api-v3/notifications.js
+++ b/website/server/controllers/api-v3/notifications.js
@@ -9,14 +9,18 @@ import {
 const api = {};
 
 /**
- * @api {post} /api/v3/notifications/:notificationId/read Mark one notification as read
- * @apiName ReadNotification
+ * @api {post} /api/v3/notifications/read Mark multiple notifications as read
+ * @apiName ReadMultipleNotifications
  * @apiGroup Notification
  *
- * @apiParam (Path) {UUID} notificationId
+ * @apiBody {UUID[]} notificationIds Required. An array of notification IDs to mark as read.
  *
  * @apiSuccess {Object} data user.notifications
+ *
+ * @apiError (400) MissingParameter notificationIds must be provided.
  */
+
+
 api.readNotification = {
   method: 'POST',
   url: '/notifications/:notificationId/read',


### PR DESCRIPTION
[//]: # (Note: See https://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

Fixes #14484

### Changes
I updated the API documentation for the **"Mark multiple notifications as read"** endpoint.  
The change documents the required parameter `notificationIds` in the request body, which was missing before.  

### Screenshots / Proof
N/A (documentation-only change)

----

UUID: 3c532c2e-45b3-4af1-aab5-aa8f09d59fa9

