### PR TITLE
Transaction for updating user+group in quest routes

### DIFF
--- a/website/server/controllers/api-v3/quests.js
+++ b/website/server/controllers/api-v3/quests.js
@@ -206,13 +206,16 @@ api.acceptQuest = {
     }
 
     user.party.quest.RSVPNeeded = false;
-    await user.save();
 
     if (canStartQuestAutomatically(group)) {
       await group.startQuest(user);
     }
 
-    const savedGroup = await group.save();
+    let savedGroup;
+    await Group.db.transaction(async session => {
+      await user.save({ session });
+      savedGroup = await group.save({ session });
+    });
 
     res.respond(200, savedGroup.quest);
 
@@ -261,13 +264,16 @@ api.rejectQuest = {
 
     user.party.quest = Group.cleanQuestUser(user.party.quest.progress);
     user.markModified('party.quest');
-    await user.save();
 
     if (canStartQuestAutomatically(group)) {
       await group.startQuest(user);
     }
 
-    const savedGroup = await group.save();
+    let savedGroup;
+    await Group.db.transaction(async session => {
+      await user.save({ session });
+      savedGroup = await group.save({ session });
+    });
 
     res.respond(200, savedGroup.quest);
 


### PR DESCRIPTION
**Previously**, accepting or rejecting a quest involved two separate MongoDB updates (via Mongoose `save()`), one on the user document and one on the group document. This meant the documents could get into an inconsistent state if one update failed while the other succeeded. For the end user, this most commonly caused a situation where they were participating in a quest, but their notifications--looking at the `party.quest.RSVPNeeded` field--still said they had an outstanding quest invite.

**Now**, these two updates are wrapped in a `transaction` call, meaning that Mongoose will only commit the updates to the db if the entire set of operations are successful, retrying if possible where one encounters an issue. We already use this tactic in e.g. [the group creation API](https://github.com/HabitRPG/habitica/blob/develop/website/server/controllers/api-v3/groups.js#L153-L156). This should eliminate situations where the group update occurs but the user's left behind.