### PR TITLE
GPC Message

### DIFF
--- a/website/client/src/assets/scss/typography.scss
+++ b/website/client/src/assets/scss/typography.scss
@@ -123,6 +123,10 @@ h4 {
   background-color: $purple-300 !important;
 }
 
+.bg-yellow-50 {
+  background-color: $yellow-50 !important;
+}
+
 .bg-white {
   background-color: $white !important;
 }

--- a/website/client/src/libs/analytics.js
+++ b/website/client/src/libs/analytics.js
@@ -19,7 +19,7 @@ let analyticsReady = false;
 function _getConsentedUser () {
   const store = getStore();
   const user = store.state.user.data;
-  if (!user?.preferences?.analyticsConsent || navigator.globalPrivacyControl) {
+  if (!user?.preferences?.analyticsConsent) {
     return false;
   }
   return user;

--- a/website/client/src/pages/settings-overview.vue
+++ b/website/client/src/pages/settings-overview.vue
@@ -98,7 +98,7 @@
   }
 
   .settings-content {
-    flex: 0 0 732px;
+    flex: 0 0 747px;
     max-width: unset;
 
     ::v-deep {

--- a/website/client/src/pages/settings-overview.vue
+++ b/website/client/src/pages/settings-overview.vue
@@ -98,7 +98,7 @@
   }
 
   .settings-content {
-    flex: 0 0 747px;
+    flex: 0 0 751px;
     max-width: unset;
 
     ::v-deep {

--- a/website/client/src/pages/settings/siteDataRows/privacyPreferencesRow.vue
+++ b/website/client/src/pages/settings/siteDataRows/privacyPreferencesRow.vue
@@ -43,9 +43,8 @@
         >
         </div>
         <div
-          v-once
           class="gpc-message"
-          v-html="$t('gpcWarning', { url: 'https://globalprivacycontrol.org/' })"
+          v-html="gpcInfo"
         >
         </div>
       </div>
@@ -174,10 +173,18 @@ export default {
     gpcEnabled () {
       return navigator.globalPrivacyControl;
     },
+    gpcInfo () {
+      const gpcUrl = 'https://globalprivacycontrol.org/';
+      if (this.user.preferences.analyticsConsent) {
+        return this.$t('gpcPlusAnalytics', { url: gpcUrl });
+      }
+      return this.$t('gpcWarning', { url: gpcUrl });
+    },
   },
   methods: {
     finalize () {
       this.setUserPreference('analyticsConsent');
+      localStorage.setItem('analyticsConsent', this.user.preferences.analyticsConsent);
       this.mixinData.inlineSettingMixin.sharedState.inlineSettingUnsavedValues = false;
     },
     prefToggled () {

--- a/website/client/src/pages/settings/siteDataRows/privacyPreferencesRow.vue
+++ b/website/client/src/pages/settings/siteDataRows/privacyPreferencesRow.vue
@@ -192,7 +192,10 @@ export default {
       this.mixinData.inlineSettingMixin.sharedState.inlineSettingUnsavedValues = newVal;
     },
     resetControls () {
-      this.user.preferences.analyticsConsent = !this.user.preferences.analyticsConsent;
+      if (this.mixinData.inlineSettingMixin.sharedState.inlineSettingUnsavedValues) {
+        this.user.preferences.analyticsConsent = !this.user.preferences.analyticsConsent;
+        this.mixinData.inlineSettingMixin.sharedState.inlineSettingUnsavedValues = false;
+      }
     },
   },
 };

--- a/website/client/src/pages/settings/siteDataRows/privacyPreferencesRow.vue
+++ b/website/client/src/pages/settings/siteDataRows/privacyPreferencesRow.vue
@@ -35,15 +35,16 @@
       </p>
       <div
         v-if="gpcEnabled"
-        class="mx-4 pl-3 py-2 mb-4 gpc-alert d-flex align-items-center black bg-yellow-50"
+        class="mx-4 px-3 py-2 mb-4 gpc-alert d-flex align-items-center black bg-yellow-50"
       >
         <div
-          class="svg svg-icon mr-1"
+          class="svg svg-icon mr-2"
           v-html="icons.alert"
         >
         </div>
         <div
           v-once
+          class="gpc-message"
           v-html="$t('gpcWarning', { url: 'https://globalprivacycontrol.org/' })"
         >
         </div>
@@ -109,7 +110,10 @@
   .gpc-alert {
     border-radius: 4px;
     line-height: 1.714;
-    opacity: 0.9;
+
+    .gpc-message {
+      opacity: 0.9;
+    }
 
     ::v-deep a {
       color: $black;

--- a/website/client/src/pages/settings/siteDataRows/privacyPreferencesRow.vue
+++ b/website/client/src/pages/settings/siteDataRows/privacyPreferencesRow.vue
@@ -34,6 +34,21 @@
       >
       </p>
       <div
+        v-if="gpcEnabled"
+        class="mx-4 pl-3 py-2 mb-4 gpc-alert d-flex align-items-center black bg-yellow-50"
+      >
+        <div
+          class="svg svg-icon mr-1"
+          v-html="icons.alert"
+        >
+        </div>
+        <div
+          v-once
+          v-html="$t('gpcWarning', { url: 'https://globalprivacycontrol.org/' })"
+        >
+        </div>
+      </div>
+      <div
         class="d-flex justify-content-center"
       >
         <div class="w-66">
@@ -91,6 +106,26 @@
     line-height: 1.33;
   }
 
+  .gpc-alert {
+    border-radius: 4px;
+    line-height: 1.714;
+    opacity: 0.9;
+
+    ::v-deep a {
+      color: $black;
+      text-decoration: underline;
+    }
+
+    .svg-icon {
+      width: 16px;
+      opacity: 0.75;
+
+      ::v-deep svg path {
+        fill: $black;
+      }
+    }
+  }
+
   .mb-28p {
     margin-bottom: 28px;
   }
@@ -110,6 +145,7 @@ import ToggleSwitch from '@/components/ui/toggleSwitch.vue';
 import { GenericUserPreferencesMixin } from '@/pages/settings/components/genericUserPreferencesMixin';
 import { InlineSettingMixin } from '../components/inlineSettingMixin';
 import { mapState } from '@/libs/store';
+import alert from '@/assets/svg/for-css/alert.svg?raw';
 
 export default {
   mixins: [
@@ -120,10 +156,20 @@ export default {
     SaveCancelButtons,
     ToggleSwitch,
   },
+  data () {
+    return {
+      icons: Object.freeze({
+        alert,
+      }),
+    };
+  },
   computed: {
     ...mapState({
       user: 'user.data',
     }),
+    gpcEnabled () {
+      return navigator.globalPrivacyControl;
+    },
   },
   methods: {
     finalize () {

--- a/website/client/src/pages/user-main.vue
+++ b/website/client/src/pages/user-main.vue
@@ -263,11 +263,12 @@ export default {
       this.$store.dispatch('tasks:fetchUserTasks'),
     ]).then(() => {
       this.$store.state.isUserLoaded = true;
-      const analyticsConsent = localStorage.getItem('analyticsConsent');
-      if (analyticsConsent !== null
-        && analyticsConsent !== this.user.preferences.analyticsConsent
-      ) {
-        this.$store.dispatch('user:set', { 'preferences.analyticsConsent': analyticsConsent });
+      let analyticsConsent = localStorage.getItem('analyticsConsent');
+      if (analyticsConsent !== null) {
+        analyticsConsent = analyticsConsent === 'true';
+        if (analyticsConsent !== this.user.preferences.analyticsConsent) {
+          this.$store.dispatch('user:set', { 'preferences.analyticsConsent': analyticsConsent });
+        }
       }
       if (window && window['habitica-i18n']) {
         if (this.user.preferences.language === window['habitica-i18n'].language.code) {

--- a/website/common/locales/en/settings.json
+++ b/website/common/locales/en/settings.json
@@ -271,5 +271,6 @@
     "performanceAnalytics": "Performance and Analytics",
     "usedForSupport": "These are used to improve the user experience, performance, and services of our website and apps. This data is used by our support team when handling requests and bug reports.",
     "savePreferences": "Save Preferences",
-    "habiticaPrivacyPolicy": "Habitica's Privacy Policy"
+    "habiticaPrivacyPolicy": "Habitica's Privacy Policy",
+    "gpcWarning": "<a href='<%= url %>' target='_blank'>GPC</a> is on. Turning on tracking below will override this and send data to our analytics partners."
 }

--- a/website/common/locales/en/settings.json
+++ b/website/common/locales/en/settings.json
@@ -272,5 +272,6 @@
     "usedForSupport": "These are used to improve the user experience, performance, and services of our website and apps. This data is used by our support team when handling requests and bug reports.",
     "savePreferences": "Save Preferences",
     "habiticaPrivacyPolicy": "Habitica's Privacy Policy",
-    "gpcWarning": "<a href='<%= url %>' target='_blank'>GPC</a> is on. Turning on tracking below will override this and send data to our analytics partners."
+    "gpcWarning": "<a href='<%= url %>' target='_blank'>GPC</a> is on. Turning on tracking below will override this and send data to our analytics partners.",
+    "gpcPlusAnalytics": "<a href='<%= url %>' target='_blank'>GPC</a> is on. You have opted in to tracking and sending data to our analytics partners."
 }


### PR DESCRIPTION
**Before**, the user having [Global Privacy Control](https://globalprivacycontrol.org/) enabled silently caused analytics scripts not to load, and even opting in via the Settings page did not allow the user to voluntarily send data.

**Now**, visiting the Preferences section of the Settings page displays a warning banner if GPC is enabled in the user's browser. If the user continues to toggle analytics collection on, events will be sent irrespective of GPC -- this allows, for example, the user to send event instrumentation in support of a bug report.

Additionally fixes some client display issues where the toggle state of the privacy preferences switch behaved inconsistently.