### PR TITLE
fix(shops): hide popover on mobile to prevent purchase blocking (#10917)

### DIFF
--- a/website/client/src/components/shops/shopItem.vue
+++ b/website/client/src/components/shops/shopItem.vue
@@ -69,7 +69,7 @@
       </div>
     </div>
     <b-popover
-      v-if="showPopover"
+      v-if="shouldShowPopover"
       ref="popover"
       :target="itemId"
       triggers="hover focus"
@@ -335,9 +335,13 @@ export default {
       }),
       timer: '',
       limitedString: '',
+      isMobile: typeof window !== 'undefined' && window.innerWidth < 768,
     };
   },
   computed: {
+    shouldShowPopover () {
+      return this.showPopover && !this.isMobile;
+    },
     showNotes () {
       if (['armoire', 'potion'].indexOf(this.item.path) > -1) return true;
       return false;
@@ -359,9 +363,11 @@ export default {
         this.$refs.popover.$emit('disable');
       }
     });
+    window.addEventListener('resize', this.handleResize);
   },
   beforeDestroy () {
     this.cancelAutoUpdate();
+    window.removeEventListener('resize', this.handleResize);
   },
   methods: {
     click () {
@@ -413,6 +419,9 @@ export default {
     },
     cancelAutoUpdate () {
       clearInterval(this.timer);
+    },
+    handleResize () {
+      this.isMobile = window.innerWidth < 768;
     },
   },
 };


### PR DESCRIPTION
Fixes #10917

### Changes

On mobile browsers (<768px), the shop item popover (triggered by `hover focus` in Bootstrap-Vue `b-popover`) activates on touch and covers the item card, preventing users from tapping to purchase pinned items. Since the popover cannot be easily dismissed on touch devices, it effectively blocks interaction with the shop.

This fix adds a mobile check to conditionally disable the popover on small screens:

- **`isMobile`** data property — checks `window.innerWidth < 768` on mount
- **`shouldShowPopover`** computed — returns `showPopover && !isMobile`, replacing the original `v-if="showPopover"` on the `<b-popover>` component
- **`handleResize`** method + `resize` event listener — updates `isMobile` on viewport changes (e.g., device rotation)

On desktop, popover behavior is unchanged. On mobile, users tap items to open the purchase modal directly without the popover blocking the UI.

### Screenshots

**Desktop — popover works normally on hover:**

<img src="https://raw.githubusercontent.com/ttpss930141011/habitica/pr-screenshots/10917-desktop-popover.png" width="600" />

**Mobile BUG (before fix) — popover covers UI on touch, blocking interaction:**

<img src="https://raw.githubusercontent.com/ttpss930141011/habitica/pr-screenshots/10917-mobile-bug.png" width="300" />

**Mobile FIXED (after fix) — no popover, clean UI:**

<img src="https://raw.githubusercontent.com/ttpss930141011/habitica/pr-screenshots/10917-mobile-fixed.png" width="300" />

**File changed:** `website/client/src/components/shops/shopItem.vue` (+10 lines)

----
UUID: 854d383c-ce47-4659-96b6-e4603aadd69e