### PR TITLE
Updating the dev version of MongoDB to 7.0.23 from 4.1.1

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -34,7 +34,7 @@ services:
       - .:/usr/src/habitica
       - /usr/src/habitica/node_modules
   mongo:
-    image: mongo:5.0.23
+    image: mongo:7.0.23
     restart: unless-stopped
     command: ["--replSet", "rs", "--bind_ip_all", "--port", "27017"]
     healthcheck:

--- a/gulp/gulp-build.js
+++ b/gulp/gulp-build.js
@@ -51,7 +51,7 @@ gulp.task('build:prepare-mongo', async () => {
   console.log('MongoDB data folder is missing, setting up.'); // eslint-disable-line no-console
 
   // use run-rs without --keep, kill it as soon as the replica set starts
-  const runRsProcess = spawn('run-rs', ['-v', '4.1.1', '-l', 'ubuntu1804', '--dbpath', 'mongodb-data', '--number', '1', '--quiet']);
+  const runRsProcess = spawn('run-rs', ['-v', '7.0.23', '-l', 'ubuntu2204', '--dbpath', 'mongodb-data', '--number', '1', '--quiet']);
 
   for await (const chunk of runRsProcess.stdout) {
     const stringChunk = chunk.toString();


### PR DESCRIPTION
### Changes

When attempting to set up Habitica for the first time, npm install currently fails due to the version of MongoDB referenced in gulp-build.js being incorrect. This update corrects the version number in both gulp-build.js and docker-compose.dev.yml, allowing npm install to successfully set up and run MongoDB.
----
UUID: 9171d9fb-7b8e-428a-9d06-926ff028c6d8
