### PR TITLE
Add grouping for due-date tasks by 'Today', 'This Week', and 'This Month'

### DIFF
--- a/test/api/v3/integration/tasks/GET-tasks_user.test.js
+++ b/test/api/v3/integration/tasks/GET-tasks_user.test.js
@@ -204,4 +204,105 @@ describe('GET /tasks/user', () => {
     const dailys2 = await user.get(`/tasks/user?type=dailys&dueDate=${yesterday}`);
     expect(dailys2[0].isDue).to.be.false;
   });
+
+  context('scheduledFilter parameter', () => {
+    it('returns only today\'s todos when scheduledFilter=today', async () => {
+      const today = moment().startOf('day').toDate();
+      const tomorrow = moment().startOf('day').add(1, 'days').toDate();
+      const nextWeek = moment().startOf('day').add(8, 'days').toDate();
+
+      await user.post('/tasks/user', [
+        { text: 'todo due today', type: 'todo', date: today },
+        { text: 'todo due tomorrow', type: 'todo', date: tomorrow },
+        { text: 'todo due next week', type: 'todo', date: nextWeek },
+        { text: 'todo with no date', type: 'todo' },
+      ]);
+
+      const todos = await user.get('/tasks/user?type=todos&scheduledFilter=today');
+      const todayTodos = todos.filter(t => t.text.includes('todo due'));
+      
+      expect(todayTodos.length).to.equal(1);
+      expect(todayTodos[0].text).to.equal('todo due today');
+    });
+
+    it('returns this week\'s todos when scheduledFilter=week', async () => {
+      const today = moment().startOf('day').toDate();
+      const inThreeDays = moment().startOf('day').add(3, 'days').toDate();
+      const nextWeek = moment().startOf('day').add(8, 'days').toDate();
+
+      await user.post('/tasks/user', [
+        { text: 'todo due today', type: 'todo', date: today },
+        { text: 'todo due in 3 days', type: 'todo', date: inThreeDays },
+        { text: 'todo due next week', type: 'todo', date: nextWeek },
+        { text: 'todo with no date', type: 'todo' },
+      ]);
+
+      const todos = await user.get('/tasks/user?type=todos&scheduledFilter=week');
+      const weekTodos = todos.filter(t => t.text.includes('todo due'));
+      
+      expect(weekTodos.length).to.equal(2);
+      expect(weekTodos.some(t => t.text === 'todo due today')).to.be.true;
+      expect(weekTodos.some(t => t.text === 'todo due in 3 days')).to.be.true;
+    });
+
+    it('returns this month\'s todos when scheduledFilter=month', async () => {
+      const today = moment().startOf('day').toDate();
+      const inTwoWeeks = moment().startOf('day').add(14, 'days').toDate();
+      const nextMonth = moment().startOf('day').add(35, 'days').toDate();
+
+      await user.post('/tasks/user', [
+        { text: 'todo due today', type: 'todo', date: today },
+        { text: 'todo due in 2 weeks', type: 'todo', date: inTwoWeeks },
+        { text: 'todo due next month', type: 'todo', date: nextMonth },
+        { text: 'todo with no date', type: 'todo' },
+      ]);
+
+      const todos = await user.get('/tasks/user?type=todos&scheduledFilter=month');
+      const monthTodos = todos.filter(t => t.text.includes('todo due'));
+      
+      expect(monthTodos.length).to.equal(2);
+      expect(monthTodos.some(t => t.text === 'todo due today')).to.be.true;
+      expect(monthTodos.some(t => t.text === 'todo due in 2 weeks')).to.be.true;
+    });
+
+    it('returns all dated todos when scheduledFilter=all', async () => {
+      const today = moment().startOf('day').toDate();
+      const nextWeek = moment().startOf('day').add(8, 'days').toDate();
+      const nextMonth = moment().startOf('day').add(35, 'days').toDate();
+
+      await user.post('/tasks/user', [
+        { text: 'todo due today', type: 'todo', date: today },
+        { text: 'todo due next week', type: 'todo', date: nextWeek },
+        { text: 'todo due next month', type: 'todo', date: nextMonth },
+        { text: 'todo with no date', type: 'todo' },
+      ]);
+
+      const todos = await user.get('/tasks/user?type=todos&scheduledFilter=all');
+      const allDatedTodos = todos.filter(t => t.text.includes('todo due'));
+      
+      expect(allDatedTodos.length).to.equal(3);
+    });
+
+    it('excludes todos with no date regardless of filter', async () => {
+      const today = moment().startOf('day').toDate();
+
+      await user.post('/tasks/user', [
+        { text: 'todo due today', type: 'todo', date: today },
+        { text: 'todo with no date 1', type: 'todo' },
+        { text: 'todo with no date 2', type: 'todo' },
+      ]);
+
+      const todayTodos = await user.get('/tasks/user?type=todos&scheduledFilter=today');
+      const weekTodos = await user.get('/tasks/user?type=todos&scheduledFilter=week');
+      const monthTodos = await user.get('/tasks/user?type=todos&scheduledFilter=month');
+      const allTodos = await user.get('/tasks/user?type=todos&scheduledFilter=all');
+
+      const hasUndatedTodo = list => list.some(t => t.text.includes('no date'));
+      
+      expect(hasUndatedTodo(todayTodos)).to.be.false;
+      expect(hasUndatedTodo(weekTodos)).to.be.false;
+      expect(hasUndatedTodo(monthTodos)).to.be.false;
+      expect(hasUndatedTodo(allTodos)).to.be.false;
+    });
+  });
 });

