### PR TITLE
add config to disable SSL and BASE_URL enforcement

### DIFF
--- a/website/server/middlewares/index.js
+++ b/website/server/middlewares/index.js
@@ -41,6 +41,8 @@ const DISABLE_LOGGING = nconf.get('DISABLE_REQUEST_LOGGING') === 'true';
 const ENABLE_HTTP_AUTH = nconf.get('SITE_HTTP_AUTH_ENABLED') === 'true';
 const LOG_REQUESTS_EXCESSIVE_MODE = nconf.get('LOG_REQUESTS_EXCESSIVE_MODE') === 'true';
 const SLOW_REQUEST_THRESHOLD = nconf.get('SLOW_REQUEST_THRESHOLD');
+const DISABLE_SSL_ENFORCEMENT = nconf.get('DISABLE_SSL_ENFORCEMENT') === 'true';
+const DISABLE_BASE_URL_ENFORCEMENT = nconf.get('DISABLE_BASE_URL_ENFORCEMENT') === 'true';
 // const PUBLIC_DIR = path.join(__dirname, '/../../client');
 
 const SESSION_SECRET = nconf.get('SESSION_SECRET');
@@ -84,8 +86,12 @@ export default function attachMiddlewares (app, server) {
   app.use(blocker);
 
   app.use(cors);
-  app.use(forceSSL);
-  app.use(forceHabitica);
+  if (!DISABLE_SSL_ENFORCEMENT) {
+    app.use(forceSSL);
+  }
+  if (!DISABLE_BASE_URL_ENFORCEMENT) {
+    app.use(forceHabitica);
+  }
 
   app.use(bodyParser.urlencoded({
     extended: true, // Uses 'qs' library as old connect middleware


### PR DESCRIPTION
If habitica is set up in a kubernetes cluster or behind a reverse proxy, the passed URL might not be the same as BASE_URL. Additionally, SSL is then managed by the cluster or proxy. This adds a config option to disable the checks/redirects to allow for those setups.