### PR TITLE
fix: remove debug console.log from payment code

### DIFF
--- a/website/client/src/components/admin/admin-panel/user-support/subscriptionAndPerks.vue
+++ b/website/client/src/components/admin/admin-panel/user-support/subscriptionAndPerks.vue
@@ -792,7 +792,6 @@ export default {
       return date ? moment(date).format('MM/DD/YYYY') : '---';
     },
     isSubscribed () {
-      console.log(this.hero.purchased.plan.customerId, this.hero.purchased.plan.dateTerminated);
       return this.hero.purchased.plan
         && this.hero.purchased.plan.customerId
         && this.hero.purchased.plan.planId

--- a/website/server/libs/payments/paypal.js
+++ b/website/server/libs/payments/paypal.js
@@ -248,7 +248,6 @@ api.getSubscriptionPaymentDetails = async function getSubscriptionPaymentDetails
   const customer = await this.paypalBillingAgreementGet(customerId);
   if (!customer) throw new NotFound(i18n.t('subscriptionNotFound'));
 
-  console.log('PayPal subscription details:', customer);
   return {
     customerId: customer.id,
     originalPurchaseDate: customer.start_date,

--- a/website/server/libs/payments/stripe/subscriptions.js
+++ b/website/server/libs/payments/stripe/subscriptions.js
@@ -44,8 +44,6 @@ export async function getSubscriptionPaymentDetails (user) {
   const lastPayment = paymentIntents.data.length > 0
     ? paymentIntents.data[0]
     : null;
-  console.log(paymentIntents.data);
-  console.log(customer);
   return {
     customerId: customer.id,
     originalPurchaseDate: new Date(Number(customer.created) * 1000),


### PR DESCRIPTION
Spotted a few console.log statements left in payment code that log customer/payment objects to stdout:

- `subscriptions.js` — logs full Stripe paymentIntents and customer objects
- `paypal.js` — logs full PayPal billing agreement
- `subscriptionAndPerks.vue` — logs customerId and dateTerminated to browser console

Just deletes the lines, nothing else.