### PR TITLE
Filter out Chrome extensions from ClientJS error logging

### DIFF
--- a/website/client/src/libs/logging.js
+++ b/website/client/src/libs/logging.js
@@ -23,7 +23,7 @@ export function setUpLogging () { // eslint-disable-line import/prefer-default-e
   window.onunhandledrejection = event => {
     console.error(`Unhandled promise rejection: ${event.reason}`);
     console.error('Full info:', event);
-    if (!event.reason) return;
+    if (!event.reason || event.reason.stack?.includes('chrome-extension')) return;
     _LTracker.push({
       message: event.reason.message,
       stack: event.reason.stack,


### PR DESCRIPTION
**Before**, we corrected our client side logging to better capture data from unhandled promise rejection events, but it turned out that a lot of the logs we've been filing came from a Chrome extension that doesn't even belong to HabitRPG, Inc.

**Now**, we look to the stack trace and skip filing an error to the logs if it's a `chrome-extension` error.