### PR TITLE
Set up analytics scripts on demand post user load

### DIFF
--- a/website/client/package-lock.json
+++ b/website/client/package-lock.json
@@ -23,6 +23,7 @@
         "eslint-config-habitrpg": "6.2.0",
         "eslint-plugin-mocha": "5.3.0",
         "eslint-plugin-vue": "7.20.0",
+        "ga-gtag": "^1.2.0",
         "habitica-markdown": "^3.0.0",
         "hellojs": "^1.20.0",
         "intro.js": "^7.2.0",
@@ -5159,6 +5160,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/ga-gtag": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ga-gtag/-/ga-gtag-1.2.0.tgz",
+      "integrity": "sha512-j9gxutMdpGMdwaX1SzOG31Ddm+IGFjeNf+N3Z5g+BBpS8FSXOALlrM+ORIGc/QKszGJEDlw+6PfIsJZICsqsGQ=="
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",

--- a/website/client/package-lock.json
+++ b/website/client/package-lock.json
@@ -42,7 +42,6 @@
         "vue": "^2.7.10",
         "vue-fragment": "^1.6.0",
         "vue-mugen-scroll": "^0.2.6",
-        "vue-plugin-load-script": "^1.3.6",
         "vue-router": "^3.6.5",
         "vuedraggable": "^2.24.3",
         "vuejs-datepicker": "git://github.com/habitrpg/vuejs-datepicker.git#153d339e4dbebb73733658aeda1d5b7fcc55b0a0"
