### PR TITLE
[Bug Fix] Fix UI task ordering jump

### DIFF
--- a/website/client/src/components/tasks/column.vue
+++ b/website/client/src/components/tasks/column.vue
@@ -551,6 +551,7 @@ export default {
       // Server
       const taskIdToReplace = filteredList[data.newIndex]._id;
       const newIndexOnServer = originTasks.findIndex(task => task._id === taskIdToReplace);
+      const oldIndexOnServer = originTasks.findIndex(task => task._id === taskIdToMove);
 
       let newOrder;
       if (taskToMove.group.id && !this.isUser) {
@@ -567,8 +568,8 @@ export default {
       if (!this.taskListOverride) this.user.tasksOrder[`${this.type}s`] = newOrder;
 
       // Client
-      const deleted = originTasks.splice(data.oldIndex, 1);
-      originTasks.splice(data.newIndex, 0, deleted[0]);
+      const deleted = originTasks.splice(oldIndexOnServer, 1);
+      originTasks.splice(newIndexOnServer, 0, deleted[0]);
       this.rerendering = true;
       await this.$nextTick();
       this.rerendering = false;

--- a/website/client/tests/unit/components/tasks/column.spec.js
+++ b/website/client/tests/unit/components/tasks/column.spec.js
@@ -316,5 +316,55 @@ describe('Task Column', () => {
         expect(wrapper.vm.user.tasksOrder.habits.join(',')).to.eq('b,a');
       });
     });
+
+    describe('taskSorted', () => {
+      test('moves tasks in the unfiltered list when the visible list is filtered', async () => {
+        const originTasks = [
+          { _id: 'hidden-a', group: {} },
+          { _id: 'visible-a', group: {} },
+          { _id: 'hidden-b', group: {} },
+          { _id: 'visible-b', group: {} },
+          { _id: 'visible-c', group: {} },
+        ];
+        const filteredTasks = [
+          originTasks[1],
+          originTasks[3],
+          originTasks[4],
+        ];
+        const newOrder = ['hidden-a', 'visible-c', 'visible-a', 'hidden-b', 'visible-b'];
+        const store = new Store({
+          getters: {
+            'tasks:getFilteredTaskList': () => () => filteredTasks,
+            'tasks:getUnfilteredTaskList': () => () => originTasks,
+          },
+          state: {
+            user: {
+              data: {
+                preferences: { tasks: { activeFilter: { daily: 'due' } } },
+                tasksOrder: { dailys: originTasks.map(task => task._id) },
+              },
+            },
+          },
+        });
+        const calls = [];
+        store.dispatch = (action, payload) => {
+          calls.push({ action, payload });
+          return Promise.resolve(newOrder);
+        };
+
+        wrapper = makeWrapper({
+          propsData: { type: 'daily', isUser: true },
+          store,
+        });
+
+        await wrapper.vm.taskSorted({ oldIndex: 2, newIndex: 0 });
+
+        expect(calls).to.have.lengthOf(1);
+        expect(calls[0].action).to.eq('tasks:move');
+        expect(calls[0].payload.position).to.eq(1);
+        expect(originTasks.map(task => task._id).join(',')).to.eq(newOrder.join(','));
+        expect(wrapper.vm.user.tasksOrder.dailys.join(',')).to.eq(newOrder.join(','));
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes a client-side task ordering issue where dragging a task in a filtered task list could briefly place it correctly, then make it jump to a different order after the move request completed. This is very consistent and easily reproducible.

## Problem

When reordering tasks by dragging, the task list could briefly place it correctly, then make it jump to a different order after the move request is completed.

Before this change, `taskSorted` used the visible `oldIndex` and `newIndex` from the drag event to mutate the unfiltered backing list. When hidden tasks were interleaved with visible tasks, those indexes no longer pointed at the same tasks in the backing list. The server saved the correct order, but the client could locally move the wrong item, causing the visible order to jump until the page was refreshed.

## How To Reproduce

1. Create five dailies in this full order:

```text
Hidden A
Visible A
Hidden B
Visible B
Visible C
```

2. Make `Hidden A` and `Hidden B` not due, for example by setting their start dates to tomorrow.
3. Switch the Dailies column to the `Due` filter.
4. Confirm the visible list is:

```text
Visible A
Visible B
Visible C
```

5. Drag `Visible C` above `Visible A`.
6. Wait for the reorder request to finish.

### Current Behavior

The task can appear in the correct place immediately after dropping, but then the visible list can jump to a different order after the server response. Refreshing the page restores the correct saved order.

### Expected Behavior

The visible list should remain in the order selected by the drag operation, both immediately after the drop and after the server response. Refreshing the page should show the same order.

## Fix

The drag event still uses visible-list indexes, but the client-side backing list is unfiltered. This change maps the dragged task back to its actual index in the unfiltered backing list before splicing:

- Find the moved task by `_id` in the unfiltered task list.
- Find the destination task by `_id` in the unfiltered task list.
- Send the unfiltered destination index to the server.
- Update the local unfiltered task list using unfiltered indexes.

That keeps the local client state aligned with the order saved by the server.

The key idea: the reorder event gives indexes for what you can see, but the app was mutating the full hidden backing list with those same indexes.

In column.vue `taskSorted` works with two lists:

`filteredList = this.taskList`
This is the visible list. For dailies, this is often filtered to only `due` dailies, and tag/search filters can shrink it too.

`originTasks = this.getUnfilteredTaskList(this.type)`
This is the full backing list in client state.

Example:

```js
originTasks = [hiddenA, visibleA, hiddenB, visibleB, visibleC]
filteredList = [visibleA, visibleB, visibleC]
```

If you drag `visibleC` from visible index `2` to visible index `0`, Sortable says:

```js
oldIndex: 2
newIndex: 0
```

Those indexes are correct for `filteredList`, but not for `originTasks`.

The old code did this:

```js
const deleted = originTasks.splice(data.oldIndex, 1);
originTasks.splice(data.newIndex, 0, deleted[0]);
```

So it removed `originTasks[2]`, which is `hiddenB`, not `visibleC`. That corrupts the local client order. The server had already received the correct position and saved the right order, which is why refreshing the page fixed it.

The fix maps the dragged task back to its real index in the unfiltered list:

```js
const oldIndexOnServer = originTasks.findIndex(task => task._id === taskIdToMove);
```

Then the local splice uses unfiltered indexes on the unfiltered list:

```js
const deleted = originTasks.splice(oldIndexOnServer, 1);
originTasks.splice(newIndexOnServer, 0, deleted[0]);
```

So now both sides agree:

- the server receives the correct unfiltered destination index
- the client removes the actual dragged task from the unfiltered list
- the client reinserts it at the same unfiltered position the server saved

## Validation

- Added a regression test covering a filtered daily list with hidden dailies interleaved in the backing list.
- Passed: `npm run test:unit -- tests/unit/components/tasks/column.spec.js`

## Manual test instructions:

Run this seed script: https://gist.github.com/luanmuniz/1b53bd6ec73275a1cc49016e4ea40442
This will create a new user, and create the tasks as described above. Then run the instructions in the `How to reproduce` section:

1. Log in with the test account.
2. Check for the current daily tasks:
    - With `All` filter expect order to be: `Hidden A, Visible A, Hidden B, Visible B, Visible C`
    - With `Due` filter expect order to be: `Visible A, Visible B, Visible C`
3. Drag `Visible C` above `Visible A`.
4. Wait 2-3 seconds for the server request to finish.
5. Confirm the Dailies `Due` filter still shows: `Visible C, Visible A, Visible B`
4. Refresh the page.
6. Confirm ordering is still the same of step 5
7. Switch the Dailies filter to `All`.
8. Expect order to be `Hidden A, Visible C, Visible A, Hidden B, Visible B`

Before this fix, during step 5, the drag could appear correct immediately, then jump to a different local order after the move request completed. Refreshing the page would restore the saved server order.

## Out Of Scope

- Server task
- Task filtering rules.
- `Move to top` / `Move to bottom` menu behavior

## Personal note

This bug has annoyed me for quite a while now. I'm happy to make any changes or provide explanations on this, so this can be merged as soon as possible!

I'm also not sure there is already an issue open for this problem, but I assume it does since it's such a consistent bug. I don't know the number of that issue tho.