### PR TITLE
Require email in social reg edge case

### DIFF
--- a/website/client/src/components/auth/registerUsername.vue
+++ b/website/client/src/components/auth/registerUsername.vue
@@ -211,7 +211,9 @@ export default {
 
     if (!this.email && this.registrationMethod !== 'apple') {
       return;
-    } else if ((!this.email || this.email === '') && this.registrationMethod === 'apple') {
+    }
+    
+    if ((!this.email || this.email === '') && this.registrationMethod === 'apple') {
       this.needsEmailField = true;
     }
     const usernameToCheck = this.email.split('@')[0].replace(/[^a-zA-Z0-9\-_]/g, '');

--- a/website/client/src/components/auth/registerUsername.vue
+++ b/website/client/src/components/auth/registerUsername.vue
@@ -21,6 +21,25 @@
           @submit.prevent.stop="register()"
         >
           <input
+            id="emailInput"
+            v-if="showEmailField"
+            v-model="email"
+            class="form-control dark"
+            type="text"
+            :placeholder="$t('emailAddress')"
+            :class="{
+              'mb-3': !emailError,
+              'input-invalid input-with-error mb-2': emailError,
+              'input-valid': email && emailValid,
+            }"
+          >
+          <div
+            v-if="emailError"
+            class="input-error"
+          >
+            {{ emailError }}
+          </div>
+          <input
             id="usernameInput"
             v-model="username"
             class="form-control dark"
@@ -58,8 +77,8 @@
             ></label>
           </div>
           <button
-            class="btn btn-info d-block w-100 sign-up mx-auto mb-5"
-            :disabled="!username || usernameInvalid || !privacyAccepted"
+            class="btn btn-info d-flex justify-content-center align-items-center w-100 sign-up mx-auto mb-5"
+            :disabled="!email || emailError || !username || usernameInvalid || !privacyAccepted"
             type="submit"
           >
             {{ $t('getStarted') }}
@@ -133,10 +152,12 @@
     border: 2px solid transparent;
     box-shadow: 0 1px 3px 0 rgba($black, 0.16), 0 1px 3px 0 rgba($black, 0.24);
 
-    &:focus, &:active {
-      background-color: $blue-50;
-      border: 2px solid $purple-400;
-      box-shadow: 0 3px 6px 0 rgba($black, 0.16), 0 3px 6px 0 rgba($black, 0.24);
+    &:not(:disabled):not(.disabled) {
+      &:focus, &:active {
+        background-color: $blue-50;
+        border: 2px solid $purple-400;
+        box-shadow: 0 3px 6px 0 rgba($black, 0.16), 0 3px 6px 0 rgba($black, 0.24);
+      }
     }
   }
 
@@ -148,22 +169,18 @@
 <script>
 import debounce from 'lodash/debounce';
 import PrivacyBanner from '@/components/header/banners/privacy';
