### PR TITLE
feat(tasks): enhance task color logic to consider user preferences

### DIFF
--- a/website/client/src/store/getters/tasks.js
+++ b/website/client/src/store/getters/tasks.js
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import { shouldDo } from '@/../../common/script/cron';
 
 // Library / Utility function
@@ -20,10 +21,23 @@ export function getTagsByIdList (store) {
   };
 }
 
-function getTaskColor (task) {
+function getTaskColor (task, userPreferences = {}) {
   if (task.type === 'reward' || task.byHabitica) return 'purple';
 
   const { value } = task;
+
+  // Check if task is a todo with a due date that hasn't passed yet
+  // If the task is not overdue yet, don't let it turn red based on value alone
+  if (task.type === 'todo' && task.date) {
+    const endOfToday = moment().subtract(userPreferences.dayStart || 0, 'hours').endOf('day');
+    const endOfDueDate = moment(task.date).endOf('day');
+    const isOverdue = moment.duration(endOfDueDate.diff(endOfToday)).asDays() < 0;
+    if (!isOverdue && value < -1) {
+      if (value < 1) {
+        return 'neutral';
+      }
+    }
+  }
 
   if (value < -20) {
     return 'worst';
@@ -133,7 +147,7 @@ export function getTaskClasses (store) {
   return (task, purpose, dueDate) => {
     if (!dueDate) dueDate = new Date(); // eslint-disable-line no-param-reassign
     const { type } = task;
-    const color = getTaskColor(task);
+    const color = getTaskColor(task, userPreferences);
 
     switch (purpose) {
       case 'edit-modal-bg':


### PR DESCRIPTION
## Issue
Tasks with due dates turn red before their deadline has passed, which is confusing for users because red indicates urgency/overdue status.

Link: https://github.com/HabitRPG/habitica/issues/15529

## Solution
Modified `getTaskColor()` function in `website/client/src/store/getters/tasks.js` to:
- Check if a todo has a due date
- Calculate if the due date has passed using user's custom day start preference
- Cap color at "neutral" (yellow) for non-overdue tasks instead of allowing red

## Benefits
- ✅ Logical color coding: Red now means "actually overdue" for todos with due dates
- ✅ Better task prioritization: Users can clearly distinguish urgent vs. incomplete tasks
- ✅ No breaking changes: Habits, dailies, and todos without due dates work as before
- ✅ Respects user preferences: Considers custom day start time

## Testing
- No linter errors
- Follows existing code patterns
- Uses same date calculation logic as UI (`checkIfOverdue()`)