### PR TITLE
Sanitize usernames come from social auth

### DIFF
--- a/test/api/v3/integration/user/auth/POST-user_auth_social.test.js
+++ b/test/api/v3/integration/user/auth/POST-user_auth_social.test.js
@@ -65,6 +65,41 @@ describe('POST /user/auth/social', () => {
       await expect(getProperty('users', response.id, 'profile.name')).to.eventually.equal('a google user');
     });
 
+    it('includes sanitized version of provided username', async () => {
+      const response = await api.post(endpoint, {
+        authResponse: { access_token: randomAccessToken }, // eslint-disable-line camelcase
+        network,
+        username: 'Google User Name',
+      });
+
+      await expect(getProperty('users', response.id, 'auth.local.username')).to.eventually.equal('GoogleUserName');
+      await expect(getProperty('users', response.id, 'auth.local.lowerCaseUsername')).to.eventually.equal('googleusername');
+    });
+
+    it('generates a random username if provided username is entirely invalid', async () => {
+      const response = await api.post(endpoint, {
+        authResponse: { access_token: randomAccessToken }, // eslint-disable-line camelcase
+        network,
+        username: 'Áîüè',
+      });
+
+      await expect(getProperty('users', response.id, 'auth.local.username')).to.eventually.contain('hb-');
+      await expect(getProperty('users', response.id, 'auth.local.lowerCaseUsername')).to.eventually.contain('hb-');
+    });
+
+    it('generates a random username if sanitized username conflicts with an extant user', async () => {
+      user = generateUser({ 'auth.local.username': 'GoogleUserName' });
+
+      const response = await api.post(endpoint, {
+        authResponse: { access_token: randomAccessToken }, // eslint-disable-line camelcase
+        network,
+        username: 'Google User Name',
+      });
+
+      await expect(getProperty('users', response.id, 'auth.local.username')).to.eventually.contain('hb-');
+      await expect(getProperty('users', response.id, 'auth.local.lowerCaseUsername')).to.eventually.contain('hb-');
+    });
+
     it('fails if allowRegister is false and user does not exist', async () => {
       await expect(api.post(endpoint, {
         authResponse: { access_token: randomAccessToken }, // eslint-disable-line camelcase

--- a/test/api/v3/integration/user/auth/POST-user_auth_social.test.js
+++ b/test/api/v3/integration/user/auth/POST-user_auth_social.test.js
@@ -76,7 +76,7 @@ describe('POST /user/auth/social', () => {
       await expect(getProperty('users', response.id, 'auth.local.lowerCaseUsername')).to.eventually.equal('googleusername');
     });
 
-    it('generates a random username if provided username is entirely invalid', async () => {
+    it('generates a random username if provided username contains only disallowed characters', async () => {
       const response = await api.post(endpoint, {
         authResponse: { access_token: randomAccessToken }, // eslint-disable-line camelcase
         network,
@@ -87,8 +87,19 @@ describe('POST /user/auth/social', () => {
       await expect(getProperty('users', response.id, 'auth.local.lowerCaseUsername')).to.eventually.contain('hb-');
     });
 
+    it('generates a random username if provided username contains a disallowed word', async () => {
+      const response = await api.post(endpoint, {
+        authResponse: { access_token: randomAccessToken }, // eslint-disable-line camelcase
+        network,
+        username: 'i am a TESTPLACEHOLDERSLURWORDHERE',
+      });
+
+      await expect(getProperty('users', response.id, 'auth.local.username')).to.eventually.contain('hb-');
+      await expect(getProperty('users', response.id, 'auth.local.lowerCaseUsername')).to.eventually.contain('hb-');
+    });
+
     it('generates a random username if sanitized username conflicts with an extant user', async () => {
-      user = generateUser({ 'auth.local.username': 'GoogleUserName' });
+      user = await generateUser({ 'auth.local.username': 'GoogleUserName' });
 
       const response = await api.post(endpoint, {
         authResponse: { access_token: randomAccessToken }, // eslint-disable-line camelcase

--- a/website/client/src/components/appFooter.vue
+++ b/website/client/src/components/appFooter.vue
@@ -303,7 +303,6 @@
             ></div>
           </div>
         </div>
-  
         <div
           v-if="TIME_TRAVEL_ENABLED && user?.permissions?.fullAccess"
           :key="lastTimeJump"
@@ -343,7 +342,6 @@
             @click="jumpTime(30)"
           >+30 Days</a>
         </div>
-  
         <div
           v-if="DEBUG_ENABLED && isUserLoaded"
           class="debug-toggle"
@@ -710,7 +708,7 @@ h3 {
 
   footer {
     padding: 24px 16px;
-    
+
     .columns {
       column-gap: 1.5rem;
       display: grid !important;

--- a/website/client/src/components/appFooter.vue
+++ b/website/client/src/components/appFooter.vue
@@ -303,6 +303,7 @@
             ></div>
           </div>
         </div>
+  
         <div
           v-if="TIME_TRAVEL_ENABLED && user?.permissions?.fullAccess"
           :key="lastTimeJump"
@@ -342,6 +343,7 @@
             @click="jumpTime(30)"
           >+30 Days</a>
         </div>
+  
         <div
           v-if="DEBUG_ENABLED && isUserLoaded"
           class="debug-toggle"
@@ -708,7 +710,7 @@ h3 {
 
   footer {
     padding: 24px 16px;
-
+    
     .columns {
       column-gap: 1.5rem;
       display: grid !important;

--- a/website/server/libs/auth/social.js
+++ b/website/server/libs/auth/social.js
@@ -70,7 +70,7 @@ export async function loginSocial (req, res) { // eslint-disable-line import/pre
     if (!user.auth.local.email) {
       user.auth.local.email = await socialEmailToLocal(user);
     }
-    // Force the updated timestampt to update, so that we know they logged in
+    // Force the updated timestamp to save, so that we know they logged in
     user.auth.timestamps.updated = new Date();
     await user.save();
     return loginRes(user, req, res);
@@ -82,7 +82,10 @@ export async function loginSocial (req, res) { // eslint-disable-line import/pre
   }
 
   if (!existingUser && email) {
-    existingUser = await User.findOne({ 'auth.local.email': email }).exec();
+    existingUser = await User.findOne(
+      { 'auth.local.email': email },
+      { auth: 1 },
+    ).exec();
   }
 
   if (!allowRegister && !existingUser) {
@@ -101,6 +104,13 @@ export async function loginSocial (req, res) { // eslint-disable-line import/pre
   let sanitizedUsername = username.replace(/[^a-zA-Z0-9_-]/g, '');
   if (!sanitizedUsername) {
     sanitizedUsername = generateUsername();
+  } else {
+    const conflictingUser = await User.findOne({
+      'auth.local.lowerCaseUsername': sanitizedUsername.toLowerCase(),
+    }, { _id: 1 });
+    if (conflictingUser) {
+      sanitizedUsername = generateUsername();
+    }
   }
 
   if (existingUser) {

--- a/website/server/libs/auth/social.js
+++ b/website/server/libs/auth/social.js
@@ -98,7 +98,7 @@ export async function loginSocial (req, res) { // eslint-disable-line import/pre
     throw new NotFound(res.t('userNotFound'));
   }
 
-  sanitizedUsername = username.replace(/[^a-zA-Z0-9_-]/g, '');
+  let sanitizedUsername = username.replace(/[^a-zA-Z0-9_-]/g, '');
   if (!sanitizedUsername) {
     sanitizedUsername = generateUsername();
   }

--- a/website/server/libs/auth/social.js
+++ b/website/server/libs/auth/social.js
@@ -82,10 +82,8 @@ export async function loginSocial (req, res) { // eslint-disable-line import/pre
   }
 
   if (!existingUser && email) {
-    existingUser = await User.findOne(
-      { 'auth.local.email': email },
-      { auth: 1 },
-    ).exec();
+    // TODO we load the whole user object here. Is that necessary?
+    existingUser = await User.findOne({ 'auth.local.email': email }).exec();
   }
 
   if (!allowRegister && !existingUser) {

--- a/website/server/libs/auth/social.js
+++ b/website/server/libs/auth/social.js
@@ -1,6 +1,7 @@
 import pick from 'lodash/pick';
 import passport from 'passport';
 import common from '../../../common';
+import { verifyUsername } from '../user/validation';
 import { BadRequest, NotAuthorized, NotFound } from '../errors';
 import logger from '../logger';
 import {
@@ -100,7 +101,8 @@ export async function loginSocial (req, res) { // eslint-disable-line import/pre
   }
 
   let sanitizedUsername = username.replace(/[^a-zA-Z0-9_-]/g, '');
-  if (!sanitizedUsername) {
+  const issues = verifyUsername(sanitizedUsername, res, true);
+  if (issues.length > 0) {
     sanitizedUsername = generateUsername();
   } else {
     const conflictingUser = await User.findOne({

--- a/website/server/libs/auth/social.js
+++ b/website/server/libs/auth/social.js
@@ -98,6 +98,11 @@ export async function loginSocial (req, res) { // eslint-disable-line import/pre
     throw new NotFound(res.t('userNotFound'));
   }
 
+  sanitizedUsername = username.replace(/[^a-zA-Z0-9_-]/g, '');
+  if (!sanitizedUsername) {
+    sanitizedUsername = generateUsername();
+  }
+
   if (existingUser) {
     existingUser.auth[network] = {
       id: profile.id,
@@ -112,8 +117,8 @@ export async function loginSocial (req, res) { // eslint-disable-line import/pre
           emails: profile.emails,
         },
         local: {
-          username,
-          lowerCaseUsername: username.toLowerCase(),
+          username: sanitizedUsername,
+          lowerCaseUsername: sanitizedUsername.toLowerCase(),
           email,
         },
       },

--- a/website/server/libs/auth/social.js
+++ b/website/server/libs/auth/social.js
@@ -98,6 +98,11 @@ export async function loginSocial (req, res) { // eslint-disable-line import/pre
     throw new NotFound(res.t('userNotFound'));
   }
 
+  let sanitizedUsername = username.replace(/[^a-zA-Z0-9_-]/g, '');
+  if (!sanitizedUsername) {
+    sanitizedUsername = generateUsername();
+  }
+
   if (existingUser) {
     existingUser.auth[network] = {
       id: profile.id,
@@ -112,8 +117,8 @@ export async function loginSocial (req, res) { // eslint-disable-line import/pre
           emails: profile.emails,
         },
         local: {
-          username,
-          lowerCaseUsername: username.toLowerCase(),
+          username: sanitizedUsername,
+          lowerCaseUsername: sanitizedUsername.toLowerCase(),
           email,
         },
       },

--- a/website/server/libs/auth/social.js
+++ b/website/server/libs/auth/social.js
@@ -98,11 +98,6 @@ export async function loginSocial (req, res) { // eslint-disable-line import/pre
     throw new NotFound(res.t('userNotFound'));
   }
 
-  let sanitizedUsername = username.replace(/[^a-zA-Z0-9_-]/g, '');
-  if (!sanitizedUsername) {
-    sanitizedUsername = generateUsername();
-  }
-
   if (existingUser) {
     existingUser.auth[network] = {
       id: profile.id,
@@ -117,8 +112,8 @@ export async function loginSocial (req, res) { // eslint-disable-line import/pre
           emails: profile.emails,
         },
         local: {
-          username: sanitizedUsername,
-          lowerCaseUsername: sanitizedUsername.toLowerCase(),
+          username,
+          lowerCaseUsername: username.toLowerCase(),
           email,
         },
       },


### PR DESCRIPTION
**Previously**, it was possible for usernames to be registered with characters we don't support, such as accented Latin characters, katakana, etc. if a `username` with such characters was passed in the request body of a social-platform-based authentication.

**Now**, we filter out invalid characters, attempting to create the user with the remaining characters. If this would result in a blank username or a username that already exists in the database, we generate a randomized username instead (the way we used to for all social accounts).
