### PR TITLE
Reject truncated unlock path

### DIFF
--- a/test/common/ops/unlock.test.js
+++ b/test/common/ops/unlock.test.js
@@ -39,6 +39,17 @@ describe('shared.ops.unlock', () => {
     }
   });
 
+  it('returns an error when path is truncated', async () => {
+    try {
+      await unlock(user, {
+        query: { path: 'background.' },
+      });
+    } catch (err) {
+      expect(err).to.be.an.instanceof(BadRequest);
+      expect(err.message).to.equal(i18n.t('invalidUnlockSet'));
+    }
+  });
+
   it('does not unlock lost gear', async () => {
     user.items.gear.owned.headAccessory_special_bearEars = false;
 

--- a/website/common/script/ops/unlock.js
+++ b/website/common/script/ops/unlock.js
@@ -16,7 +16,11 @@ const incentiveBackgrounds = ['blue', 'green', 'red', 'purple', 'yellow'];
  * and `headAccessory_wolfEars`
  */
 function splitPathItem (path) {
-  return path.match(/(.+)\.([^.]+)/).splice(1);
+  const match = path.match(/(.+)\.([^.]+)/);
+  if (!match) {
+    return [null];
+  }
+  return match.splice(1);
 }
 
 /**
@@ -31,6 +35,9 @@ function invalidSet (req) {
  */
 function getItemByPath (path, setType) {
   const [itemPathParent, itemKey] = splitPathItem(path);
+  if (!itemPathParent || !itemKey) {
+    return null;
+  }
 
   if (setType === 'gear') return content.gear.flat[itemKey];
   if (setType === 'hair') {


### PR DESCRIPTION
We've been getting `TypeError`s in the logs when a client (apparently the official mobile app?) attempts to unlock `background.`, missing the closing part of the path. Now instead of ending up at a 500 error, we return the informative "invalid unlock set" BadRequest error.