@@ -8817,11 +8816,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/vue-plugin-load-script": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/vue-plugin-load-script/-/vue-plugin-load-script-1.3.6.tgz",
-      "integrity": "sha512-O+mpw32dXY3tMBBNKm7/qIByJV1QbHJ+0CXI4GeXx4NHU/Rg+bv7bvzugkEWnYcB/43WvR8ZD2K9KQIeVng1bA=="
     },
     "node_modules/vue-router": {
       "version": "3.6.5",

--- a/website/client/package.json
+++ b/website/client/package.json
@@ -27,6 +27,7 @@
     "eslint-config-habitrpg": "6.2.0",
     "eslint-plugin-mocha": "5.3.0",
     "eslint-plugin-vue": "7.20.0",
+    "ga-gtag": "^1.2.0",
     "habitica-markdown": "^3.0.0",
     "hellojs": "^1.20.0",
     "intro.js": "^7.2.0",

--- a/website/client/package.json
+++ b/website/client/package.json
@@ -46,7 +46,6 @@
     "vue": "^2.7.10",
     "vue-fragment": "^1.6.0",
     "vue-mugen-scroll": "^0.2.6",
-    "vue-plugin-load-script": "^1.3.6",
     "vue-router": "^3.6.5",
     "vuedraggable": "^2.24.3",
     "vuejs-datepicker": "git://github.com/habitrpg/vuejs-datepicker.git#153d339e4dbebb73733658aeda1d5b7fcc55b0a0"

--- a/website/client/src/libs/analytics.js
+++ b/website/client/src/libs/analytics.js
@@ -78,7 +78,7 @@ export function setup (userId) {
   analyticsLoading = false;
 }
 
-export async function track (properties, options = {}) {
+export function track (properties, options = {}) {
   const user = _getConsentedUser();
   if (!user) return;
   if (!analyticsReady) {
@@ -100,7 +100,7 @@ export async function track (properties, options = {}) {
   });
 }
 
-export async function updateUser (properties = {}) {
+export function updateUser (properties = {}) {
   const user = _getConsentedUser();
   if (!user) return;
   if (!analyticsReady) {

--- a/website/client/src/libs/analytics.js
+++ b/website/client/src/libs/analytics.js
@@ -4,7 +4,6 @@ import keys from 'lodash/keys';
 import pick from 'lodash/pick';
 import amplitude from 'amplitude-js';
 import Vue from 'vue';
-import LoadScript from 'vue-plugin-load-script';
 import getStore from '@/store';
 
 const AMPLITUDE_KEY = import.meta.env.AMPLITUDE_KEY;
@@ -13,10 +12,10 @@ const GA_ID = import.meta.env.GA_ID;
 const IS_PRODUCTION = import.meta.env.NODE_ENV === 'production';
 const REQUIRED_FIELDS = ['eventCategory', 'eventAction'];
 
+import gtag from `https://www.googletagmanager.com/gtag/js?id=${GA_ID}`;
+
 let analyticsLoading = false;
 let analyticsReady = false;
-
-Vue.use(LoadScript);
 
 function _getConsentedUser () {
   const store = getStore();
@@ -68,11 +67,11 @@ function _gatherUserStats (properties) {
   if (user.purchased.plan.planId) properties.subscription = user.purchased.plan.planId;
 }
 
-export async function setup (userId) {
+export function setup (userId) {
   if (analyticsLoading) return;
   analyticsLoading = true;
-  await Vue.loadScript(`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`);
-  gtag('config', GA_ID, { // eslint-disable-line no-undef
+  gtag('js', new Date());
+  gtag('config', GA_ID, {
     debug_mode: DEBUG_ENABLED || !IS_PRODUCTION,
     user_id: userId,
   });
@@ -85,7 +84,7 @@ export async function setUser () {
   const user = _getConsentedUser();
   if (!user) return;
   if (!analyticsReady) {
-    await setup(user._id);
+    setup(user._id);
   }
   amplitude.setUserId(user._id);
 }
@@ -94,7 +93,7 @@ export async function track (properties, options = {}) {
   const user = _getConsentedUser();
   if (!user) return;
   if (!analyticsReady) {
-    await setup(user._id);
+    setup(user._id);
   }
   // Use nextTick to avoid blocking the UI
   Vue.nextTick(() => {
@@ -104,7 +103,7 @@ export async function track (properties, options = {}) {
     // Track events on the server by default
     if (trackOnClient === true) {
       amplitude.track(properties.eventAction, properties);
-      gtag('event', properties.eventAction, properties); // eslint-disable-line no-undef
+      gtag('event', properties.eventAction, properties);
     } else {
       const store = getStore();
       store.dispatch('analytics:trackEvent', properties);
@@ -116,12 +115,12 @@ export async function updateUser (properties = {}) {
   const user = _getConsentedUser();
   if (!user) return;
   if (!analyticsReady) {
-    await setup(user._id);
+    setup(user._id);
   }
   // Use nextTick to avoid blocking the UI
   Vue.nextTick(() => {
     _gatherUserStats(properties);
-    gtag('set', 'user_properties', properties); // eslint-disable-line no-undef
+    gtag('set', 'user_properties', properties);
     forEach(properties, (value, key) => {
       const identify = new amplitude.Identify().set(key, value);
       amplitude.identify(identify);

--- a/website/client/src/libs/analytics.js
+++ b/website/client/src/libs/analytics.js
@@ -73,8 +73,7 @@ export function setup (userId) {
     debug_mode: DEBUG_ENABLED || !IS_PRODUCTION,
     user_id: userId,
   });
-  amplitude.init(AMPLITUDE_KEY);
-  amplitude.setUserId(userId);
+  amplitude.getInstance().init(AMPLITUDE_KEY, userId);
   analyticsReady = true;
   analyticsLoading = false;
 }
@@ -92,7 +91,7 @@ export async function track (properties, options = {}) {
     const trackOnClient = options && options.trackOnClient === true;
     // Track events on the server by default
     if (trackOnClient === true) {
-      amplitude.track(properties.eventAction, properties);
+      amplitude.getInstance().logEvent(properties.eventAction, properties);
       gtag('event', properties.eventAction, properties);
     } else {
       const store = getStore();
@@ -113,7 +112,7 @@ export async function updateUser (properties = {}) {
     gtag('set', 'user_properties', properties);
     forEach(properties, (value, key) => {
       const identify = new amplitude.Identify().set(key, value);
-      amplitude.identify(identify);
+      amplitude.getInstance().identify(identify);
     });
   });
 }

--- a/website/client/src/libs/analytics.js
+++ b/website/client/src/libs/analytics.js
@@ -3,9 +3,9 @@ import isEqual from 'lodash/isEqual';
 import keys from 'lodash/keys';
 import pick from 'lodash/pick';
 import amplitude from 'amplitude-js';
+import { gtag, install } from 'ga-gtag';
 import Vue from 'vue';
 import getStore from '@/store';
-import { gtag, install } from 'ga-gtag';
 
 const AMPLITUDE_KEY = import.meta.env.AMPLITUDE_KEY;
 const DEBUG_ENABLED = import.meta.env.DEBUG_ENABLED === 'true';

--- a/website/client/src/libs/analytics.js
+++ b/website/client/src/libs/analytics.js
@@ -65,13 +65,13 @@ function _gatherUserStats (properties) {
   if (user.purchased.plan.planId) properties.subscription = user.purchased.plan.planId;
 }
 
-export async function setup () {
+export async function setup (userId) {
   if (analyticsLoading) return;
   analyticsLoading = true;
   await Vue.loadScript(`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`);
   window.gtag('config', GA_ID, {
     debug_mode: DEBUG_ENABLED || !IS_PRODUCTION,
-    user_id: user._id,
+    user_id: userId,
   });
   amplitude.getInstance().init(AMPLITUDE_KEY);
   analyticsReady = true;
@@ -82,7 +82,7 @@ export async function setUser () {
   const user = _getConsentedUser();
   if (!user) return;
   if (!analyticsReady) {
-    await setup();
+    await setup(user._id);
   }
   amplitude.getInstance().setUserId(user._id);
 }
@@ -91,7 +91,7 @@ export async function track (properties, options = {}) {
   const user = _getConsentedUser();
   if (!user) return;
   if (!analyticsReady) {
-    await setup();
+    await setup(user._id);
   }
   // Use nextTick to avoid blocking the UI
   Vue.nextTick(() => {
@@ -115,7 +115,7 @@ export async function updateUser (properties = {}) {
   const user = _getConsentedUser();
   if (!user) return;
   if (!analyticsReady) {
-    await setup();
+    await setup(user._id);
   }
   // Use nextTick to avoid blocking the UI
   Vue.nextTick(() => {

--- a/website/client/src/libs/analytics.js
+++ b/website/client/src/libs/analytics.js
@@ -74,17 +74,9 @@ export function setup (userId) {
     user_id: userId,
   });
   amplitude.init(AMPLITUDE_KEY);
+  amplitude.setUserId(userId);
   analyticsReady = true;
   analyticsLoading = false;
-}
-
-export async function setUser () {
-  const user = _getConsentedUser();
-  if (!user) return;
-  if (!analyticsReady) {
-    setup(user._id);
-  }
-  amplitude.setUserId(user._id);
 }
 
 export async function track (properties, options = {}) {

--- a/website/client/src/libs/analytics.js
+++ b/website/client/src/libs/analytics.js
@@ -103,7 +103,7 @@ export async function track (properties, options = {}) {
     const trackOnClient = options && options.trackOnClient === true;
     // Track events on the server by default
     if (trackOnClient === true) {
-      amplitude.logEvent(properties.eventAction, properties);
+      amplitude.track(properties.eventAction, properties);
       gtag('event', properties.eventAction, properties); // eslint-disable-line no-undef
     } else {
       const store = getStore();

--- a/website/client/src/libs/analytics.js
+++ b/website/client/src/libs/analytics.js
@@ -66,8 +66,8 @@ function _gatherUserStats (properties) {
   if (user.purchased.plan.planId) properties.subscription = user.purchased.plan.planId;
 }
 
-export function setup (userId) {
-  if (analyticsLoading) return;
+export function safeSetup (userId) {
+  if (analyticsLoading || analyticsReady) return;
   analyticsLoading = true;
   install(GA_ID, {
     debug_mode: DEBUG_ENABLED || !IS_PRODUCTION,
@@ -81,9 +81,7 @@ export function setup (userId) {
 export function track (properties, options = {}) {
   const user = _getConsentedUser();
   if (!user) return;
-  if (!analyticsReady) {
-    setup(user._id);
-  }
+  safeSetup(user._id);
   // Use nextTick to avoid blocking the UI
   Vue.nextTick(() => {
     if (_doesNotHaveRequiredFields(properties)) return;
@@ -103,9 +101,7 @@ export function track (properties, options = {}) {
 export function updateUser (properties = {}) {
   const user = _getConsentedUser();
   if (!user) return;
-  if (!analyticsReady) {
-    setup(user._id);
-  }
+  safeSetup(user._id);
   // Use nextTick to avoid blocking the UI
   Vue.nextTick(() => {
     _gatherUserStats(properties);

--- a/website/client/src/libs/analytics.js
+++ b/website/client/src/libs/analytics.js
@@ -69,11 +69,11 @@ export async function setup (userId) {
   if (analyticsLoading) return;
   analyticsLoading = true;
   await Vue.loadScript(`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`);
-  window.gtag('config', GA_ID, {
+  gtag('config', GA_ID, { // eslint-disable-line no-undef
     debug_mode: DEBUG_ENABLED || !IS_PRODUCTION,
     user_id: userId,
   });
-  amplitude.getInstance().init(AMPLITUDE_KEY);
+  amplitude.init(AMPLITUDE_KEY);
   analyticsReady = true;
   analyticsLoading = false;
 }
@@ -84,7 +84,7 @@ export async function setUser () {
   if (!analyticsReady) {
     await setup(user._id);
   }
-  amplitude.getInstance().setUserId(user._id);
+  amplitude.setUserId(user._id);
 }
 
 export async function track (properties, options = {}) {
@@ -100,10 +100,8 @@ export async function track (properties, options = {}) {
     const trackOnClient = options && options.trackOnClient === true;
     // Track events on the server by default
     if (trackOnClient === true) {
-      amplitude.getInstance().logEvent(properties.eventAction, properties);
-      if (window.gtag) {
-        window.gtag('event', properties.eventAction, properties);
-      }
+      amplitude.logEvent(properties.eventAction, properties);
+      gtag('event', properties.eventAction, properties); // eslint-disable-line no-undef
     } else {
       const store = getStore();
       store.dispatch('analytics:trackEvent', properties);
@@ -120,12 +118,10 @@ export async function updateUser (properties = {}) {
   // Use nextTick to avoid blocking the UI
   Vue.nextTick(() => {
     _gatherUserStats(properties);
-    if (window.gtag) {
-      window.gtag('set', 'user_properties', properties);
-    }
+    gtag('set', 'user_properties', properties); // eslint-disable-line no-undef
     forEach(properties, (value, key) => {
       const identify = new amplitude.Identify().set(key, value);
-      amplitude.getInstance().identify(identify);
+      amplitude.identify(identify);
     });
   });
 }

--- a/website/client/src/libs/analytics.js
+++ b/website/client/src/libs/analytics.js
@@ -10,8 +10,9 @@ const AMPLITUDE_KEY = import.meta.env.AMPLITUDE_KEY;
 const DEBUG_ENABLED = import.meta.env.DEBUG_ENABLED === 'true';
 const GA_ID = import.meta.env.GA_ID;
 const IS_PRODUCTION = import.meta.env.NODE_ENV === 'production';
-
 const REQUIRED_FIELDS = ['eventCategory', 'eventAction'];
+
+let analyticsReady = false;
 
 function _getConsentedUser () {
   const store = getStore();
@@ -63,13 +64,31 @@ function _gatherUserStats (properties) {
   if (user.purchased.plan.planId) properties.subscription = user.purchased.plan.planId;
 }
 
-export function setUser () {
+export async function setup () {
+  const user = _getConsentedUser();
+  if (!user) return;
+  await Vue.loadScript(`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`);
+  window.gtag('config', GA_ID, {
+    debug_mode: DEBUG_ENABLED || !IS_PRODUCTION,
+    user_id: user._id,
+  });
+  amplitude.getInstance().init(AMPLITUDE_KEY);
+  analyticsReady = true;
+}
+
+export async function setUser () {
+  if (!analyticsReady) {
+    await setup();
+  }
   const user = _getConsentedUser();
   if (!user) return;
   amplitude.getInstance().setUserId(user._id);
 }
 
-export function track (properties, options = {}) {
+export async function track (properties, options = {}) {
+  if (!analyticsReady) {
+    await setup();
+  }
   const user = _getConsentedUser();
   if (!user) return;
   // Use nextTick to avoid blocking the UI
@@ -90,7 +109,10 @@ export function track (properties, options = {}) {
   });
 }
 
-export function updateUser (properties = {}) {
+export async function updateUser (properties = {}) {
+  if (!analyticsReady) {
+    await setup();
+  }
   const user = _getConsentedUser();
   if (!user) return;
   // Use nextTick to avoid blocking the UI
@@ -104,15 +126,4 @@ export function updateUser (properties = {}) {
       amplitude.getInstance().identify(identify);
     });
   });
-}
-
-export async function setup () {
-  const user = _getConsentedUser();
-  if (!user) return;
-  await Vue.loadScript(`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`);
-  window.gtag('config', GA_ID, {
-    debug_mode: DEBUG_ENABLED || !IS_PRODUCTION,
-    user_id: user._id,
-  });
-  amplitude.getInstance().init(AMPLITUDE_KEY);
 }

--- a/website/client/src/libs/analytics.js
+++ b/website/client/src/libs/analytics.js
@@ -4,6 +4,7 @@ import keys from 'lodash/keys';
 import pick from 'lodash/pick';
 import amplitude from 'amplitude-js';
 import Vue from 'vue';
+import LoadScript from 'vue-plugin-load-script';
 import getStore from '@/store';
 
 const AMPLITUDE_KEY = import.meta.env.AMPLITUDE_KEY;
@@ -14,6 +15,8 @@ const REQUIRED_FIELDS = ['eventCategory', 'eventAction'];
 
 let analyticsLoading = false;
 let analyticsReady = false;
+
+Vue.use(LoadScript);
 
 function _getConsentedUser () {
   const store = getStore();

--- a/website/client/src/libs/analytics.js
+++ b/website/client/src/libs/analytics.js
@@ -5,14 +5,13 @@ import pick from 'lodash/pick';
 import amplitude from 'amplitude-js';
 import Vue from 'vue';
 import getStore from '@/store';
+import { gtag, install } from 'ga-gtag';
 
 const AMPLITUDE_KEY = import.meta.env.AMPLITUDE_KEY;
 const DEBUG_ENABLED = import.meta.env.DEBUG_ENABLED === 'true';
 const GA_ID = import.meta.env.GA_ID;
 const IS_PRODUCTION = import.meta.env.NODE_ENV === 'production';
 const REQUIRED_FIELDS = ['eventCategory', 'eventAction'];
-
-import gtag from `https://www.googletagmanager.com/gtag/js?id=${GA_ID}`;
 
 let analyticsLoading = false;
 let analyticsReady = false;
@@ -70,8 +69,7 @@ function _gatherUserStats (properties) {
 export function setup (userId) {
   if (analyticsLoading) return;
   analyticsLoading = true;
-  gtag('js', new Date());
-  gtag('config', GA_ID, {
+  install(GA_ID, {
     debug_mode: DEBUG_ENABLED || !IS_PRODUCTION,
     user_id: userId,
   });

--- a/website/client/src/libs/analytics.js
+++ b/website/client/src/libs/analytics.js
@@ -12,6 +12,7 @@ const GA_ID = import.meta.env.GA_ID;
 const IS_PRODUCTION = import.meta.env.NODE_ENV === 'production';
 const REQUIRED_FIELDS = ['eventCategory', 'eventAction'];
 
+let analyticsLoading = false;
 let analyticsReady = false;
 
 function _getConsentedUser () {
@@ -65,8 +66,8 @@ function _gatherUserStats (properties) {
 }
 
 export async function setup () {
-  const user = _getConsentedUser();
-  if (!user) return;
+  if (analyticsLoading) return;
+  analyticsLoading = true;
   await Vue.loadScript(`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`);
   window.gtag('config', GA_ID, {
     debug_mode: DEBUG_ENABLED || !IS_PRODUCTION,
@@ -74,23 +75,24 @@ export async function setup () {
   });
   amplitude.getInstance().init(AMPLITUDE_KEY);
   analyticsReady = true;
+  analyticsLoading = false;
 }
 
 export async function setUser () {
+  const user = _getConsentedUser();
+  if (!user) return;
   if (!analyticsReady) {
     await setup();
   }
-  const user = _getConsentedUser();
-  if (!user) return;
   amplitude.getInstance().setUserId(user._id);
 }
 
 export async function track (properties, options = {}) {
+  const user = _getConsentedUser();
+  if (!user) return;
   if (!analyticsReady) {
     await setup();
   }
-  const user = _getConsentedUser();
-  if (!user) return;
   // Use nextTick to avoid blocking the UI
   Vue.nextTick(() => {
     if (_doesNotHaveRequiredFields(properties)) return;
@@ -110,11 +112,11 @@ export async function track (properties, options = {}) {
 }
 
 export async function updateUser (properties = {}) {
+  const user = _getConsentedUser();
+  if (!user) return;
   if (!analyticsReady) {
     await setup();
   }
-  const user = _getConsentedUser();
-  if (!user) return;
   // Use nextTick to avoid blocking the UI
   Vue.nextTick(() => {
     _gatherUserStats(properties);

--- a/website/client/src/main.js
+++ b/website/client/src/main.js
@@ -14,9 +14,6 @@ import {
 import Fragment from 'vue-fragment';
 import LoadScript from 'vue-plugin-load-script';
 import AppComponent from './app';
-import {
-  setup as setupAnalytics,
-} from '@/libs/analytics';
 import { setUpLogging } from '@/libs/logging';
 import router from './router/index';
 import getStore from './store';
@@ -52,7 +49,6 @@ Vue.use(Fragment.Plugin);
 Vue.use(LoadScript);
 
 setUpLogging();
-setupAnalytics();
 const store = getStore();
 
 if (import.meta.env.TIME_TRAVEL_ENABLED === 'true') {

--- a/website/client/src/main.js
+++ b/website/client/src/main.js
@@ -12,7 +12,6 @@ import {
   CollapsePlugin,
 } from 'bootstrap-vue';
 import Fragment from 'vue-fragment';
-import LoadScript from 'vue-plugin-load-script';
 import AppComponent from './app';
 import { setUpLogging } from '@/libs/logging';
 import router from './router/index';
@@ -46,7 +45,6 @@ Vue.use(TooltipPlugin);
 Vue.use(NavbarPlugin);
 Vue.use(CollapsePlugin);
 Vue.use(Fragment.Plugin);
-Vue.use(LoadScript);
 
 setUpLogging();
 const store = getStore();

--- a/website/client/src/pages/user-main.vue
+++ b/website/client/src/pages/user-main.vue
@@ -263,8 +263,6 @@ export default {
       this.$store.dispatch('tasks:fetchUserTasks'),
     ]).then(() => {
       this.$store.state.isUserLoaded = true;
-      Analytics.setUser();
-      Analytics.updateUser();
       const analyticsConsent = localStorage.getItem('analyticsConsent');
       if (analyticsConsent !== null
         && analyticsConsent !== this.user.preferences.analyticsConsent
@@ -281,6 +279,7 @@ export default {
           return null;
         }
       }
+      Analytics.updateUser();
       return axios.get(
         '/api/v4/i18n/browser-script',
         {


### PR DESCRIPTION
**Before**, we attempted to set up analytics in the client `main.js`. However, we now rely on being able to retrieve the analytics consent preference from the user record, and the user record is not yet available during the initial load of the web app. This meant that the analytics setup function would fail, and subsequent attempts to track analytics events on the client would not send data as intended.

**Now**, we keep track of the load state within the client analytics library. If the scripts haven't been set up yet, then we load them on demand the first time we attempt to send an event.