### PR TITLE
Scrub UUID where requested

### DIFF
--- a/test/api/v3/integration/payments/amazon/GET-payments_amazon_subscribe_cancel.test.js
+++ b/test/api/v3/integration/payments/amazon/GET-payments_amazon_subscribe_cancel.test.js
@@ -9,12 +9,9 @@ describe('payments : amazon #subscribeCancel', () => {
   const endpoint = '/amazon/subscribe/cancel?noRedirect=true';
   let user; let group; let
     amazonSubscribeCancelStub;
-
-  beforeEach(async () => {
-    user = await generateUser();
-  });
-
+  
   it('throws error when there users has no subscription', async () => {
+    user = await generateUser();
     await expect(user.get(endpoint)).to.eventually.be.rejected.and.eql({
       code: 401,
       error: 'NotAuthorized',
@@ -34,6 +31,7 @@ describe('payments : amazon #subscribeCancel', () => {
     it('cancels a user subscription', async () => {
       user = await generateUser({
         'profile.name': 'sender',
+        'preferences.analyticsConsent': true,
         'purchased.plan.customerId': 'customer-id',
         'purchased.plan.planId': 'basic_3mo',
         'purchased.plan.lastBillingDate': new Date(),
@@ -58,6 +56,7 @@ describe('payments : amazon #subscribeCancel', () => {
         },
         leaderDetails: {
           'profile.name': 'sender',
+          'preferences.analyticsConsent': true,
           'purchased.plan.customerId': 'customer-id',
           'purchased.plan.planId': 'basic_3mo',
           'purchased.plan.lastBillingDate': new Date(),

--- a/test/api/v3/integration/payments/amazon/GET-payments_amazon_subscribe_cancel.test.js
+++ b/test/api/v3/integration/payments/amazon/GET-payments_amazon_subscribe_cancel.test.js
@@ -9,7 +9,7 @@ describe('payments : amazon #subscribeCancel', () => {
   const endpoint = '/amazon/subscribe/cancel?noRedirect=true';
   let user; let group; let
     amazonSubscribeCancelStub;
-  
+
   it('throws error when there users has no subscription', async () => {
     user = await generateUser();
     await expect(user.get(endpoint)).to.eventually.be.rejected.and.eql({

--- a/test/api/v3/integration/payments/amazon/POST-payments_amazon_checkout.test.js
+++ b/test/api/v3/integration/payments/amazon/POST-payments_amazon_checkout.test.js
@@ -8,11 +8,8 @@ describe('payments - amazon - #checkout', () => {
   let user; let
     amazonCheckoutStub;
 
-  beforeEach(async () => {
-    user = await generateUser();
-  });
-
   it('verifies credentials', async () => {
+    user = await generateUser();
     await expect(user.post(endpoint)).to.eventually.be.rejected.and.eql({
       code: 400,
       error: 'BadRequest',
@@ -31,6 +28,7 @@ describe('payments - amazon - #checkout', () => {
 
     it('makes a purchase with amazon checkout', async () => {
       user = await generateUser({
+        'preferences.analyticsConsent': true,
         'profile.name': 'sender',
         'purchased.plan.customerId': 'customer-id',
         'purchased.plan.planId': 'basic_3mo',

--- a/test/api/v3/integration/payments/amazon/POST-payments_amazon_subscribe.test.js
+++ b/test/api/v3/integration/payments/amazon/POST-payments_amazon_subscribe.test.js
@@ -10,11 +10,8 @@ describe('payments - amazon - #subscribe', () => {
   let user; let group; let
     subscribeWithAmazonStub;
 
-  beforeEach(async () => {
-    user = await generateUser();
-  });
-
   it('verifies subscription code', async () => {
+    user = await generateUser();
     await expect(user.post(endpoint)).to.eventually.be.rejected.and.eql({
       code: 400,
       error: 'BadRequest',
@@ -27,8 +24,16 @@ describe('payments - amazon - #subscribe', () => {
     const subscription = 'basic_3mo';
     let coupon;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       subscribeWithAmazonStub = sinon.stub(amzLib, 'subscribe').resolves({});
+      user = await generateUser({
+        'preferences.analyticsConsent': true,
+        'profile.name': 'sender',
+        'purchased.plan.customerId': 'customer-id',
+        'purchased.plan.planId': 'basic_3mo',
+        'purchased.plan.lastBillingDate': new Date(),
+        balance: 2,
+      });
     });
 
     afterEach(() => {
@@ -36,14 +41,6 @@ describe('payments - amazon - #subscribe', () => {
     });
 
     it('creates a user subscription', async () => {
-      user = await generateUser({
-        'profile.name': 'sender',
-        'purchased.plan.customerId': 'customer-id',
-        'purchased.plan.planId': 'basic_3mo',
-        'purchased.plan.lastBillingDate': new Date(),
-        balance: 2,
-      });
-
       await user.post(endpoint, {
         billingAgreementId,
         subscription,
@@ -60,14 +57,6 @@ describe('payments - amazon - #subscribe', () => {
     });
 
     it('creates a group subscription', async () => {
-      user = await generateUser({
-        'profile.name': 'sender',
-        'purchased.plan.customerId': 'customer-id',
-        'purchased.plan.planId': 'basic_3mo',
-        'purchased.plan.lastBillingDate': new Date(),
-        balance: 2,
-      });
-
       group = await generateGroup(user, {
         name: 'test group',
         type: 'party',

--- a/test/api/v3/integration/payments/apple/GET-payments_apple_cancelSubscribe.js
+++ b/test/api/v3/integration/payments/apple/GET-payments_apple_cancelSubscribe.js
@@ -5,10 +5,6 @@ describe('payments : apple #cancelSubscribe', () => {
   const endpoint = '/iap/ios/subscribe/cancel?noRedirect=true';
   let user;
 
-  beforeEach(async () => {
-    user = await generateUser();
-  });
-
   describe('success', () => {
     let cancelStub;
 
@@ -22,6 +18,7 @@ describe('payments : apple #cancelSubscribe', () => {
 
     it('cancels the subscription', async () => {
       user = await generateUser({
+        'preferences.analyticsConsent': true,
         'profile.name': 'sender',
         'purchased.plan.paymentMethod': 'Apple',
         'purchased.plan.customerId': 'customer-id',

--- a/test/api/v3/integration/payments/apple/POST-payments_apple_norenewsubscribe.test.js
+++ b/test/api/v3/integration/payments/apple/POST-payments_apple_norenewsubscribe.test.js
@@ -5,12 +5,12 @@ describe('payments : apple #norenewsubscribe', () => {
   const endpoint = '/iap/ios/norenew-subscribe';
   const sku = 'com.habitrpg.ios.habitica.subscription.3month';
   let user;
-  
+
   describe('verification', () => {
     beforeEach(async () => {
       user = await generateUser();
     });
-    
+
     it('verifies sub key', async () => {
       await expect(user.post(endpoint)).to.eventually.be.rejected.and.eql({
         code: 400,
@@ -18,7 +18,7 @@ describe('payments : apple #norenewsubscribe', () => {
         message: t('missingSubscriptionCode'),
       });
     });
-  
+
     it('verifies receipt existence', async () => {
       await expect(user.post(endpoint, {
         sku,

--- a/test/api/v3/integration/payments/apple/POST-payments_apple_norenewsubscribe.test.js
+++ b/test/api/v3/integration/payments/apple/POST-payments_apple_norenewsubscribe.test.js
@@ -5,26 +5,28 @@ describe('payments : apple #norenewsubscribe', () => {
   const endpoint = '/iap/ios/norenew-subscribe';
   const sku = 'com.habitrpg.ios.habitica.subscription.3month';
   let user;
-
-  beforeEach(async () => {
-    user = await generateUser();
-  });
-
-  it('verifies sub key', async () => {
-    await expect(user.post(endpoint)).to.eventually.be.rejected.and.eql({
-      code: 400,
-      error: 'BadRequest',
-      message: t('missingSubscriptionCode'),
+  
+  describe('verification', () => {
+    beforeEach(async () => {
+      user = await generateUser();
     });
-  });
-
-  it('verifies receipt existence', async () => {
-    await expect(user.post(endpoint, {
-      sku,
-    })).to.eventually.be.rejected.and.eql({
-      code: 400,
-      error: 'BadRequest',
-      message: t('missingReceipt'),
+    
+    it('verifies sub key', async () => {
+      await expect(user.post(endpoint)).to.eventually.be.rejected.and.eql({
+        code: 400,
+        error: 'BadRequest',
+        message: t('missingSubscriptionCode'),
+      });
+    });
+  
+    it('verifies receipt existence', async () => {
+      await expect(user.post(endpoint, {
+        sku,
+      })).to.eventually.be.rejected.and.eql({
+        code: 400,
+        error: 'BadRequest',
+        message: t('missingReceipt'),
+      });
     });
   });
 
@@ -41,6 +43,7 @@ describe('payments : apple #norenewsubscribe', () => {
 
     it('makes a purchase', async () => {
       user = await generateUser({
+        'preferences.analyticsConsent': true,
         'profile.name': 'sender',
         'purchased.plan.customerId': 'customer-id',
         'purchased.plan.planId': 'basic_3mo',

--- a/test/api/v3/integration/payments/apple/POST-payments_apple_subscribe.test.js
+++ b/test/api/v3/integration/payments/apple/POST-payments_apple_subscribe.test.js
@@ -5,11 +5,8 @@ describe('payments : apple #subscribe', () => {
   const endpoint = '/iap/ios/subscribe';
   let user;
 
-  beforeEach(async () => {
-    user = await generateUser();
-  });
-
   it('verifies sub key', async () => {
+    user = await generateUser();
     await expect(user.post(endpoint)).to.eventually.be.rejected.and.eql({
       code: 400,
       error: 'BadRequest',
@@ -30,6 +27,7 @@ describe('payments : apple #subscribe', () => {
 
     it('makes a purchase', async () => {
       user = await generateUser({
+        'preferences.analyticsConsent': true,
         'profile.name': 'sender',
         'purchased.plan.customerId': 'customer-id',
         'purchased.plan.planId': 'basic_3mo',

--- a/test/api/v3/integration/payments/apple/POST-payments_apple_verifyiap.js
+++ b/test/api/v3/integration/payments/apple/POST-payments_apple_verifyiap.js
@@ -5,11 +5,8 @@ describe('payments : apple #verify', () => {
   const endpoint = '/iap/ios/verify';
   let user;
 
-  beforeEach(async () => {
-    user = await generateUser();
-  });
-
   it('verifies receipt existence', async () => {
+    user = await generateUser();
     await expect(user.post(endpoint)).to.eventually.be.rejected.and.eql({
       code: 400,
       error: 'BadRequest',
@@ -22,6 +19,10 @@ describe('payments : apple #verify', () => {
 
     beforeEach(async () => {
       verifyStub = sinon.stub(applePayments, 'verifyPurchase').resolves({});
+      user = await generateUser({
+        'preferences.analyticsConsent': true,
+        balance: 2,
+      });
     });
 
     afterEach(() => {
@@ -29,10 +30,6 @@ describe('payments : apple #verify', () => {
     });
 
     it('makes a purchase', async () => {
-      user = await generateUser({
-        balance: 2,
-      });
-
       await user.post(endpoint, {
         transaction: {
           receipt: 'receipt',
@@ -47,10 +44,6 @@ describe('payments : apple #verify', () => {
     });
 
     it('gifts a purchase', async () => {
-      user = await generateUser({
-        balance: 2,
-      });
-
       await user.post(endpoint, {
         transaction: {
           receipt: 'receipt',

--- a/test/api/v3/integration/payments/google/GET-payments_google_cancelSubscribe.js
+++ b/test/api/v3/integration/payments/google/GET-payments_google_cancelSubscribe.js
@@ -5,10 +5,6 @@ describe('payments : google #cancelSubscribe', () => {
   const endpoint = '/iap/android/subscribe/cancel?noRedirect=true';
   let user;
 
-  beforeEach(async () => {
-    user = await generateUser();
-  });
-
   describe('success', () => {
     let cancelStub;
 
@@ -22,6 +18,7 @@ describe('payments : google #cancelSubscribe', () => {
 
     it('makes a purchase', async () => {
       user = await generateUser({
+        'preferences.analyticsConsent': true,
         'profile.name': 'sender',
         'purchased.plan.paymentMethod': 'Google',
         'purchased.plan.customerId': 'customer-id',

--- a/test/api/v3/integration/payments/google/POST-payments_google_norenewsubscribe.test.js
+++ b/test/api/v3/integration/payments/google/POST-payments_google_norenewsubscribe.test.js
@@ -6,25 +6,27 @@ describe('payments : google #norenewsubscribe', () => {
   const sku = 'com.habitrpg.android.habitica.subscription.3month';
   let user;
 
-  beforeEach(async () => {
-    user = await generateUser();
-  });
-
-  it('verifies sub key', async () => {
-    await expect(user.post(endpoint)).to.eventually.be.rejected.and.eql({
-      code: 400,
-      error: 'BadRequest',
-      message: t('missingSubscriptionCode'),
+  describe('verification', () => {
+    beforeEach(async () => {
+      user = await generateUser();
     });
-  });
 
-  it('verifies receipt existence', async () => {
-    await expect(user.post(endpoint, {
-      sku,
-    })).to.eventually.be.rejected.and.eql({
-      code: 400,
-      error: 'BadRequest',
-      message: t('missingReceipt'),
+    it('verifies sub key', async () => {
+      await expect(user.post(endpoint)).to.eventually.be.rejected.and.eql({
+        code: 400,
+        error: 'BadRequest',
+        message: t('missingSubscriptionCode'),
+      });
+    });
+  
+    it('verifies receipt existence', async () => {
+      await expect(user.post(endpoint, {
+        sku,
+      })).to.eventually.be.rejected.and.eql({
+        code: 400,
+        error: 'BadRequest',
+        message: t('missingReceipt'),
+      });
     });
   });
 
@@ -33,6 +35,14 @@ describe('payments : google #norenewsubscribe', () => {
 
     beforeEach(async () => {
       subscribeStub = sinon.stub(googlePayments, 'noRenewSubscribe').resolves({});
+      user = await generateUser({
+        'preferences.analyticsConsent': true,
+        'profile.name': 'sender',
+        'purchased.plan.customerId': 'customer-id',
+        'purchased.plan.planId': 'basic_3mo',
+        'purchased.plan.lastBillingDate': new Date(),
+        balance: 2,
+      });
     });
 
     afterEach(() => {
@@ -40,14 +50,6 @@ describe('payments : google #norenewsubscribe', () => {
     });
 
     it('makes a purchase', async () => {
-      user = await generateUser({
-        'profile.name': 'sender',
-        'purchased.plan.customerId': 'customer-id',
-        'purchased.plan.planId': 'basic_3mo',
-        'purchased.plan.lastBillingDate': new Date(),
-        balance: 2,
-      });
-
       await user.post(endpoint, {
         sku,
         transaction: {
@@ -66,14 +68,6 @@ describe('payments : google #norenewsubscribe', () => {
     });
 
     it('gifts a purchase', async () => {
-      user = await generateUser({
-        'profile.name': 'sender',
-        'purchased.plan.customerId': 'customer-id',
-        'purchased.plan.planId': 'basic_3mo',
-        'purchased.plan.lastBillingDate': new Date(),
-        balance: 2,
-      });
-
       await user.post(endpoint, {
         sku,
         transaction: {

--- a/test/api/v3/integration/payments/google/POST-payments_google_norenewsubscribe.test.js
+++ b/test/api/v3/integration/payments/google/POST-payments_google_norenewsubscribe.test.js
@@ -18,7 +18,7 @@ describe('payments : google #norenewsubscribe', () => {
         message: t('missingSubscriptionCode'),
       });
     });
-  
+
     it('verifies receipt existence', async () => {
       await expect(user.post(endpoint, {
         sku,

--- a/test/api/v3/integration/payments/google/POST-payments_google_subscribe.test.js
+++ b/test/api/v3/integration/payments/google/POST-payments_google_subscribe.test.js
@@ -5,11 +5,8 @@ describe('payments : google #subscribe', () => {
   const endpoint = '/iap/android/subscribe';
   let user;
 
-  beforeEach(async () => {
-    user = await generateUser();
-  });
-
   it('verifies sub key', async () => {
+    user = await generateUser();
     await expect(user.post(endpoint)).to.eventually.be.rejected.and.eql({
       code: 400,
       error: 'BadRequest',
@@ -30,6 +27,7 @@ describe('payments : google #subscribe', () => {
 
     it('makes a purchase', async () => {
       user = await generateUser({
+        'preferences.analyticsConsent': true,
         'profile.name': 'sender',
         'purchased.plan.customerId': 'customer-id',
         'purchased.plan.planId': 'basic_3mo',

--- a/test/api/v3/integration/payments/google/POST-payments_google_verifyiap.js
+++ b/test/api/v3/integration/payments/google/POST-payments_google_verifyiap.js
@@ -5,11 +5,8 @@ describe('payments : google #verify', () => {
   const endpoint = '/iap/android/verify';
   let user;
 
-  beforeEach(async () => {
-    user = await generateUser();
-  });
-
   it('verifies receipt existence', async () => {
+    user = await generateUser();
     await expect(user.post(endpoint)).to.eventually.be.rejected.and.eql({
       code: 400,
       error: 'BadRequest',
@@ -21,6 +18,10 @@ describe('payments : google #verify', () => {
     let verifyStub;
 
     beforeEach(async () => {
+      user = await generateUser({
+        balance: 2,
+        'preferences.analyticsConsent': true,
+      });
       verifyStub = sinon.stub(googlePayments, 'verifyPurchase').resolves({});
     });
 
@@ -29,10 +30,6 @@ describe('payments : google #verify', () => {
     });
 
     it('makes a purchase', async () => {
-      user = await generateUser({
-        balance: 2,
-      });
-
       await user.post(endpoint, {
         transaction: { receipt: 'receipt', signature: 'signature' },
       });
@@ -46,10 +43,6 @@ describe('payments : google #verify', () => {
     });
 
     it('gifts a purchase', async () => {
-      user = await generateUser({
-        balance: 2,
-      });
-
       await user.post(endpoint, {
         transaction: { receipt: 'receipt', signature: 'signature' },
         gift: { uuid: '1' },

--- a/website/server/middlewares/auth.js
+++ b/website/server/middlewares/auth.js
@@ -103,6 +103,9 @@ export function authWithHeaders (options = {}) {
         if (!user || apiToken !== user.apiToken) {
           throw new InvalidCredentialsError(res.t('invalidCredentials'));
         }
+        if (!user.preferences.analyticsConsent) {
+          req.headers['x-api-user'] = 'Private';
+        }
 
         if (user.auth.blocked) {
           // We want the accountSuspended message to be translated but the language
@@ -149,6 +152,9 @@ export function authWithSession (req, res, next) {
     .exec()
     .then(user => {
       if (!user) throw new NotAuthorized(res.t('invalidCredentials'));
+      if (!user.preferences.analyticsConsent) {
+        req.headers['x-api-user'] = 'Private';
+      }
 
       res.locals.user = user;
       stackdriverTraceUserId(user._id);


### PR DESCRIPTION
Habitica files various error and informational messages to Loggly, a third-party application monitoring platform. 

**Before**, these messages always include the user's ID in the `x-api-user` header field, which could be used to uniquely identify the originator of recorded app activity.

**Now**, if the user has not given consent for their data to be recorded to third-party platforms, we scrub this header after authenticating that it corresponds to a valid Habitica account. Should an error or other message be logged after this point in server request handling, the `x-api-user` field will simply show "Private".