### PR TITLE
feat: add cooldown to prevent rapid Enchanted Armoire purchases

### DIFF
--- a/website/common/locales/en/content.json
+++ b/website/common/locales/en/content.json
@@ -6,6 +6,7 @@
   "armoireNotesFull": "Open the Armoire to randomly receive special Equipment, Experience, or food! Equipment pieces remaining:",
   "armoireLastItem": "You've found the last piece of rare Equipment in the Enchanted Armoire.",
   "armoireNotesEmpty": "The Armoire will have new Equipment in the first week of every month. Until then, keep clicking for Experience and Pet Food!",
+  "armoirePurchaseTooFast": "Please wait before purchasing another Enchanted Armoire item. Rapid clicks are not allowed.",
 
   "dropEggWolfText": "Wolf",
   "dropEggWolfMountText": "Wolf",

--- a/website/common/locales/en_GB/content.json
+++ b/website/common/locales/en_GB/content.json
@@ -5,6 +5,7 @@
     "armoireNotesFull": "Open the Armoire to randomly receive special Equipment, Experience, or food! Equipment pieces remaining:",
     "armoireLastItem": "You've found the last piece of rare Equipment in the Enchanted Armoire.",
     "armoireNotesEmpty": "The Armoire will have new Equipment in the first week of every month. Until then, keep clicking for Experience and Pet Food!",
+    "armoirePurchaseTooFast": "Please wait before purchasing another Enchanted Armoire item. Rapid clicks are not allowed.",
     "dropEggWolfText": "Wolf",
     "dropEggWolfMountText": "Wolf",
     "dropEggWolfAdjective": "a loyal",

--- a/website/common/script/ops/buy/buyArmoire.js
+++ b/website/common/script/ops/buy/buyArmoire.js
@@ -25,6 +25,15 @@ export class BuyArmoireOperation extends AbstractGoldItemOperation { // eslint-d
   extractAndValidateParams (user) {
     const item = content.armoire;
 
+    // Check for cooldown period to prevent rapid purchases
+    const now = new Date();
+    const lastPurchaseTime = user.flags.lastArmoirePurchase ? new Date(user.flags.lastArmoirePurchase) : null;
+    const COOLDOWN_MILLISECONDS = 2000; // 2 second cooldown to prevent rapid purchases
+    
+    if (lastPurchaseTime && (now - lastPurchaseTime) < COOLDOWN_MILLISECONDS) {
+      throw new NotAuthorized(this.i18n('armoirePurchaseTooFast'));
+    }
+
     this.canUserPurchase(user, item);
   }
 
@@ -50,6 +59,9 @@ export class BuyArmoireOperation extends AbstractGoldItemOperation { // eslint-d
     }
 
     this.subtractCurrency(user, item);
+
+    // Set the last armoire purchase time to prevent rapid purchases
+    user.flags.lastArmoirePurchase = new Date();
 
     let { message } = result;
     const { armoireResp } = result;

--- a/website/server/models/user/schema.js
+++ b/website/server/models/user/schema.js
@@ -338,6 +338,7 @@ export const UserSchema = new Schema({
     armoireEnabled: { $type: Boolean, default: true },
     armoireOpened: { $type: Boolean, default: false },
     armoireEmpty: { $type: Boolean, default: false },
+    lastArmoirePurchase: { $type: Date },
     cardReceived: { $type: Boolean, default: false },
     warnedLowHealth: { $type: Boolean, default: false },
     verifiedUsername: { $type: Boolean, default: false },


### PR DESCRIPTION
# Fix for Issue #15541: Add Cooldown for Enchanted Armoire Purchases

## Summary
This PR implements a cooldown mechanism to prevent users from making rapid, consecutive purchases from the Enchanted Armoire. A 2-second cooldown has been added to ensure that users must wait between purchases, addressing potential abuse or accidental rapid clicks.

## Changes
- **Added new translation strings** (`armoirePurchaseTooFast`) in both `en` and `en_GB` locales to inform users when they are clicking too rapidly.
- **Implemented a 2-second cooldown** in the `buyArmoire.js` operation:
  - Checks the `lastArmoirePurchase` timestamp in the user's flags before allowing a new purchase.
  - Throws a `NotAuthorized` error with the new translation string if the cooldown period hasn't elapsed.
  - Updates the `lastArmoirePurchase` timestamp after a successful purchase.
- **Updated the user schema** to include a `lastArmoirePurchase` field to track the last purchase time.

## Technical Details
- The cooldown is implemented server-side to prevent client-side bypass.
- The `lastArmoirePurchase` field is stored in the user's `flags` object in the database.
- The cooldown duration is set to 2 seconds to balance preventing spam with allowing reasonable usage.

## Testing
- Verify that the cooldown prevents multiple purchases within 2 seconds
- Check that the error message is displayed appropriately
- Ensure that purchases work normally after the cooldown period has elapsed
- Confirm that the user schema change does not break existing functionality