### PR TITLE
Blank reset code on manual pw change

### DIFF
--- a/test/api/v3/integration/user/auth/PUT-user_update_password.test.js
+++ b/test/api/v3/integration/user/auth/PUT-user_update_password.test.js
@@ -37,7 +37,7 @@ describe('PUT /user/auth/update-password', async () => {
     expect(user.auth.local.hashed_password).to.not.eql(previousHashedPassword);
   });
 
-  it('should change the apiToken on password change', async () => {
+  it('changes the apiToken on password change', async () => {
     const previousToken = user.apiToken;
     const response = await user.put(ENDPOINT, {
       password,
@@ -53,7 +53,7 @@ describe('PUT /user/auth/update-password', async () => {
     expect(user.apiToken).to.not.eql(previousToken);
   });
 
-  it('should blank the reset code on password change', async () => {
+  it('blanks the reset code on password change', async () => {
     const response = await user.put(ENDPOINT, {
       password,
       newPassword,

--- a/test/api/v3/integration/user/auth/PUT-user_update_password.test.js
+++ b/test/api/v3/integration/user/auth/PUT-user_update_password.test.js
@@ -54,7 +54,7 @@ describe('PUT /user/auth/update-password', async () => {
   });
 
   it('blanks the reset code on password change', async () => {
-    const response = await user.put(ENDPOINT, {
+    await user.put(ENDPOINT, {
       password,
       newPassword,
       confirmPassword: newPassword,

--- a/test/api/v3/integration/user/auth/PUT-user_update_password.test.js
+++ b/test/api/v3/integration/user/auth/PUT-user_update_password.test.js
@@ -17,7 +17,9 @@ describe('PUT /user/auth/update-password', async () => {
   const newPassword = 'new-password';
 
   beforeEach(async () => {
-    user = await generateUser();
+    user = await generateUser(
+      { 'auth.local.passwordResetCode': 'passwordResetCode' },
+    );
   });
 
   it('successfully changes the password', async () => {
@@ -49,6 +51,17 @@ describe('PUT /user/auth/update-password', async () => {
     await user.sync();
     expect(user.apiToken).to.eql(newToken);
     expect(user.apiToken).to.not.eql(previousToken);
+  });
+
+  it('should blank the reset code on password change', async () => {
+    const response = await user.put(ENDPOINT, {
+      password,
+      newPassword,
+      confirmPassword: newPassword,
+    });
+
+    await user.sync();
+    expect(user.auth.local.passwordResetCode).to.not.exist;
   });
 
   it('returns an error when confirmPassword does not match newPassword', async () => {

--- a/website/server/controllers/api-v3/auth.js
+++ b/website/server/controllers/api-v3/auth.js
@@ -316,7 +316,7 @@ api.updatePassword = {
     await passwordUtils.convertToBcrypt(user, newPassword);
 
     user.apiToken = common.uuid();
-    user.auth.local.passwordResetCode = null;
+    user.auth.local.passwordResetCode = undefined;
 
     await user.save();
 

--- a/website/server/controllers/api-v3/auth.js
+++ b/website/server/controllers/api-v3/auth.js
@@ -316,6 +316,7 @@ api.updatePassword = {
     await passwordUtils.convertToBcrypt(user, newPassword);
 
     user.apiToken = common.uuid();
+    user.auth.local.passwordResetCode = null;
 
     await user.save();
 


### PR DESCRIPTION
**Before**, we invalidated the user's password reset code if they changed their email address or used the code to change their password, but if the user requested a reset then changed the password manually, the code could linger.

**Now**, we invalidate the password reset code in the direct password change workflow as well as the workflow employing the code.