### PR TITLE
Fixes #14484: Add missing notificationIds to API documentation

### DIFF
--- a/website/server/controllers/api-v3/notifications.js
+++ b/website/server/controllers/api-v3/notifications.js
@@ -55,6 +55,8 @@ api.readNotification = {
  * @apiName ReadNotifications
  * @apiGroup Notification
  *
+ * @apiParam (Body) {String[]} notificationIds Array of notification IDs to mark as read.
+ * 
  * @apiSuccess {Object} data user.notifications
  */
 api.readNotifications = {


### PR DESCRIPTION
Fixes #14484

### Changes

- Added the missing `notificationIds` body parameter to the API documentation for the "Mark multiple notifications as read" endpoint.
- Used `@apiParam (Body)` to remain consistent with the existing apidoc format used in the codebase.
- Included a clear description explaining that the parameter is required and contains the IDs of the notifications to be marked as read.

----
UUID: imsanupm
