### PR TITLE
docs(api): add missing notificationIds param to POST /notifications/see

### DIFF
--- a/website/server/controllers/api-v3/notifications.js
+++ b/website/server/controllers/api-v3/notifications.js
@@ -150,8 +150,16 @@ api.seeNotification = {
  * @apiName SeeNotifications
  * @apiGroup Notification
  *
+ * @apiParam {String[]} notificationIds Required. Array of notification ID strings to mark as seen.
+ *
+ * @apiExample {json} Request-Example:
+ * {
+ *   "notificationIds": ["abcdef123", "ghi456789"]
+ * }
+ *
  * @apiSuccess {Object} data user.notifications
  */
+
 api.seeNotifications = {
   method: 'POST',
   url: '/notifications/see',


### PR DESCRIPTION
Adds documentation for the required `notificationIds` request body
parameter for the POST /notifications/see API endpoint.
