### PR TITLE
fix: use Promise.all for mention push notifications in sendChat

### DIFF
--- a/test/api/unit/models/group.test.js
+++ b/test/api/unit/models/group.test.js
@@ -1530,6 +1530,62 @@ describe('Group Model', () => {
           mentionedMembers: [mentionedUser],
         })).to.eventually.be.rejectedWith('Push notification failed');
       });
+
+      it('does not send mention push notification to the sender', async () => {
+        sandbox.stub(pushNotifications, 'sendNotification').resolves();
+
+        const sender = new User({
+          party: { _id: party._id },
+          profile: { name: 'Sender' },
+          preferences: {
+            pushNotifications: {
+              mentionParty: true,
+              unsubscribeFromAll: false,
+            },
+          },
+          pushDevices: [{ regId: 'device-1', type: 'android' }],
+        });
+
+        await sender.save();
+
+        await party.sendChat({
+          message: 'I mentioned myself @sender',
+          user: sender,
+          mentionedMembers: [sender],
+        });
+
+        expect(pushNotifications.sendNotification).to.not.be.called;
+      });
+
+      it('does not send mention push notification when mentionParty preference is false', async () => {
+        sandbox.stub(pushNotifications, 'sendNotification').resolves();
+
+        const sender = new User({
+          profile: { name: 'Sender' },
+        });
+
+        const mentionedUser = new User({
+          party: { _id: party._id },
+          profile: { name: 'Mentioned User' },
+          preferences: {
+            pushNotifications: {
+              mentionParty: false,
+              unsubscribeFromAll: false,
+            },
+          },
+          pushDevices: [{ regId: 'device-1', type: 'android' }],
+        });
+
+        await Promise.all([sender.save(), mentionedUser.save()]);
+
+        await party.sendChat({
+          message: 'Hey @mentioned',
+          user: sender,
+          mentionedMembers: [mentionedUser],
+        });
+
+        expect(pushNotifications.sendNotification).to.not.be.called;
+      });
     });
 
     describe('#startQuest', () => {

--- a/test/api/unit/models/group.test.js
+++ b/test/api/unit/models/group.test.js
@@ -17,6 +17,7 @@ import {
 } from '../../../../website/server/libs/webhook';
 import * as email from '../../../../website/server/libs/email';
 import * as pushNotifications from '../../../../website/server/libs/pushNotifications';
+import logger from '../../../../website/server/libs/logger';
 import { TAVERN_ID } from '../../../../website/common/script/constants';
 import shared from '../../../../website/common';
 
@@ -1502,9 +1503,10 @@ describe('Group Model', () => {
         );
       });
 
-      it('awaits all mention push notifications (does not swallow errors)', async () => {
+      it('logs mention push notification errors without blocking chat delivery', async () => {
         const pushError = new Error('Push notification failed');
         sandbox.stub(pushNotifications, 'sendNotification').rejects(pushError);
+        sandbox.stub(logger, 'error');
 
         const sender = new User({
           profile: { name: 'Sender' },
@@ -1524,11 +1526,20 @@ describe('Group Model', () => {
 
         await Promise.all([sender.save(), mentionedUser.save()]);
 
-        await expect(party.sendChat({
+        const chatMessage = await party.sendChat({
           message: 'Hey @mentioned check this',
           user: sender,
           mentionedMembers: [mentionedUser],
-        })).to.eventually.be.rejectedWith('Push notification failed');
+        });
+
+        expect(chatMessage).to.exist;
+        expect(chatMessage.text).to.eql('Hey @mentioned check this');
+
+        // Wait for the fire-and-forget Promise.all to settle
+        await new Promise(resolve => { setTimeout(resolve, 50); });
+
+        expect(logger.error).to.be.calledOnce;
+        expect(logger.error).to.be.calledWith(pushError);
       });
 
       it('does not send mention push notification to the sender', async () => {

--- a/test/api/unit/models/group.test.js
+++ b/test/api/unit/models/group.test.js
@@ -1502,6 +1502,34 @@ describe('Group Model', () => {
         );
       });
 
+      it('awaits all mention push notifications (does not swallow errors)', async () => {
+        const pushError = new Error('Push notification failed');
+        sandbox.stub(pushNotifications, 'sendNotification').rejects(pushError);
+
+        const sender = new User({
+          profile: { name: 'Sender' },
+        });
+
+        const mentionedUser = new User({
+          party: { _id: party._id },
+          profile: { name: 'Mentioned User' },
+          preferences: {
+            pushNotifications: {
+              mentionParty: true,
+              unsubscribeFromAll: false,
+            },
+          },
+          pushDevices: [{ regId: 'device-1', type: 'android' }],
+        });
+
+        await Promise.all([sender.save(), mentionedUser.save()]);
+
+        await expect(party.sendChat({
+          message: 'Hey @mentioned check this',
+          user: sender,
+          mentionedMembers: [mentionedUser],
+        })).to.eventually.be.rejectedWith('Push notification failed');
+      });
     });
 
     describe('#startQuest', () => {

--- a/test/api/unit/models/group.test.js
+++ b/test/api/unit/models/group.test.js
@@ -16,6 +16,7 @@ import {
   questActivityWebhook,
 } from '../../../../website/server/libs/webhook';
 import * as email from '../../../../website/server/libs/email';
+import * as pushNotifications from '../../../../website/server/libs/pushNotifications';
 import { TAVERN_ID } from '../../../../website/common/script/constants';
 import shared from '../../../../website/common';
 
@@ -1460,6 +1461,47 @@ describe('Group Model', () => {
 
         expect(User.updateMany).to.not.be.called;
       });
+
+      it('sends push notifications to mentioned members', async () => {
+        sandbox.stub(pushNotifications, 'sendNotification').resolves();
+
+        const sender = new User({
+          profile: { name: 'Sender' },
+        });
+
+        const mentionedUser = new User({
+          party: { _id: party._id },
+          profile: { name: 'Mentioned User' },
+          preferences: {
+            pushNotifications: {
+              mentionParty: true,
+              unsubscribeFromAll: false,
+            },
+          },
+          pushDevices: [{ regId: 'device-1', type: 'android' }],
+        });
+
+        party.members = [sender._id, mentionedUser._id];
+
+        await Promise.all([sender.save(), mentionedUser.save()]);
+
+        await party.sendChat({
+          message: 'Hey @mentionedUser check this out',
+          user: sender,
+          mentionedMembers: [mentionedUser],
+        });
+
+        expect(pushNotifications.sendNotification).to.be.calledOnce;
+        expect(pushNotifications.sendNotification).to.be.calledWithMatch(
+          sinon.match({ _id: mentionedUser._id }),
+          sinon.match({
+            identifier: 'chatMention',
+            title: sinon.match('Sender mentioned you'),
+            message: sinon.match.string,
+          }),
+        );
+      });
+
     });
 
     describe('#startQuest', () => {

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -621,7 +621,7 @@ schema.methods.sendChat = async function sendChat (options = {}) {
     sendChatPushNotifications(user, this, newChatMessage, mentions, translate);
   }
   if (mentionedMembers) {
-    await Promise.all(mentionedMembers.map(async member => {
+    Promise.all(mentionedMembers.map(async member => {
       if (member._id === user._id) return;
       const pushNotifPrefs = member.preferences.pushNotifications;
       if (this.type === 'party') {
@@ -649,7 +649,7 @@ schema.methods.sendChat = async function sendChat (options = {}) {
           payload: { type: this.type, groupID: this._id },
         });
       }
-    }));
+    })).catch(err => logger.error(err));
   }
   return newChatMessage;
 };

--- a/website/server/models/group.js
+++ b/website/server/models/group.js
@@ -621,7 +621,7 @@ schema.methods.sendChat = async function sendChat (options = {}) {
     sendChatPushNotifications(user, this, newChatMessage, mentions, translate);
   }
   if (mentionedMembers) {
-    await mentionedMembers.forEach(async member => {
+    await Promise.all(mentionedMembers.map(async member => {
       if (member._id === user._id) return;
       const pushNotifPrefs = member.preferences.pushNotifications;
       if (this.type === 'party') {
@@ -649,7 +649,7 @@ schema.methods.sendChat = async function sendChat (options = {}) {
           payload: { type: this.type, groupID: this._id },
         });
       }
-    });
+    }));
   }
   return newChatMessage;
 };


### PR DESCRIPTION
## Summary

`group.sendChat()` used `await mentionedMembers.forEach(async ...)` to send push notifications for @mentions, but `Array.forEach` ignores returned promises, so the `await` was a no-op and all errors were silently dropped.

Replaced with `Promise.all(mentionedMembers.map(...)).catch(err => logger.error(err))` which properly resolves all async callbacks while keeping notifications fire-and-forget, matching the existing pattern on line 616-618 for other chat notifications.

Added 4 unit tests covering the previously untested mention notification path: delivery, error logging, sender exclusion, and preference filtering.

## Test plan

- [ ] `npm run test:api:unit` - group model tests pass, including 4 new mention notification tests
- [ ] Verify mention push notifications still fire for party members with `mentionParty: true`
- [ ] Verify push notification failures are logged but do not block chat message delivery
- [ ] Verify sender does not receive a push notification for mentioning themselves
- [ ] Verify `mentionParty: false` preference is respected