### PR TITLE
Add cooldown to enchanted armoire purchases to prevent rapid buying

### DIFF
--- a/website/common/locales/en/messages.json
+++ b/website/common/locales/en/messages.json
@@ -35,6 +35,7 @@
   "armoireEquipment": "<%= image %> You found a piece of rare Equipment in the Armoire: <%= dropText %>! Awesome!",
   "armoireFood": "<%= image %> You rummage in the Armoire and find <%= dropText %>. What's that doing in here?",
   "armoireExp": "You wrestle with the Armoire and gain Experience. Take that!",
+  "armoirePurchaseTooFast": "Please wait a moment before purchasing from the Enchanted Armoire again.",
   "messageInsufficientGems": "Not enough gems!",
   "messageGroupAlreadyInParty": "Already in a party, try refreshing.",
   "messageGroupOnlyLeaderCanUpdate": "Only the group leader can update the group!",

--- a/website/common/locales/en_GB/messages.json
+++ b/website/common/locales/en_GB/messages.json
@@ -30,6 +30,7 @@
     "armoireEquipment": "<%= image %> You found a piece of rare Equipment in the Armoire: <%= dropText %>! Awesome!",
     "armoireFood": "<%= image %> You rummage in the Armoire and find <%= dropText %>. What's that doing in here?",
     "armoireExp": "You wrestle with the Armoire and gain Experience. Take that!",
+    "armoirePurchaseTooFast": "Please wait a moment before purchasing from the Enchanted Armoire again.",
     "messageInsufficientGems": "Not enough gems!",
     "messageGroupAlreadyInParty": "Already in a party, try refreshing.",
     "messageGroupOnlyLeaderCanUpdate": "Only the group leader can update the group!",

--- a/website/common/script/ops/buy/buyArmoire.js
+++ b/website/common/script/ops/buy/buyArmoire.js
@@ -16,6 +16,7 @@ import updateStats from '../../fns/updateStats';
 
 const YIELD_EQUIPMENT_THRESHOLD = 0.6;
 const YIELD_FOOD_THRESHOLD = 0.8;
+const ARMOIRE_COOLDOWN_MS = 2000; // 2 seconds cooldown
 
 export class BuyArmoireOperation extends AbstractGoldItemOperation { // eslint-disable-line import/prefer-default-export, max-len
   multiplePurchaseAllowed () { // eslint-disable-line class-methods-use-this
@@ -24,6 +25,16 @@ export class BuyArmoireOperation extends AbstractGoldItemOperation { // eslint-d
 
   extractAndValidateParams (user) {
     const item = content.armoire;
+
+    // Check cooldown to prevent rapid purchases
+    const lastPurchase = user.flags.lastArmoirePurchase;
+    if (lastPurchase) {
+      const now = Date.now();
+      const timeSinceLastPurchase = now - new Date(lastPurchase).getTime();
+      if (timeSinceLastPurchase < ARMOIRE_COOLDOWN_MS) {
+        throw new NotAuthorized(this.i18n('armoirePurchaseTooFast'));
+      }
+    }
 
     this.canUserPurchase(user, item);
   }
@@ -50,6 +61,9 @@ export class BuyArmoireOperation extends AbstractGoldItemOperation { // eslint-d
     }
 
     this.subtractCurrency(user, item);
+
+    // Update the last armoire purchase time to prevent rapid purchases
+    user.flags.lastArmoirePurchase = new Date();
 
     let { message } = result;
     const { armoireResp } = result;

--- a/website/server/models/user/schema.js
+++ b/website/server/models/user/schema.js
@@ -320,6 +320,7 @@ export const UserSchema = new Schema({
       $type: Schema.Types.Mixed,
       default: () => ({}),
     },
+    lastArmoirePurchase: Date,
     chatRevoked: Boolean,
     chatShadowMuted: Boolean,
     // Used to track the status of recapture emails sent to each user,


### PR DESCRIPTION
## Overview
This PR implements a cooldown mechanism for the Enchanted Armoire purchases to prevent users from making rapid consecutive purchases. A 2-second cooldown has been added, and a new user flag tracks the last purchase time.

## Checklist
- [x] Code changes implemented
- [x] New user schema field added
- [x] UI messages added for cooldown notification
- [ ] Tests updated (pending)
- [x] Documentation updated

## Proof
The fix adds a check in `buyArmoire.js` to verify the time elapsed since the last purchase before allowing a new one. If the cooldown period hasn't passed, an error message is thrown. The user's last purchase time is updated after a successful purchase. The new message `armoirePurchaseTooFast` is included in the English and British English locales.

## Closes #15546