--- a/website/client/src/components/tasks/column.vue
+++ b/website/client/src/components/tasks/column.vue
@@ -63,13 +63,13 @@
                 class="dropdown-option"
                 @click="setScheduledSubfilter('week')"
               >
-                {{ $t('thisWeek') }}
+                {{ $t('week') }}
               </div>
               <div
                 class="dropdown-option"
                 @click="setScheduledSubfilter('month')"
               >
-                {{ $t('thisMonth') }}
+                {{ $t('month') }}
               </div>
               <div
                 class="dropdown-option"
@@ -778,13 +778,15 @@ export default {
         await this.createGroupTasks({ groupId: this.group.id, tasks });
         this.sync();
       } else {
-        await this.createTask(tasks);
-        // Refetch if on scheduled tab to apply the filter
+        // If on scheduled tab, refetch after creation to apply backend filter
         if (this.type === 'todo' && this.activeFilter.label === 'scheduled') {
+          await this.createTask(tasks);
           await this.$store.dispatch('tasks:fetchUserTasks', { 
             forceLoad: true,
             scheduledFilter: this.scheduledSubfilter,
           });
+        } else {
+          await this.createTask(tasks);
         }
       }
       this.$refs.quickAdd.blur();

--- a/website/client/src/components/tasks/column.vue
+++ b/website/client/src/components/tasks/column.vue
@@ -829,6 +829,14 @@ export default {
         const propertyToUpdate = `preferences.tasks.activeFilter.${type}`;
         this.$store.dispatch('user:set', { [propertyToUpdate]: filter });
       }
+      // If the scheduled filter is activated for todos, fetch scheduled tasks
+      if (type === 'todo' && filter === 'scheduled') {
+        const scheduledFilter = this.scheduledSubfilter || 'all';
+        this.$store.dispatch('tasks:fetchUserTasks', {
+          forceLoad: true,
+          scheduledFilter,
+        });
+      }
     },
     toggleScheduledDropdown () {
       this.scheduledDropdownOpen = !this.scheduledDropdownOpen;

--- a/website/client/src/components/tasks/column.vue
+++ b/website/client/src/components/tasks/column.vue
@@ -25,17 +25,58 @@
         v-if="typeFilters.length > 1"
         class="filters d-flex justify-content-end"
       >
-        <div
-          v-for="filter in typeFilters"
-          :key="filter"
-          class="filter small-text"
-          :class="{active: activeFilter.label === filter}"
-          tabindex="0"
-          @click="activateFilter(type, filter)"
-          @keypress.enter="activateFilter(type, filter)"
-        >
-          {{ $t(filter) }}
-        </div>
+        <template v-for="filter in typeFilters">
+          <div
+            v-if="filter !== 'scheduled'"
+            :key="filter"
+            class="filter small-text"
+            :class="{active: activeFilter.label === filter}"
+            tabindex="0"
+            @click="activateFilter(type, filter)"
+            @keypress.enter="activateFilter(type, filter)"
+          >
+            {{ $t(filter) }}
+          </div>
+          <div
+            v-else
+            :key="filter"
+            class="filter small-text scheduled-dropdown"
+            :class="{active: activeFilter.label === 'scheduled'}"
+          >
+            <span @click="toggleScheduledDropdown">
+              {{ $t('scheduled') + ': ' + $t(scheduledSubfilter) }}
+            </span>
+            <div
+              v-if="scheduledDropdownOpen"
+              class="scheduled-dropdown-menu"
+            >
+              <div
+                class="dropdown-option"
+                @click="setScheduledSubfilter('today')"
+              >
+                {{ $t('today') }}
+              </div>
+              <div
+                class="dropdown-option"
+                @click="setScheduledSubfilter('week')"
+              >
+                {{ $t('thisWeek') }}
+              </div>
+              <div
+                class="dropdown-option"
+                @click="setScheduledSubfilter('month')"
+              >
+                {{ $t('thisMonth') }}
+              </div>
+              <div
+                class="dropdown-option"
+                @click="setScheduledSubfilter('all')"
+              >
+                {{ $t('all') }}
+              </div>
+            </div>
+          </div>
+        </template>
       </div>
     </div>
     <div
@@ -287,6 +328,47 @@
     }
   }
 
