### PR TITLE
Filter junk ClientJS logs

### DIFF
--- a/website/client/src/libs/logging.js
+++ b/website/client/src/libs/logging.js
@@ -1,4 +1,5 @@
 import Vue from 'vue';
+import isEqual from 'lodash/isEqual';
 
 /* eslint-disable no-console */
 export function setUpLogging () { // eslint-disable-line import/prefer-default-export
@@ -23,7 +24,7 @@ export function setUpLogging () { // eslint-disable-line import/prefer-default-e
   window.onunhandledrejection = event => {
     console.error(`Unhandled promise rejection: ${event.reason}`);
     console.error('Full info:', event);
-    if (event == { isTrusted: true }) return; // eslint-disable-line eqeqeq
+    if (isEqual(event, { isTrusted: true })) return;
     _LTracker.push({
       event,
     });

--- a/website/client/src/libs/logging.js
+++ b/website/client/src/libs/logging.js
@@ -1,5 +1,4 @@
 import Vue from 'vue';
-import isEqual from 'lodash/isEqual';
 
 /* eslint-disable no-console */
 export function setUpLogging () { // eslint-disable-line import/prefer-default-export

--- a/website/client/src/libs/logging.js
+++ b/website/client/src/libs/logging.js
@@ -24,9 +24,9 @@ export function setUpLogging () { // eslint-disable-line import/prefer-default-e
   window.onunhandledrejection = event => {
     console.error(`Unhandled promise rejection: ${event.reason}`);
     console.error('Full info:', event);
-    if (isEqual(event, { isTrusted: true })) return;
     _LTracker.push({
-      event,
+      message: event.reason.message,
+      stack: event.reason.stack,
     });
   };
 

--- a/website/client/src/libs/logging.js
+++ b/website/client/src/libs/logging.js
@@ -23,6 +23,7 @@ export function setUpLogging () { // eslint-disable-line import/prefer-default-e
   window.onunhandledrejection = event => {
     console.error(`Unhandled promise rejection: ${event.reason}`);
     console.error('Full info:', event);
+    if (event == { isTrusted: true }) return; // eslint-disable-line eqeqeq
     _LTracker.push({
       event,
     });

--- a/website/client/src/libs/logging.js
+++ b/website/client/src/libs/logging.js
@@ -23,6 +23,7 @@ export function setUpLogging () { // eslint-disable-line import/prefer-default-e
   window.onunhandledrejection = event => {
     console.error(`Unhandled promise rejection: ${event.reason}`);
     console.error('Full info:', event);
+    if (!event.reason) return;
     _LTracker.push({
       message: event.reason.message,
       stack: event.reason.stack,


### PR DESCRIPTION
**Before**: We were getting a lot of Loggly events from the client library with nothing but `{ isTrusted: true }` in the data.

**Now**: We correctly access the properties of the `PromiseRejectionEvent` to send meaningful data to the error logs.