### PR TITLE
Allow content api to be cached

### DIFF
--- a/website/server/controllers/api-v3/content.js
+++ b/website/server/controllers/api-v3/content.js
@@ -58,6 +58,9 @@ api.getContent = {
   method: 'GET',
   url: '/content',
   noLanguage: true,
+  // Content is not user-specific (auth here is only used to pick up the user's
+  // language preference), so it's safe to allow caching/ETags for this route.
+  allowCache: true,
   middlewares: [authWithHeaders({ optional: true, leanUser: true, userFieldsToInclude: ['preferences'] })],
   async handler (req, res) {
     let language = 'en';

--- a/website/server/controllers/api-v4/content.js
+++ b/website/server/controllers/api-v4/content.js
@@ -63,6 +63,9 @@ api.getContent = {
   method: 'GET',
   url: '/content',
   noLanguage: true,
+  // Content is not user-specific (auth here is only used to pick up the user's
+  // language preference), so it's safe to allow caching/ETags for this route.
+  allowCache: true,
   middlewares: [authWithHeaders({ optional: true })],
   async handler (req, res) {
     let language = 'en';

--- a/website/server/libs/routes.js
+++ b/website/server/libs/routes.js
@@ -33,8 +33,9 @@ export function readController (router, controller, overrides = []) {
 
     method = method.toLowerCase();
 
-    // disable caching for all routes with mandatory or optional authentication
-    if (authMiddlewareIndex !== -1) {
+    // disable caching for all routes with mandatory or optional authentication,
+    // unless the route explicitly opts in to allow caching (e.g. /content)
+    if (authMiddlewareIndex !== -1 && !action.allowCache) {
       middlewares.unshift(disableCache);
       authMiddlewareIndex += 1;
     }


### PR DESCRIPTION
Previously content caching was disabled for the content api call. This adds a new optional field `allowCache` that allows caching on authenticated api calls. Currently this field is only used on the content api calls. This should save a significant amount of network traffic.