### PR TITLE
PayPal debug

### DIFF
--- a/website/server/libs/payments/paypal.js
+++ b/website/server/libs/payments/paypal.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import logger from '../../logger';
+import logger from '../logger';
 import nconf from 'nconf';
 import moment from 'moment';
 import util from 'util';

--- a/website/server/libs/payments/paypal.js
+++ b/website/server/libs/payments/paypal.js
@@ -1,4 +1,5 @@
 /* eslint-disable camelcase */
+import logger from '../../logger';
 import nconf from 'nconf';
 import moment from 'moment';
 import util from 'util';
@@ -213,6 +214,7 @@ api.subscribeSuccess = async function subscribeSuccess (options = {}) {
     user, groupId, block, headers, token,
   } = options;
   const result = await this.paypalBillingAgreementExecute(token, {});
+  logger.info('PayPal Subscription', { state: result.state, details: result.agreement_details });
   await payments.createSubscription({
     user,
     groupId,

--- a/website/server/libs/payments/paypal.js
+++ b/website/server/libs/payments/paypal.js
@@ -1,5 +1,4 @@
 /* eslint-disable camelcase */
-import logger from '../logger';
 import nconf from 'nconf';
 import moment from 'moment';
 import util from 'util';
@@ -7,6 +6,7 @@ import _ from 'lodash';
 import paypalIpn from 'pp-ipn';
 import paypal from 'paypal-rest-sdk';
 import cc from 'coupon-code';
+import logger from '../logger';
 import shared from '../../../common';
 import payments from './payments'; // eslint-disable-line import/no-cycle
 import { getGemsBlock, validateGiftMessage } from './gems'; // eslint-disable-line import/no-cycle


### PR DESCRIPTION
Adds a `logger` call during PayPal subscriptions to note the "state" and "agreement_details" fields received in the API response. (These fields do not contain personally identifiable information.) This will allow us to gather data on situations we've seen where users receive subscription benefits even though their payment only made it to a "Pending" state.