+import accountCreation from '@/mixins/accountCreation';
 import sanitizeRedirect from '@/mixins/sanitizeRedirect';
 
 export default {
   components: {
     PrivacyBanner,
   },
-  mixins: [sanitizeRedirect],
+  mixins: [accountCreation, sanitizeRedirect],
   data () {
     return {
-      authData: {},
-      email: '',
-      password: '',
-      passwordConfirm: '',
       privacyAccepted: false,
-      registrationMethod: null,
-      username: '',
+      showEmailField: false,
       usernameIssues: [],
     };
   },
@@ -197,6 +214,7 @@ export default {
     this.passwordConfirm = this.$store.state.registrationOptions.passwordConfirm;
 
     if (!this.email) {
+      this.showEmailField = true;
       return;
     }
     const usernameToCheck = this.email.split('@')[0].replace(/[^a-zA-Z0-9\-_]/g, '');

--- a/website/client/src/components/auth/registerUsername.vue
+++ b/website/client/src/components/auth/registerUsername.vue
@@ -229,14 +229,16 @@ export default {
     if ((!this.email || this.email === '') && this.registrationMethod === 'apple') {
       this.needsEmailField = true;
     }
-    const usernameToCheck = this.email.split('@')[0].replace(/[^a-zA-Z0-9\-_]/g, '');
-    this.$store.dispatch('auth:verifyUsername', {
-      username: usernameToCheck,
-    }).then(res => {
-      if (!res.issues) {
-        this.username = usernameToCheck;
-      }
-    });
+    if (this.email) {
+      const usernameToCheck = this.email.split('@')[0].replace(/[^a-zA-Z0-9\-_]/g, '');
+      this.$store.dispatch('auth:verifyUsername', {
+        username: usernameToCheck,
+      }).then(res => {
+        if (!res.issues) {
+          this.username = usernameToCheck;
+        }
+      });
+    }
     document.getElementById('usernameInput').focus();
   },
   methods: {

--- a/website/client/src/components/auth/registerUsername.vue
+++ b/website/client/src/components/auth/registerUsername.vue
@@ -20,24 +20,28 @@
           class="form mx-auto"
           @submit.prevent.stop="register()"
         >
-          <input
-            id="emailInput"
-            v-if="showEmailField"
-            v-model="email"
-            class="form-control dark"
-            type="text"
-            :placeholder="$t('emailAddress')"
-            :class="{
-              'mb-3': !emailError,
-              'input-invalid input-with-error mb-2': emailError,
-              'input-valid': email && emailValid,
-            }"
-          >
-          <div
-            v-if="emailError"
-            class="input-error"
-          >
-            {{ emailError }}
+          <div v-if="showEmailField">
+            <input
+              id="emailInput"
+              v-model="email"
+              class="form-control dark"
+              type="text"
+              :placeholder="$t('emailAddress')"
+              :class="{
+                'mb-3': !emailError,
+                'input-invalid input-with-error mb-2': emailError,
+                'input-valid': email && emailValid,
+              }"
+            >
+            <div
+              v-if="emailError"
+              class="input-error"
+            >
+              {{ emailError }}
+            </div>
+            <p class="purple-600 mb-3">
+              {{ $t('emailRequiredForSupport') }}
+            </p>
           </div>
           <input
             id="usernameInput"

--- a/website/client/src/components/auth/registerUsername.vue
+++ b/website/client/src/components/auth/registerUsername.vue
@@ -185,7 +185,6 @@ export default {
   data () {
     return {
       privacyAccepted: false,
-      showEmailField: false,
       usernameIssues: [],
       needsEmailField: false,
     };

--- a/website/client/src/components/auth/registerUsername.vue
+++ b/website/client/src/components/auth/registerUsername.vue
@@ -81,7 +81,8 @@
             ></label>
           </div>
           <button
-            class="btn btn-info d-flex justify-content-center align-items-center w-100 sign-up mx-auto mb-5"
+            class="btn btn-info d-flex justify-content-center
+              align-items-center w-100 sign-up mx-auto mb-5"
             :disabled="!email || emailError || !username || usernameInvalid || !privacyAccepted"
             type="submit"
           >

--- a/website/client/src/components/auth/registerUsername.vue
+++ b/website/client/src/components/auth/registerUsername.vue
@@ -43,6 +43,14 @@
           <p class="purple-600">
             {{ $t('usernameLimitations') }}
           </p>
+          <input
+            v-if="needsEmailField"
+            id="emailInput"
+            v-model="email"
+            class="form-control dark"
+            type="text"
+            :placeholder="$t('email')"
+          >
           <div class="custom-control custom-checkbox mb-4">
             <input
               id="privacyTOS"
@@ -165,6 +173,7 @@ export default {
       registrationMethod: null,
       username: '',
       usernameIssues: [],
+      needsEmailField: false,
     };
   },
   computed: {
@@ -183,21 +192,27 @@ export default {
     },
   },
   mounted () {
-    if (window.sessionStorage.getItem('apple-token')) {
-      this.registrationMethod = 'apple';
-    } else if (!this.$store.state.registrationOptions.registrationMethod) {
-      this.$router.push('/');
-    } else {
-      this.registrationMethod = this.$store.state.registrationOptions.registrationMethod;
-    }
     this.authData = this.$store.state.registrationOptions.authData;
     this.email = this.$store.state.registrationOptions.email;
     this.username = this.$store.state.registrationOptions.username;
     this.password = this.$store.state.registrationOptions.password;
     this.passwordConfirm = this.$store.state.registrationOptions.passwordConfirm;
 
-    if (!this.email) {
+    if (window.sessionStorage.getItem('apple-token')) {
+      this.registrationMethod = 'apple';
+      if (!this.email) {
+        this.email = window.sessionStorage.getItem('apple-email');
+      }
+    } else if (!this.$store.state.registrationOptions.registrationMethod) {
+      this.$router.push('/');
+    } else {
+      this.registrationMethod = this.$store.state.registrationOptions.registrationMethod;
+    }
+
+    if (!this.email && this.registrationMethod !== 'apple') {
       return;
+    } else if ((!this.email || this.email === '') && this.registrationMethod === 'apple') {
+      this.needsEmailField = true;
     }
     const usernameToCheck = this.email.split('@')[0].replace(/[^a-zA-Z0-9\-_]/g, '');
     this.$store.dispatch('auth:verifyUsername', {
@@ -237,6 +252,7 @@ export default {
           idToken: window.sessionStorage.getItem('apple-token'),
           name: window.sessionStorage.getItem('apple-name'),
           username: this.username,
+          email: this.email,
           allowRegister: true,
         });
       } else {

--- a/website/client/src/components/auth/registerUsername.vue
+++ b/website/client/src/components/auth/registerUsername.vue
@@ -212,7 +212,7 @@ export default {
     if (!this.email && this.registrationMethod !== 'apple') {
       return;
     }
-    
+
     if ((!this.email || this.email === '') && this.registrationMethod === 'apple') {
       this.needsEmailField = true;
     }

--- a/website/client/src/components/static/appleRedirect.vue
+++ b/website/client/src/components/static/appleRedirect.vue
@@ -37,7 +37,9 @@ export default {
       window.location.href = '/';
     } else {
       window.sessionStorage.setItem('apple-token', response.idToken);
-      window.sessionStorage.setItem('apple-email', response.email);
+      if (response.email) {
+        window.sessionStorage.setItem('apple-email', response.email);
+      }
       window.location.href = '/username';
     }
   },

--- a/website/client/src/components/static/appleRedirect.vue
+++ b/website/client/src/components/static/appleRedirect.vue
@@ -37,6 +37,7 @@ export default {
       window.location.href = '/';
     } else {
       window.sessionStorage.setItem('apple-token', response.idToken);
+      window.sessionStorage.setItem('apple-email', response.email);
       window.location.href = '/username';
     }
   },

--- a/website/client/src/store/actions/auth.js
+++ b/website/client/src/store/actions/auth.js
@@ -101,6 +101,7 @@ export async function appleAuth (store, params) {
       id_token: params.idToken,
       name: params.name,
       username: params.username,
+      email: params.email,
     },
   });
 
@@ -111,7 +112,7 @@ export async function appleAuth (store, params) {
   if (result.data.message && result.data.id_token) {
     return {
       idToken: result.data.id_token,
-      email: result.data.data && result.data.data.email,
+      email: result.data.email,
     };
   }
 

--- a/website/client/src/store/actions/auth.js
+++ b/website/client/src/store/actions/auth.js
@@ -109,7 +109,10 @@ export async function appleAuth (store, params) {
   }
 
   if (result.data.message && result.data.id_token) {
-    return { idToken: result.data.id_token };
+    return {
+      idToken: result.data.id_token,
+      email: result.data.data && result.data.data.email,
+    };
   }
 
   const user = result.data.data;

--- a/website/common/locales/en/front.json
+++ b/website/common/locales/en/front.json
@@ -187,5 +187,6 @@
   "learnMore": "Learn More",
   "translateHabitica": "Translate Habitica",
   "whatToCallYou": "What should we call you?",
-  "acceptPrivacyTOS": "You confirm that you are at least 18 years old, and that you have read and agree to our <a href='/static/terms' target='_blank'>Terms of Service</a> and <a href='/static/privacy' target='_blank'>Privacy Policy</a>"
+  "acceptPrivacyTOS": "You confirm that you are at least 18 years old, and that you have read and agree to our <a href='/static/terms' target='_blank'>Terms of Service</a> and <a href='/static/privacy' target='_blank'>Privacy Policy</a>",
+  "emailAddress": "Email address"
 }

--- a/website/common/locales/en/front.json
+++ b/website/common/locales/en/front.json
@@ -188,5 +188,6 @@
   "translateHabitica": "Translate Habitica",
   "whatToCallYou": "What should we call you?",
   "acceptPrivacyTOS": "You confirm that you are at least 18 years old, and that you have read and agree to our <a href='/static/terms' target='_blank'>Terms of Service</a> and <a href='/static/privacy' target='_blank'>Privacy Policy</a>",
-  "emailAddress": "Email address"
+  "emailAddress": "Email address",
+  "emailRequiredForSupport": "We require an email address for user support. Please enter an email address to continue creating your account."
 }

--- a/website/server/controllers/api-v3/auth.js
+++ b/website/server/controllers/api-v3/auth.js
@@ -187,6 +187,7 @@ api.loginApple = {
     req.body.network = 'apple';
     req.body.allowRegister = req.query.allowRegister === 'true';
     req.body.username = req.query.username;
+    req.body.email = req.query.email;
     return loginSocial(req, res);
   },
 };

