### PR TITLE
docs(api): clarify required notificationId path param

### DIFF
--- a/website/server/controllers/api-v3/notifications.js
+++ b/website/server/controllers/api-v3/notifications.js
@@ -13,7 +13,7 @@ const api = {};
  * @apiName ReadNotification
  * @apiGroup Notification
  *
- * @apiParam (Path) {UUID} notificationId
+ * @apiParam (Path) {UUID} notificationId Required. ID of the notification to mark as read.
  *
  * @apiSuccess {Object} data user.notifications
  */


### PR DESCRIPTION
Improves API documentation by explicitly marking the notificationId
path parameter as required for the single notification read endpoint.
