### PR TITLE
feat(groups): add ctrl+enter shortcut to save party description (#15500)

### DIFF
--- a/website/client/src/components/groups/groupFormModal.vue
+++ b/website/client/src/components/groups/groupFormModal.vue
@@ -169,6 +169,7 @@ label.custom-control-label(v-once) {{ $t('allowGuildInvitationsFromNonMembers') 
           textarea="textarea"
           :placeholder="isParty
             ? $t('partyDescriptionPlaceholder') : $t('guildDescriptionPlaceholder')"
+          @keydown.ctrl.enter.prevent="submit"
         ></textarea>
       </div>
       <div


### PR DESCRIPTION
[//]: # (Note: See https://habitica.fandom.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes #15500

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)

Added Ctrl+Enter keyboard shortcut to save party description in the group form modal. This allows users to quickly save changes without having to move their cursor to click the save button.

The changes include:
- Added `@keydown.ctrl.enter.prevent="submit"` to the description textarea in `groupFormModal.vue`
- Uses the existing `submit()` method
- No additional dependencies required

This feature matches similar functionality throughout Habitica where Ctrl+Enter is used to submit forms.

[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: d47b8eb5-4daa-4c47-82e3-e5c571a80fcf