--- a/website/server/libs/auth/apple.js
+++ b/website/server/libs/auth/apple.js
@@ -44,9 +44,13 @@ export async function appleProfile (req) {
 
   const verifiedPayload = await jwt.verify(idToken, applePublicKey, { algorithms: 'RS256' });
 
+  let { email } = verifiedPayload;
+  if ((!email || email === '') && req.body.email) {
+    email = req.body.email;
+  }
   return {
     id: verifiedPayload.sub,
-    emails: [{ value: verifiedPayload.email }],
+    emails: [{ value: email }],
     name: verifiedPayload.name || req.body.name || req.query.name,
     idToken,
   };

--- a/website/server/libs/auth/social.js
+++ b/website/server/libs/auth/social.js
@@ -91,6 +91,7 @@ export async function loginSocial (req, res) { // eslint-disable-line import/pre
     if (network === 'apple') {
       return res.status(200).send({
         message: res.t('userNotFound'),
+        email,
         id_token: profile.idToken,
       });
     }

--- a/website/server/libs/auth/utils.js
+++ b/website/server/libs/auth/utils.js
@@ -35,7 +35,6 @@ export function loginRes (user, req, res) {
     apiToken: user.apiToken,
     newUser: user.newUser || false,
     username: user.auth.local.username,
-    email: user.auth.local.email,
   };
   return res.respond(200, responseData);
 }

--- a/website/server/libs/auth/utils.js
+++ b/website/server/libs/auth/utils.js
@@ -35,6 +35,7 @@ export function loginRes (user, req, res) {
     apiToken: user.apiToken,
     newUser: user.newUser || false,
     username: user.auth.local.username,
+    email: user.auth.local.email,
   };
   return res.respond(200, responseData);
 }


### PR DESCRIPTION
Some regions don't require an email to be associated with Apple/Google accounts used for app authentication (they have phone numbers, instead).

**Previously**, we didn't have intentional handling for this--we'd go ahead and create the account, but without an email address recorded, making communication features of the app fail to work and making user support more difficult.

**Now**, if we arrive at the part of the registration flow where the user fills out a username, and we lack an email pulled in from the social data, we add a required field for the user to supply Habitica with an email address.

The PR also corrects some small style issues on that username page.
* The text on the Continue button is vertically as well as horizontally centered.
* Clicking the Continue button while it's disabled no longer highlights it in blue and purple.