### PR TITLE
Fix client side errors that happened on page load

### DIFF
--- a/website/client/src/components/avatar.vue
+++ b/website/client/src/components/avatar.vue
@@ -321,8 +321,8 @@ export default {
       return null;
     },
     petClass () {
-      const foolEvent = this.currentEventList?.find(event => moment()
-        .isBetween(event.start, event.end) && event.aprilFools);
+      const foolEvent = this.currentEventList?.find(event => event.aprilFools && moment()
+        .isBetween(event.start, event.end));
       if (foolEvent) {
         return this.foolPet(this.member.items.currentPet, foolEvent.aprilFools);
       }

--- a/website/client/src/components/tasks/column.vue
+++ b/website/client/src/components/tasks/column.vue
@@ -86,8 +86,8 @@
         v-if="taskList.length > 0"
         ref="tasksList"
         class="sortable-tasks"
-        :options="{disabled: activeFilter.label === 'scheduled' || !canBeDragged(),
-                   scrollSensitivity: 64}"
+        :disabled="activeFilter.label === 'scheduled' || !canBeDragged()"
+        scrollSensitivity="64"
         :delay-on-touch-only="true"
         :delay="100"
         @update="taskSorted"

--- a/website/client/src/components/tasks/modal-controls/checklist.vue
+++ b/website/client/src/components/tasks/modal-controls/checklist.vue
@@ -21,11 +21,9 @@
     >
       <draggable
         v-model="checklist"
-        :options="{
-          handle: '.grippy',
-          filter: '.task-dropdown',
-          disabled: disabled,
-        }"
+        handle=".grippy"
+        filter=".task-dropdown"
+        :disabled="disabled"
         @update="updateChecklist"
       >
         <div

--- a/website/client/src/libs/i18n.js
+++ b/website/client/src/libs/i18n.js
@@ -21,7 +21,7 @@ function loadLocale (i18nData) {
     script.type = 'text/javascript';
     script.text = i18nData.momentLang;
     head.appendChild(script);
-    moment.locale(language.momentLangCode);
+    moment.updateLocale(language.momentLangCode);
   }
 }
 


### PR DESCRIPTION
- Fixed an error with moment trying to parse the date format we use for galas. Switching around the check fixes this as it then only checks actual April fools events
- Fixed setting the moment locale where we were using the wrong method
- Fixed the use of the deprecated options api in vie-draggable