### PR TITLE
Armoire and Health Potion behavior change

### DIFF
--- a/website/client/src/assets/scss/form.scss
+++ b/website/client/src/assets/scss/form.scss
@@ -180,7 +180,7 @@ input, textarea, input.form-control, textarea.form-control {
   font-size: 12px;
   line-height: 1.33;
 
-  color: $maroon-10;
+  color: $maroon-100;
 }
 
 .input-group-spaced {

--- a/website/client/src/assets/scss/item.scss
+++ b/website/client/src/assets/scss/item.scss
@@ -60,7 +60,7 @@
 }
 
 .flat {
-  .item {
+  .item, &.avatar.item {
     box-shadow: none;
     border: none;
   }
@@ -70,8 +70,8 @@
   }
 }
 
-.bordered-item .item {
-  background: $gray-700 !important;
+.bordered-item .item, .bordered-item.avatar.item {
+  background: $gray-600 !important;
   margin: 0 auto;
 }
 

--- a/website/client/src/assets/scss/popover.scss
+++ b/website/client/src/assets/scss/popover.scss
@@ -1,5 +1,5 @@
 .popover {
-  border-radius: 4px;
+  border-radius: 8px;
   background-color: rgba($gray-10, 0.96);
   box-shadow: 0 2px 2px 0 rgba($black, 0.16), 0 1px 4px 0 rgba($black, 0.12);
 

--- a/website/client/src/assets/scss/popover.scss
+++ b/website/client/src/assets/scss/popover.scss
@@ -2,6 +2,7 @@
   border-radius: 8px;
   background-color: rgba($gray-10, 0.96);
   box-shadow: 0 2px 2px 0 rgba($black, 0.16), 0 1px 4px 0 rgba($black, 0.12);
+  max-width: 300px;
 
   &::after, &::before, .arrow {
     display: none;

--- a/website/client/src/components/inventory/equipment/attributesGrid.vue
+++ b/website/client/src/components/inventory/equipment/attributesGrid.vue
@@ -9,8 +9,8 @@
       <div class="group-content">
         <span
           class="popover-content-attr-cell key"
-          :class="{'hasValue': hasSumValue(attr) }"
-        >{{ `${$t(attr)}: ` }}</span>
+          :class="attributeMap[attr]"
+        >{{ `${$t(attributeMap[attr])}: ` }}</span>
         <span
           class="popover-content-attr-cell label key-value value"
           :class="{'green': hasSumValue(attr) }"
@@ -61,6 +61,14 @@
     .attr-con, .attr-per {
       padding-bottom: 0.75rem;
       padding-top: 0.5rem;
+    }
+
+    &:nth-of-type(3) {
+      border-bottom-left-radius: 4px;
+    }
+
+    &:nth-of-type(4) {
+      border-bottom-right-radius: 4px;
     }
 
     &:nth-of-type(even) {
@@ -123,13 +131,32 @@
   }
 
   .modal-body {
+    .attributes-group {
+      margin: inherit;
+      gap: 8px;
+
+      .strength {
+        color: $maroon-100;
+      }
+      .intelligence {
+        color: $blue-10;
+      }
+      .constitution {
+        color: $yellow-5;
+      }
+      .perception {
+        color: $purple-300;
+      }
+    }
 
     .group-content {
       padding: 0.25rem 1rem;
     }
 
     .popover-content-attr {
-      background-color: #f4f4f4;
+      width: calc(50% - 9px);
+      background-color: $gray-700;
+      border-radius: 4px;
 
       &:nth-of-type(even) {
         margin-left: 1px;
@@ -139,23 +166,15 @@
 
     .popover-content-attr-cell {
       &.key {
-        color: $gray-100;
         font-size: 0.875rem;
         font-weight: bold;
         line-height: 1.71;
-
-        opacity: 0.5;
-
-        &.hasValue {
-          opacity: 1;
-        }
       }
 
       &.label {
-        color: $gray-100;
+        color: $gray-300;
         font-size: 0.75rem;
         line-height: 1.33;
-        opacity: 0.5;
 
         &.bold {
           font-weight: bold;
@@ -166,7 +185,7 @@
         }
 
         &.hasValue {
-          opacity: 1;
+          color: $gray-100;
         }
       }
 
@@ -196,6 +215,16 @@ export default {
     user: {
       type: Object,
     },
+  },
+  data () {
+    return {
+      attributeMap: {
+        con: 'constitution',
+        int: 'intelligence',
+        per: 'perception',
+        str: 'strength',
+      },
+    };
   },
   computed: {
     ...mapState({

--- a/website/client/src/components/inventory/equipment/attributesGrid.vue
+++ b/website/client/src/components/inventory/equipment/attributesGrid.vue
@@ -50,7 +50,7 @@
 
   .popover-content-attr {
     font-weight: bold;
-    width: calc(50% - 1px);
+    width: calc(50%);
     background-color: $gray-50;
 
     .attr-str, .attr-int {
@@ -64,26 +64,19 @@
     }
 
     &:nth-of-type(3) {
-      border-bottom-left-radius: 4px;
+      border-bottom-left-radius: 8px;
     }
 
     &:nth-of-type(4) {
-      border-bottom-right-radius: 4px;
-    }
-
-    &:nth-of-type(even) {
-      margin-left: 1px;
-    }
-
-    &:nth-child(1), &:nth-child(2) {
-      margin-bottom: 1px;
+      border-bottom-right-radius: 8px;
+      padding-bottom: 8px;
     }
   }
 
   .group-content {
     display: inline-flex;
     flex-wrap: wrap;
-    padding: 4px 12px;
+    padding: 8px 16px;
     width: 100%;
   }
 
@@ -101,12 +94,17 @@
       font-size: 12px;
       font-weight: bold;
       line-height: 1.33;
+      white-space: nowrap;
     }
 
     &.label {
       font-size: 10px;
       line-height: 1.2;
       color: $gray-300;
+
+      &.hasValue {
+        color: $gray-500;
+      }
     }
 
     &.label.bold {
@@ -121,7 +119,7 @@
       white-space: nowrap;
 
       &.green {
-        color: $green-10;
+        color: $green-500;
 
         &:before {
           content: '+';
@@ -159,7 +157,6 @@
       border-radius: 4px;
 
       &:nth-of-type(even) {
-        margin-left: 1px;
         width: 50%;
       }
     }

--- a/website/client/src/components/inventory/equipment/attributesPopover.vue
+++ b/website/client/src/components/inventory/equipment/attributesPopover.vue
@@ -12,11 +12,10 @@
       </div>
       <div
         v-else
-        class="popover-content-text"
+        class="popover-content-text mb-0"
       >
         {{ `${$t('tierLockedItem')}` }}
       </div>
-      <p></p>
     </div>
     <div v-else>
       <h4 class="popover-content-title">

--- a/website/client/src/components/inventory/equipment/equipGearModal.vue
+++ b/website/client/src/components/inventory/equipment/equipGearModal.vue
@@ -7,8 +7,8 @@
     :hide-footer="true"
     @change="onChange($event)"
   >
-    <div class="dialog-close">
-      <close-icon @click="hideDialog()" />
+    <div>
+      <close-x @close="hideDialog()" />
     </div>
     <div
       v-if="item != null"
@@ -21,10 +21,12 @@
           :with-background="true"
           :hide-class-badge="true"
           :override-avatar-gear="memberOverrideAvatarGear(item)"
-          :sprites-margin="'0px auto auto -1px'"
+          :sprites-margin="user.preferences.background ? '0px auto 0px -2px'
+            : '0px auto 0px -23px'"
           :show-visual-buffs="false"
+          :class="{ 'item flat bordered-item': !user.preferences.background }"
         />
-        <h4 class="title mt-3">
+        <h4 class="title">
           {{ itemText }}
         </h4>
         <div
@@ -51,7 +53,7 @@
           :item="item"
         />
         <button
-          class="btn with-icon mt-4"
+          class="btn with-icon mb-4"
           :class="{'btn-primary': !isEquipped, 'btn-secondary': isEquipped }"
           @click="equipItem()"
         >
@@ -79,40 +81,51 @@
   #equipgear-modal {
     @include centeredModal();
 
+    .attributes-group {
+      margin: 28px 32px;
+      border-radius: 4px;
+      line-height: 1.71;
+      font-size: 0.875;
+    }
+
+    .attributesGrid {
+      border-radius: 2px;
+    }
+
+    .inner-content {
+      margin: 32px auto auto;
+    }
+
+    .item {
+      border-radius: 8px;
+    }
+
+    .modal-body {
+      padding-left: 0px;
+      padding-right: 0px;
+      padding-bottom: 0px;
+    }
+
     .modal-content {
       border-radius: 8px;
       box-shadow: 0 14px 28px 0 #1a181d3d, 0 10px 10px 0 #1a181d47;
     }
 
-    .modal-body {
-      padding: 2rem 1.5rem;
-    }
-
     .modal-dialog {
-      width: 330px;
-
-      .text {
-        min-height: 0;
-      }
+      width: 448px;
     }
 
     .text {
+      margin-top: 8px;
+      padding-left: 49px;
+      padding-right: 49px;
       font-size: 0.875rem;
       line-height: 1.71;
-      text-align: center;
-      color: $gray-50;
+      min-height: 0px;
     }
 
     .content {
       text-align: center;
-    }
-
-    .item-wrapper {
-      margin-bottom: 0 !important;
-    }
-
-    .inner-content {
-      width: 282px;
     }
 
     .classTag {
@@ -148,23 +161,13 @@
     }
 
     .title {
+      margin-top: 25px;
       color: $gray-10;
-    }
-
-    .attributesGrid {
-      background-color: $gray-500;
-      margin: 1rem 0 0;
-      border-radius: 4px;
-      border: 1px solid #f4f4f4;
     }
 
     .avatar {
       cursor: default;
       margin: 0 auto;
-
-      .character-sprites span {
-        left: 24px;
-      }
     }
 
     button.btn {
@@ -188,14 +191,14 @@ import svgUnEquipIcon from '@/assets/svg/unequip.svg?raw';
 
 import Avatar from '@/components/avatar';
 import attributesGrid from '@/components/inventory/equipment/attributesGrid.vue';
-import closeIcon from '@/components/shared/closeIcon';
+import closeX from '@/components/ui/closeX';
 // TODO @common/ path alias
 
 export default {
   components: {
     Avatar,
     attributesGrid,
-    closeIcon,
+    closeX,
   },
   props: {
     item: {

--- a/website/client/src/components/inventory/item.vue
+++ b/website/client/src/components/inventory/item.vue
@@ -23,6 +23,9 @@
           :item="item"
         ></slot><Sprite
           class="item-content"
+          :class="{ 'pet-item':
+            ['eggs', 'premiumHatchingPotion', 'hatchingPotions', 'food'].includes(item.pinType)
+          }"
           :image-name="itemContentClass"
         />
       </div><span
@@ -43,6 +46,12 @@
     </b-popover>
   </div>
 </template>
+
+<style lang="scss" scoped>
+  .pet-item {
+    top: -25px;
+  }
+</style>
 
 <script>
 import { v4 as uuid } from 'uuid';

--- a/website/client/src/components/shared/numberIncrement.vue
+++ b/website/client/src/components/shared/numberIncrement.vue
@@ -46,19 +46,16 @@
   }
 
   .input-group {
-    width: 94px;
     height: 32px;
-    width: 48px;
+    width: 40px;
     margin: 0px 16px 0px 16px;
-    padding: 0;
-    border-radius: 2px;
+    border-radius: 3px;
     border: solid 1px $gray-400;
-    background-color: $white;
   }
 
   .gray-circle {
     border-radius: 100%;
-    border: solid 2px $gray-300;
+    border: solid 2px $gray-100;
     width: 32px;
     height: 32px;
     cursor: pointer;
@@ -82,7 +79,7 @@
     margin: 4px auto;
 
     & ::v-deep svg path {
-      fill: $gray-300;
+      fill: $gray-100;
     }
   }
 

--- a/website/client/src/components/shops/buyModal.vue
+++ b/website/client/src/components/shops/buyModal.vue
@@ -42,7 +42,8 @@
               :hide-class-badge="true"
               :with-background="true"
               :override-avatar-gear="getAvatarOverrides(item)"
-              :sprites-margin="'0px auto 0px -2px'"
+              :sprites-margin="user.preferences.background ? '0px auto 0px -2px' : '0px auto 0px -23px'"
+              :class="{ 'item flat bordered-item': !user.preferences.background }"
             />
           </div>
           <item
@@ -68,7 +69,19 @@
           <!-- eslint-disable-next-line max-len -->
           <span class="owned-text">{{ $t('owned') }}: <span class="user-amount">{{ totalOwned }}</span></span>
         </div>
-        <h4 class="title">
+        <h4
+          class="title d-flex justify-content-center align-items-center"
+          :class="{ 'gray-100': item.locked }"
+        >
+          <div
+            class="lock-bubble mr-2 d-flex justify-content-center align-items-center"
+            v-if="item.locked"
+          >
+            <div
+              class="svg svg-icon icon-12 gray-50 color"
+              v-html="icons.lock"
+            ></div>
+          </div>
           {{ itemText }}
         </h4>
         <div class="item-notes">
@@ -89,7 +102,7 @@
           v-if="item.value > 0 && !(item.key === 'gem' && gemsLeft < 1)"
           class="purchase-amount"
         >
-          <div class="item-cost justify-content-center my-3">
+          <div class="item-cost justify-content-center mt-4 mb-3">
             <span
               class="cost d-flex mx-auto"
               :class="getPriceClass()"
@@ -166,7 +179,7 @@
         </button>
         <button
           v-else-if="!(item.key === 'gem' && gemsLeft < 1)"
-          class="btn btn-primary"
+          class="btn btn-primary mt-4"
           :disabled="item.key === 'gem' && gemsLeft === 0 ||
             attemptingToPurchaseMoreGemsThanAreLeft || numberInvalid || item.locked ||
             !preventHealthPotion ||
@@ -179,6 +192,12 @@
           {{ $t('buyNow') }}
         </button>
       </div>
+    </div>
+    <div
+      v-if="buyIssue"
+      class="input-error text-center mt-3"
+    >
+      {{ buyIssue }}
     </div>
     <countdown-banner
       v-if="item.end && item.owned == null"
@@ -321,10 +340,7 @@
     .item {
       width: 141px;
       height: 147px;
-      border-top-left-radius: 4px;
-      border-top-right-radius: 4px;
-      border-bottom-right-radius: 0px;
-      border-bottom-left-radius: 0px;
+      border-radius: 8px;
       cursor: default;
     }
 
@@ -381,10 +397,6 @@
 
     .inner-content {
       margin: 32px auto auto;
-    }
-
-    .btn-primary {
-      margin-top: 16px;
     }
 
     .purchase-amount {
@@ -470,7 +482,6 @@
     .attributesGrid {
       margin-top: 28px;
       border-radius: 2px;
-      background-color: $gray-500;
     }
 
     .item-cost {
@@ -541,7 +552,6 @@
   }
 
     button.btn.btn-primary {
-      margin-top: 16px;
       padding: 2px 12px;
       line-height: 1.714;
 
@@ -557,7 +567,6 @@
 
       .notEnough {
         pointer-events: none;
-        opacity: 0.55;
       }
 
       .free-rebirth {
@@ -608,6 +617,17 @@
     color: $yellow-5;
     font-size: 12px;
   }
+
+  .lock-bubble {
+    background-color: $gray-600;
+    width: 30px;
+    height: 28px;
+    border-radius: 999px;
+
+    .svg {
+      margin-bottom: 2px;
+    }
+  }
 </style>
 
 <script>
@@ -628,6 +648,7 @@ import svgClose from '@/assets/svg/close.svg?raw';
 import svgGold from '@/assets/svg/gold.svg?raw';
 import svgGem from '@/assets/svg/gem.svg?raw';
 import svgHourglasses from '@/assets/svg/hourglass.svg?raw';
+import svgLock from '@/assets/svg/lock.svg?raw';
 import svgClock from '@/assets/svg/clock.svg?raw';
 import svgWhiteClock from '@/assets/svg/clock-white.svg?raw';
 import svgPositive from '@/assets/svg/positive.svg?raw';
@@ -706,6 +727,7 @@ export default {
         gems: svgGem,
         hourglasses: svgHourglasses,
         clock: svgClock,
+        lock: svgLock,
         whiteClock: svgWhiteClock,
         positive: svgPositive,
         negative: svgNegative,
@@ -723,7 +745,6 @@ export default {
       return ['backgrounds', 'gear', 'mystery_set', 'customization']
         .includes(this.item.purchaseType);
     },
-
     preventHealthPotion () {
       if (this.item.key === 'potion' && this.user.stats.hp >= 50) {
         return false;
@@ -731,11 +752,9 @@ export default {
 
       return true;
     },
-
     showAttributesGrid () {
       return this.item.purchaseType === 'gear';
     },
-
     itemText () {
       if (this.item.text instanceof Function) {
         return this.item.text();
@@ -783,6 +802,15 @@ export default {
     totalOwned () {
       return this.user.items[this.item.purchaseType][this.item.key] || 0;
     },
+    buyIssue () {
+      if (this.item.locked) {
+        return this.$t('classLockedItemShort');
+      }
+      if (!this.preventHealthPotion) {
+        return this.$t('messageHealthAlreadyMax');
+      }
+      return null;
+    }
   },
   watch: {
     item: function itemChanged () {

--- a/website/client/src/components/shops/buyModal.vue
+++ b/website/client/src/components/shops/buyModal.vue
@@ -330,7 +330,6 @@
 
     .item-content {
       transform: scale(1.45, 1.45);
-      top: -25.67px;
       left: 1px;
 
       &.shop_gem {

--- a/website/client/src/components/shops/buyModal.vue
+++ b/website/client/src/components/shops/buyModal.vue
@@ -16,14 +16,7 @@
       />
     </span>
     <div>
-      <span
-        class="svg-icon close-icon icon-16 color"
-        aria-hidden="true"
-        tabindex="0"
-        @click="hideDialog()"
-        @keypress.enter="hideDialog()"
-        v-html="icons.close"
-      ></span>
+      <close-x @close="hideDialog()" />
     </div>
     <div
       v-if="item != null"
@@ -313,7 +306,7 @@
       margin: 0 auto;
     }
 
-   .owned {
+    .owned {
       height: 32px;
       width: 141px;
       margin-top: -36px;
@@ -357,18 +350,16 @@
     }
 
     .title {
-      height: 28px;
       color: $gray-10;
-      font-size: 1.25rem;
       margin-top: 25px;
     }
 
     .item-notes {
-       margin-top: 8px;
-       padding-left: 48.5px;
-       padding-right: 48.5px;
-       line-height: 1.71;
-       font-size: 0.875rem;
+      margin-top: 8px;
+      padding-left: 49px;
+      padding-right: 49px;
+      line-height: 1.71;
+      font-size: 0.875rem;
     }
 
     .content {
@@ -533,7 +524,7 @@
       }
     }
 
-  .total-text {
+    .total-text {
       color: $gray-50;
       font-weight: bold;
       font-size: 0.875rem;
@@ -550,7 +541,7 @@
       &.hourglasses {
         color: $hourglass-color;
       }
-  }
+    }
 
     button.btn.btn-primary {
       padding: 2px 12px;
@@ -566,17 +557,17 @@
       }
     }
 
-      .notEnough {
-        pointer-events: none;
-      }
+    .notEnough {
+      pointer-events: none;
+    }
 
-      .free-rebirth {
-        background-color: $yellow-5;
-        color: $white;
-        height: 2rem;
-        line-height: 16px;
-        margin: 24px auto -24px;
-      }
+    .free-rebirth {
+      background-color: $yellow-5;
+      color: $white;
+      height: 2rem;
+      line-height: 16px;
+      margin: 24px auto -24px;
+    }
 
     .gems-left {
       height: 32px;
@@ -608,7 +599,6 @@
       margin-bottom: -24px;
     }
   }
-
 </style>
 
 <style lang="scss" scoped>
@@ -645,7 +635,6 @@ import numberInvalid from '@/mixins/numberInvalid';
 import spellsMixin from '@/mixins/spells';
 import sync from '@/mixins/sync';
 
-import svgClose from '@/assets/svg/close.svg?raw';
 import svgGold from '@/assets/svg/gold.svg?raw';
 import svgGem from '@/assets/svg/gem.svg?raw';
 import svgHourglasses from '@/assets/svg/hourglass.svg?raw';
@@ -656,6 +645,7 @@ import svgPositive from '@/assets/svg/positive.svg?raw';
 import svgNegative from '@/assets/svg/negative.svg?raw';
 
 import BalanceInfo from './balanceInfo.vue';
+import closeX from '@/components/ui/closeX';
 import PinBadge from '@/components/ui/pinBadge';
 import CountdownBanner from './countdownBanner';
 import currencyMixin from './_currencyMixin';
@@ -688,6 +678,7 @@ export default {
   components: {
     BalanceInfo,
     EquipmentAttributesGrid,
+    closeX,
     Item,
     Avatar,
     PinBadge,
@@ -723,7 +714,6 @@ export default {
   data () {
     return {
       icons: Object.freeze({
-        close: svgClose,
         gold: svgGold,
         gems: svgGem,
         hourglasses: svgHourglasses,

--- a/website/client/src/components/shops/buyModal.vue
+++ b/website/client/src/components/shops/buyModal.vue
@@ -42,7 +42,8 @@
               :hide-class-badge="true"
               :with-background="true"
               :override-avatar-gear="getAvatarOverrides(item)"
-              :sprites-margin="user.preferences.background ? '0px auto 0px -2px' : '0px auto 0px -23px'"
+              :sprites-margin="user.preferences.background ? '0px auto 0px -2px'
+                : '0px auto 0px -23px'"
               :class="{ 'item flat bordered-item': !user.preferences.background }"
             />
           </div>
@@ -810,7 +811,7 @@ export default {
         return this.$t('messageHealthAlreadyMax');
       }
       return null;
-    }
+    },
   },
   watch: {
     item: function itemChanged () {

--- a/website/client/src/components/tasks/column.vue
+++ b/website/client/src/components/tasks/column.vue
@@ -750,14 +750,6 @@ export default {
     openBuyDialog (rewardItem) {
       if (rewardItem.locked) return;
 
-      // Buy armoire and health potions immediately
-      const itemsToPurchaseImmediately = ['potion', 'armoire'];
-      if (itemsToPurchaseImmediately.indexOf(rewardItem.key) !== -1) {
-        this.makeGenericPurchase(rewardItem);
-        this.$emit('buyPressed', rewardItem);
-        return;
-      }
-
       if (rewardItem.purchaseType === 'quests') {
         this.selectedItemToBuy = rewardItem;
         this.$root.$emit('bv::show::modal', 'buy-quest-modal');

--- a/website/common/locales/en/gear.json
+++ b/website/common/locales/en/gear.json
@@ -13,6 +13,7 @@
   "moreArmoireGearAvailable": "Until then, there's <%= armoireCount %> pieces of gear in the Enchanted Armoire to find!",
   "moreArmoireGearComing": "The Enchanted Armoire gets new stock every month too!",
   "classLockedItem": "This item is only available to a specific class. At level 10 or above, you can change your class under the User icon > Settings > Character Build!",
+  "classLockedItemShort": "This item is only available to a specific class",
   "tierLockedItem": "This item is only available once you've purchased the previous items in sequence. Keep working your way up!",
 
   "sortByType": "Type",


### PR DESCRIPTION
**Before**, the Enchanted Armoire and Health Potion reward items had special handling so that they only took one click to buy without requiring confirmation.

**Now**, these items open the purchase modal like any other in-app reward item, requiring a second click but also allowing the user to specify a quantity.

In addition, the design of this modal and some related components, such as the equipment attributes grid used in tooltips, have received a design refresh.