### PR TITLE
fix(groups): expired guild plans not showing in upgrade modal

### DIFF
--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -159,7 +159,7 @@ schema.plugin(baseModel, {
     if (plainObj.purchased) {
       plainObj.purchased.active = originalDoc.hasActiveGroupPlan();
       const plan = originalDoc.purchased && originalDoc.purchased.plan;
-      if (plan && plan.customerId) {
+      if (plan && plan.dateCreated) {
         plainObj.purchased.wasUpgraded = true;
         if (plan.dateTerminated) {
           plainObj.purchased.dateTerminated = plan.dateTerminated;
@@ -317,7 +317,7 @@ schema.statics.getGroups = async function getGroups (options = {}) {
           type: 'guild',
           privacy: 'private',
           _id: { $in: user.guilds },
-          'purchased.plan.customerId': { $exists: true },
+          'purchased.plan.dateCreated': { $exists: true },
         };
         if (!filters.includeExpiredPlans) {
           query.$or = [


### PR DESCRIPTION
Use dateCreated instead of customerId to identify previously upgraded groups. 

Team cron clears customerId on expired plans as a query optimization, which makes them invisible to the upgrade flow. dateCreated is set on every group plan since the feature was introduced and is never cleared, so it reliably indicates a group was previously upgraded.
