### PR TITLE
Responsive equipGear modal and popover - fixes #10048

### DIFF
--- a/website/client/src/assets/scss/popover.scss
+++ b/website/client/src/assets/scss/popover.scss
@@ -2,6 +2,7 @@
   border-radius: 4px;
   background-color: rgba($gray-10, 0.96);
   box-shadow: 0 2px 2px 0 rgba($black, 0.16), 0 1px 4px 0 rgba($black, 0.12);
+  max-width: 90vw;
 
   &::after, &::before, .arrow {
     display: none;

--- a/website/client/src/components/inventory/equipment/attributesGrid.vue
+++ b/website/client/src/components/inventory/equipment/attributesGrid.vue
@@ -42,10 +42,11 @@
 
   .attributes-group {
     border-radius: 4px;
-    // unless we have a way to give a popover an id or class, it needs expand the attributes area
+    // unless we have a way to give a popover an id or class, it needs to expand the attributes area
     margin: -12px -16px;
     display: grid;
     grid-template-columns: repeat(2, 1fr);
+    gap: 1px;
   }
 
   .popover-content-attr {

--- a/website/client/src/components/inventory/equipment/attributesGrid.vue
+++ b/website/client/src/components/inventory/equipment/attributesGrid.vue
@@ -9,183 +9,175 @@
       <div class="group-content">
         <span
           class="popover-content-attr-cell key"
-          :class="{'hasValue': hasSumValue(attr) }"
-        >{{ `${$t(attr)}: ` }}</span>
+          :class="{ hasValue: hasSumValue(attr) }"
+          >{{ `${$t(attr)}: ` }}</span
+        >
         <span
           class="popover-content-attr-cell label key-value value"
-          :class="{'green': hasSumValue(attr) }"
-        >{{ `${stats.sum[attr]}` }}</span>
+          :class="{ green: hasSumValue(attr) }"
+          >{{ `${stats.sum[attr]}` }}</span
+        >
         <span
           class="popover-content-attr-cell label bold"
-          :class="{'hasValue': hasGearValue(attr) }"
-        >{{ $t('gear') }}:</span>
+          :class="{ hasValue: hasGearValue(attr) }"
+          >{{ $t("gear") }}:</span
+        >
         <span
           class="popover-content-attr-cell label"
-          :class="{'hasValue': hasGearValue(attr) }"
-        >{{ stats.gear[attr] }}</span>
+          :class="{ hasValue: hasGearValue(attr) }"
+          >{{ stats.gear[attr] }}</span
+        >
         <span
           class="popover-content-attr-cell label bold"
-          :class="{'hasValue': hasClassBonus(attr) }"
-        >{{ $t('classEquipBonus') }}:</span>
+          :class="{ hasValue: hasClassBonus(attr) }"
+          >{{ $t("classEquipBonus") }}:</span
+        >
         <span
           class="popover-content-attr-cell label"
-          :class="{'hasValue': hasClassBonus(attr) }"
-        >{{ `${stats.classBonus[attr]}` }}</span>
+          :class="{ hasValue: hasClassBonus(attr) }"
+          >{{ `${stats.classBonus[attr]}` }}</span
+        >
       </div>
     </div>
   </div>
 </template>
 
 <style lang="scss">
+@import "@/assets/scss/colors.scss";
 
-  @import '@/assets/scss/colors.scss';
+.attributes-group {
+  border-radius: 4px;
+  // unless we have a way to give a popover an id or class, it needs expand the attributes area
+  margin: -12px -16px;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+}
 
-  .attributes-group {
-    border-radius: 4px;
-    // unless we have a way to give a popover an id or class, it needs expand the attributes area
-    margin: -12px -16px;
-    display:flex;
-    flex-wrap: wrap;
+.popover-content-attr {
+  font-weight: bold;
+  width: fit-content;
+  background-color: $gray-50;
+
+  .attr-str,
+  .attr-int {
+    padding-top: 0.25rem;
+    padding-bottom: 0.5rem;
+  }
+
+  .attr-con,
+  .attr-per {
+    padding-bottom: 0.75rem;
+    padding-top: 0.5rem;
+  }
+}
+
+.group-content {
+  display: grid;
+  grid-template-columns: auto auto;
+  column-gap: 2rem;
+  justify-content: start;
+  padding: 4px 12px;
+  width: fit-content;
+}
+
+.popover-content-attr-cell {
+  text-align: left;
+
+  &:nth-of-type(even) {
+    text-align: right;
+  }
+
+  &.key {
+    color: $white;
+    font-size: 12px;
+    font-weight: bold;
+    line-height: 1.33;
+  }
+
+  &.label {
+    font-size: 10px;
+    line-height: 1.2;
+    color: $gray-300;
+  }
+
+  &.label.bold {
+    font-weight: bold;
+  }
+
+  &.label.value {
+    font-size: 12px;
+    font-weight: bold;
+    line-height: 1.33;
+    text-align: right;
+    white-space: nowrap;
+
+    &.green {
+      color: $green-10;
+
+      &:before {
+        content: "+";
+      }
+    }
+  }
+}
+
+.modal-body {
+  .group-content {
+    padding: 0.25rem 1rem;
   }
 
   .popover-content-attr {
-    font-weight: bold;
-    width: calc(50% - 1px);
-    background-color: $gray-50;
-
-    .attr-str, .attr-int {
-      padding-top: 0.25rem;
-      padding-bottom: 0.5rem;
-    }
-
-    .attr-con, .attr-per {
-      padding-bottom: 0.75rem;
-      padding-top: 0.5rem;
-    }
-
-    &:nth-of-type(even) {
-      margin-left: 1px;
-    }
-
-    &:nth-child(1), &:nth-child(2) {
-      margin-bottom: 1px;
-    }
-  }
-
-  .group-content {
-    display: inline-flex;
-    flex-wrap: wrap;
-    padding: 4px 12px;
-    width: 100%;
+    background-color: #f4f4f4;
   }
 
   .popover-content-attr-cell {
-    width: 65%;
-    text-align: left;
-
-    &:nth-of-type(even) {
-      text-align: right;
-      width: 35%;
-    }
-
     &.key {
-      color: $white;
-      font-size: 12px;
+      color: $gray-100;
+      font-size: 0.875rem;
       font-weight: bold;
-      line-height: 1.33;
+      line-height: 1.71;
+
+      opacity: 0.5;
+
+      &.hasValue {
+        opacity: 1;
+      }
     }
 
     &.label {
-      font-size: 10px;
-      line-height: 1.2;
-      color: $gray-300;
-    }
+      color: $gray-100;
+      font-size: 0.75rem;
+      line-height: 1.33;
+      opacity: 0.5;
 
-    &.label.bold {
-      font-weight: bold;
+      &.bold {
+        font-weight: bold;
+      }
+
+      &.key-value {
+        line-height: 1.71;
+      }
+
+      &.hasValue {
+        opacity: 1;
+      }
     }
 
     &.label.value {
-      font-size: 12px;
-      font-weight: bold;
-      line-height: 1.33;
       text-align: right;
-      white-space: nowrap;
 
       &.green {
         color: $green-10;
-
-        &:before {
-          content: '+';
-        }
+        opacity: 1;
       }
     }
   }
-
-  .modal-body {
-
-    .group-content {
-      padding: 0.25rem 1rem;
-    }
-
-    .popover-content-attr {
-      background-color: #f4f4f4;
-
-      &:nth-of-type(even) {
-        margin-left: 1px;
-        width: 50%;
-      }
-    }
-
-    .popover-content-attr-cell {
-      &.key {
-        color: $gray-100;
-        font-size: 0.875rem;
-        font-weight: bold;
-        line-height: 1.71;
-
-        opacity: 0.5;
-
-        &.hasValue {
-          opacity: 1;
-        }
-      }
-
-      &.label {
-        color: $gray-100;
-        font-size: 0.75rem;
-        line-height: 1.33;
-        opacity: 0.5;
-
-        &.bold {
-          font-weight: bold;
-        }
-
-        &.key-value {
-          line-height: 1.71;
-        }
-
-        &.hasValue {
-          opacity: 1;
-        }
-      }
-
-      &.label.value {
-        text-align: right;
-
-        &.green {
-          color: $green-10;
-          opacity: 1;
-        }
-      }
-    }
-
-  }
+}
 </style>
 
 <script>
-import { mapState } from '@/libs/store';
-import statsMixin from '@/mixins/stats';
+import { mapState } from "@/libs/store";
+import statsMixin from "@/mixins/stats";
 
 export default {
   mixins: [statsMixin],
@@ -199,18 +191,18 @@ export default {
   },
   computed: {
     ...mapState({
-      ATTRIBUTES: 'constants.ATTRIBUTES',
-      flatGear: 'content.gear.flat',
+      ATTRIBUTES: "constants.ATTRIBUTES",
+      flatGear: "content.gear.flat",
     }),
   },
   methods: {
-    hasSumValue (attr) {
+    hasSumValue(attr) {
       return this.stats.sum[attr] > 0;
     },
-    hasGearValue (attr) {
+    hasGearValue(attr) {
       return this.stats.gear[attr] > 0;
     },
-    hasClassBonus (attr) {
+    hasClassBonus(attr) {
       return this.stats.classBonus[attr] > 0;
     },
   },

--- a/website/client/src/components/inventory/equipment/attributesGrid.vue
+++ b/website/client/src/components/inventory/equipment/attributesGrid.vue
@@ -9,175 +9,170 @@
       <div class="group-content">
         <span
           class="popover-content-attr-cell key"
-          :class="{ hasValue: hasSumValue(attr) }"
-          >{{ `${$t(attr)}: ` }}</span
-        >
+          :class="{'hasValue': hasSumValue(attr) }"
+        >{{ `${$t(attr)}: ` }}</span>
         <span
           class="popover-content-attr-cell label key-value value"
-          :class="{ green: hasSumValue(attr) }"
-          >{{ `${stats.sum[attr]}` }}</span
-        >
+          :class="{'green': hasSumValue(attr) }"
+        >{{ `${stats.sum[attr]}` }}</span>
         <span
           class="popover-content-attr-cell label bold"
-          :class="{ hasValue: hasGearValue(attr) }"
-          >{{ $t("gear") }}:</span
-        >
+          :class="{'hasValue': hasGearValue(attr) }"
+        >{{ $t('gear') }}:</span>
         <span
           class="popover-content-attr-cell label"
-          :class="{ hasValue: hasGearValue(attr) }"
-          >{{ stats.gear[attr] }}</span
-        >
+          :class="{'hasValue': hasGearValue(attr) }"
+        >{{ stats.gear[attr] }}</span>
         <span
           class="popover-content-attr-cell label bold"
-          :class="{ hasValue: hasClassBonus(attr) }"
-          >{{ $t("classEquipBonus") }}:</span
-        >
+          :class="{'hasValue': hasClassBonus(attr) }"
+        >{{ $t('classEquipBonus') }}:</span>
         <span
           class="popover-content-attr-cell label"
-          :class="{ hasValue: hasClassBonus(attr) }"
-          >{{ `${stats.classBonus[attr]}` }}</span
-        >
+          :class="{'hasValue': hasClassBonus(attr) }"
+        >{{ `${stats.classBonus[attr]}` }}</span>
       </div>
     </div>
   </div>
 </template>
 
 <style lang="scss">
-@import "@/assets/scss/colors.scss";
 
-.attributes-group {
-  border-radius: 4px;
-  // unless we have a way to give a popover an id or class, it needs expand the attributes area
-  margin: -12px -16px;
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-}
+  @import '@/assets/scss/colors.scss';
 
-.popover-content-attr {
-  font-weight: bold;
-  width: fit-content;
-  background-color: $gray-50;
-
-  .attr-str,
-  .attr-int {
-    padding-top: 0.25rem;
-    padding-bottom: 0.5rem;
-  }
-
-  .attr-con,
-  .attr-per {
-    padding-bottom: 0.75rem;
-    padding-top: 0.5rem;
-  }
-}
-
-.group-content {
-  display: grid;
-  grid-template-columns: auto auto;
-  column-gap: 2rem;
-  justify-content: start;
-  padding: 4px 12px;
-  width: fit-content;
-}
-
-.popover-content-attr-cell {
-  text-align: left;
-
-  &:nth-of-type(even) {
-    text-align: right;
-  }
-
-  &.key {
-    color: $white;
-    font-size: 12px;
-    font-weight: bold;
-    line-height: 1.33;
-  }
-
-  &.label {
-    font-size: 10px;
-    line-height: 1.2;
-    color: $gray-300;
-  }
-
-  &.label.bold {
-    font-weight: bold;
-  }
-
-  &.label.value {
-    font-size: 12px;
-    font-weight: bold;
-    line-height: 1.33;
-    text-align: right;
-    white-space: nowrap;
-
-    &.green {
-      color: $green-10;
-
-      &:before {
-        content: "+";
-      }
-    }
-  }
-}
-
-.modal-body {
-  .group-content {
-    padding: 0.25rem 1rem;
+  .attributes-group {
+    border-radius: 4px;
+    // unless we have a way to give a popover an id or class, it needs expand the attributes area
+    margin: -12px -16px;
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
   }
 
   .popover-content-attr {
-    background-color: #f4f4f4;
+    font-weight: bold;
+    width: fit-content;
+    background-color: $gray-50;
+
+    .attr-str, .attr-int {
+      padding-top: 0.25rem;
+      padding-bottom: 0.5rem;
+    }
+
+    .attr-con, .attr-per {
+      padding-bottom: 0.75rem;
+      padding-top: 0.5rem;
+    }
+  }
+
+  .group-content {
+    display: grid;
+    grid-template-columns: auto auto;
+    column-gap: 2rem;
+    justify-content: start;
+    padding: 4px 12px;
+    width: fit-content;
   }
 
   .popover-content-attr-cell {
+    text-align: left;
+
+    &:nth-of-type(even) {
+      text-align: right;
+    }
+
     &.key {
-      color: $gray-100;
-      font-size: 0.875rem;
+      color: $white;
+      font-size: 12px;
       font-weight: bold;
-      line-height: 1.71;
-
-      opacity: 0.5;
-
-      &.hasValue {
-        opacity: 1;
-      }
+      line-height: 1.33;
     }
 
     &.label {
-      color: $gray-100;
-      font-size: 0.75rem;
-      line-height: 1.33;
-      opacity: 0.5;
+      font-size: 10px;
+      line-height: 1.2;
+      color: $gray-300;
+    }
 
-      &.bold {
-        font-weight: bold;
-      }
-
-      &.key-value {
-        line-height: 1.71;
-      }
-
-      &.hasValue {
-        opacity: 1;
-      }
+    &.label.bold {
+      font-weight: bold;
     }
 
     &.label.value {
+      font-size: 12px;
+      font-weight: bold;
+      line-height: 1.33;
       text-align: right;
+      white-space: nowrap;
 
       &.green {
         color: $green-10;
-        opacity: 1;
+
+        &:before {
+          content: '+';
+        }
       }
     }
   }
-}
+
+  .modal-body {
+
+    .group-content {
+      padding: 0.25rem 1rem;
+    }
+
+    .popover-content-attr {
+      background-color: #f4f4f4;
+    }
+
+    .popover-content-attr-cell {
+      &.key {
+        color: $gray-100;
+        font-size: 0.875rem;
+        font-weight: bold;
+        line-height: 1.71;
+
+        opacity: 0.5;
+
+        &.hasValue {
+          opacity: 1;
+        }
+      }
+
+      &.label {
+        color: $gray-100;
+        font-size: 0.75rem;
+        line-height: 1.33;
+        opacity: 0.5;
+
+        &.bold {
+          font-weight: bold;
+        }
+
+        &.key-value {
+          line-height: 1.71;
+        }
+
+        &.hasValue {
+          opacity: 1;
+        }
+      }
+
+      &.label.value {
+        text-align: right;
+
+        &.green {
+          color: $green-10;
+          opacity: 1;
+        }
+      }
+    }
+
+  }
 </style>
 
 <script>
-import { mapState } from "@/libs/store";
-import statsMixin from "@/mixins/stats";
+import { mapState } from '@/libs/store';
+import statsMixin from '@/mixins/stats';
 
 export default {
   mixins: [statsMixin],
@@ -191,18 +186,18 @@ export default {
   },
   computed: {
     ...mapState({
-      ATTRIBUTES: "constants.ATTRIBUTES",
-      flatGear: "content.gear.flat",
+      ATTRIBUTES: 'constants.ATTRIBUTES',
+      flatGear: 'content.gear.flat',
     }),
   },
   methods: {
-    hasSumValue(attr) {
+    hasSumValue (attr) {
       return this.stats.sum[attr] > 0;
     },
-    hasGearValue(attr) {
+    hasGearValue (attr) {
       return this.stats.gear[attr] > 0;
     },
-    hasClassBonus(attr) {
+    hasClassBonus (attr) {
       return this.stats.classBonus[attr] > 0;
     },
   },

--- a/website/client/src/components/inventory/equipment/equipGearModal.vue
+++ b/website/client/src/components/inventory/equipment/equipGearModal.vue
@@ -10,7 +10,10 @@
     <div class="dialog-close">
       <close-icon @click="hideDialog()" />
     </div>
-    <div v-if="item != null" class="content">
+    <div
+      v-if="item != null"
+      class="content"
+    >
       <div class="inner-content">
         <avatar
           :member="user"
@@ -24,15 +27,22 @@
         <h4 class="title mt-3">
           {{ itemText }}
         </h4>
-        <div class="text" v-html="itemNotes"></div>
-        <span v-if="showClassTag" class="classTag mt-3">
+        <div
+          class="text"
+          v-html="itemNotes"
+        ></div>
+        <span
+          v-if="showClassTag"
+          class="classTag mt-3"
+        >
           <span
             class="svg-icon inline icon-16"
             v-html="icons[itemClass]"
           ></span>
-          <span class="className" :class="itemClass">{{
-            getClassName(itemClass)
-          }}</span>
+          <span
+            class="className"
+            :class="itemClass"
+          >{{ getClassName(itemClass) }}</span>
         </span>
         <attributesGrid
           v-if="attributesGridVisible"
@@ -42,7 +52,7 @@
         />
         <button
           class="btn with-icon mt-4"
-          :class="{ 'btn-primary': !isEquipped, 'btn-secondary': isEquipped }"
+          :class="{'btn-primary': !isEquipped, 'btn-secondary': isEquipped }"
           @click="equipItem()"
         >
           <span
@@ -50,142 +60,145 @@
             v-html="isEquipped ? icons.unEquip : icons.equip"
           ></span>
           <span class="button-label">
-            {{ $t(isEquipped ? "unequip" : "equip") }}
+            {{ $t(isEquipped ? 'unequip' : 'equip') }}
           </span>
         </button>
       </div>
     </div>
-    <div slot="modal-footer" class="clearfix"></div>
+    <div
+      slot="modal-footer"
+      class="clearfix"
+    ></div>
   </b-modal>
 </template>
 
 <style lang="scss">
-@import "@/assets/scss/colors.scss";
-@import "@/assets/scss/mixins.scss";
+  @import '@/assets/scss/colors.scss';
+  @import '@/assets/scss/mixins.scss';
 
-#equipgear-modal {
-  @include centeredModal();
-  width: fit-content;
-  left: 0;
-  right: 0;
-  margin: auto;
-
-  .modal-content {
-    border-radius: 8px;
-    box-shadow: 0 14px 28px 0 #1a181d3d, 0 10px 10px 0 #1a181d47;
+  #equipgear-modal {
+    @include centeredModal();
     width: fit-content;
-  }
+    left: 0;
+    right: 0;
+    margin: auto;
 
-  .modal-body {
-    padding: 2rem 1.5rem;
-    width: fit-content;
-  }
+    .modal-content {
+      border-radius: 8px;
+      box-shadow: 0 14px 28px 0 #1a181d3d, 0 10px 10px 0 #1a181d47;
+      width: fit-content;
+    }
 
-  .modal-dialog {
-    width: fit-content;
-    min-width: 330px;
-    max-width: 90vw;
+    .modal-body {
+      padding: 2rem 1.5rem;
+      width: fit-content;
+    }
+
+    .modal-dialog {
+      width: fit-content;
+      min-width: 330px;
+      max-width: 90vw;
+
+      .text {
+        min-height: 0;
+      }
+    }
 
     .text {
-      min-height: 0;
+      font-size: 0.875rem;
+      line-height: 1.71;
+      text-align: center;
+      color: $gray-50;
+    }
+
+    .content {
+      text-align: center;
+      width: fit-content;
+    }
+
+    .item-wrapper {
+      margin-bottom: 0 !important;
+    }
+
+    .inner-content {
+      width: fit-content;
+      min-width: 282px;
+    }
+
+    .classTag {
+      height: 24px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .className {
+      height: 24px;
+      font-size: 0.875rem;
+      line-height: 1.71;
+      text-align: left;
+      margin-left: 8px;
+      font-weight: bold;
+    }
+
+    .healer {
+      color: $healer-color;
+    }
+
+    .rogue {
+      color: $rogue-color;
+    }
+
+    .warrior {
+      color: $warrior-color;
+    }
+
+    .wizard {
+      color: $wizard-color;
+    }
+
+    .title {
+      color: $gray-10;
+    }
+
+    .attributesGrid {
+      background-color: $gray-500;
+      margin: 1rem 0 0;
+      border-radius: 4px;
+      border: 1px solid #f4f4f4;
+    }
+
+    .avatar {
+      cursor: default;
+      margin: 0 auto;
+
+      .character-sprites span {
+        left: 24px;
+      }
+    }
+
+    button.btn {
+      display: inline-flex;
+      align-items: center;
     }
   }
-
-  .text {
-    font-size: 0.875rem;
-    line-height: 1.71;
-    text-align: center;
-    color: $gray-50;
-  }
-
-  .content {
-    text-align: center;
-    width: fit-content;
-  }
-
-  .item-wrapper {
-    margin-bottom: 0 !important;
-  }
-
-  .inner-content {
-    width: fit-content;
-    min-width: 282px;
-  }
-
-  .classTag {
-    height: 24px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .className {
-    height: 24px;
-    font-size: 0.875rem;
-    line-height: 1.71;
-    text-align: left;
-    margin-left: 8px;
-    font-weight: bold;
-  }
-
-  .healer {
-    color: $healer-color;
-  }
-
-  .rogue {
-    color: $rogue-color;
-  }
-
-  .warrior {
-    color: $warrior-color;
-  }
-
-  .wizard {
-    color: $wizard-color;
-  }
-
-  .title {
-    color: $gray-10;
-  }
-
-  .attributesGrid {
-    background-color: $gray-500;
-    margin: 1rem 0 0;
-    border-radius: 4px;
-    border: 1px solid #f4f4f4;
-  }
-
-  .avatar {
-    cursor: default;
-    margin: 0 auto;
-
-    .character-sprites span {
-      left: 24px;
-    }
-  }
-
-  button.btn {
-    display: inline-flex;
-    align-items: center;
-  }
-}
 </style>
 
 <script>
-import { getClassName } from "@/../../common/script/libs/getClassName";
-import { mapState } from "@/libs/store";
+import { getClassName } from '@/../../common/script/libs/getClassName';
+import { mapState } from '@/libs/store';
 
-import svgClose from "@/assets/svg/close.svg?raw";
-import svgEquipIcon from "@/assets/svg/equip.svg?raw";
-import svgHealer from "@/assets/svg/healer.svg?raw";
-import svgRogue from "@/assets/svg/rogue.svg?raw";
-import svgUnEquipIcon from "@/assets/svg/unequip.svg?raw";
-import svgWarrior from "@/assets/svg/warrior.svg?raw";
-import svgWizard from "@/assets/svg/wizard.svg?raw";
+import svgClose from '@/assets/svg/close.svg?raw';
+import svgWarrior from '@/assets/svg/warrior.svg?raw';
+import svgWizard from '@/assets/svg/wizard.svg?raw';
+import svgRogue from '@/assets/svg/rogue.svg?raw';
+import svgHealer from '@/assets/svg/healer.svg?raw';
+import svgEquipIcon from '@/assets/svg/equip.svg?raw';
+import svgUnEquipIcon from '@/assets/svg/unequip.svg?raw';
 
-import Avatar from "@/components/avatar";
-import attributesGrid from "@/components/inventory/equipment/attributesGrid.vue";
-import closeIcon from "@/components/shared/closeIcon";
+import Avatar from '@/components/avatar';
+import attributesGrid from '@/components/inventory/equipment/attributesGrid.vue';
+import closeIcon from '@/components/shared/closeIcon';
 // TODO @common/ path alias
 
 export default {
@@ -208,7 +221,7 @@ export default {
       type: Boolean,
     },
   },
-  data() {
+  data () {
     return {
       icons: Object.freeze({
         close: svgClose,
@@ -223,28 +236,28 @@ export default {
   },
   computed: {
     ...mapState({
-      content: "content",
-      user: "user.data",
+      content: 'content',
+      user: 'user.data',
     }),
-    showClassTag() {
+    showClassTag () {
       return this.content.classes.includes(this.itemClass);
     },
-    itemText() {
+    itemText () {
       if (this.item.text instanceof Function) {
         return this.item.text();
       }
       return this.item.text;
     },
-    itemNotes() {
+    itemNotes () {
       if (this.item.notes instanceof Function) {
         return this.item.notes();
       }
       return this.item.notes;
     },
-    itemClass() {
+    itemClass () {
       return this.item.klass || this.item.specialClass;
     },
-    attributesGridVisible() {
+    attributesGridVisible () {
       if (this.costumeMode) {
         return false;
       }
@@ -253,22 +266,22 @@ export default {
     },
   },
   methods: {
-    onChange($event) {
-      this.$emit("change", $event);
+    onChange ($event) {
+      this.$emit('change', $event);
     },
-    equipItem() {
-      this.$emit("equipItem", this.item);
+    equipItem () {
+      this.$emit('equipItem', this.item);
       this.hideDialog();
     },
-    hideDialog() {
-      this.$root.$emit("bv::hide::modal", "equipgear-modal");
+    hideDialog () {
+      this.$root.$emit('bv::hide::modal', 'equipgear-modal');
     },
-    memberOverrideAvatarGear(gear) {
+    memberOverrideAvatarGear (gear) {
       return {
         [gear.type]: gear.key,
       };
     },
-    getClassName(classType) {
+    getClassName (classType) {
       return this.$t(getClassName(classType));
     },
   },

--- a/website/client/src/components/inventory/equipment/equipGearModal.vue
+++ b/website/client/src/components/inventory/equipment/equipGearModal.vue
@@ -10,10 +10,7 @@
     <div class="dialog-close">
       <close-icon @click="hideDialog()" />
     </div>
-    <div
-      v-if="item != null"
-      class="content"
-    >
+    <div v-if="item != null" class="content">
       <div class="inner-content">
         <avatar
           :member="user"
@@ -27,22 +24,15 @@
         <h4 class="title mt-3">
           {{ itemText }}
         </h4>
-        <div
-          class="text"
-          v-html="itemNotes"
-        ></div>
-        <span
-          v-if="showClassTag"
-          class="classTag mt-3"
-        >
+        <div class="text" v-html="itemNotes"></div>
+        <span v-if="showClassTag" class="classTag mt-3">
           <span
             class="svg-icon inline icon-16"
             v-html="icons[itemClass]"
           ></span>
-          <span
-            class="className"
-            :class="itemClass"
-          >{{ getClassName(itemClass) }}</span>
+          <span class="className" :class="itemClass">{{
+            getClassName(itemClass)
+          }}</span>
         </span>
         <attributesGrid
           v-if="attributesGridVisible"
@@ -52,7 +42,7 @@
         />
         <button
           class="btn with-icon mt-4"
-          :class="{'btn-primary': !isEquipped, 'btn-secondary': isEquipped }"
+          :class="{ 'btn-primary': !isEquipped, 'btn-secondary': isEquipped }"
           @click="equipItem()"
         >
           <span
@@ -60,139 +50,142 @@
             v-html="isEquipped ? icons.unEquip : icons.equip"
           ></span>
           <span class="button-label">
-            {{ $t(isEquipped ? 'unequip' : 'equip') }}
+            {{ $t(isEquipped ? "unequip" : "equip") }}
           </span>
         </button>
       </div>
     </div>
-    <div
-      slot="modal-footer"
-      class="clearfix"
-    ></div>
+    <div slot="modal-footer" class="clearfix"></div>
   </b-modal>
 </template>
 
 <style lang="scss">
-  @import '@/assets/scss/colors.scss';
-  @import '@/assets/scss/mixins.scss';
+@import "@/assets/scss/colors.scss";
+@import "@/assets/scss/mixins.scss";
 
-  #equipgear-modal {
-    @include centeredModal();
+#equipgear-modal {
+  @include centeredModal();
+  width: fit-content;
+  left: 0;
+  right: 0;
+  margin: auto;
 
-    .modal-content {
-      border-radius: 8px;
-      box-shadow: 0 14px 28px 0 #1a181d3d, 0 10px 10px 0 #1a181d47;
-    }
+  .modal-content {
+    border-radius: 8px;
+    box-shadow: 0 14px 28px 0 #1a181d3d, 0 10px 10px 0 #1a181d47;
+    width: fit-content;
+  }
 
-    .modal-body {
-      padding: 2rem 1.5rem;
-    }
+  .modal-body {
+    padding: 2rem 1.5rem;
+    width: fit-content;
+  }
 
-    .dialog-close {
-
-    }
-
-    .modal-dialog {
-      width: 330px;
-
-      .text {
-        min-height: 0;
-      }
-    }
+  .modal-dialog {
+    width: fit-content;
+    min-width: 330px;
+    max-width: 90vw;
 
     .text {
-      font-size: 0.875rem;
-      line-height: 1.71;
-      text-align: center;
-      color: $gray-50;
-    }
-
-    .content {
-      text-align: center;
-    }
-
-    .item-wrapper {
-      margin-bottom: 0 !important;
-    }
-
-    .inner-content {
-      width: 282px;
-    }
-
-    .classTag {
-      height: 24px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-
-    .className {
-      height: 24px;
-      font-size: 0.875rem;
-      line-height: 1.71;
-      text-align: left;
-      margin-left: 8px;
-      font-weight: bold;
-    }
-
-    .healer {
-      color: $healer-color;
-    }
-
-    .rogue {
-      color: $rogue-color;
-    }
-
-    .warrior {
-      color: $warrior-color;
-    }
-
-    .wizard {
-      color: $wizard-color;
-    }
-
-    .title {
-      color: $gray-10;
-    }
-
-    .attributesGrid {
-      background-color: $gray-500;
-      margin: 1rem 0 0;
-      border-radius: 4px;
-      border: 1px solid #f4f4f4;
-    }
-
-    .avatar {
-      cursor: default;
-      margin: 0 auto;
-
-      .character-sprites span {
-        left: 24px;
-      }
-    }
-
-    button.btn {
-      display: inline-flex;
-      align-items: center;
+      min-height: 0;
     }
   }
+
+  .text {
+    font-size: 0.875rem;
+    line-height: 1.71;
+    text-align: center;
+    color: $gray-50;
+  }
+
+  .content {
+    text-align: center;
+    width: fit-content;
+  }
+
+  .item-wrapper {
+    margin-bottom: 0 !important;
+  }
+
+  .inner-content {
+    width: fit-content;
+    min-width: 282px;
+  }
+
+  .classTag {
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .className {
+    height: 24px;
+    font-size: 0.875rem;
+    line-height: 1.71;
+    text-align: left;
+    margin-left: 8px;
+    font-weight: bold;
+  }
+
+  .healer {
+    color: $healer-color;
+  }
+
+  .rogue {
+    color: $rogue-color;
+  }
+
+  .warrior {
+    color: $warrior-color;
+  }
+
+  .wizard {
+    color: $wizard-color;
+  }
+
+  .title {
+    color: $gray-10;
+  }
+
+  .attributesGrid {
+    background-color: $gray-500;
+    margin: 1rem 0 0;
+    border-radius: 4px;
+    border: 1px solid #f4f4f4;
+  }
+
+  .avatar {
+    cursor: default;
+    margin: 0 auto;
+
+    .character-sprites span {
+      left: 24px;
+    }
+  }
+
+  button.btn {
+    display: inline-flex;
+    align-items: center;
+  }
+}
 </style>
 
 <script>
-import { getClassName } from '@/../../common/script/libs/getClassName';
-import { mapState } from '@/libs/store';
+import { getClassName } from "@/../../common/script/libs/getClassName";
+import { mapState } from "@/libs/store";
 
-import svgClose from '@/assets/svg/close.svg?raw';
-import svgWarrior from '@/assets/svg/warrior.svg?raw';
-import svgWizard from '@/assets/svg/wizard.svg?raw';
-import svgRogue from '@/assets/svg/rogue.svg?raw';
-import svgHealer from '@/assets/svg/healer.svg?raw';
-import svgEquipIcon from '@/assets/svg/equip.svg?raw';
-import svgUnEquipIcon from '@/assets/svg/unequip.svg?raw';
+import svgClose from "@/assets/svg/close.svg?raw";
+import svgEquipIcon from "@/assets/svg/equip.svg?raw";
+import svgHealer from "@/assets/svg/healer.svg?raw";
+import svgRogue from "@/assets/svg/rogue.svg?raw";
+import svgUnEquipIcon from "@/assets/svg/unequip.svg?raw";
+import svgWarrior from "@/assets/svg/warrior.svg?raw";
+import svgWizard from "@/assets/svg/wizard.svg?raw";
 
-import Avatar from '@/components/avatar';
-import attributesGrid from '@/components/inventory/equipment/attributesGrid.vue';
-import closeIcon from '@/components/shared/closeIcon';
+import Avatar from "@/components/avatar";
+import attributesGrid from "@/components/inventory/equipment/attributesGrid.vue";
+import closeIcon from "@/components/shared/closeIcon";
 // TODO @common/ path alias
 
 export default {
@@ -215,7 +208,7 @@ export default {
       type: Boolean,
     },
   },
-  data () {
+  data() {
     return {
       icons: Object.freeze({
         close: svgClose,
@@ -230,28 +223,28 @@ export default {
   },
   computed: {
     ...mapState({
-      content: 'content',
-      user: 'user.data',
+      content: "content",
+      user: "user.data",
     }),
-    showClassTag () {
+    showClassTag() {
       return this.content.classes.includes(this.itemClass);
     },
-    itemText () {
+    itemText() {
       if (this.item.text instanceof Function) {
         return this.item.text();
       }
       return this.item.text;
     },
-    itemNotes () {
+    itemNotes() {
       if (this.item.notes instanceof Function) {
         return this.item.notes();
       }
       return this.item.notes;
     },
-    itemClass () {
+    itemClass() {
       return this.item.klass || this.item.specialClass;
     },
-    attributesGridVisible () {
+    attributesGridVisible() {
       if (this.costumeMode) {
         return false;
       }
@@ -260,22 +253,22 @@ export default {
     },
   },
   methods: {
-    onChange ($event) {
-      this.$emit('change', $event);
+    onChange($event) {
+      this.$emit("change", $event);
     },
-    equipItem () {
-      this.$emit('equipItem', this.item);
+    equipItem() {
+      this.$emit("equipItem", this.item);
       this.hideDialog();
     },
-    hideDialog () {
-      this.$root.$emit('bv::hide::modal', 'equipgear-modal');
+    hideDialog() {
+      this.$root.$emit("bv::hide::modal", "equipgear-modal");
     },
-    memberOverrideAvatarGear (gear) {
+    memberOverrideAvatarGear(gear) {
       return {
         [gear.type]: gear.key,
       };
     },
-    getClassName (classType) {
+    getClassName(classType) {
       return this.$t(getClassName(classType));
     },
   },


### PR DESCRIPTION
Fixes #10048 

### Changes
When using non-English languages, the equipment stat grid (STR/INT/CON/PER) in both the equip gear modal and the equipment popover could cause translated text to wrap mid-word or overflow its container. This happened because the layout relied on fixed widths and percentage-based sizing that did not accommodate longer translated strings.

The root cause was a circular width expansion chain: .inner-content used width: max-content, which caused it to expand to the size of its children. Those children (.popover-content-attr) used calc(50% - 1px) percentages, which calculated against the inflated parent — creating a feedback loop. Additionally, the flex-wrap layout on .attributes-group had no stable column-width reference, so stat boxes could end up different sizes or wrap unexpectedly.

- Changed .attributes-group from display: flex; flex-wrap: wrap to display: grid; grid-template-columns: repeat(2, 1fr). The CSS Grid always places stat boxes in pairs and sizes columns by content, eliminating flex-wrap timing issues.
- Changed .popover-content-attr from percentage-based width (calc(50% - 1px)) to width: fit-content. Each stat box is now only as wide as its content requires; the grid handles column placement.
- Added width: fit-content to .group-content so the inner label/value grid does not stretch beyond its content.
- Removed now-redundant 1px margin hacks on even/first-two children (the grid handles placement natively).
- Added width: fit-content to .modal-content, .modal-body, and .content to propagate content-driven sizing up through the Bootstrap modal structure.
- Changed .inner-content from width: max-content to width: fit-content, breaking the circular expansion chain. The existing min-width: 282px is retained to enforce a minimum size in English.

----
UUID: 894f5a0d-d3f7-4f45-a0f9-29bf86e6d461
