### PR TITLE
Kalista/groups txn

### DIFF
--- a/website/client/src/components/groups/membersModal.vue
+++ b/website/client/src/components/groups/membersModal.vue
@@ -603,8 +603,12 @@ export default {
       this.memberToRemove.index = index;
       this.$root.$emit('bv::show::modal', 'remove-member');
     },
-    memberRemoved () {
-      this.members.splice(this.memberToRemove.index, 1);
+    memberRemoved (removedMember) {
+      // Wrong member is getting removed, let's make sure we've got the right one
+      const memberIndex = this.members.findIndex(member => {
+        member._id === removedMember._id;
+      });
+      this.members.splice(memberIndex, 1);
       this.group.memberCount -= 1;
       this.memberToRemove = {};
     },

--- a/website/client/src/components/groups/membersModal.vue
+++ b/website/client/src/components/groups/membersModal.vue
@@ -605,11 +605,10 @@ export default {
     },
     memberRemoved (removedMember) {
       // Wrong member is getting removed, let's make sure we've got the right one
-      const memberIndex = this.members.findIndex(member => 
-        member._id === removedMember._id
-      );
+      const memberIndex = this.members.findIndex(member => member._id === removedMember._id);
       this.members.splice(memberIndex, 1);
       this.group.memberCount -= 1;
+      this.$store.state.memberModalOptions.memberCount -= 1;
       this.memberToRemove = {};
     },
     async quickReply (uid) {

--- a/website/client/src/components/groups/membersModal.vue
+++ b/website/client/src/components/groups/membersModal.vue
@@ -605,9 +605,9 @@ export default {
     },
     memberRemoved (removedMember) {
       // Wrong member is getting removed, let's make sure we've got the right one
-      const memberIndex = this.members.findIndex(member => {
-        member._id === removedMember._id;
-      });
+      const memberIndex = this.members.findIndex(member => 
+        member._id === removedMember._id
+      );
       this.members.splice(memberIndex, 1);
       this.group.memberCount -= 1;
       this.memberToRemove = {};

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -8,6 +8,7 @@ import mergeWith from 'lodash/mergeWith';
 import uniqBy from 'lodash/uniqBy';
 import nconf from 'nconf';
 import moment from 'moment';
+import mongoose from 'mongoose';
 import { authWithHeaders, chatPrivilegesRequired } from '../../middlewares/auth';
 import {
   model as Group,
@@ -39,6 +40,7 @@ import {
   leaveGroup,
   removeMessagesFromMember,
 } from '../../libs/groups';
+import { session } from 'passport';
 
 const { MAX_SUMMARY_SIZE_FOR_GUILDS } = common.constants;
 const MAX_EMAIL_INVITES_BY_USER = 200;
@@ -538,7 +540,7 @@ api.joinGroup = {
   middlewares: [authWithHeaders()],
   async handler (req, res) {
     const { user } = res.locals;
-    let inviter;
+    let inviter, session;
 
     req.checkParams('groupId', apiError('groupIdRequired')).notEmpty(); // .isUUID(); can't be used because it would block 'habitrpg' or 'party'
 
@@ -619,64 +621,69 @@ api.joinGroup = {
       group.leader = user._id; // If new user is only member -> set as leader
     }
 
-    let promises = [user.save()];
+    try {
+      session = await mongoose.startSession();
 
-    if (group.type === 'party') {
-      // For parties we count the number of members from the database to get the correct value.
-      // See #12275 on why this is necessary and only done for parties.
-      const currentMembers = await group.getMemberCount({ excludeUserId: user._id });
-      // Load the inviter
-      if (inviter) inviter = await User.findById(inviter).exec();
+      if (group.type === 'party') {
+        // Load the inviter
+        if (inviter) inviter = await User.findById(inviter).exec();
 
-      // Check the inviter again, could be a deleted account
-      if (inviter) {
-        // Reward Inviter
-        if (!inviter.items.quests.basilist) {
-          inviter.items.quests.basilist = 0;
+        // Check the inviter again, could be a deleted account
+        if (inviter) {
+          // Reward Inviter
+          if (!inviter.items.quests.basilist) {
+            inviter.items.quests.basilist = 0;
+          }
+          inviter.items.quests.basilist += 1;
+          inviter.markModified('items.quests');
         }
-        inviter.items.quests.basilist += 1;
-        inviter.markModified('items.quests');
-        promises.push(inviter.save());
+
+        // Handle awarding party-related achievements
+        if (group.memberCount > 1) {
+          const notification = new UserNotification({ type: 'ACHIEVEMENT_PARTY_UP' });
+
+          await User.updateMany(
+            {
+              $or: [{ 'party._id': group._id }, { _id: user._id }],
+              'achievements.partyUp': { $ne: true },
+            },
+            {
+              $set: { 'achievements.partyUp': true },
+              $push: { notifications: notification.toObject() },
+            },
+            { session },
+          );
+        }
+
+        if (group.memberCount > 3) {
+          const notification = new UserNotification({ type: 'ACHIEVEMENT_PARTY_ON' });
+
+          await User.updateMany(
+            {
+              $or: [{ 'party._id': group._id }, { _id: user._id }],
+              'achievements.partyOn': { $ne: true },
+            },
+            {
+              $set: { 'achievements.partyOn': true },
+              $push: { notifications: notification.toObject() },
+            },
+            { session },
+          );
+        }
+      } else {
+        group.memberCount += 1;
       }
-      group.memberCount = currentMembers + 1;
 
-      // Handle awarding party-related achievements
-      if (group.memberCount > 1) {
-        const notification = new UserNotification({ type: 'ACHIEVEMENT_PARTY_UP' });
-
-        promises.push(User.updateMany(
-          {
-            $or: [{ 'party._id': group._id }, { _id: user._id }],
-            'achievements.partyUp': { $ne: true },
-          },
-          {
-            $set: { 'achievements.partyUp': true },
-            $push: { notifications: notification.toObject() },
-          },
-        ).exec());
+      await user.save({ session });
+      await group.save({ session });
+      if (inviter) {
+        await inviter.save({ session });
       }
-
-      if (group.memberCount > 3) {
-        const notification = new UserNotification({ type: 'ACHIEVEMENT_PARTY_ON' });
-
-        promises.push(User.updateMany(
-          {
-            $or: [{ 'party._id': group._id }, { _id: user._id }],
-            'achievements.partyOn': { $ne: true },
-          },
-          {
-            $set: { 'achievements.partyOn': true },
-            $push: { notifications: notification.toObject() },
-          },
-        ).exec());
-      }
-    } else {
-      group.memberCount += 1;
+    } catch (err) {
+      throw err;
+    } finally {
+      await session.endSession();
     }
-
-    promises.push(group.save());
-
-    promises = await Promise.all(promises);
 
     if (group.hasNotCancelled()) {
       await payments.addSubToGroupUser(user, group);
@@ -854,6 +861,7 @@ api.removeGroupMember = {
   middlewares: [authWithHeaders()],
   async handler (req, res) {
     const { user } = res.locals;
+    let session;
 
     req.checkParams('groupId', apiError('groupIdRequired')).notEmpty();
     req.checkParams('memberId', res.t('userIdRequired')).notEmpty().isUUID();
@@ -894,14 +902,7 @@ api.removeGroupMember = {
     }
 
     if (isInGroup) {
-      // For parties we count the number of members from the database to get the correct value.
-      // See #12275 on why this is necessary and only done for parties.
-      if (group.type === 'party') {
-        const currentMembers = await group.getMemberCount();
-        group.memberCount = currentMembers - 1;
-      } else {
         group.memberCount -= 1;
-      }
 
       if (group.quest && group.quest.leader === member._id) {
         throw new NotAuthorized(res.t('cannotRemoveQuestOwner'));
@@ -942,10 +943,17 @@ api.removeGroupMember = {
     const message = req.query.message || req.body.message;
     _sendMessageToRemoved(group, member, message, isInGroup);
 
-    await Promise.all([
-      member.save(),
-      group.save(),
-    ]);
+    try {
+      session = await mongoose.startSession();
+      await session.withTransaction(async () => {
+        await member.save({ session });
+        await group.save({ session });
+      });
+    } catch (err) {
+      throw err;
+    } finally {
+      await session.endSession();
+    }
 
     if (isInGroup && group.hasNotCancelled()) {
       await group.updateGroupPlan(true);

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -916,7 +916,9 @@ api.removeGroupMember = {
         removeFromArray(member.guilds, group._id);
       }
       if (isInGroup === 'party') {
-        member.party._id = undefined; // TODO remove quest information too? Use group.leave()?
+        member.party._id = undefined;
+        member.party.quest.key = null;
+        member.party.quest.RSVPNeeded = false;
       }
 
       removeMessagesFromMember(member, group._id);

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -40,7 +40,6 @@ import {
   leaveGroup,
   removeMessagesFromMember,
 } from '../../libs/groups';
-import { session } from 'passport';
 
 const { MAX_SUMMARY_SIZE_FOR_GUILDS } = common.constants;
 const MAX_EMAIL_INVITES_BY_USER = 200;
@@ -540,7 +539,8 @@ api.joinGroup = {
   middlewares: [authWithHeaders()],
   async handler (req, res) {
     const { user } = res.locals;
-    let inviter, session;
+    let inviter;
+    let session;
 
     req.checkParams('groupId', apiError('groupIdRequired')).notEmpty(); // .isUUID(); can't be used because it would block 'habitrpg' or 'party'
 
@@ -679,8 +679,6 @@ api.joinGroup = {
       if (inviter) {
         await inviter.save({ session });
       }
-    } catch (err) {
-      throw err;
     } finally {
       await session.endSession();
     }
@@ -902,7 +900,7 @@ api.removeGroupMember = {
     }
 
     if (isInGroup) {
-        group.memberCount -= 1;
+      group.memberCount -= 1;
 
       if (group.quest && group.quest.leader === member._id) {
         throw new NotAuthorized(res.t('cannotRemoveQuestOwner'));
@@ -951,8 +949,6 @@ api.removeGroupMember = {
         await member.save({ session });
         await group.save({ session });
       });
-    } catch (err) {
-      throw err;
     } finally {
       await session.endSession();
     }

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -621,6 +621,8 @@ api.joinGroup = {
       group.leader = user._id; // If new user is only member -> set as leader
     }
 
+    group.memberCount += 1;
+
     try {
       session = await mongoose.startSession();
 
@@ -670,8 +672,6 @@ api.joinGroup = {
             { session },
           );
         }
-      } else {
-        group.memberCount += 1;
       }
 
       await user.save({ session });

--- a/website/server/controllers/api-v3/groups.js
+++ b/website/server/controllers/api-v3/groups.js
@@ -948,7 +948,7 @@ api.removeGroupMember = {
       await session.withTransaction(async () => {
         await member.save({ session });
         await group.save({ session });
-      });
+      }, { readPreference: 'primary' });
     } finally {
       await session.endSession();
     }


### PR DESCRIPTION
* Consolidates group join and leave operations into transactions to avoid discrepancies across collections
* Fixes an issue where a party member on a quest, or invited to a quest, would be stuck in a liminal quest state if kicked from their Party 
* Fixes an issue where the wrong member would disappear from the members list when removing someone from an independent (not attached to a Party) Group Plan
* Fixes an issue where the Load More button would appear in the members list, with no further load possible, after removing someone from a party or Group Plan