### PR TITLE
fix(groups): use atomic operation for memberCount on member removal

### DIFF
--- a/test/api/v3/integration/groups/POST-groups_id_removeMember.test.js
+++ b/test/api/v3/integration/groups/POST-groups_id_removeMember.test.js
@@ -13,6 +13,7 @@ describe('POST /groups/:groupId/removeMember/:memberId', () => {
   let member;
   let member2;
   let adminUser;
+  let guildMembers;
 
   beforeEach(async () => {
     const {
@@ -24,10 +25,11 @@ describe('POST /groups/:groupId/removeMember/:memberId', () => {
         privacy: 'private',
       },
       invites: 1,
-      members: 2,
+      members: 8,
       upgradeToGroupPlan: true,
     });
 
+    guildMembers = members;
     guild = group;
     leader = groupLeader;
     invitedUser = invitees[0]; // eslint-disable-line prefer-destructuring
@@ -136,6 +138,17 @@ describe('POST /groups/:groupId/removeMember/:memberId', () => {
       expect(email.sendTxn.args[1][0]._id).to.eql(member._id);
       expect(email.sendTxn.args[1][1]).to.eql('group-member-removed');
     });
+
+    it('keep the member count consistent under concurrent member removals', async () => {
+      await Promise.all(guildMembers.map((member) => leader.post(`/groups/${guild._id}/removeMember/${member._id}`)))
+      const newMemberCount = (await leader.get(`/groups/${guild._id}`))?.memberCount;
+      expect(newMemberCount).eq(
+        1,
+        `Expected to have only a single leader left but instead ${
+          newMemberCount ? `found ${newMemberCount} members` : 'failed at GET request to retrieve number of members'
+        }`,
+      );
+    })
   });
 
   context('Party', () => {
@@ -144,7 +157,7 @@ describe('POST /groups/:groupId/removeMember/:memberId', () => {
     let partyInvitedUser;
     let partyMember;
     let removedMember;
-
+    let partyMembers;
     beforeEach(async () => {
       const {
         group, groupLeader, invitees, members,
@@ -161,6 +174,7 @@ describe('POST /groups/:groupId/removeMember/:memberId', () => {
 
       party = group;
       partyLeader = groupLeader;
+      partyMembers = members;
       partyInvitedUser = invitees[0]; // eslint-disable-line prefer-destructuring
       partyMember = members[0]; // eslint-disable-line prefer-destructuring
       removedMember = members[1]; // eslint-disable-line prefer-destructuring
@@ -293,5 +307,16 @@ describe('POST /groups/:groupId/removeMember/:memberId', () => {
       expect(email.sendTxn.args[0][0]._id).to.eql(partyMember._id);
       expect(email.sendTxn.args[0][1]).to.eql('kicked-from-party');
     });
+
+    it('keep the member count consistent under concurrent member removals', async () => {
+      await Promise.all(partyMembers.map((member) => partyLeader.post(`/groups/${party._id}/removeMember/${member._id}`)))
+      const newMemberCount = (await partyLeader.get(`/groups/${party._id}`))?.memberCount;
+      expect(newMemberCount).eq(
+        1,
+        `Expected to have only a single leader left but instead ${
+          newMemberCount ? `found ${newMemberCount} members` : 'failed at GET request to retrieve number of members'
+        }`,
+      );
+    })
   });
 });

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -862,6 +862,56 @@ function _sendMessageToRemoved (group, removedUser, message, isInGroup) {
   }
 }
 
+function _userHasModeratorPermission(user)
+{
+  return user.hasPermission('moderator');
+}
+
+function _doesMemberBelongToParty(memberToRemove, group)
+{
+  return memberToRemove.party._id === group._id;
+}
+
+function _doesMemberBelongToGuild(memberToRemove, group)
+{
+  return memberToRemove.guilds.indexOf(group._id) !== -1;
+}
+
+function _isMemberInvitedToParty(memberToRemove, group)
+{
+  return find(memberToRemove.invitations.parties, {id: group._id});
+}
+
+function _isMemberInvitedToGuild(memberToRemove, group)
+{
+  return findIndex(memberToRemove.invitations.guilds, {id: group._id}) !== -1;
+}
+
+function _isMemberAGroupQuestOwner(group, member)
+{
+  return Boolean(group.quest) && group.quest.leader === member._id;
+}
+
+function _removeUserGuildInvitation(member, group)
+{
+  removeFromArray(member.invitations.guilds, {id: group._id});
+}
+
+function _removeUserPartyInvitation(member, group)
+{
+  removeFromArray(member.invitations.parties, {id: group._id});
+  member.invitations.party = member.invitations.parties.length > 0
+    ? member.invitations.parties[member.invitations.parties.length - 1]
+    : {};
+  member.markModified('invitations.party');
+}
+
+function _removeGroupQuestMember(group, memberToRemove)
+{
+  delete group.quest.members[memberToRemove._id];
+  group.markModified('quest.members');
+}
+
 /**
  * @api {post} /api/v3/groups/:groupId/removeMember/:memberId Remove a member from a group
  * @apiName RemoveGroupMember
@@ -902,96 +952,112 @@ api.removeGroupMember = {
 
     const validationErrors = req.validationErrors();
     if (validationErrors) throw validationErrors;
-    const optionalMembership = Boolean(user.hasPermission('moderator'));
+
+    const requestDataToRemoveMember = {
+      groupId: req.params.groupId,
+      memberId: req.params.memberId,
+    }
+    if (user._id === requestDataToRemoveMember.memberId)
+    {
+      throw new NotAuthorized(res.t('memberCannotRemoveYourself'));
+    }
+
+    const isUserWithModeratorPermission = _userHasModeratorPermission(user);
+
     const group = await Group.getGroup({
-      user, groupId: req.params.groupId, optionalMembership, fields: '-chat',
+      user, groupId: req.params.groupId, optionalMembership: isUserWithModeratorPermission, fields: '-chat'
     }); // Do not fetch chat
 
-    if (!group) throw new NotFound(res.t('groupNotFound'));
-
-    const uuid = req.params.memberId;
-
-    if (group.leader !== user._id && group.type === 'party') throw new NotAuthorized(res.t('onlyLeaderCanRemoveMember'));
-    if (group.leader !== user._id && !user.hasPermission('moderator')) throw new NotAuthorized(res.t('onlyLeaderCanRemoveMember'));
-
-    if (group.leader === uuid && user.hasPermission('moderator')) throw new NotAuthorized(res.t('cannotRemoveCurrentLeader'));
-
-    if (user._id === uuid) throw new NotAuthorized(res.t('memberCannotRemoveYourself'));
-
-    const member = await User.findOne({ _id: uuid }).exec();
-
-    // We're removing the user from a guild or a party? is the user invited only?
-    let isInGroup;
-    if (member.party._id === group._id) {
-      isInGroup = 'party';
-    } else if (member.guilds.indexOf(group._id) !== -1) {
-      isInGroup = 'guild';
+    if (!group)
+    {
+      throw new NotFound(res.t('groupNotFound'));
+    }
+    if (!group.isUserALeader(user._id))
+    {
+      if (group.isParty())
+      {
+        throw new NotAuthorized(res.t('onlyLeaderCanRemoveMember'));
+      }
+      if (!isUserWithModeratorPermission)
+      {
+        throw new NotAuthorized(res.t('onlyLeaderCanRemoveMember'));
+      }
+    }
+    if (group.isUserALeader(requestDataToRemoveMember.memberId) && isUserWithModeratorPermission)
+    {
+      throw new NotAuthorized(res.t('cannotRemoveCurrentLeader'));
     }
 
-    let isInvited;
-    if (find(member.invitations.parties, { id: group._id })) {
-      isInvited = 'party';
-    } else if (findIndex(member.invitations.guilds, { id: group._id }) !== -1) {
-      isInvited = 'guild';
-    }
+    const memberToRemove = await User.findOne({_id: requestDataToRemoveMember.memberId}).exec();
+    const memberBelongsToParty = _doesMemberBelongToParty(memberToRemove, group);
+    const memberBelongsToGuild = _doesMemberBelongToGuild(memberToRemove, group);
+    const isMemberInGroup = memberBelongsToParty || memberBelongsToGuild;
 
-    if (isInGroup) {
-      // For parties we count the number of members from the database to get the correct value.
-      // See #12275 on why this is necessary and only done for parties.
-      if (group.type === 'party') {
-        const currentMembers = await group.getMemberCount();
-        group.memberCount = currentMembers - 1;
-      } else {
-        group.memberCount -= 1;
-      }
+    const isMemberInvitedToParty = _isMemberInvitedToParty(memberToRemove, group);
+    const isMemberInvitedToGuild = _isMemberInvitedToGuild(memberToRemove, group);
+    const isMemberInvited = isMemberInvitedToParty || isMemberInvitedToGuild;
 
-      if (group.quest && group.quest.leader === member._id) {
-        throw new NotAuthorized(res.t('cannotRemoveQuestOwner'));
-      } else if (group.quest && group.quest.members) {
-        // remove member from quest
-        delete group.quest.members[member._id];
-        group.markModified('quest.members');
-      }
-
-      if (isInGroup === 'guild') {
-        removeFromArray(member.guilds, group._id);
-      }
-      if (isInGroup === 'party') {
-        member.party._id = undefined; // TODO remove quest information too? Use group.leave()?
-      }
-
-      removeMessagesFromMember(member, group._id);
-
-      if (group.quest && group.quest.active && group.quest.leader === member._id) {
-        member.items.quests[group.quest.key] += 1;
-        member.markModified('items.quests');
-      }
-    } else if (isInvited) {
-      if (isInvited === 'guild') {
-        removeFromArray(member.invitations.guilds, { id: group._id });
-      }
-      if (isInvited === 'party') {
-        removeFromArray(member.invitations.parties, { id: group._id });
-        member.invitations.party = member.invitations.parties.length > 0
-          ? member.invitations.parties[member.invitations.parties.length - 1]
-          : {};
-        member.markModified('invitations.party');
-      }
-    } else {
+    if (!isMemberInGroup && !isMemberInvited)
+    {
       throw new NotFound(res.t('groupMemberNotFound'));
     }
+    let dbWritePromises = []
+    if (isMemberInGroup)
+    {
+      if (_isMemberAGroupQuestOwner(group, memberToRemove))
+      {
+        throw new NotAuthorized(res.t('cannotRemoveQuestOwner'));
+      }
+      else if (group.questIncludesUser(memberToRemove._id))
+      {
+        _removeGroupQuestMember(group, memberToRemove);
+      }
 
-    const message = req.query.message || req.body.message;
-    _sendMessageToRemoved(group, member, message, isInGroup);
+      if (memberBelongsToGuild)
+      {
+        removeFromArray(memberToRemove.guilds, group._id);
+      }
+      if (memberBelongsToParty)
+      {
+        memberToRemove.party._id = undefined; // TODO remove quest information too? Use group.leave()?
+      }
 
+      removeMessagesFromMember(memberToRemove, group._id);
+
+      if (group.quest && group.quest.active && group.quest.leader === memberToRemove._id)
+      {
+        memberToRemove.items.quests[group.quest.key] += 1;
+        memberToRemove.markModified('items.quests');
+      }
+
+      dbWritePromises.push(Group.updateOne(
+        { _id: group._id },
+        { $inc: { memberCount: -1 } }
+      ));
+    }
+    else
+    {
+      if (isMemberInvitedToGuild)
+      {
+        _removeUserGuildInvitation(memberToRemove, group);
+      }
+      if (isMemberInvitedToParty)
+      {
+        _removeUserPartyInvitation(memberToRemove, group);
+      }
+    }
     await Promise.all([
-      member.save(),
-      group.save(),
+      ...dbWritePromises,
+      memberToRemove.save(),
+      group.save()
     ]);
 
-    if (isInGroup && group.hasNotCancelled()) {
+    const message = req.query.message || req.body.message;
+    _sendMessageToRemoved(group, memberToRemove, message, isMemberInGroup);
+
+    if (isMemberInGroup && group.hasNotCancelled()) {
       await group.updateGroupPlan(true);
-      await payments.cancelGroupSubscriptionForUser(member, group, true);
+      await payments.cancelGroupSubscriptionForUser(memberToRemove, group, true);
     }
 
     res.respond(200, {});

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -1665,6 +1665,21 @@ schema.methods.updateGroupPlan = async function updateGroupPlan (removingMember)
   }
 };
 
+schema.methods.isUserALeader = function isUserALeader(userId)
+{
+  return this.leader === userId
+}
+
+schema.methods.isParty = function isParty()
+{
+  return this.type === 'party';
+}
+
+schema.methods.questIncludesUser = function questIncludesUser(userId)
+{
+  return Boolean(this.quest?.members && userId in this.quest.members);
+}
+
 export const model = mongoose.model('Group', schema);
 
 // initialize tavern if !exists (fresh installs)


### PR DESCRIPTION
Related to #12286

### Changes
- Fixed a race condition in `removeGroupMember` where `memberCount` could become inconsistent under concurrent removals
- Replaced read-modify-write logic with an atomic `$inc` update for `memberCount` field
- Refactored control flow for clarity
- Added integration test verifying consistent member count under concurrent removals

### Notes
This PR addresses `removeGroupMember` only. Other group endpoints that modify
`memberCount` are intentionally out of scope to keep the change minimal
and easy to review

UUID:
ddbb1bd4-bb04-4798-8d69-02e77ad7ff71