### PR TITLE
Remove join retired public guild loophole

### DIFF
--- a/test/api/unit/libs/payments/amazon/cancel.test.js
+++ b/test/api/unit/libs/payments/amazon/cancel.test.js
@@ -66,13 +66,15 @@ describe('Amazon Payments - Cancel Subscription', () => {
     group = generateGroup({
       name: 'test group',
       type: 'guild',
-      privacy: 'public',
+      privacy: 'private',
       leader: user._id,
     });
     group.purchased.plan.customerId = 'customer-id';
     group.purchased.plan.planId = subKey;
     group.purchased.plan.lastBillingDate = new Date();
     await group.save();
+    user.guilds.push(group._id);
+    await user.save();
 
     subscriptionBlock = common.content.subscriptionBlocks[subKey];
     subscriptionLength = subscriptionBlock.months * 30;

--- a/test/api/unit/libs/payments/amazon/subscribe.test.js
+++ b/test/api/unit/libs/payments/amazon/subscribe.test.js
@@ -30,7 +30,7 @@ describe('Amazon Payments - Subscribe', () => {
     group = generateGroup({
       name: 'test group',
       type: 'guild',
-      privacy: 'public',
+      privacy: 'private',
       leader: user._id,
     });
     group.purchased.plan.customerId = 'customer-id';

--- a/test/api/unit/libs/payments/amazon/subscribe.test.js
+++ b/test/api/unit/libs/payments/amazon/subscribe.test.js
@@ -248,11 +248,6 @@ describe('Amazon Payments - Subscribe', () => {
     user.guilds.push(groupId);
     await user.save();
 
-    // Add existing users
-    user = new User();
-    user.guilds.push(groupId);
-    await user.save();
-
     // Set expected amount
     sub.key = 'group_monthly';
     sub.price = 9;

--- a/test/api/unit/libs/payments/amazon/subscribe.test.js
+++ b/test/api/unit/libs/payments/amazon/subscribe.test.js
@@ -36,6 +36,8 @@ describe('Amazon Payments - Subscribe', () => {
     group.purchased.plan.customerId = 'customer-id';
     group.purchased.plan.planId = subKey;
     await group.save();
+    user.guilds.push(group._id);
+    await user.save();
 
     amount = common.content.subscriptionBlocks[subKey].price;
     billingAgreementId = 'billingAgreementId';

--- a/test/api/unit/libs/payments/group-plans/group-payments-create.test.js
+++ b/test/api/unit/libs/payments/group-plans/group-payments-create.test.js
@@ -128,11 +128,12 @@ describe('Purchasing a group plan for group', () => {
     expect(publicGroup.purchased.plan.planId).to.not.exist;
     data.groupId = publicGroup._id;
 
+    // Public Guilds are no longer even findable
     await expect(api.createSubscription(data))
       .to.eventually.be.rejected.and.to.eql({
-        httpCode: 401,
-        name: 'NotAuthorized',
-        message: i18n.t('onlyPrivateGuildsCanUpgrade'),
+        httpCode: 404,
+        name: 'NotFound',
+        message: i18n.t('groupNotFound'),
       });
 
     const updatedGroup = await Group.findById(publicGroup._id).exec();

--- a/test/api/unit/libs/payments/paypal/subscribe-cancel.test.js
+++ b/test/api/unit/libs/payments/paypal/subscribe-cancel.test.js
@@ -30,13 +30,15 @@ describe('paypal - subscribeCancel', () => {
     group = generateGroup({
       name: 'test group',
       type: 'guild',
-      privacy: 'public',
+      privacy: 'private',
       leader: user._id,
     });
     group.purchased.plan.customerId = groupCustomerId;
     group.purchased.plan.planId = subKey;
     group.purchased.plan.lastBillingDate = new Date();
     await group.save();
+    user.guilds.push(group._id);
+    await user.save();
 
     nextBillingDate = new Date();
 

--- a/test/api/unit/libs/payments/stripe/checkout.test.js
+++ b/test/api/unit/libs/payments/stripe/checkout.test.js
@@ -236,7 +236,7 @@ describe('Stripe - Checkout', () => {
       const group = generateGroup({
         name: 'test group',
         type: 'guild',
-        privacy: 'public',
+        privacy: 'private',
         leader: user._id,
       });
       const groupId = group._id;

--- a/test/api/unit/libs/payments/stripe/checkout.test.js
+++ b/test/api/unit/libs/payments/stripe/checkout.test.js
@@ -376,11 +376,13 @@ describe('Stripe - Checkout', () => {
         group = generateGroup({
           name: 'test group',
           type: 'guild',
-          privacy: 'public',
+          privacy: 'private',
           leader: user._id,
         });
         groupId = group._id;
         await group.save();
+        user.guilds.push(group._id);
+        await user.save();
       });
 
       it('throws if user is not allowed to change group plan', async () => {

--- a/test/api/unit/libs/payments/stripe/subscriptions.test.js
+++ b/test/api/unit/libs/payments/stripe/subscriptions.test.js
@@ -315,7 +315,7 @@ describe('Stripe - Subscriptions', () => {
       group = generateGroup({
         name: 'test group',
         type: 'guild',
-        privacy: 'public',
+        privacy: 'private',
         leader: user._id,
       });
       group.purchased.plan.customerId = 'customer-id';

--- a/test/api/unit/libs/payments/stripe/subscriptions.test.js
+++ b/test/api/unit/libs/payments/stripe/subscriptions.test.js
@@ -136,7 +136,7 @@ describe('Stripe - Subscriptions', () => {
       group = generateGroup({
         name: 'test group',
         type: 'guild',
-        privacy: 'public',
+        privacy: 'private',
         leader: user._id,
       });
       groupId = group._id;

--- a/test/api/unit/libs/payments/stripe/subscriptions.test.js
+++ b/test/api/unit/libs/payments/stripe/subscriptions.test.js
@@ -321,6 +321,8 @@ describe('Stripe - Subscriptions', () => {
       group.purchased.plan.customerId = 'customer-id';
       group.purchased.plan.planId = subKey;
       await group.save();
+      user.guilds.push(group._id);
+      await user.save();
 
       groupId = group._id;
     });

--- a/test/api/v3/integration/challenges/POST-challenges_challengeId_join.test.js
+++ b/test/api/v3/integration/challenges/POST-challenges_challengeId_join.test.js
@@ -6,6 +6,7 @@ import {
   translate as t,
 } from '../../../../helpers/api-integration/v3';
 import { model as Group } from '../../../../../website/server/models/group';
+import { TAVERN_ID } from '../../../../../website/common/script/constants';
 
 describe('POST /challenges/:challengeId/join', () => {
   it('returns error when challengeId is not a valid UUID', async () => {
@@ -99,7 +100,8 @@ describe('POST /challenges/:challengeId/join', () => {
     });
 
     it('succeeds when it\'s a Tavern challenge, even if the user isn\'t a "member" of Tavern', async () => {
-      const tavernChallenge = await generateChallenge(groupLeader, { _id: 'habitrpg' }, { prize: 1 });
+      const tavern = await groupLeader.get(`/groups/${TAVERN_ID}`);
+      const tavernChallenge = await generateChallenge(groupLeader, tavern, { prize: 1 });
       const generalUser = await generateUser();
 
       const res = await generalUser.post(`/challenges/${tavernChallenge._id}/join`);

--- a/test/api/v3/integration/challenges/POST-challenges_challengeId_join.test.js
+++ b/test/api/v3/integration/challenges/POST-challenges_challengeId_join.test.js
@@ -99,7 +99,7 @@ describe('POST /challenges/:challengeId/join', () => {
     });
 
     it('succeeds when it\'s a Tavern challenge, even if the user isn\'t a "member" of Tavern', async () => {
-      const tavernChallenge = await generateChallenge(groupLeader, { _id: 'habitrpg', prize: 1 });
+      const tavernChallenge = await generateChallenge(groupLeader, { _id: 'habitrpg' }, { prize: 1 });
       const generalUser = await generateUser();
 
       const res = await generalUser.post(`/challenges/${tavernChallenge._id}/join`);

--- a/test/api/v3/integration/challenges/POST-challenges_challengeId_join.test.js
+++ b/test/api/v3/integration/challenges/POST-challenges_challengeId_join.test.js
@@ -5,6 +5,7 @@ import {
   createAndPopulateGroup,
   translate as t,
 } from '../../../../helpers/api-integration/v3';
+import { model as Group } from '../../../../../website/server/models/group';
 
 describe('POST /challenges/:challengeId/join', () => {
   it('returns error when challengeId is not a valid UUID', async () => {
@@ -21,6 +22,26 @@ describe('POST /challenges/:challengeId/join', () => {
     const user = await generateUser({ balance: 1 });
 
     await expect(user.post(`/challenges/${generateUUID()}/join`)).to.eventually.be.rejected.and.eql({
+      code: 404,
+      error: 'NotFound',
+      message: t('challengeNotFound'),
+    });
+  });
+
+  it('returns error when challengeId is in an old public Guild', async () => {
+    const user = await generateUser({ balance: 1 });
+    const populatedGroup = await createAndPopulateGroup({
+      members: 1,
+    });
+    const groupLeader = populatedGroup.groupLeader;
+    const group = populatedGroup.group;
+    const authorizedUser = populatedGroup.members[0]; // eslint-disable-line prefer-destructuring
+    const challenge = await generateChallenge(groupLeader, group);
+
+    // Creation API is shut down, we need to simulate an extant public group
+    await Group.updateOne({ _id: populatedGroup._id }, { $set: { privacy: 'public' }}).exec();
+
+    await expect(user.post(`/challenges/${challenge._id}/join`)).to.eventually.be.rejected.and.eql({
       code: 404,
       error: 'NotFound',
       message: t('challengeNotFound'),
@@ -63,6 +84,14 @@ describe('POST /challenges/:challengeId/join', () => {
       expect(groupLeader.guilds).to.be.empty; // check that leaving worked
 
       const res = await groupLeader.post(`/challenges/${challenge._id}/join`);
+      expect(res.name).to.equal(challenge.name);
+    });
+
+    it('succeeds when it\'s a Tavern challenge, even if the user isn\'t a "member" of Tavern', async () => {
+      const tavernChallenge = await generateChallenge(groupLeader, 'habitrpg');
+      const generalUser = await generateUser();
+
+      const res = await generalUser.post(`/challenges/${tavernChallenge._id}/join`);
       expect(res.name).to.equal(challenge.name);
     });
 

--- a/test/api/v3/integration/challenges/POST-challenges_challengeId_join.test.js
+++ b/test/api/v3/integration/challenges/POST-challenges_challengeId_join.test.js
@@ -50,7 +50,7 @@ describe('POST /challenges/:challengeId/join', () => {
 
     it('returns error when challengeId is in an old public Guild', async () => {
       const authorizedUser = members[0]; // eslint-disable-line prefer-destructuring
-        
+
       await expect(authorizedUser.post(`/challenges/${challenge._id}/join`)).to.eventually.be.rejected.and.eql({
         code: 404,
         error: 'NotFound',

--- a/test/api/v3/integration/challenges/POST-challenges_challengeId_join.test.js
+++ b/test/api/v3/integration/challenges/POST-challenges_challengeId_join.test.js
@@ -29,19 +29,17 @@ describe('POST /challenges/:challengeId/join', () => {
   });
 
   it('returns error when challengeId is in an old public Guild', async () => {
-    const user = await generateUser({ balance: 1 });
     const populatedGroup = await createAndPopulateGroup({
       members: 1,
     });
-    const groupLeader = populatedGroup.groupLeader;
-    const group = populatedGroup.group;
+    const { group, groupLeader } = populatedGroup;
     const authorizedUser = populatedGroup.members[0]; // eslint-disable-line prefer-destructuring
     const challenge = await generateChallenge(groupLeader, group);
 
     // Creation API is shut down, we need to simulate an extant public group
-    await Group.updateOne({ _id: populatedGroup._id }, { $set: { privacy: 'public' }}).exec();
+    await Group.updateOne({ _id: populatedGroup._id }, { $set: { privacy: 'public' } }).exec();
 
-    await expect(user.post(`/challenges/${challenge._id}/join`)).to.eventually.be.rejected.and.eql({
+    await expect(authorizedUser.post(`/challenges/${challenge._id}/join`)).to.eventually.be.rejected.and.eql({
       code: 404,
       error: 'NotFound',
       message: t('challengeNotFound'),
@@ -88,11 +86,11 @@ describe('POST /challenges/:challengeId/join', () => {
     });
 
     it('succeeds when it\'s a Tavern challenge, even if the user isn\'t a "member" of Tavern', async () => {
-      const tavernChallenge = await generateChallenge(groupLeader, 'habitrpg');
+      const tavernChallenge = await generateChallenge(groupLeader, { _id: 'habitrpg' });
       const generalUser = await generateUser();
 
       const res = await generalUser.post(`/challenges/${tavernChallenge._id}/join`);
-      expect(res.name).to.equal(challenge.name);
+      expect(res.name).to.equal(tavernChallenge.name);
     });
 
     it('returns challenge data', async () => {

--- a/test/api/v3/integration/challenges/POST-challenges_challengeId_join.test.js
+++ b/test/api/v3/integration/challenges/POST-challenges_challengeId_join.test.js
@@ -28,21 +28,34 @@ describe('POST /challenges/:challengeId/join', () => {
     });
   });
 
-  it('returns error when challengeId is in an old public Guild', async () => {
-    const populatedGroup = await createAndPopulateGroup({
-      members: 1,
+  context('public Guild', () => {
+    let group;
+    let groupLeader;
+    let members;
+    let challenge;
+    before(async () => {
+      ({ group, groupLeader, members } = await createAndPopulateGroup({
+        groupDetails: {
+          name: 'test group',
+          type: 'guild',
+          privacy: 'private',
+        },
+        members: 1,
+        upgradeToGroupPlan: true,
+      }));
+      challenge = await generateChallenge(groupLeader, group);
+      // Creation API is shut down, we need to simulate an extant public group
+      await Group.updateOne({ _id: group._id }, { $set: { privacy: 'public' }, $unset: { 'purchased.plan': 1 } }).exec();
     });
-    const { group, groupLeader } = populatedGroup;
-    const authorizedUser = populatedGroup.members[0]; // eslint-disable-line prefer-destructuring
-    const challenge = await generateChallenge(groupLeader, group);
 
-    // Creation API is shut down, we need to simulate an extant public group
-    await Group.updateOne({ _id: populatedGroup._id }, { $set: { privacy: 'public' } }).exec();
-
-    await expect(authorizedUser.post(`/challenges/${challenge._id}/join`)).to.eventually.be.rejected.and.eql({
-      code: 404,
-      error: 'NotFound',
-      message: t('challengeNotFound'),
+    it('returns error when challengeId is in an old public Guild', async () => {
+      const authorizedUser = members[0]; // eslint-disable-line prefer-destructuring
+        
+      await expect(authorizedUser.post(`/challenges/${challenge._id}/join`)).to.eventually.be.rejected.and.eql({
+        code: 404,
+        error: 'NotFound',
+        message: t('challengeNotFound'),
+      });
     });
   });
 
@@ -86,7 +99,7 @@ describe('POST /challenges/:challengeId/join', () => {
     });
 
     it('succeeds when it\'s a Tavern challenge, even if the user isn\'t a "member" of Tavern', async () => {
-      const tavernChallenge = await generateChallenge(groupLeader, { _id: 'habitrpg' });
+      const tavernChallenge = await generateChallenge(groupLeader, { _id: 'habitrpg', prize: 1 });
       const generalUser = await generateUser();
 
       const res = await generalUser.post(`/challenges/${tavernChallenge._id}/join`);

--- a/test/api/v3/integration/chat/GET-chat.test.js
+++ b/test/api/v3/integration/chat/GET-chat.test.js
@@ -62,9 +62,9 @@ describe('GET /groups/:groupId/chat', () => {
 
     it('returns error if user attempts to fetch a sunset Guild', async () => {
       await expect(user.get(`/groups/${group._id}/chat`)).to.eventually.be.rejected.and.eql({
-        code: 400,
-        error: 'BadRequest',
-        message: t('featureRetired'),
+        code: 404,
+        error: 'NotFound',
+        message: t('groupNotFound'),
       });
     });
   });

--- a/test/api/v3/integration/chat/POST-chat.like.test.js
+++ b/test/api/v3/integration/chat/POST-chat.like.test.js
@@ -121,9 +121,9 @@ describe('POST /chat/:chatId/like', () => {
 
     await expect(user.post(`/groups/${groupWithChat._id}/chat/${message.message.id}/like`))
       .to.eventually.be.rejected.and.eql({
-        code: 400,
-        error: 'BadRequest',
-        message: t('featureRetired'),
+        code: 404,
+        error: 'NotFound',
+        message: t('groupNotFound'),
       });
   });
 });

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -583,6 +583,9 @@ api.joinGroup = {
     const group = await Group
       .getGroup({ user, groupId: req.params.groupId, optionalMembership: true });
     if (!group) throw new NotFound(res.t('groupNotFound'));
+    if (group.privacy == 'public') {
+      throw new BadRequest(res.t('featureRetired'));
+    }
 
     let isUserInvited = false;
     const seekingParty = Boolean(user.party.seeking);

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -583,9 +583,6 @@ api.joinGroup = {
     const group = await Group
       .getGroup({ user, groupId: req.params.groupId, optionalMembership: true });
     if (!group) throw new NotFound(res.t('groupNotFound'));
-    if (group.privacy == 'public') {
-      throw new BadRequest(res.t('featureRetired'));
-    }
 
     let isUserInvited = false;
     const seekingParty = Boolean(user.party.seeking);

--- a/website/server/libs/payments/amazon.js
+++ b/website/server/libs/payments/amazon.js
@@ -316,6 +316,7 @@ api.subscribe = async function subscribe (options) {
     const group = await Group.getGroup({
       user, groupId, populateLeader: false, groupFields,
     });
+    if (!group) throw new NotFound(i18n.t('groupNotFound'));
     const membersCount = await group.getMemberCount();
     amount = sub.price + (membersCount - leaderCount) * priceOfSingleMember;
   }

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -261,7 +261,7 @@ schema.statics.getGroup = async function getGroup (options = {}) {
   } else if (isTavern) {
     query = { _id: TAVERN_ID };
   } else if (optionalMembership === true) {
-    query = { _id: groupId };
+    query = { privacy: 'private', _id: groupId };
   } else if (isUserGuild) {
     query = { type: 'guild', privacy: 'private', _id: groupId };
   } else {

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -263,9 +263,9 @@ schema.statics.getGroup = async function getGroup (options = {}) {
   } else if (optionalMembership === true) {
     query = { _id: groupId };
   } else if (isUserGuild) {
-    query = { type: 'guild', _id: groupId };
+    query = { type: 'guild', privacy: 'private', _id: groupId };
   } else {
-    query = { type: 'guild', privacy: 'public', _id: groupId };
+    return null;
   }
 
   const mQuery = this.findOne(query);


### PR DESCRIPTION
**Previously**, it was still possible to join old public Guilds lingering in the database. This was an oversight--we had perhaps planned to purge these from the database shortly after sunsetting the rest of the public Guild features, rendering these workflows moot, but that didn't happen as soon as we'd thought.

**Now**, we catch attempts to access dormant public Guilds by filtering them out in the `getGroup` method of the group model. It now no longer has a case for fetching public Guilds other than the Tavern (which is still needed for public Challenges). Attempting to look one up will return null and thus result in a `404 Not Found` downstream, regardless of whether or not the user is already a member.

TODO
- [x] Update tests
- [x] Double-check that users can't sneak past this to join Challenges attached to old public Guilds