### PR TITLE
fix: shrink header avatar on mobile so stats bars stay visible

### DIFF
--- a/website/client/src/components/memberDetails.vue
+++ b/website/client/src/components/memberDetails.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="member-details d-flex"
-    :class="{ condensed, expanded }"
+    :class="{ condensed, expanded, 'is-header': isHeader}"
     @click="showMemberModal(member)"
   >
     <div class="avatar-container">
@@ -95,15 +95,31 @@
 
 <style lang="scss" scoped>
   @import '@/assets/scss/colors.scss';
+.member-details {
+  white-space: nowrap;
+  transition: all 0.15s ease-out;
 
-  .member-details {
-    white-space: nowrap;
-    transition: all 0.15s ease-out;
+  .avatar-container {
+    margin-bottom: 20px;
+  }
+}
 
+// Smaller header avatar on phones so HP/XP bars stay visible
+@media (max-width: 575.98px) {
+  .member-details.is-header {
     .avatar-container {
-      margin-bottom: 20px;
+      margin-bottom: 8px;
+      max-width: 96px;
+    }
+
+    ::v-deep .avatar {
+      width: 96px !important;
+      height: auto !important;
+      transform: scale(0.72);
+      transform-origin: top left;
     }
   }
+}
 
   .standard-page .member-details {
     padding-left: 24px;


### PR DESCRIPTION
## Summary
- Fixes #11201: on narrow viewports the header avatar could crowd/clip the HP/XP bars.
- On `max-width: 575.98px`, header `member-details` uses a smaller avatar so stats remain fully visible.
- Desktop layout unchanged (media query scoped to `.member-details.is-header`).

## Test plan
- [x] Local: iPhone SE / 375px — HP and XP values fully visible next to avatar
- [x] Local: wide desktop — header avatar and party CTA look normal
- [ ] Reviewer: spot-check mobile + desktop header after merge