### PR TITLE
Trim logs sent to loggly

### DIFF
--- a/website/server/libs/logger.js
+++ b/website/server/libs/logger.js
@@ -27,11 +27,16 @@ export { _config as _loggerConfig }; // exported for use during tests
 const slimLogs = winston.format(info => {
   if (info && info.message && info.message.indexOf('BadRequest: Missing x-client headers') === 0) {
     info.body = undefined;
-    info.headers = {
-      'x-api-user': info.headers['x-api-user'] || 'unknown',
-    };
     info.message = 'BadRequest: Missing x-client headers';
   }
+  if (info && info.message && info.message.indexOf('TooManyRequests') === 0) {
+    info.message = 'TooManyRequests';
+  }
+  info.headers = {
+    'x-api-user': info.headers['x-api-user'] || 'unknown',
+    'x-client': info.headers['x-client'] || 'unknown',
+    'user-agent': info.headers['user-agent'] || 'unknown',
+  };
   return info;
 });
 

--- a/website/server/libs/logger.js
+++ b/website/server/libs/logger.js
@@ -55,10 +55,14 @@ if (IS_PROD) {
   }
 
   if (LOGGLY_TOKEN && LOGGLY_SUBDOMAIN) {
+    const tags = ['Winston-NodeJS'];
+    if (nconf.get('SERVER_EMOJI')) {
+      tags.push(nconf.get('SERVER_EMOJI'));
+    }
     logger.add(new Loggly({
       inputToken: LOGGLY_TOKEN,
       subdomain: LOGGLY_SUBDOMAIN,
-      tags: ['Winston-NodeJS'],
+      tags,
       json: true,
       format: winston.format.combine(
         slimLogs(),

--- a/website/server/libs/logger.js
+++ b/website/server/libs/logger.js
@@ -24,6 +24,17 @@ const _config = {
 
 export { _config as _loggerConfig }; // exported for use during tests
 
+const slimLogs = winston.format(info => {
+  if (info && info.message && info.message.indexOf('BadRequest: Missing x-client headers') === 0) {
+    info.body = undefined;
+    info.headers = {
+      'x-api-user': info.headers['x-api-user'] || 'unknown',
+    };
+    info.message = 'BadRequest: Missing x-client headers';
+  }
+  return info;
+});
+
 if (IS_PROD) {
   if (ENABLE_CONSOLE_LOGS_IN_PROD) {
     logger
@@ -49,6 +60,11 @@ if (IS_PROD) {
       subdomain: LOGGLY_SUBDOMAIN,
       tags: ['Winston-NodeJS'],
       json: true,
+      format: winston.format.combine(
+        slimLogs(),
+        winston.format.timestamp(),
+        winston.format.json(),
+      ),
     }));
   }
 // Do not log anything when testing unless specified


### PR DESCRIPTION
This removes most of the headers sent to loggly and also trims the error message for specific errors that happen often.