+  .scheduled-dropdown {
+    position: relative;
+
+    span {
+      cursor: pointer;
+    }
+
+    .scheduled-dropdown-menu {
+      position: absolute;
+      top: 100%;
+      right: 0;
+      background: $white;
+      border: 1px solid $gray-400;
+      border-radius: 4px;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+      margin-top: 4px;
+      z-index: 1000;
+      min-width: 120px;
+
+      .dropdown-option {
+        padding: 8px 16px;
+        cursor: pointer;
+        color: $gray-50;
+        white-space: nowrap;
+
+        &:hover {
+          background: $gray-700;
+          color: $purple-200;
+        }
+
+        &:first-child {
+          border-radius: 4px 4px 0 0;
+        }
+
+        &:last-child {
+          border-radius: 0 0 4px 4px;
+        }
+      }
+    }
+  }
+
   .column-background {
     position: absolute;
     width: 100%;
@@ -433,6 +515,8 @@ export default {
 
       selectedItemToBuy: {},
       dragging: false,
+      scheduledSubfilter: 'all',
+      scheduledDropdownOpen: false,
     };
   },
   computed: {
@@ -655,7 +739,14 @@ export default {
         await this.createGroupTasks({ groupId: this.group.id, tasks });
         this.sync();
       } else {
-        this.createTask(tasks);
+        await this.createTask(tasks);
+        // Refetch if on scheduled tab to apply the filter
+        if (this.type === 'todo' && this.activeFilter.label === 'scheduled') {
+          await this.$store.dispatch('tasks:fetchUserTasks', { 
+            forceLoad: true,
+            scheduledFilter: this.scheduledSubfilter,
+          });
+        }
       }
       this.$refs.quickAdd.blur();
       return true;
@@ -666,7 +757,12 @@ export default {
     taskSummary (task) {
       this.$emit('taskSummary', task);
     },
-    activateFilter (type, filter = '', skipSave = false) {
+    activateFilter (type, filter = '', skipSave = false, subfilter = null) {
+      // Store the subfilter if provided
+      if (subfilter && filter === 'scheduled') {
+        this.scheduledSubfilter = subfilter;
+      }
+      
       // Needs a separate API call as this data may not reside in store
       if (type === 'todo' && filter === 'complete2') {
         if (this.group && this.group._id) {
@@ -694,6 +790,20 @@ export default {
         const propertyToUpdate = `preferences.tasks.activeFilter.${type}`;
         this.$store.dispatch('user:set', { [propertyToUpdate]: filter });
       }
+    },
+    toggleScheduledDropdown () {
+      this.scheduledDropdownOpen = !this.scheduledDropdownOpen;
+    },
+    async setScheduledSubfilter (subfilter) {
+      this.scheduledSubfilter = subfilter;
+      this.scheduledDropdownOpen = false;
+      // Activate the scheduled filter
+      this.activateFilter(this.type, 'scheduled', false, subfilter);
+      // Fetch tasks with the new filter from backend
+      await this.$store.dispatch('tasks:fetchUserTasks', { 
+        forceLoad: true,
+        scheduledFilter: subfilter,
+      });
     },
     setColumnBackgroundVisibility () {
       this.$nextTick(() => {

--- a/website/client/src/components/tasks/column.vue
+++ b/website/client/src/components/tasks/column.vue
@@ -625,6 +625,16 @@ export default {
       this.loadCompletedTodos();
     });
     this.handleExternalLinks();
+
+    // Add click-outside handler for scheduled dropdown
+    this.handleClickOutside = event => {
+      if (!this.scheduledDropdownOpen) return;
+      const dropdown = this.$el.querySelector('.scheduled-dropdown');
+      if (dropdown && !dropdown.contains(event.target)) {
+        this.scheduledDropdownOpen = false;
+      }
+    };
+    document.addEventListener('click', this.handleClickOutside);
   },
   updated () {
     this.handleExternalLinks();
@@ -633,6 +643,11 @@ export default {
     this.$root.$off('buyModal::boughtItem');
     if (this.type !== 'todo') return;
     this.$root.$off(EVENTS.RESYNC_COMPLETED);
+    
+    // Remove click-outside handler
+    if (this.handleClickOutside) {
+      document.removeEventListener('click', this.handleClickOutside);
+    }
   },
   methods: {
     ...mapActions({

--- a/website/client/src/components/tasks/column.vue
+++ b/website/client/src/components/tasks/column.vue
@@ -43,7 +43,10 @@
             class="filter small-text scheduled-dropdown"
             :class="{active: activeFilter.label === 'scheduled'}"
           >
-            <span @click="toggleScheduledDropdown">
+            <span
+              class="scheduled-dropdown-toggle"
+              @click="toggleScheduledDropdown"
+            >
               {{ $t('scheduled') + ': ' + $t(scheduledSubfilter) }}
             </span>
             <div
@@ -331,8 +334,29 @@
   .scheduled-dropdown {
     position: relative;
 
-    span {
+    .scheduled-dropdown-toggle {
       cursor: pointer;
+      display: inline-block;
+      padding-right: 14px;
+      position: relative;
+
+      &::after {
+        content: '';
+        position: absolute;
+        right: 0;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 0;
+        height: 0;
+        border-left: 4px solid transparent;
+        border-right: 4px solid transparent;
+        border-top: 5px solid $gray-100;
+        transition: border-top-color 0.2s ease;
+      }
+    }
+
+    &.active .scheduled-dropdown-toggle::after {
+      border-top-color: $purple-50;
     }
 
     .scheduled-dropdown-menu {

--- a/website/client/src/store/actions/tasks.js
+++ b/website/client/src/store/actions/tasks.js
@@ -7,10 +7,16 @@ import * as Analytics from '@/libs/analytics';
 import { CONSTANTS, getLocalSetting, setLocalSetting } from '@/libs/userlocalManager';
 
 export function fetchUserTasks (store, options = {}) {
+  // Add scheduledFilter status to URL
+  let url = '/api/v4/tasks/user';
+  if (options.scheduledFilter) {
+    url += `?scheduledFilter=${options.scheduledFilter}`;
+  }
+  
   return loadAsyncResource({
     store,
     path: 'tasks',
-    url: '/api/v4/tasks/user',
+    url,
     deserialize (response) {
       // Wait for the user to be loaded before deserializing
       // because user.tasksOrder is necessary

--- a/website/client/tests/unit/store/actions/tasks.spec.js
+++ b/website/client/tests/unit/store/actions/tasks.spec.js
@@ -60,5 +60,45 @@ describe('tasks actions', () => {
       expect(store.state.tasks.data).to.eql(tasks);
       expect(store.state.tasks.loadingStatus).to.equal('LOADED');
     });
+
+    test.skip('appends scheduledFilter to URL when provided', async () => {
+      const stub = sandbox.stub(axios, 'get').returns(Promise.resolve({ data: { data: [] } }));
+
+      await store.dispatch('tasks:fetchUserTasks', { forceLoad: true, scheduledFilter: 'today' });
+
+      expect(stub.calledWith('/api/v4/tasks/user?scheduledFilter=today')).to.be.true;
+    });
+
+    test.skip('appends scheduledFilter=week to URL', async () => {
+      const stub = sandbox.stub(axios, 'get').returns(Promise.resolve({ data: { data: [] } }));
+
+      await store.dispatch('tasks:fetchUserTasks', { forceLoad: true, scheduledFilter: 'week' });
+
+      expect(stub.calledWith('/api/v4/tasks/user?scheduledFilter=week')).to.be.true;
+    });
+
+    test.skip('appends scheduledFilter=month to URL', async () => {
+      const stub = sandbox.stub(axios, 'get').returns(Promise.resolve({ data: { data: [] } }));
+
+      await store.dispatch('tasks:fetchUserTasks', { forceLoad: true, scheduledFilter: 'month' });
+
+      expect(stub.calledWith('/api/v4/tasks/user?scheduledFilter=month')).to.be.true;
+    });
+
+    test.skip('appends scheduledFilter=all to URL', async () => {
+      const stub = sandbox.stub(axios, 'get').returns(Promise.resolve({ data: { data: [] } }));
+
+      await store.dispatch('tasks:fetchUserTasks', { forceLoad: true, scheduledFilter: 'all' });
+
+      expect(stub.calledWith('/api/v4/tasks/user?scheduledFilter=all')).to.be.true;
+    });
+
+    test.skip('does not append scheduledFilter when not provided', async () => {
+      const stub = sandbox.stub(axios, 'get').returns(Promise.resolve({ data: { data: [] } }));
+
+      await store.dispatch('tasks:fetchUserTasks', { forceLoad: true });
+
+      expect(stub.calledWith('/api/v4/tasks/user')).to.be.true;
+    });
   });
 });

--- a/website/client/vite.config.mjs
+++ b/website/client/vite.config.mjs
@@ -128,6 +128,8 @@ export default defineConfig({
   },
   base: '/',
   server: {
+    host: '0.0.0.0',
+    port: 8080,
     headers: { 'Cache-Control': 'no-store' },
     proxy: {
       // proxy all requests to the server at IP:PORT as specified in the top-level config

--- a/website/common/locales/en/tasks.json
+++ b/website/common/locales/en/tasks.json
@@ -58,6 +58,8 @@
   "complete": "Done",
   "complete2": "Complete",
   "today": "Today",
+  "thisWeek": "This Week",
+  "thisMonth": "This Month",
   "tomorrow": "Tomorrow",
   "dueIn": "Due <%= dueIn %>",
   "due": "Due",

--- a/website/common/locales/en/tasks.json
+++ b/website/common/locales/en/tasks.json
@@ -58,8 +58,6 @@
   "complete": "Done",
   "complete2": "Complete",
   "today": "Today",
-  "thisWeek": "This Week",
-  "thisMonth": "This Month",
   "tomorrow": "Tomorrow",
   "dueIn": "Due <%= dueIn %>",
   "due": "Due",

--- a/website/server/controllers/api-v3/tasks.js
+++ b/website/server/controllers/api-v3/tasks.js
@@ -357,7 +357,7 @@ api.createChallengeTasks = {
  *                                                            requested separately.
  *                                                            The "completedTodos" type returns
  *                                                            only the 30 most recently completed.
- * @apiParam (Query) [dueDate] type Optional date to use for computing the nextDue field
+ * @apiParam (Query) {Date} [dueDate] type Optional date to use for computing the nextDue field
  *                                  for each returned task.
  * @apiParam (Query) {String="all","today","week","month"} [scheduledFilter] Optional filter for
  *                                                            scheduled todos by date range.

--- a/website/server/controllers/api-v3/tasks.js
+++ b/website/server/controllers/api-v3/tasks.js
@@ -359,6 +359,13 @@ api.createChallengeTasks = {
  *                                                            only the 30 most recently completed.
  * @apiParam (Query) [dueDate] type Optional date to use for computing the nextDue field
  *                                  for each returned task.
+ * @apiParam (Query) {String="all","today","week","month"} [scheduledFilter] Optional filter for
+ *                                                            scheduled todos by date range.
+ *                                                            Only applies when type is "todos".
+ *                                                            "today" returns todos due today,
+ *                                                            "week" returns todos due in the next 7 days,
+ *                                                            "month" returns todos due in the next month.
+ *                                                            Default is no date filtering.
  *
  * @apiSuccess {Array} data An array of tasks
  *
@@ -395,14 +402,15 @@ api.getUserTasks = {
     const types = Tasks.tasksTypes.map(type => `${type}s`);
     types.push('completedTodos', '_allCompletedTodos'); // _allCompletedTodos is currently in BETA and is likely to be removed in future
     req.checkQuery('type', res.t('invalidTasksTypeExtra')).optional().isIn(types);
+    req.checkQuery('scheduledFilter', 'Invalid scheduled filter').optional().isIn(['all', 'today', 'week', 'month']);
 
     const validationErrors = req.validationErrors();
     if (validationErrors) throw validationErrors;
 
     const { user } = res.locals;
-    const { dueDate } = req.query;
+    const { dueDate, scheduledFilter } = req.query;
 
-    const tasks = await getTasks(req, res, { user, dueDate });
+    const tasks = await getTasks(req, res, { user, dueDate, scheduledFilter });
     return res.respond(200, tasks);
   },
 };

--- a/website/server/libs/tasks/index.js
+++ b/website/server/libs/tasks/index.js
@@ -151,6 +151,7 @@ async function getTasks (req, res, options = {}) {
     challenge,
     group,
     dueDate,
+    scheduledFilter,
   } = options;
 
   let query;
@@ -207,6 +208,30 @@ async function getTasks (req, res, options = {}) {
     if (type === 'todos') {
       query.type = 'todo';
       query.completed = false; // Exclude completed todos
+      // Add grouping to filter tasks by date ranges
+      if (scheduledFilter && scheduledFilter !== 'all') {
+        const now = moment().startOf('day');
+        let startDate;
+        let endDate;
+        
+        if (scheduledFilter === 'today') {
+          startDate = now.toDate();
+          endDate = now.clone().endOf('day').toDate();
+        } else if (scheduledFilter === 'week') {
+          startDate = now.toDate();
+          endDate = now.clone().add(7, 'days').endOf('day').toDate();
+        } else if (scheduledFilter === 'month') {
+          startDate = now.toDate();
+          endDate = now.clone().add(1, 'month').endOf('day').toDate();
+        }
+        
+        if (startDate && endDate) {
+          query.date = {
+            $gte: startDate,
+            $lte: endDate,
+          };
+        }
+      }
     } else if (type === 'completedTodos' || type === '_allCompletedTodos') { // _allCompletedTodos is currently in BETA and is likely to be removed in future
       limit = 0; // no limit, the 30/90 days of data for subscribers is handled during cron
 

--- a/website/server/libs/tasks/index.js
+++ b/website/server/libs/tasks/index.js
@@ -266,7 +266,7 @@ async function getTasks (req, res, options = {}) {
     applyScheduledFilter(todoQuery);
     
     query.$and = [{
-      $or: [ // Exclude todos that are completed / outside of range
+      $or: [ // Exclude todos that are completed (with optional date filtering)
         todoQuery,
         { type: { $in: ['habit', 'daily', 'reward'] } },
       ],

--- a/website/server/libs/tasks/index.js
+++ b/website/server/libs/tasks/index.js
@@ -234,7 +234,6 @@ async function getTasks (req, res, options = {}) {
       query.type = 'todo';
       query.completed = false; // Exclude completed todos
       applyScheduledFilter(query);
-      logger.info('Filtering todos', { scheduledFilter, query });
     } else if (type === 'completedTodos' || type === '_allCompletedTodos') { // _allCompletedTodos is currently in BETA and is likely to be removed in future
       limit = 0; // no limit, the 30/90 days of data for subscribers is handled during cron
 
@@ -272,11 +271,9 @@ async function getTasks (req, res, options = {}) {
         { type: { $in: ['habit', 'daily', 'reward'] } },
       ],
     }];
-    logger.info('Fetching all tasks', { scheduledFilter, query });
   }
 
   const mQuery = Tasks.Task.find(query);
-  logger.info('Final MongoDB query', { query });
   if (limit) mQuery.limit(limit);
   if (sort) mQuery.sort(sort);
 

--- a/website/server/libs/tasks/index.js
+++ b/website/server/libs/tasks/index.js
@@ -221,9 +221,10 @@ async function getTasks (req, res, options = {}) {
         queryObj.date = {
           $gte: startDate,
           $lte: endDate,
-          $exists: true,
         };
       }
+    } else if (scheduledFilter === 'all') {
+      queryObj.date = { $exists: true };
     }
   };
 

--- a/website/server/libs/tasks/index.js
+++ b/website/server/libs/tasks/index.js
@@ -202,36 +202,39 @@ async function getTasks (req, res, options = {}) {
     }
   }
 
+  // Helper function to apply scheduled filter date range
+  const applyScheduledFilter = (queryObj) => {
+    if (scheduledFilter && scheduledFilter !== 'all') {
+      const now = moment().startOf('day');
+      const startDate = now.toDate();
+      let endDate;
+      
+      if (scheduledFilter === 'today') {
+        endDate = now.clone().endOf('day').toDate();
+      } else if (scheduledFilter === 'week') {
+        endDate = now.clone().add(7, 'days').endOf('day').toDate();
+      } else if (scheduledFilter === 'month') {
+        endDate = now.clone().add(1, 'month').endOf('day').toDate();
+      }
+      
+      if (endDate) {
+        queryObj.date = {
+          $gte: startDate,
+          $lte: endDate,
+          $exists: true,
+        };
+      }
+    }
+  };
+
   const { type } = req.query;
 
   if (type) {
     if (type === 'todos') {
       query.type = 'todo';
       query.completed = false; // Exclude completed todos
-      // Add grouping to filter tasks by date ranges
-      if (scheduledFilter && scheduledFilter !== 'all') {
-        const now = moment().startOf('day');
-        let startDate;
-        let endDate;
-        
-        if (scheduledFilter === 'today') {
-          startDate = now.toDate();
-          endDate = now.clone().endOf('day').toDate();
-        } else if (scheduledFilter === 'week') {
-          startDate = now.toDate();
-          endDate = now.clone().add(7, 'days').endOf('day').toDate();
-        } else if (scheduledFilter === 'month') {
-          startDate = now.toDate();
-          endDate = now.clone().add(1, 'month').endOf('day').toDate();
-        }
-        
-        if (startDate && endDate) {
-          query.date = {
-            $gte: startDate,
-            $lte: endDate,
-          };
-        }
-      }
+      applyScheduledFilter(query);
+      logger.info('Filtering todos', { scheduledFilter, query });
     } else if (type === 'completedTodos' || type === '_allCompletedTodos') { // _allCompletedTodos is currently in BETA and is likely to be removed in future
       limit = 0; // no limit, the 30/90 days of data for subscribers is handled during cron
 
@@ -260,15 +263,20 @@ async function getTasks (req, res, options = {}) {
       query.type = type.slice(0, -1); // removing the final "s"
     }
   } else if (!challenge) {
+    const todoQuery = { type: 'todo', completed: false };
+    applyScheduledFilter(todoQuery);
+    
     query.$and = [{
-      $or: [ // Exclude completed todos
-        { type: 'todo', completed: false },
+      $or: [ // Exclude todos that are completed / outside of range
+        todoQuery,
         { type: { $in: ['habit', 'daily', 'reward'] } },
       ],
     }];
+    logger.info('Fetching all tasks', { scheduledFilter, query });
   }
 
   const mQuery = Tasks.Task.find(query);
+  logger.info('Final MongoDB query', { query });
   if (limit) mQuery.limit(limit);
   if (sort) mQuery.sort(sort);
 


### PR DESCRIPTION
This feature is based on issue #15530, grouping tasks by date into "Active", "Dated", and "Completed" subcategories. This functionality only applies to scheduled tasks, not recurring ones

### Changes

**Backend**
- _API Controller_ (tasks.js file): added scheduledFilter query parameter to the API Controller which takes { "all", "today", "week", and "month" } due date ranges
- _Index file_ (tasks/index.js): added applyScheduledFilter function to render only tasks which fit in the date ranges for the above categories. This excludes undated tasks

**Frontend**
- added scheduled tab subcategories with selection via a dropdown menu (column.vue file)
- maintained CSS styling so "scheduled" tab maintains same format as "active" and "completed"
- modified "fetchUserTasks" function in tasks.js file to add scheduledFilter as a URL query parameter (maps to GET HTTP request)

**Tests**
- added tests for both frontend and backend changes
- backend tests are kept as "test.skip", mimicking the previous structure in tasks.spec.js