### PR TITLE
Fix g1g1 notification not staying dismissed

### DIFF
--- a/website/client/src/components/header/notifications/g1g1.vue
+++ b/website/client/src/components/header/notifications/g1g1.vue
@@ -34,7 +34,7 @@
     >
     <div
       class="close-x"
-      @click="remove()"
+      @click.stop="remove()"
     >
       <div
         class="svg-icon svg-close"
@@ -140,7 +140,7 @@ export default {
   methods: {
     remove () {
       if (this.eventKey) {
-        window.sessionStorage.setItem(`hide-g1g1-${this.eventKey}`, 'true');
+        window.localStorage.setItem(`hide-g1g1-${this.eventKey}`, 'true');
       }
       this.$emit('notification-removed');
     },

--- a/website/client/src/components/header/notificationsDropdown.vue
+++ b/website/client/src/components/header/notificationsDropdown.vue
@@ -318,7 +318,7 @@ export default {
     shouldShowG1g1 () {
       if (!this.currentG1g1Event) return false;
       const eventKey = this.g1g1EventKey;
-      if (eventKey && window.sessionStorage.getItem(`hide-g1g1-${eventKey}`) === 'true') {
+      if (eventKey && window.localStorage.getItem(`hide-g1g1-${eventKey}`) === 'true') {
         return false;
       }
       return !this.g1g1Hidden;


### PR DESCRIPTION
- use localStorage instead of sessionStorage so dismissal persists across browser sessions
- Add .stop modifier to close button click
